### PR TITLE
feat(operations): add evolution tracking for boolean operations

### DIFF
--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -1006,6 +1006,134 @@ pub(crate) fn assemble_solid(
     Ok(solid)
 }
 
+// ---------------------------------------------------------------------------
+// Evolution-tracking wrapper
+// ---------------------------------------------------------------------------
+
+/// Perform a boolean operation and return an [`EvolutionMap`] tracking face
+/// provenance.
+///
+/// This wraps [`boolean`] and uses a heuristic (normal + centroid similarity)
+/// to match output faces back to their input faces. Faces whose best match
+/// score exceeds the similarity threshold are classified as "modified";
+/// unmatched input faces are classified as "deleted".
+///
+/// # Errors
+///
+/// Returns the same errors as [`boolean`].
+pub fn boolean_with_evolution(
+    topo: &mut Topology,
+    op: BooleanOp,
+    a: SolidId,
+    b: SolidId,
+) -> Result<(SolidId, crate::evolution::EvolutionMap), crate::OperationsError> {
+    use crate::evolution::EvolutionMap;
+
+    // Collect input face normals + centroids before the operation mutates topology.
+    let input_faces_a = collect_face_signatures(topo, a)?;
+    let input_faces_b = collect_face_signatures(topo, b)?;
+
+    let mut input_faces: Vec<(usize, Vec3, Point3)> = Vec::with_capacity(
+        input_faces_a.len() + input_faces_b.len(),
+    );
+    input_faces.extend(input_faces_a);
+    input_faces.extend(input_faces_b);
+
+    // Run the actual boolean.
+    let result = boolean(topo, op, a, b)?;
+
+    // Collect output face normals + centroids.
+    let output_faces = collect_face_signatures(topo, result)?;
+
+    // Build evolution map via heuristic matching.
+    let mut evo = EvolutionMap::new();
+    let mut matched_inputs: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+    // Normal dot threshold: cos(30deg) — faces with normals diverging more
+    // than ~30 degrees are not considered matches.
+    let normal_threshold = 0.866;
+    // Maximum centroid distance squared for a match (generous, scaled to unit).
+    let centroid_dist_sq_max = 10.0;
+
+    for &(out_idx, out_normal, out_centroid) in &output_faces {
+        let mut best_score = f64::NEG_INFINITY;
+        let mut best_input: Option<usize> = None;
+
+        for &(in_idx, in_normal, in_centroid) in &input_faces {
+            let dot = out_normal.dot(in_normal);
+            if dot < normal_threshold {
+                continue;
+            }
+
+            let dx = out_centroid.x() - in_centroid.x();
+            let dy = out_centroid.y() - in_centroid.y();
+            let dz = out_centroid.z() - in_centroid.z();
+            let dist_sq = dx.mul_add(dx, dy.mul_add(dy, dz * dz));
+
+            if dist_sq > centroid_dist_sq_max {
+                continue;
+            }
+
+            // Score: higher normal alignment + closer centroid = better.
+            // Normalize distance contribution to [0, 1] range.
+            let score = dot - dist_sq / centroid_dist_sq_max;
+            if score > best_score {
+                best_score = score;
+                best_input = Some(in_idx);
+            }
+        }
+
+        if let Some(in_idx) = best_input {
+            evo.add_modified(in_idx, out_idx);
+            matched_inputs.insert(in_idx);
+        }
+    }
+
+    // Any input face not matched to any output is deleted.
+    for &(in_idx, _, _) in &input_faces {
+        if !matched_inputs.contains(&in_idx) {
+            evo.add_deleted(in_idx);
+        }
+    }
+
+    Ok((result, evo))
+}
+
+/// Collect `(FaceId.index(), normal, centroid)` for each face in a solid.
+fn collect_face_signatures(
+    topo: &Topology,
+    solid_id: SolidId,
+) -> Result<Vec<(usize, Vec3, Point3)>, crate::OperationsError> {
+    let solid = topo.solid(solid_id)?;
+    let shell = topo.shell(solid.outer_shell())?;
+    let mut result = Vec::with_capacity(shell.faces().len());
+
+    for &fid in shell.faces() {
+        let face = topo.face(fid)?;
+        let normal = if let FaceSurface::Plane { normal, .. } = face.surface() {
+            *normal
+        } else {
+            // For non-planar faces, approximate normal from first triangle.
+            let verts = face_vertices(topo, fid)?;
+            if verts.len() >= 3 {
+                let e1 = verts[1] - verts[0];
+                let e2 = verts[2] - verts[0];
+                e1.cross(e2)
+                    .normalize()
+                    .unwrap_or(Vec3::new(0.0, 0.0, 1.0))
+            } else {
+                Vec3::new(0.0, 0.0, 1.0)
+            }
+        };
+
+        let verts = face_vertices(topo, fid)?;
+        let centroid = polygon_centroid(&verts);
+        result.push((fid.index(), normal, centroid));
+    }
+
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]

--- a/crates/operations/src/evolution.rs
+++ b/crates/operations/src/evolution.rs
@@ -1,0 +1,79 @@
+//! Evolution tracking for modeling operations.
+//!
+//! Records how faces evolve through booleans, fillets, and other operations,
+//! enabling downstream consumers to track face provenance (e.g., for applying
+//! persistent attributes like color or constraints).
+
+use std::collections::{HashMap, HashSet};
+
+/// Tracks how faces evolve through a modeling operation.
+///
+/// After a boolean, fillet, or other operation, this map records:
+/// - **modified**: input face -> output faces that replace it
+/// - **generated**: input face -> new faces created adjacent to it
+/// - **deleted**: input faces that were completely removed
+#[derive(Debug, Clone, Default)]
+pub struct EvolutionMap {
+    /// Input face -> output faces that are modified versions of it.
+    pub modified: HashMap<usize, Vec<usize>>,
+    /// Input face -> new faces generated from it (e.g., blend faces from fillet).
+    pub generated: HashMap<usize, Vec<usize>>,
+    /// Input faces that were completely removed.
+    pub deleted: HashSet<usize>,
+}
+
+impl EvolutionMap {
+    /// Create an empty evolution map.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `input` was modified into `output`.
+    pub fn add_modified(&mut self, input: usize, output: usize) {
+        self.modified.entry(input).or_default().push(output);
+    }
+
+    /// Record that `output` was generated from `input`.
+    pub fn add_generated(&mut self, input: usize, output: usize) {
+        self.generated.entry(input).or_default().push(output);
+    }
+
+    /// Record that `input` was deleted.
+    pub fn add_deleted(&mut self, input: usize) {
+        self.deleted.insert(input);
+    }
+
+    /// Serialize to JSON without serde.
+    ///
+    /// Produces a JSON object with `modified`, `generated`, and `deleted` fields.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        let modified_entries: Vec<String> = self
+            .modified
+            .iter()
+            .map(|(k, vs)| {
+                let vals: Vec<String> = vs.iter().map(ToString::to_string).collect();
+                format!("\"{k}\":[{}]", vals.join(","))
+            })
+            .collect();
+
+        let generated_entries: Vec<String> = self
+            .generated
+            .iter()
+            .map(|(k, vs)| {
+                let vals: Vec<String> = vs.iter().map(ToString::to_string).collect();
+                format!("\"{k}\":[{}]", vals.join(","))
+            })
+            .collect();
+
+        let deleted_vals: Vec<String> = self.deleted.iter().map(ToString::to_string).collect();
+
+        format!(
+            "{{\"modified\":{{{}}},\"generated\":{{{}}},\"deleted\":[{}]}}",
+            modified_entries.join(","),
+            generated_entries.join(","),
+            deleted_vals.join(",")
+        )
+    }
+}

--- a/crates/operations/src/lib.rs
+++ b/crates/operations/src/lib.rs
@@ -16,6 +16,7 @@ pub mod copy;
 pub mod defeature;
 pub mod distance;
 pub mod draft;
+pub mod evolution;
 pub mod extrude;
 pub mod feature_recognition;
 pub mod fill_face;

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -676,6 +676,80 @@ impl BrepKernel {
         Ok(solid_id_to_u32(result))
     }
 
+    // ── Boolean operations with evolution tracking ─────────────────
+
+    /// Fuse (union) two solids and return evolution tracking data.
+    ///
+    /// Returns a JSON string: `{"solid": <u32>, "evolution": {...}}`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either solid handle is invalid or the operation
+    /// produces an empty or non-manifold result.
+    #[wasm_bindgen(js_name = "fuseWithEvolution")]
+    pub fn fuse_with_evolution(&mut self, a: u32, b: u32) -> Result<JsValue, JsError> {
+        let a_id = self.resolve_solid(a)?;
+        let b_id = self.resolve_solid(b)?;
+        let (result, evo) =
+            brepkit_operations::boolean::boolean_with_evolution(
+                &mut self.topo, BooleanOp::Fuse, a_id, b_id,
+            )?;
+        let json = format!(
+            "{{\"solid\":{},\"evolution\":{}}}",
+            solid_id_to_u32(result),
+            evo.to_json()
+        );
+        Ok(JsValue::from_str(&json))
+    }
+
+    /// Cut (subtract) solid `b` from solid `a` and return evolution tracking data.
+    ///
+    /// Returns a JSON string: `{"solid": <u32>, "evolution": {...}}`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either solid handle is invalid or the operation
+    /// produces an empty or non-manifold result.
+    #[wasm_bindgen(js_name = "cutWithEvolution")]
+    pub fn cut_with_evolution(&mut self, a: u32, b: u32) -> Result<JsValue, JsError> {
+        let a_id = self.resolve_solid(a)?;
+        let b_id = self.resolve_solid(b)?;
+        let (result, evo) =
+            brepkit_operations::boolean::boolean_with_evolution(
+                &mut self.topo, BooleanOp::Cut, a_id, b_id,
+            )?;
+        let json = format!(
+            "{{\"solid\":{},\"evolution\":{}}}",
+            solid_id_to_u32(result),
+            evo.to_json()
+        );
+        Ok(JsValue::from_str(&json))
+    }
+
+    /// Intersect two solids and return evolution tracking data.
+    ///
+    /// Returns a JSON string: `{"solid": <u32>, "evolution": {...}}`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either solid handle is invalid or the operation
+    /// produces an empty result.
+    #[wasm_bindgen(js_name = "intersectWithEvolution")]
+    pub fn intersect_with_evolution(&mut self, a: u32, b: u32) -> Result<JsValue, JsError> {
+        let a_id = self.resolve_solid(a)?;
+        let b_id = self.resolve_solid(b)?;
+        let (result, evo) =
+            brepkit_operations::boolean::boolean_with_evolution(
+                &mut self.topo, BooleanOp::Intersect, a_id, b_id,
+            )?;
+        let json = format!(
+            "{{\"solid\":{},\"evolution\":{}}}",
+            solid_id_to_u32(result),
+            evo.to_json()
+        );
+        Ok(JsValue::from_str(&json))
+    }
+
     // ── Export ─────────────────────────────────────────────────────
 
     /// Export a solid to 3MF format (ZIP archive as bytes).


### PR DESCRIPTION
## Summary
New `EvolutionMap` in `crates/operations/src/evolution.rs` tracks face provenance:
- `modified`: input face → output faces that replace it
- `generated`: reserved for fillet/chamfer blend faces
- `deleted`: input faces completely removed

Heuristic matching (normal + centroid similarity) correlates output faces to inputs after boolean ops.

New WASM exports: `fuseWithEvolution`, `cutWithEvolution`, `intersectWithEvolution`

## Test plan
- [x] `cargo test --workspace` — 717 tests pass
- [x] `cargo clippy --all-targets` clean
- [x] `cargo check -p brepkit-wasm --target wasm32-unknown-unknown` compiles