### PR TITLE
feat(operations): exact analytic booleans preserving surface types

### DIFF
--- a/crates/io/src/iges/writer.rs
+++ b/crates/io/src/iges/writer.rs
@@ -107,6 +107,43 @@ impl IgesWriteContext {
                 EdgeCurve::NurbsCurve(nurbs) => {
                     self.write_nurbs_curve_entity(nurbs);
                 }
+                EdgeCurve::Circle(circle) => {
+                    // IGES entity 100: Circular Arc (in the circle's local plane)
+                    // For simplicity, write as a polyline approximation using entity 110 (lines)
+                    let n = 32;
+                    let t0 = circle.project(start_pt);
+                    let mut t1 = circle.project(end_pt);
+                    if (start_pt - end_pt).length() < 1e-10 {
+                        t1 = t0 + std::f64::consts::TAU;
+                    } else if t1 <= t0 {
+                        t1 += std::f64::consts::TAU;
+                    }
+                    let dt = (t1 - t0) / n as f64;
+                    let mut prev = circle.evaluate(t0);
+                    for i in 1..=n {
+                        let cur = circle.evaluate(t0 + dt * i as f64);
+                        self.write_line_entity(prev, cur);
+                        prev = cur;
+                    }
+                }
+                EdgeCurve::Ellipse(ellipse) => {
+                    // Approximate as polyline segments
+                    let n = 32;
+                    let t0 = ellipse.project(start_pt);
+                    let mut t1 = ellipse.project(end_pt);
+                    if (start_pt - end_pt).length() < 1e-10 {
+                        t1 = t0 + std::f64::consts::TAU;
+                    } else if t1 <= t0 {
+                        t1 += std::f64::consts::TAU;
+                    }
+                    let dt = (t1 - t0) / n as f64;
+                    let mut prev = ellipse.evaluate(t0);
+                    for i in 1..=n {
+                        let cur = ellipse.evaluate(t0 + dt * i as f64);
+                        self.write_line_entity(prev, cur);
+                        prev = cur;
+                    }
+                }
             }
         }
 

--- a/crates/io/src/step/writer.rs
+++ b/crates/io/src/step/writer.rs
@@ -302,6 +302,35 @@ impl StepWriteContext {
                 line
             }
             EdgeCurve::NurbsCurve(nurbs) => self.write_nurbs_curve(nurbs),
+            EdgeCurve::Circle(circle) => {
+                let placement =
+                    self.write_axis2_placement(circle.center(), circle.normal(), circle.u_axis());
+                let cid = self.next_id();
+                self.write_entity(
+                    cid,
+                    "CIRCLE",
+                    &format!("'', #{placement}, {}", fmt_f64(circle.radius())),
+                );
+                cid
+            }
+            EdgeCurve::Ellipse(ellipse) => {
+                let placement = self.write_axis2_placement(
+                    ellipse.center(),
+                    ellipse.normal(),
+                    ellipse.u_axis(),
+                );
+                let eid = self.next_id();
+                self.write_entity(
+                    eid,
+                    "ELLIPSE",
+                    &format!(
+                        "'', #{placement}, {}, {}",
+                        fmt_f64(ellipse.semi_major()),
+                        fmt_f64(ellipse.semi_minor())
+                    ),
+                );
+                eid
+            }
         };
 
         let edge_curve = self.next_id();

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -7,10 +7,194 @@
 use std::f64::consts::{FRAC_PI_2, TAU};
 
 use crate::MathError;
+use crate::curves::{Circle3D, Ellipse3D};
 use crate::nurbs::fitting::interpolate;
 use crate::nurbs::intersection::{IntersectionCurve, IntersectionPoint};
 use crate::surfaces::{ConicalSurface, CylindricalSurface, SphericalSurface, ToroidalSurface};
 use crate::vec::{Point3, Vec3};
+
+/// Exact curve type resulting from plane-analytic surface intersection.
+#[derive(Debug, Clone)]
+pub enum ExactIntersectionCurve {
+    /// A circle (plane perpendicular to axis of cylinder/cone/sphere).
+    Circle(Circle3D),
+    /// An ellipse (plane oblique to cylinder/cone axis).
+    Ellipse(Ellipse3D),
+    /// Fallback to sampled point chain (torus, degenerate cases).
+    Points(Vec<Point3>),
+}
+
+/// Compute exact intersection curves between a plane and an analytic surface.
+///
+/// Returns exact `Circle3D` or `Ellipse3D` where possible, falling back to
+/// sampled points for complex cases (torus).
+///
+/// The plane is defined by `dot(normal, p) = d`.
+///
+/// # Errors
+///
+/// Returns an error if the intersection computation fails.
+pub fn exact_plane_analytic(
+    surface: AnalyticSurface<'_>,
+    plane_normal: Vec3,
+    plane_d: f64,
+) -> Result<Vec<ExactIntersectionCurve>, MathError> {
+    match surface {
+        AnalyticSurface::Cylinder(cyl) => exact_plane_cylinder(cyl, plane_normal, plane_d),
+        AnalyticSurface::Sphere(sphere) => exact_plane_sphere(sphere, plane_normal, plane_d),
+        AnalyticSurface::Cone(cone) => exact_plane_cone(cone, plane_normal, plane_d),
+        AnalyticSurface::Torus(torus) => {
+            // Torus intersections are degree-4 — fall back to sampling.
+            let chains = sample_plane_torus(torus, plane_normal, plane_d)?;
+            Ok(chains
+                .into_iter()
+                .map(ExactIntersectionCurve::Points)
+                .collect())
+        }
+    }
+}
+
+/// Exact plane-cylinder intersection.
+///
+/// - Plane perpendicular to axis → `Circle3D`
+/// - Plane oblique to axis → `Ellipse3D`
+/// - Plane parallel to axis → `Points` fallback (0 or 2 lines)
+fn exact_plane_cylinder(
+    cyl: &CylindricalSurface,
+    normal: Vec3,
+    d: f64,
+) -> Result<Vec<ExactIntersectionCurve>, MathError> {
+    let axis = cyl.axis();
+    let cos_theta = normal.dot(axis).abs();
+    let r = cyl.radius();
+
+    if cos_theta < 1e-10 {
+        // Plane parallel to cylinder axis → 0 or 2 line segments.
+        // Fall back to sampled points.
+        let chains = sample_plane_cylinder(cyl, normal, d)?;
+        return Ok(chains
+            .into_iter()
+            .map(ExactIntersectionCurve::Points)
+            .collect());
+    }
+
+    // Find where axis intersects the plane: axis_point + t*axis, dot(normal, P) = d
+    // t = (d - dot(normal, origin)) / dot(normal, axis)
+    let n_dot_axis = normal.dot(axis);
+    let n_dot_origin = dot_np(normal, cyl.origin());
+    let t = (d - n_dot_origin) / n_dot_axis;
+    let center_on_axis = Point3::new(
+        cyl.origin().x() + t * axis.x(),
+        cyl.origin().y() + t * axis.y(),
+        cyl.origin().z() + t * axis.z(),
+    );
+
+    if cos_theta > 1.0 - 1e-10 {
+        // Plane perpendicular to axis → Circle
+        let circle = Circle3D::new(center_on_axis, normal, r)?;
+        Ok(vec![ExactIntersectionCurve::Circle(circle)])
+    } else {
+        // Oblique plane → Ellipse
+        // Semi-minor = r (the cylinder radius, unchanged)
+        // Semi-major = r / cos(θ) where θ = angle between plane normal and axis
+        let semi_minor = r;
+        let semi_major = r / cos_theta;
+
+        // The major axis direction lies in the intersection of the plane
+        // with the plane containing the axis and the plane normal.
+        // It's the projection of the axis onto the cutting plane, normalized.
+        let axis_proj = Vec3::new(
+            axis.x() - n_dot_axis * normal.x(),
+            axis.y() - n_dot_axis * normal.y(),
+            axis.z() - n_dot_axis * normal.z(),
+        );
+        let u_axis = axis_proj.normalize()?;
+        let v_axis = normal.cross(u_axis);
+
+        let ellipse = Ellipse3D::with_axes(
+            center_on_axis,
+            normal,
+            semi_major,
+            semi_minor,
+            u_axis,
+            v_axis,
+        )?;
+        Ok(vec![ExactIntersectionCurve::Ellipse(ellipse)])
+    }
+}
+
+/// Exact plane-sphere intersection.
+///
+/// Always produces a `Circle3D` (or empty if no intersection).
+fn exact_plane_sphere(
+    sphere: &SphericalSurface,
+    normal: Vec3,
+    d: f64,
+) -> Result<Vec<ExactIntersectionCurve>, MathError> {
+    let h = dot_np(normal, sphere.center()) - d;
+    let r = sphere.radius();
+
+    if h.abs() > r - 1e-10 {
+        return Ok(vec![]);
+    }
+
+    let circle_r = (r.mul_add(r, -(h * h))).sqrt();
+    let circle_center = Point3::new(
+        h.mul_add(-normal.x(), sphere.center().x()),
+        h.mul_add(-normal.y(), sphere.center().y()),
+        h.mul_add(-normal.z(), sphere.center().z()),
+    );
+
+    let circle = Circle3D::new(circle_center, normal, circle_r)?;
+    Ok(vec![ExactIntersectionCurve::Circle(circle)])
+}
+
+/// Exact plane-cone intersection.
+///
+/// - Plane perpendicular to axis → `Circle3D`
+/// - Otherwise → `Points` fallback (could be ellipse, parabola, or hyperbola)
+fn exact_plane_cone(
+    cone: &ConicalSurface,
+    normal: Vec3,
+    d: f64,
+) -> Result<Vec<ExactIntersectionCurve>, MathError> {
+    let axis = cone.axis();
+    let cos_theta = normal.dot(axis).abs();
+    let half_angle = cone.half_angle();
+
+    if cos_theta > 1.0 - 1e-10 {
+        // Plane perpendicular to axis → Circle
+        // Find where axis meets the plane
+        let n_dot_axis = normal.dot(axis);
+        let n_dot_apex = dot_np(normal, cone.apex());
+        let t = (d - n_dot_apex) / n_dot_axis;
+
+        if t < 1e-10 {
+            return Ok(vec![]);
+        }
+
+        let center = Point3::new(
+            cone.apex().x() + t * axis.x(),
+            cone.apex().y() + t * axis.y(),
+            cone.apex().z() + t * axis.z(),
+        );
+        let circle_r = t * half_angle.tan();
+        if circle_r < 1e-15 {
+            return Ok(vec![]);
+        }
+
+        let circle = Circle3D::new(center, normal, circle_r)?;
+        Ok(vec![ExactIntersectionCurve::Circle(circle)])
+    } else {
+        // Oblique → could be ellipse, parabola, or hyperbola depending on angle vs half_angle.
+        // For MVP, fall back to sampling.
+        let chains = sample_plane_cone(cone, normal, d)?;
+        Ok(chains
+            .into_iter()
+            .map(ExactIntersectionCurve::Points)
+            .collect())
+    }
+}
 
 /// Reference to an analytic surface for intersection dispatch.
 #[derive(Clone, Copy)]

--- a/crates/math/src/curves.rs
+++ b/crates/math/src/curves.rs
@@ -179,6 +179,46 @@ impl Circle3D {
         let v_comp = self.v_axis.dot(v);
         v_comp.atan2(u_comp)
     }
+
+    /// The u-axis direction (major axis in the circle plane).
+    #[must_use]
+    pub const fn u_axis(&self) -> Vec3 {
+        self.u_axis
+    }
+
+    /// The v-axis direction (minor axis in the circle plane).
+    #[must_use]
+    pub const fn v_axis(&self) -> Vec3 {
+        self.v_axis
+    }
+
+    /// Create a circle with explicit basis vectors (for transform/copy).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `radius` is non-positive.
+    pub fn with_axes(
+        center: Point3,
+        normal: Vec3,
+        radius: f64,
+        u_axis: Vec3,
+        v_axis: Vec3,
+    ) -> Result<Self, MathError> {
+        if radius <= 0.0 {
+            return Err(MathError::ParameterOutOfRange {
+                value: radius,
+                min: 0.0,
+                max: f64::INFINITY,
+            });
+        }
+        Ok(Self {
+            center,
+            normal,
+            radius,
+            u_axis,
+            v_axis,
+        })
+    }
 }
 
 // ── Ellipse3D ──────────────────────────────────────────────────────
@@ -293,6 +333,57 @@ impl Ellipse3D {
         let b = self.semi_minor;
         let h = (a - b) * (a - b) / ((a + b) * (a + b));
         PI * (a + b) * (1.0 + 3.0 * h / (10.0 + (3.0f64.mul_add(-h, 4.0)).sqrt()))
+    }
+
+    /// Project a point onto the ellipse, returning the angle parameter.
+    #[must_use]
+    pub fn project(&self, point: Point3) -> f64 {
+        let v = point - self.center;
+        let u_comp = self.u_axis.dot(v) / self.semi_major;
+        let v_comp = self.v_axis.dot(v) / self.semi_minor;
+        v_comp.atan2(u_comp)
+    }
+
+    /// The u-axis direction (major axis direction).
+    #[must_use]
+    pub const fn u_axis(&self) -> Vec3 {
+        self.u_axis
+    }
+
+    /// The v-axis direction (minor axis direction).
+    #[must_use]
+    pub const fn v_axis(&self) -> Vec3 {
+        self.v_axis
+    }
+
+    /// Create an ellipse with explicit basis vectors (for transform/copy).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either semi-axis is non-positive.
+    pub fn with_axes(
+        center: Point3,
+        normal: Vec3,
+        semi_major: f64,
+        semi_minor: f64,
+        u_axis: Vec3,
+        v_axis: Vec3,
+    ) -> Result<Self, MathError> {
+        if semi_major <= 0.0 || semi_minor <= 0.0 {
+            return Err(MathError::ParameterOutOfRange {
+                value: semi_major.min(semi_minor),
+                min: 0.0,
+                max: f64::INFINITY,
+            });
+        }
+        Ok(Self {
+            center,
+            normal,
+            semi_major,
+            semi_minor,
+            u_axis,
+            v_axis,
+        })
     }
 }
 

--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -85,6 +85,11 @@ struct FacePairSide<'a> {
 
 /// Perform a boolean operation on two solids.
 ///
+/// When both solids are composed entirely of analytic faces (planes,
+/// cylinders, cones, spheres), uses an exact analytic path that preserves
+/// surface types through the boolean. Falls back to the tessellated path
+/// for NURBS faces or analytic-analytic face pairs.
+///
 /// # Errors
 ///
 /// Returns an error if either solid contains NURBS faces, or if the operation
@@ -97,6 +102,14 @@ pub fn boolean(
     b: SolidId,
 ) -> Result<SolidId, crate::OperationsError> {
     let tol = Tolerance::new();
+
+    // ── Try analytic fast path ──────────────────────────────────────────
+    if is_all_analytic(topo, a)? && is_all_analytic(topo, b)? {
+        if let Ok(solid) = analytic_boolean(topo, op, a, b, tol) {
+            return Ok(solid);
+        }
+        // Fall through to tessellated path on error.
+    }
 
     // ── Phase 0: Guard + Precompute ──────────────────────────────────────
 
@@ -1033,9 +1046,8 @@ pub fn boolean_with_evolution(
     let input_faces_a = collect_face_signatures(topo, a)?;
     let input_faces_b = collect_face_signatures(topo, b)?;
 
-    let mut input_faces: Vec<(usize, Vec3, Point3)> = Vec::with_capacity(
-        input_faces_a.len() + input_faces_b.len(),
-    );
+    let mut input_faces: Vec<(usize, Vec3, Point3)> =
+        Vec::with_capacity(input_faces_a.len() + input_faces_b.len());
     input_faces.extend(input_faces_a);
     input_faces.extend(input_faces_b);
 
@@ -1118,9 +1130,7 @@ fn collect_face_signatures(
             if verts.len() >= 3 {
                 let e1 = verts[1] - verts[0];
                 let e2 = verts[2] - verts[0];
-                e1.cross(e2)
-                    .normalize()
-                    .unwrap_or(Vec3::new(0.0, 0.0, 1.0))
+                e1.cross(e2).normalize().unwrap_or(Vec3::new(0.0, 0.0, 1.0))
             } else {
                 Vec3::new(0.0, 0.0, 1.0)
             }
@@ -1132,6 +1142,683 @@ fn collect_face_signatures(
     }
 
     Ok(result)
+}
+
+// ── Analytic boolean fast path ─────────────────────────────────────────
+
+/// Check if a solid is composed entirely of analytic surfaces (no NURBS).
+fn is_all_analytic(topo: &Topology, solid: SolidId) -> Result<bool, crate::OperationsError> {
+    let s = topo.solid(solid)?;
+    let shell = topo.shell(s.outer_shell())?;
+    for &fid in shell.faces() {
+        let face = topo.face(fid)?;
+        if matches!(face.surface(), FaceSurface::Nurbs(_)) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Snapshot of face data for analytic boolean processing.
+struct FaceSnapshot {
+    id: FaceId,
+    surface: FaceSurface,
+    vertices: Vec<Point3>,
+    normal: Vec3,
+    d: f64,
+}
+
+/// Analytic face fragment preserving the original surface type.
+struct AnalyticFragment {
+    /// Polygon boundary in 3D (for classification and planar assembly fallback).
+    vertices: Vec<Point3>,
+    /// The original surface type of the face.
+    surface: FaceSurface,
+    /// Normal of the face (for planar) or of the polygon approximation.
+    normal: Vec3,
+    /// Plane d coefficient (for planar faces).
+    d: f64,
+    /// Which operand this fragment came from.
+    source: Source,
+    /// Edge curve types for the boundary segments.
+    /// `None` = straight line, `Some(curve)` = exact curve (circle, ellipse).
+    edge_curves: Vec<Option<EdgeCurve>>,
+}
+
+/// Perform an analytic boolean preserving exact surface types.
+///
+/// This is the fast path for solids with only analytic faces. It computes
+/// exact plane-analytic intersections and preserves `FaceSurface::Cylinder`,
+/// `FaceSurface::Sphere`, etc. in the result.
+///
+/// Returns `Err` to signal fallback to the tessellated path.
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::single_match_else)]
+fn analytic_boolean(
+    topo: &mut Topology,
+    op: BooleanOp,
+    a: SolidId,
+    b: SolidId,
+    tol: Tolerance,
+) -> Result<SolidId, crate::OperationsError> {
+    use brepkit_math::analytic_intersection::{
+        AnalyticSurface, ExactIntersectionCurve, exact_plane_analytic,
+    };
+
+    // Collect face info for both solids.
+    let solid_a = topo.solid(a)?;
+    let shell_a = topo.shell(solid_a.outer_shell())?;
+    let face_ids_a: Vec<FaceId> = shell_a.faces().to_vec();
+
+    let solid_b = topo.solid(b)?;
+    let shell_b = topo.shell(solid_b.outer_shell())?;
+    let face_ids_b: Vec<FaceId> = shell_b.faces().to_vec();
+
+    let mut snaps_a = Vec::new();
+    for &fid in &face_ids_a {
+        let face = topo.face(fid)?;
+        let surface = face.surface().clone();
+        let verts = face_vertices(topo, fid)?;
+        let (normal, d) = match &surface {
+            FaceSurface::Plane { normal, d } => (*normal, *d),
+            _ => {
+                // For non-planar faces, compute a representative normal from tessellation.
+                let mesh = crate::tessellate::tessellate(topo, fid, 1.0)?;
+                let avg_normal = if mesh.normals.is_empty() {
+                    Vec3::new(0.0, 0.0, 1.0)
+                } else {
+                    mesh.normals[0]
+                };
+                let d_val = if mesh.positions.is_empty() {
+                    0.0
+                } else {
+                    dot_normal_point(avg_normal, mesh.positions[0])
+                };
+                (avg_normal, d_val)
+            }
+        };
+        snaps_a.push(FaceSnapshot {
+            id: fid,
+            surface,
+            vertices: verts,
+            normal,
+            d,
+        });
+    }
+
+    let mut snaps_b = Vec::new();
+    for &fid in &face_ids_b {
+        let face = topo.face(fid)?;
+        let surface = face.surface().clone();
+        let verts = face_vertices(topo, fid)?;
+        let (normal, d) = match &surface {
+            FaceSurface::Plane { normal, d } => (*normal, *d),
+            _ => {
+                let mesh = crate::tessellate::tessellate(topo, fid, 1.0)?;
+                let avg_normal = if mesh.normals.is_empty() {
+                    Vec3::new(0.0, 0.0, 1.0)
+                } else {
+                    mesh.normals[0]
+                };
+                let d_val = if mesh.positions.is_empty() {
+                    0.0
+                } else {
+                    dot_normal_point(avg_normal, mesh.positions[0])
+                };
+                (avg_normal, d_val)
+            }
+        };
+        snaps_b.push(FaceSnapshot {
+            id: fid,
+            surface,
+            vertices: verts,
+            normal,
+            d,
+        });
+    }
+
+    // Compute AABBs for face pairs.
+    let aabbs_a: Vec<Aabb3> = snaps_a
+        .iter()
+        .map(|s| Aabb3::from_points(s.vertices.iter().copied()).expanded(tol.linear))
+        .collect();
+    let aabbs_b: Vec<Aabb3> = snaps_b
+        .iter()
+        .map(|s| Aabb3::from_points(s.vertices.iter().copied()).expanded(tol.linear))
+        .collect();
+
+    // Find intersection curves for each face pair.
+    // For each face that gets split, store the intersection points.
+    let mut face_intersections_a: HashMap<usize, Vec<(Point3, Point3, Option<EdgeCurve>)>> =
+        HashMap::new();
+    let mut face_intersections_b: HashMap<usize, Vec<(Point3, Point3, Option<EdgeCurve>)>> =
+        HashMap::new();
+
+    // Track which faces have non-planar intersection partners (analytic-analytic).
+    let mut has_analytic_analytic = false;
+
+    for (ia, snap_a) in snaps_a.iter().enumerate() {
+        for (ib, snap_b) in snaps_b.iter().enumerate() {
+            // Skip non-overlapping AABBs.
+            if !aabbs_a[ia].intersects(aabbs_b[ib]) {
+                continue;
+            }
+
+            let is_plane_a = matches!(snap_a.surface, FaceSurface::Plane { .. });
+            let is_plane_b = matches!(snap_b.surface, FaceSurface::Plane { .. });
+
+            if is_plane_a && is_plane_b {
+                // Plane-plane: use existing logic (chord intersection).
+                if let Some(seg) = plane_plane_chord_analytic(
+                    snap_a.normal,
+                    snap_a.d,
+                    &snap_a.vertices,
+                    snap_b.normal,
+                    snap_b.d,
+                    &snap_b.vertices,
+                    tol,
+                ) {
+                    face_intersections_a
+                        .entry(ia)
+                        .or_default()
+                        .push((seg.0, seg.1, None));
+                    face_intersections_b
+                        .entry(ib)
+                        .or_default()
+                        .push((seg.0, seg.1, None));
+                }
+            } else if is_plane_a && !is_plane_b {
+                // Plane cuts analytic surface.
+                let analytic_surf = match &snap_b.surface {
+                    FaceSurface::Cylinder(c) => AnalyticSurface::Cylinder(c),
+                    FaceSurface::Cone(c) => AnalyticSurface::Cone(c),
+                    FaceSurface::Sphere(s) => AnalyticSurface::Sphere(s),
+                    FaceSurface::Torus(t) => AnalyticSurface::Torus(t),
+                    _ => {
+                        has_analytic_analytic = true;
+                        continue;
+                    }
+                };
+
+                if let Ok(curves) = exact_plane_analytic(analytic_surf, snap_a.normal, snap_a.d) {
+                    for curve in curves {
+                        match curve {
+                            ExactIntersectionCurve::Circle(ref circle) => {
+                                // Sample the circle for chord splitting of the planar face.
+                                let samples = sample_curve_clipped(
+                                    &curve,
+                                    &snap_a.vertices,
+                                    snap_a.normal,
+                                    tol,
+                                );
+                                let edge_curve = Some(EdgeCurve::Circle(circle.clone()));
+                                for pair in samples.windows(2) {
+                                    face_intersections_a.entry(ia).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                    face_intersections_b.entry(ib).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                }
+                            }
+                            ExactIntersectionCurve::Ellipse(ref ellipse) => {
+                                let samples = sample_curve_clipped(
+                                    &curve,
+                                    &snap_a.vertices,
+                                    snap_a.normal,
+                                    tol,
+                                );
+                                let edge_curve = Some(EdgeCurve::Ellipse(ellipse.clone()));
+                                for pair in samples.windows(2) {
+                                    face_intersections_a.entry(ia).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                    face_intersections_b.entry(ib).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                }
+                            }
+                            ExactIntersectionCurve::Points(ref pts) => {
+                                for pair in pts.windows(2) {
+                                    face_intersections_a
+                                        .entry(ia)
+                                        .or_default()
+                                        .push((pair[0], pair[1], None));
+                                    face_intersections_b
+                                        .entry(ib)
+                                        .or_default()
+                                        .push((pair[0], pair[1], None));
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if !is_plane_a && is_plane_b {
+                // Analytic surface cut by plane (symmetric case).
+                let analytic_surf = match &snap_a.surface {
+                    FaceSurface::Cylinder(c) => AnalyticSurface::Cylinder(c),
+                    FaceSurface::Cone(c) => AnalyticSurface::Cone(c),
+                    FaceSurface::Sphere(s) => AnalyticSurface::Sphere(s),
+                    FaceSurface::Torus(t) => AnalyticSurface::Torus(t),
+                    _ => {
+                        has_analytic_analytic = true;
+                        continue;
+                    }
+                };
+
+                if let Ok(curves) = exact_plane_analytic(analytic_surf, snap_b.normal, snap_b.d) {
+                    for curve in curves {
+                        match curve {
+                            ExactIntersectionCurve::Circle(ref circle) => {
+                                let samples = sample_curve_clipped(
+                                    &curve,
+                                    &snap_b.vertices,
+                                    snap_b.normal,
+                                    tol,
+                                );
+                                let edge_curve = Some(EdgeCurve::Circle(circle.clone()));
+                                for pair in samples.windows(2) {
+                                    face_intersections_a.entry(ia).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                    face_intersections_b.entry(ib).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                }
+                            }
+                            ExactIntersectionCurve::Ellipse(ref ellipse) => {
+                                let samples = sample_curve_clipped(
+                                    &curve,
+                                    &snap_b.vertices,
+                                    snap_b.normal,
+                                    tol,
+                                );
+                                let edge_curve = Some(EdgeCurve::Ellipse(ellipse.clone()));
+                                for pair in samples.windows(2) {
+                                    face_intersections_a.entry(ia).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                    face_intersections_b.entry(ib).or_default().push((
+                                        pair[0],
+                                        pair[1],
+                                        edge_curve.clone(),
+                                    ));
+                                }
+                            }
+                            ExactIntersectionCurve::Points(ref pts) => {
+                                for pair in pts.windows(2) {
+                                    face_intersections_a
+                                        .entry(ia)
+                                        .or_default()
+                                        .push((pair[0], pair[1], None));
+                                    face_intersections_b
+                                        .entry(ib)
+                                        .or_default()
+                                        .push((pair[0], pair[1], None));
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Analytic-analytic: bail to tessellated path.
+                has_analytic_analytic = true;
+            }
+        }
+    }
+
+    // If we encountered analytic-analytic pairs, fall back.
+    if has_analytic_analytic {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "analytic-analytic intersection not supported, falling back".into(),
+        });
+    }
+
+    // ── Split faces into fragments ───────────────────────────────────────
+
+    let mut fragments: Vec<AnalyticFragment> = Vec::new();
+
+    // Process solid A faces.
+    for (ia, snap) in snaps_a.iter().enumerate() {
+        if let Some(chords) = face_intersections_a.get(&ia) {
+            let chord_pairs: Vec<(Point3, Point3)> =
+                chords.iter().map(|&(p0, p1, _)| (p0, p1)).collect();
+            let edge_curve_for_face = chords.first().and_then(|c| c.2.clone());
+
+            // Use existing polygon splitting for the face boundary.
+            let mut chord_map_local: HashMap<usize, Vec<(Point3, Point3)>> = HashMap::new();
+            chord_map_local.insert(snap.id.index(), chord_pairs);
+
+            let planar_frags = split_face(
+                snap.id,
+                &snap.vertices,
+                snap.normal,
+                snap.d,
+                Source::A,
+                &chord_map_local,
+                tol,
+            );
+
+            for frag in planar_frags {
+                let edge_curves = vec![None; frag.vertices.len()];
+                fragments.push(AnalyticFragment {
+                    vertices: frag.vertices,
+                    surface: snap.surface.clone(),
+                    normal: frag.normal,
+                    d: frag.d,
+                    source: Source::A,
+                    edge_curves,
+                });
+            }
+
+            // For non-planar faces (cylinder, etc.), also create an analytic fragment
+            // representing the portion of the analytic surface inside/outside.
+            if !matches!(snap.surface, FaceSurface::Plane { .. }) {
+                // The analytic face itself becomes a fragment.
+                // Its boundary is the intersection curve (circle/ellipse).
+                if let Some(ref ec) = edge_curve_for_face {
+                    let curve_verts = sample_edge_curve(ec, 32);
+                    if curve_verts.len() >= 3 {
+                        let avg_normal = snap.normal;
+                        let d_val = snap.d;
+                        fragments.push(AnalyticFragment {
+                            vertices: curve_verts,
+                            surface: snap.surface.clone(),
+                            normal: avg_normal,
+                            d: d_val,
+                            source: Source::A,
+                            edge_curves: vec![Some(ec.clone())],
+                        });
+                    }
+                }
+            }
+        } else {
+            // Unsplit face — keep as-is.
+            fragments.push(AnalyticFragment {
+                vertices: snap.vertices.clone(),
+                surface: snap.surface.clone(),
+                normal: snap.normal,
+                d: snap.d,
+                source: Source::A,
+                edge_curves: vec![None; snap.vertices.len()],
+            });
+        }
+    }
+
+    // Process solid B faces (same logic).
+    for (ib, snap) in snaps_b.iter().enumerate() {
+        if let Some(chords) = face_intersections_b.get(&ib) {
+            let chord_pairs: Vec<(Point3, Point3)> =
+                chords.iter().map(|&(p0, p1, _)| (p0, p1)).collect();
+            let edge_curve_for_face = chords.first().and_then(|c| c.2.clone());
+
+            let mut chord_map_local: HashMap<usize, Vec<(Point3, Point3)>> = HashMap::new();
+            chord_map_local.insert(snap.id.index(), chord_pairs);
+
+            let planar_frags = split_face(
+                snap.id,
+                &snap.vertices,
+                snap.normal,
+                snap.d,
+                Source::B,
+                &chord_map_local,
+                tol,
+            );
+
+            for frag in planar_frags {
+                let edge_curves = vec![None; frag.vertices.len()];
+                fragments.push(AnalyticFragment {
+                    vertices: frag.vertices,
+                    surface: snap.surface.clone(),
+                    normal: frag.normal,
+                    d: frag.d,
+                    source: Source::B,
+                    edge_curves,
+                });
+            }
+
+            if !matches!(snap.surface, FaceSurface::Plane { .. }) {
+                if let Some(ref ec) = edge_curve_for_face {
+                    let curve_verts = sample_edge_curve(ec, 32);
+                    if curve_verts.len() >= 3 {
+                        fragments.push(AnalyticFragment {
+                            vertices: curve_verts,
+                            surface: snap.surface.clone(),
+                            normal: snap.normal,
+                            d: snap.d,
+                            source: Source::B,
+                            edge_curves: vec![Some(ec.clone())],
+                        });
+                    }
+                }
+            }
+        } else {
+            fragments.push(AnalyticFragment {
+                vertices: snap.vertices.clone(),
+                surface: snap.surface.clone(),
+                normal: snap.normal,
+                d: snap.d,
+                source: Source::B,
+                edge_curves: vec![None; snap.vertices.len()],
+            });
+        }
+    }
+
+    // ── Classification ───────────────────────────────────────────────────
+
+    // Build FaceData for classification (tessellated faces of opposite solid).
+    let face_data_a = collect_face_data(topo, a)?;
+    let face_data_b = collect_face_data(topo, b)?;
+
+    let classes: Vec<FaceClass> = fragments
+        .iter()
+        .map(|frag| {
+            let opposite = match frag.source {
+                Source::A => &face_data_b,
+                Source::B => &face_data_a,
+            };
+            let pseudo = FaceFragment {
+                vertices: frag.vertices.clone(),
+                normal: frag.normal,
+                d: frag.d,
+                source: frag.source,
+            };
+            classify_fragment(&pseudo, opposite, tol)
+        })
+        .collect();
+
+    // ── Selection + Assembly ─────────────────────────────────────────────
+
+    let resolution = 1e7;
+    let mut vertex_map: HashMap<(i64, i64, i64), VertexId> = HashMap::new();
+    let mut face_ids_out = Vec::new();
+
+    for (frag, &class) in fragments.iter().zip(classes.iter()) {
+        let Some(flip) = select_fragment(frag.source, class, op) else {
+            continue;
+        };
+
+        let (verts, normal, d_val) = if flip {
+            let rev: Vec<_> = frag.vertices.iter().copied().rev().collect();
+            (rev, -frag.normal, -frag.d)
+        } else {
+            (frag.vertices.clone(), frag.normal, frag.d)
+        };
+
+        let n = verts.len();
+        if n < 3 {
+            continue;
+        }
+
+        // Allocate vertices.
+        let vert_ids: Vec<VertexId> = verts
+            .iter()
+            .map(|p| {
+                let key = (
+                    quantize(p.x(), resolution),
+                    quantize(p.y(), resolution),
+                    quantize(p.z(), resolution),
+                );
+                *vertex_map
+                    .entry(key)
+                    .or_insert_with(|| topo.vertices.alloc(Vertex::new(*p, tol.linear)))
+            })
+            .collect();
+
+        // Build edges — use exact curve types where available.
+        let mut oriented_edges = Vec::with_capacity(n);
+        for i in 0..n {
+            let j = (i + 1) % n;
+
+            // Check if this edge segment has an exact curve from the intersection.
+            let edge_curve = if frag.edge_curves.len() == 1 {
+                // Single curve for entire boundary (analytic face fragment).
+                frag.edge_curves[0].clone().unwrap_or(EdgeCurve::Line)
+            } else if i < frag.edge_curves.len() {
+                frag.edge_curves[i].clone().unwrap_or(EdgeCurve::Line)
+            } else {
+                EdgeCurve::Line
+            };
+
+            let vi = vert_ids[i];
+            let vj = vert_ids[j];
+            let eid = topo.edges.alloc(Edge::new(vi, vj, edge_curve));
+            oriented_edges.push(OrientedEdge::new(eid, true));
+        }
+
+        let wire = Wire::new(oriented_edges, true).map_err(crate::OperationsError::Topology)?;
+        let wire_id = topo.wires.alloc(wire);
+
+        let surface = match &frag.surface {
+            FaceSurface::Plane { .. } => FaceSurface::Plane { normal, d: d_val },
+            other => other.clone(),
+        };
+
+        let face = topo.faces.alloc(Face::new(wire_id, vec![], surface));
+        face_ids_out.push(face);
+    }
+
+    if face_ids_out.is_empty() {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "analytic boolean produced no faces".into(),
+        });
+    }
+
+    let shell = Shell::new(face_ids_out).map_err(crate::OperationsError::Topology)?;
+    let shell_id = topo.shells.alloc(shell);
+    Ok(topo.solids.alloc(Solid::new(shell_id, vec![])))
+}
+
+/// Compute a plane-plane intersection chord clipped to both face polygons.
+fn plane_plane_chord_analytic(
+    normal_a: Vec3,
+    d_a: f64,
+    verts_a: &[Point3],
+    normal_b: Vec3,
+    d_b: f64,
+    verts_b: &[Point3],
+    tol: Tolerance,
+) -> Option<(Point3, Point3)> {
+    let (line_origin, line_dir) =
+        plane_plane_intersection(normal_a, d_a, normal_b, d_b, tol.angular)?;
+
+    let t_range_a = cyrus_beck_clip(&line_origin, &line_dir, verts_a, &normal_a, tol);
+    let t_range_b = cyrus_beck_clip(&line_origin, &line_dir, verts_b, &normal_b, tol);
+
+    let (t_min_a, t_max_a) = t_range_a?;
+    let (t_min_b, t_max_b) = t_range_b?;
+
+    let t_min = t_min_a.max(t_min_b);
+    let t_max = t_max_a.min(t_max_b);
+
+    if t_max - t_min < tol.linear {
+        return None;
+    }
+
+    Some((
+        point_along_line(&line_origin, &line_dir, t_min),
+        point_along_line(&line_origin, &line_dir, t_max),
+    ))
+}
+
+/// Sample an exact intersection curve, keeping only points inside a planar face polygon.
+fn sample_curve_clipped(
+    curve: &brepkit_math::analytic_intersection::ExactIntersectionCurve,
+    face_verts: &[Point3],
+    face_normal: Vec3,
+    _tol: Tolerance,
+) -> Vec<Point3> {
+    use brepkit_math::analytic_intersection::ExactIntersectionCurve;
+
+    let n_samples = 64;
+    let raw_points: Vec<Point3> = match curve {
+        ExactIntersectionCurve::Circle(c) => (0..=n_samples)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = std::f64::consts::TAU * (i as f64) / (n_samples as f64);
+                c.evaluate(t)
+            })
+            .collect(),
+        ExactIntersectionCurve::Ellipse(e) => (0..=n_samples)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = std::f64::consts::TAU * (i as f64) / (n_samples as f64);
+                e.evaluate(t)
+            })
+            .collect(),
+        ExactIntersectionCurve::Points(pts) => pts.clone(),
+    };
+
+    // Filter to points inside the face polygon (project to face plane).
+    raw_points
+        .into_iter()
+        .filter(|pt| point_in_face_3d(*pt, face_verts, &face_normal))
+        .collect()
+}
+
+/// Sample an `EdgeCurve` into N points.
+fn sample_edge_curve(curve: &EdgeCurve, n: usize) -> Vec<Point3> {
+    match curve {
+        EdgeCurve::Circle(c) => (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = std::f64::consts::TAU * (i as f64) / (n as f64);
+                c.evaluate(t)
+            })
+            .collect(),
+        EdgeCurve::Ellipse(e) => (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = std::f64::consts::TAU * (i as f64) / (n as f64);
+                e.evaluate(t)
+            })
+            .collect(),
+        EdgeCurve::NurbsCurve(nc) => {
+            let (u0, u1) = nc.domain();
+            (0..n)
+                .map(|i| {
+                    #[allow(clippy::cast_precision_loss)]
+                    let t = u0 + (u1 - u0) * (i as f64) / ((n - 1) as f64);
+                    nc.evaluate(t)
+                })
+                .collect()
+        }
+        EdgeCurve::Line => vec![],
+    }
 }
 
 #[cfg(test)]
@@ -1285,5 +1972,216 @@ mod tests {
             "cylinder should produce more than 2 face entries, got {}",
             faces.len()
         );
+    }
+
+    // ── Analytic boolean tests ──────────────────────────────────────────
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn cylinder_circle_edges() {
+        // make_cylinder should produce Circle edges for the boundary circles.
+        let mut topo = Topology::new();
+        let cyl = crate::primitives::make_cylinder(&mut topo, 1.0, 2.0).unwrap();
+        let solid = topo.solid(cyl).unwrap();
+        let shell = topo.shell(solid.outer_shell()).unwrap();
+
+        let mut has_circle_edge = false;
+        for &fid in shell.faces() {
+            let face = topo.face(fid).unwrap();
+            let wire = topo.wire(face.outer_wire()).unwrap();
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge()).unwrap();
+                if matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Circle(_)) {
+                    has_circle_edge = true;
+                }
+            }
+        }
+        assert!(has_circle_edge, "cylinder should have Circle edges");
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn circle_edge_length() {
+        let mut topo = Topology::new();
+        let cyl = crate::primitives::make_cylinder(&mut topo, 1.0, 2.0).unwrap();
+        let solid = topo.solid(cyl).unwrap();
+        let shell = topo.shell(solid.outer_shell()).unwrap();
+
+        // Find a Circle edge and check its length.
+        for &fid in shell.faces() {
+            let face = topo.face(fid).unwrap();
+            let wire = topo.wire(face.outer_wire()).unwrap();
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge()).unwrap();
+                if matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Circle(_)) {
+                    let len = crate::measure::edge_length(&topo, oe.edge()).unwrap();
+                    let expected = 2.0 * std::f64::consts::PI * 1.0; // circumference
+                    assert!(
+                        (len - expected).abs() < 1e-6,
+                        "circle edge length should be 2πr = {expected}, got {len}"
+                    );
+                    return;
+                }
+            }
+        }
+        panic!("no Circle edge found");
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn exact_plane_cylinder_circle() {
+        use brepkit_math::analytic_intersection::{
+            AnalyticSurface, ExactIntersectionCurve, exact_plane_analytic,
+        };
+        use brepkit_math::surfaces::CylindricalSurface;
+        use brepkit_math::vec::{Point3 as P3, Vec3 as V3};
+
+        let cyl =
+            CylindricalSurface::new(P3::new(0.0, 0.0, 0.0), V3::new(0.0, 0.0, 1.0), 2.0).unwrap();
+        let curves =
+            exact_plane_analytic(AnalyticSurface::Cylinder(&cyl), V3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        assert_eq!(curves.len(), 1);
+        match &curves[0] {
+            ExactIntersectionCurve::Circle(c) => {
+                assert!((c.radius() - 2.0).abs() < 1e-10, "radius should be 2.0");
+                assert!(
+                    (c.center().z() - 3.0).abs() < 1e-10,
+                    "center z should be 3.0"
+                );
+            }
+            _ => panic!("expected Circle, got {:?}", curves[0]),
+        }
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn exact_plane_sphere_circle() {
+        use brepkit_math::analytic_intersection::{
+            AnalyticSurface, ExactIntersectionCurve, exact_plane_analytic,
+        };
+        use brepkit_math::surfaces::SphericalSurface;
+        use brepkit_math::vec::{Point3 as P3, Vec3 as V3};
+
+        let sphere = SphericalSurface::new(P3::new(0.0, 0.0, 0.0), 3.0).unwrap();
+        let curves = exact_plane_analytic(
+            AnalyticSurface::Sphere(&sphere),
+            V3::new(0.0, 0.0, 1.0),
+            0.0,
+        )
+        .unwrap();
+        assert_eq!(curves.len(), 1);
+        match &curves[0] {
+            ExactIntersectionCurve::Circle(c) => {
+                assert!(
+                    (c.radius() - 3.0).abs() < 1e-10,
+                    "equator radius = sphere radius"
+                );
+            }
+            _ => panic!("expected Circle"),
+        }
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn exact_plane_cylinder_ellipse() {
+        use brepkit_math::analytic_intersection::{
+            AnalyticSurface, ExactIntersectionCurve, exact_plane_analytic,
+        };
+        use brepkit_math::surfaces::CylindricalSurface;
+        use brepkit_math::vec::{Point3 as P3, Vec3 as V3};
+
+        let cyl =
+            CylindricalSurface::new(P3::new(0.0, 0.0, 0.0), V3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        // Oblique plane (45 degrees)
+        let n = V3::new(0.0, 1.0, 1.0).normalize().unwrap();
+        let curves = exact_plane_analytic(AnalyticSurface::Cylinder(&cyl), n, 0.0).unwrap();
+        assert_eq!(curves.len(), 1);
+        match &curves[0] {
+            ExactIntersectionCurve::Ellipse(e) => {
+                assert!((e.semi_minor() - 1.0).abs() < 1e-10, "semi_minor = radius");
+                let expected_major = 1.0 / (std::f64::consts::FRAC_1_SQRT_2);
+                assert!(
+                    (e.semi_major() - expected_major).abs() < 1e-6,
+                    "semi_major = r/cos(45°) = {expected_major}, got {}",
+                    e.semi_major()
+                );
+            }
+            _ => panic!("expected Ellipse, got {:?}", curves[0]),
+        }
+    }
+
+    #[test]
+    fn box_fuse_box_unchanged() {
+        // Pure planar case should still work correctly through analytic path.
+        let mut topo = Topology::new();
+        let a = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+        let b = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+        // Translate b by (1,0,0)
+        crate::transform::transform_solid(
+            &mut topo,
+            b,
+            &brepkit_math::mat::Mat4::translation(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let result = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+        let s = topo.solid(result).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        assert!(!sh.faces().is_empty(), "fuse should produce faces");
+    }
+
+    #[test]
+    fn cylinder_tessellates_with_circle_edges() {
+        // Verify that tessellation of a cylinder's cap (which has Circle edges) works.
+        let mut topo = Topology::new();
+        let cyl = crate::primitives::make_cylinder(&mut topo, 1.0, 2.0).unwrap();
+        let solid = topo.solid(cyl).unwrap();
+        let shell = topo.shell(solid.outer_shell()).unwrap();
+
+        for &fid in shell.faces() {
+            let face = topo.face(fid).unwrap();
+            if matches!(face.surface(), FaceSurface::Plane { .. }) {
+                // This is a cap face — tessellate it.
+                let mesh = crate::tessellate::tessellate(&topo, fid, 1.0).unwrap();
+                assert!(
+                    mesh.positions.len() >= 3,
+                    "cap face should tessellate to at least 3 positions, got {}",
+                    mesh.positions.len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn is_all_analytic_detection() {
+        let mut topo = Topology::new();
+        let box_s = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+        assert!(is_all_analytic(&topo, box_s).unwrap());
+
+        let cyl = crate::primitives::make_cylinder(&mut topo, 1.0, 2.0).unwrap();
+        assert!(is_all_analytic(&topo, cyl).unwrap());
+    }
+
+    #[test]
+    fn cone_has_circle_edges() {
+        let mut topo = Topology::new();
+        let cone = crate::primitives::make_cone(&mut topo, 2.0, 0.0, 3.0).unwrap();
+        let solid = topo.solid(cone).unwrap();
+        let shell = topo.shell(solid.outer_shell()).unwrap();
+
+        let mut has_circle = false;
+        for &fid in shell.faces() {
+            let face = topo.face(fid).unwrap();
+            let wire = topo.wire(face.outer_wire()).unwrap();
+            for oe in wire.edges() {
+                if matches!(
+                    topo.edge(oe.edge()).unwrap().curve(),
+                    brepkit_topology::edge::EdgeCurve::Circle(_)
+                ) {
+                    has_circle = true;
+                }
+            }
+        }
+        assert!(has_circle, "cone should have Circle edges");
     }
 }

--- a/crates/operations/src/copy.rs
+++ b/crates/operations/src/copy.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 
+use brepkit_math::curves::{Circle3D, Ellipse3D};
 use brepkit_math::vec::Point3;
 use brepkit_topology::Topology;
 use brepkit_topology::edge::{Edge, EdgeCurve};
@@ -375,6 +376,64 @@ pub fn copy_and_transform_solid(
                     c.knots().to_vec(),
                     new_cps,
                     c.weights().to_vec(),
+                )?)
+            }
+            EdgeCurve::Circle(c) => {
+                let new_center = matrix.mul_point(c.center());
+                let origin = matrix.mul_point(Point3::new(0.0, 0.0, 0.0));
+                let transform_dir = |d: brepkit_math::vec::Vec3| -> brepkit_math::vec::Vec3 {
+                    matrix.mul_point(Point3::new(d.x(), d.y(), d.z())) - origin
+                };
+                let new_u = transform_dir(c.u_axis());
+                let new_v = transform_dir(c.v_axis());
+                let su = new_u.length();
+                let sv = new_v.length();
+                let new_normal = new_u.cross(new_v).normalize()?;
+                if (su - sv).abs() < 1e-12 * su.max(sv).max(1.0) {
+                    EdgeCurve::Circle(Circle3D::with_axes(
+                        new_center,
+                        new_normal,
+                        c.radius() * su,
+                        new_u.normalize()?,
+                        new_v.normalize()?,
+                    )?)
+                } else {
+                    let (semi_major, semi_minor, u_dir, v_dir) = if su >= sv {
+                        (
+                            c.radius() * su,
+                            c.radius() * sv,
+                            new_u.normalize()?,
+                            new_v.normalize()?,
+                        )
+                    } else {
+                        (
+                            c.radius() * sv,
+                            c.radius() * su,
+                            new_v.normalize()?,
+                            new_u.normalize()?,
+                        )
+                    };
+                    EdgeCurve::Ellipse(Ellipse3D::with_axes(
+                        new_center, new_normal, semi_major, semi_minor, u_dir, v_dir,
+                    )?)
+                }
+            }
+            EdgeCurve::Ellipse(e) => {
+                let new_center = matrix.mul_point(e.center());
+                let origin = matrix.mul_point(Point3::new(0.0, 0.0, 0.0));
+                let transform_dir = |d: brepkit_math::vec::Vec3| -> brepkit_math::vec::Vec3 {
+                    matrix.mul_point(Point3::new(d.x(), d.y(), d.z())) - origin
+                };
+                let new_u = transform_dir(e.u_axis());
+                let new_v = transform_dir(e.v_axis());
+                let new_normal = new_u.cross(new_v).normalize()?;
+                EdgeCurve::Ellipse(Ellipse3D::with_axes(
+                    new_center,
+                    new_normal,
+                    e.semi_major() * new_u.length(),
+                    e.semi_minor() * new_v.length(),
+                    new_u.normalize()?,
+                    new_v.normalize()?,
                 )?)
             }
         };

--- a/crates/operations/src/measure.rs
+++ b/crates/operations/src/measure.rs
@@ -361,6 +361,47 @@ pub fn edge_length(
             Ok((end - start).length())
         }
         brepkit_topology::edge::EdgeCurve::NurbsCurve(curve) => Ok(curve.arc_length(50)),
+        brepkit_topology::edge::EdgeCurve::Circle(circle) => {
+            if edge.is_closed() {
+                Ok(circle.circumference())
+            } else {
+                let start = topo.vertex(edge.start())?.point();
+                let end = topo.vertex(edge.end())?.point();
+                let t0 = circle.project(start);
+                let t1 = circle.project(end);
+                let mut angle = t1 - t0;
+                if angle < 0.0 {
+                    angle += std::f64::consts::TAU;
+                }
+                Ok(angle * circle.radius())
+            }
+        }
+        brepkit_topology::edge::EdgeCurve::Ellipse(ellipse) => {
+            if edge.is_closed() {
+                Ok(ellipse.approximate_circumference())
+            } else {
+                // Approximate arc length via sampling
+                let start = topo.vertex(edge.start())?.point();
+                let end = topo.vertex(edge.end())?.point();
+                let t0 = ellipse.project(start);
+                let t1 = ellipse.project(end);
+                let mut angle = t1 - t0;
+                if angle < 0.0 {
+                    angle += std::f64::consts::TAU;
+                }
+                let n = 50;
+                let dt = angle / n as f64;
+                let mut length = 0.0;
+                let mut prev = ellipse.evaluate(t0);
+                for i in 1..=n {
+                    let t = t0 + dt * i as f64;
+                    let curr = ellipse.evaluate(t);
+                    length += (curr - prev).length();
+                    prev = curr;
+                }
+                Ok(length)
+            }
+        }
     }
 }
 

--- a/crates/operations/src/primitives.rs
+++ b/crates/operations/src/primitives.rs
@@ -237,8 +237,25 @@ pub fn make_cylinder(
         .vertices
         .alloc(Vertex::new(Point3::new(radius, 0.0, hz), tol.linear));
 
-    let e_bot_circle = topo.edges.alloc(Edge::new(v_bot, v_bot, EdgeCurve::Line));
-    let e_top_circle = topo.edges.alloc(Edge::new(v_top, v_top, EdgeCurve::Line));
+    let bot_circle = brepkit_math::curves::Circle3D::new(
+        Point3::new(0.0, 0.0, -hz),
+        Vec3::new(0.0, 0.0, 1.0),
+        radius,
+    )
+    .map_err(crate::OperationsError::Math)?;
+    let top_circle = brepkit_math::curves::Circle3D::new(
+        Point3::new(0.0, 0.0, hz),
+        Vec3::new(0.0, 0.0, 1.0),
+        radius,
+    )
+    .map_err(crate::OperationsError::Math)?;
+
+    let e_bot_circle = topo
+        .edges
+        .alloc(Edge::new(v_bot, v_bot, EdgeCurve::Circle(bot_circle)));
+    let e_top_circle = topo
+        .edges
+        .alloc(Edge::new(v_top, v_top, EdgeCurve::Circle(top_circle)));
     let e_seam = topo.edges.alloc(Edge::new(v_bot, v_top, EdgeCurve::Line));
 
     let lateral_wire = Wire::new(
@@ -377,7 +394,15 @@ pub fn make_cone(
             .vertices
             .alloc(Vertex::new(Point3::new(r_big, 0.0, big_z), tol.linear));
 
-        let e_circle = topo.edges.alloc(Edge::new(v_base, v_base, EdgeCurve::Line));
+        let base_circle = brepkit_math::curves::Circle3D::new(
+            Point3::new(0.0, 0.0, big_z),
+            Vec3::new(0.0, 0.0, 1.0),
+            r_big,
+        )
+        .map_err(crate::OperationsError::Math)?;
+        let e_circle = topo
+            .edges
+            .alloc(Edge::new(v_base, v_base, EdgeCurve::Circle(base_circle)));
         let e_seam = topo.edges.alloc(Edge::new(v_base, v_apex, EdgeCurve::Line));
 
         let lateral_wire = Wire::new(
@@ -417,8 +442,24 @@ pub fn make_cone(
             .vertices
             .alloc(Vertex::new(Point3::new(top_radius, 0.0, hz), tol.linear));
 
-        let e_bot = topo.edges.alloc(Edge::new(v_bot, v_bot, EdgeCurve::Line));
-        let e_top = topo.edges.alloc(Edge::new(v_top, v_top, EdgeCurve::Line));
+        let bot_circle = brepkit_math::curves::Circle3D::new(
+            Point3::new(0.0, 0.0, -hz),
+            Vec3::new(0.0, 0.0, 1.0),
+            bottom_radius,
+        )
+        .map_err(crate::OperationsError::Math)?;
+        let top_circle = brepkit_math::curves::Circle3D::new(
+            Point3::new(0.0, 0.0, hz),
+            Vec3::new(0.0, 0.0, 1.0),
+            top_radius,
+        )
+        .map_err(crate::OperationsError::Math)?;
+        let e_bot = topo
+            .edges
+            .alloc(Edge::new(v_bot, v_bot, EdgeCurve::Circle(bot_circle)));
+        let e_top = topo
+            .edges
+            .alloc(Edge::new(v_top, v_top, EdgeCurve::Circle(top_circle)));
         let e_seam = topo.edges.alloc(Edge::new(v_bot, v_top, EdgeCurve::Line));
 
         let lateral_wire = Wire::new(

--- a/crates/operations/src/tessellate.rs
+++ b/crates/operations/src/tessellate.rs
@@ -212,17 +212,123 @@ fn tessellate_planar(
     face_data: &brepkit_topology::face::Face,
     normal: Vec3,
 ) -> Result<TriangleMesh, crate::OperationsError> {
+    use brepkit_topology::edge::EdgeCurve;
+
     let wire = topo.wire(face_data.outer_wire())?;
     let mut positions = Vec::new();
+    let tol = 1e-10;
+
+    // Sample a parametric curve into `positions`, skipping consecutive duplicates.
+    // `t_for_index(i)` maps a sample index to a parameter value.
+    // Iterates forward when `forward` is true, reversed otherwise.
+    let sample_curve = |evaluate: &dyn Fn(f64) -> Point3,
+                        t_for_index: &dyn Fn(usize) -> f64,
+                        n_samples: usize,
+                        forward: bool,
+                        positions: &mut Vec<Point3>| {
+        let indices: Box<dyn Iterator<Item = usize>> = if forward {
+            Box::new(0..n_samples)
+        } else {
+            Box::new((0..n_samples).rev())
+        };
+        for i in indices {
+            #[allow(clippy::cast_precision_loss)]
+            let t = t_for_index(i);
+            let pt = evaluate(t);
+            if positions
+                .last()
+                .is_none_or(|p: &Point3| (*p - pt).length() > tol)
+            {
+                positions.push(pt);
+            }
+        }
+    };
 
     for oe in wire.edges() {
         let edge = topo.edge(oe.edge())?;
-        let vid = if oe.is_forward() {
-            edge.start()
-        } else {
-            edge.end()
-        };
-        positions.push(topo.vertex(vid)?.point());
+        match edge.curve() {
+            EdgeCurve::Circle(circle) => {
+                let n_samples = 32;
+                let (t_start, t_end) = if edge.is_closed() {
+                    (0.0, std::f64::consts::TAU)
+                } else {
+                    let sp = topo.vertex(edge.start())?.point();
+                    let ep = topo.vertex(edge.end())?.point();
+                    let ts = circle.project(sp);
+                    let mut te = circle.project(ep);
+                    if te <= ts {
+                        te += std::f64::consts::TAU;
+                    }
+                    (ts, te)
+                };
+                #[allow(clippy::cast_precision_loss)]
+                sample_curve(
+                    &|t| circle.evaluate(t),
+                    &|i| t_start + (t_end - t_start) * (i as f64) / (n_samples as f64),
+                    n_samples,
+                    oe.is_forward(),
+                    &mut positions,
+                );
+            }
+            EdgeCurve::Ellipse(ellipse) => {
+                let n_samples = 32;
+                let (t_start, t_end) = if edge.is_closed() {
+                    (0.0, std::f64::consts::TAU)
+                } else {
+                    let sp = topo.vertex(edge.start())?.point();
+                    let ep = topo.vertex(edge.end())?.point();
+                    let ts = ellipse.project(sp);
+                    let mut te = ellipse.project(ep);
+                    if te <= ts {
+                        te += std::f64::consts::TAU;
+                    }
+                    (ts, te)
+                };
+                #[allow(clippy::cast_precision_loss)]
+                sample_curve(
+                    &|t| ellipse.evaluate(t),
+                    &|i| t_start + (t_end - t_start) * (i as f64) / (n_samples as f64),
+                    n_samples,
+                    oe.is_forward(),
+                    &mut positions,
+                );
+            }
+            EdgeCurve::NurbsCurve(nurbs) => {
+                let n_samples = 16;
+                let (u0, u1) = nurbs.domain();
+                #[allow(clippy::cast_precision_loss)]
+                sample_curve(
+                    &|t| nurbs.evaluate(t),
+                    &|i| u0 + (u1 - u0) * (i as f64) / (n_samples as f64),
+                    n_samples,
+                    oe.is_forward(),
+                    &mut positions,
+                );
+            }
+            EdgeCurve::Line => {
+                let vid = if oe.is_forward() {
+                    edge.start()
+                } else {
+                    edge.end()
+                };
+                let pt = topo.vertex(vid)?.point();
+                if positions
+                    .last()
+                    .is_none_or(|p: &Point3| (*p - pt).length() > tol)
+                {
+                    positions.push(pt);
+                }
+            }
+        }
+    }
+
+    // Remove last point if it duplicates the first (closed wire).
+    if positions.len() > 2 {
+        if let (Some(first), Some(last)) = (positions.first(), positions.last()) {
+            if (*last - *first).length() < tol {
+                positions.pop();
+            }
+        }
     }
 
     let n = positions.len();

--- a/crates/operations/src/transform.rs
+++ b/crates/operations/src/transform.rs
@@ -47,24 +47,88 @@ pub fn transform_solid(
         vertex.set_point(new_point);
     }
 
-    // Mutate phase 2: transform NURBS edge curves.
+    // Mutate phase 2: transform edge curves (NURBS, Circle, Ellipse).
     // Line edges need no update — their geometry is defined by vertices.
+    let origin = matrix.mul_point(brepkit_math::vec::Point3::new(0.0, 0.0, 0.0));
+    let transform_dir = |d: brepkit_math::vec::Vec3| -> brepkit_math::vec::Vec3 {
+        matrix.mul_point(brepkit_math::vec::Point3::new(d.x(), d.y(), d.z())) - origin
+    };
     for eid in edge_ids {
         let edge = topo.edge(eid)?;
-        if let EdgeCurve::NurbsCurve(c) = edge.curve() {
-            let new_control_points: Vec<_> = c
-                .control_points()
-                .iter()
-                .map(|pt| matrix.mul_point(*pt))
-                .collect();
-            let new_curve = NurbsCurve::new(
-                c.degree(),
-                c.knots().to_vec(),
-                new_control_points,
-                c.weights().to_vec(),
-            );
-            topo.edge_mut(eid)?
-                .set_curve(EdgeCurve::NurbsCurve(new_curve?));
+        let new_curve = match edge.curve() {
+            EdgeCurve::Line => None,
+            EdgeCurve::NurbsCurve(c) => {
+                let new_control_points: Vec<_> = c
+                    .control_points()
+                    .iter()
+                    .map(|pt| matrix.mul_point(*pt))
+                    .collect();
+                Some(EdgeCurve::NurbsCurve(NurbsCurve::new(
+                    c.degree(),
+                    c.knots().to_vec(),
+                    new_control_points,
+                    c.weights().to_vec(),
+                )?))
+            }
+            EdgeCurve::Circle(c) => {
+                let new_center = matrix.mul_point(c.center());
+                let new_u = transform_dir(c.u_axis());
+                let new_v = transform_dir(c.v_axis());
+                let su = new_u.length();
+                let sv = new_v.length();
+                let new_normal = new_u.cross(new_v).normalize()?;
+                if (su - sv).abs() < 1e-12 * su.max(sv).max(1.0) {
+                    Some(EdgeCurve::Circle(
+                        brepkit_math::curves::Circle3D::with_axes(
+                            new_center,
+                            new_normal,
+                            c.radius() * su,
+                            new_u.normalize()?,
+                            new_v.normalize()?,
+                        )?,
+                    ))
+                } else {
+                    let (semi_major, semi_minor, u_dir, v_dir) = if su >= sv {
+                        (
+                            c.radius() * su,
+                            c.radius() * sv,
+                            new_u.normalize()?,
+                            new_v.normalize()?,
+                        )
+                    } else {
+                        (
+                            c.radius() * sv,
+                            c.radius() * su,
+                            new_v.normalize()?,
+                            new_u.normalize()?,
+                        )
+                    };
+                    Some(EdgeCurve::Ellipse(
+                        brepkit_math::curves::Ellipse3D::with_axes(
+                            new_center, new_normal, semi_major, semi_minor, u_dir, v_dir,
+                        )?,
+                    ))
+                }
+            }
+            EdgeCurve::Ellipse(e) => {
+                let new_center = matrix.mul_point(e.center());
+                let new_u = transform_dir(e.u_axis());
+                let new_v = transform_dir(e.v_axis());
+                let new_normal = new_u.cross(new_v).normalize()?;
+                Some(EdgeCurve::Ellipse(
+                    brepkit_math::curves::Ellipse3D::with_axes(
+                        new_center,
+                        new_normal,
+                        e.semi_major() * new_u.length(),
+                        e.semi_minor() * new_v.length(),
+                        new_u.normalize()?,
+                        new_v.normalize()?,
+                    )?,
+                ))
+            }
+        };
+        if let Some(curve) = new_curve {
+            topo.edge_mut(eid)?.set_curve(curve);
         }
     }
 

--- a/crates/topology/src/edge.rs
+++ b/crates/topology/src/edge.rs
@@ -1,5 +1,6 @@
 //! Edge — a curve bounded by two vertices.
 
+use brepkit_math::curves::{Circle3D, Ellipse3D};
 use brepkit_math::nurbs::curve::NurbsCurve;
 
 use crate::arena;
@@ -15,6 +16,10 @@ pub enum EdgeCurve {
     Line,
     /// A NURBS curve defining the edge geometry.
     NurbsCurve(NurbsCurve),
+    /// A circular arc (or full circle when the edge is closed).
+    Circle(Circle3D),
+    /// An elliptical arc (or full ellipse when the edge is closed).
+    Ellipse(Ellipse3D),
 }
 
 /// A topological edge: a curve bounded by a start and end vertex.

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -57,6 +57,25 @@ struct SketchState {
     constraints: Vec<brepkit_operations::sketch::Constraint>,
 }
 
+/// Sample a closed periodic curve (period = TAU) into a flat `[x, y, z, ...]` buffer.
+///
+/// Produces `n` evenly-spaced points in `[0, TAU)` using the supplied `evaluate` function.
+fn sample_full_period_curve(
+    n: usize,
+    evaluate: impl Fn(f64) -> brepkit_math::vec::Point3,
+) -> Vec<f64> {
+    let mut result = Vec::with_capacity(n * 3);
+    for i in 0..n {
+        #[allow(clippy::cast_precision_loss)]
+        let t = std::f64::consts::TAU * (i as f64) / ((n - 1) as f64);
+        let p = evaluate(t);
+        result.push(p.x());
+        result.push(p.y());
+        result.push(p.z());
+    }
+    result
+}
+
 #[wasm_bindgen]
 impl BrepKernel {
     // ── Construction ────────────────────────────────────────────────
@@ -690,10 +709,12 @@ impl BrepKernel {
     pub fn fuse_with_evolution(&mut self, a: u32, b: u32) -> Result<JsValue, JsError> {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
-        let (result, evo) =
-            brepkit_operations::boolean::boolean_with_evolution(
-                &mut self.topo, BooleanOp::Fuse, a_id, b_id,
-            )?;
+        let (result, evo) = brepkit_operations::boolean::boolean_with_evolution(
+            &mut self.topo,
+            BooleanOp::Fuse,
+            a_id,
+            b_id,
+        )?;
         let json = format!(
             "{{\"solid\":{},\"evolution\":{}}}",
             solid_id_to_u32(result),
@@ -714,10 +735,12 @@ impl BrepKernel {
     pub fn cut_with_evolution(&mut self, a: u32, b: u32) -> Result<JsValue, JsError> {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
-        let (result, evo) =
-            brepkit_operations::boolean::boolean_with_evolution(
-                &mut self.topo, BooleanOp::Cut, a_id, b_id,
-            )?;
+        let (result, evo) = brepkit_operations::boolean::boolean_with_evolution(
+            &mut self.topo,
+            BooleanOp::Cut,
+            a_id,
+            b_id,
+        )?;
         let json = format!(
             "{{\"solid\":{},\"evolution\":{}}}",
             solid_id_to_u32(result),
@@ -738,10 +761,12 @@ impl BrepKernel {
     pub fn intersect_with_evolution(&mut self, a: u32, b: u32) -> Result<JsValue, JsError> {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
-        let (result, evo) =
-            brepkit_operations::boolean::boolean_with_evolution(
-                &mut self.topo, BooleanOp::Intersect, a_id, b_id,
-            )?;
+        let (result, evo) = brepkit_operations::boolean::boolean_with_evolution(
+            &mut self.topo,
+            BooleanOp::Intersect,
+            a_id,
+            b_id,
+        )?;
         let json = format!(
             "{{\"solid\":{},\"evolution\":{}}}",
             solid_id_to_u32(result),
@@ -1876,6 +1901,8 @@ impl BrepKernel {
         Ok(match edge_data.curve() {
             EdgeCurve::Line => "line",
             EdgeCurve::NurbsCurve(_) => "bspline",
+            EdgeCurve::Circle(_) => "circle",
+            EdgeCurve::Ellipse(_) => "ellipse",
         }
         .into())
     }
@@ -1900,6 +1927,7 @@ impl BrepKernel {
                 let (u_start, u_end) = curve.domain();
                 Ok(vec![u_start, u_end])
             }
+            EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => Ok(vec![0.0, std::f64::consts::TAU]),
         }
     }
 
@@ -1929,6 +1957,8 @@ impl BrepKernel {
                 }
             }
             EdgeCurve::NurbsCurve(curve) => curve.evaluate(t),
+            EdgeCurve::Circle(circle) => circle.evaluate(t),
+            EdgeCurve::Ellipse(ellipse) => ellipse.evaluate(t),
         };
         Ok(vec![point.x(), point.y(), point.z()])
     }
@@ -1975,6 +2005,30 @@ impl BrepKernel {
                 } else {
                     Vec3::new(1.0, 0.0, 0.0)
                 };
+                Ok(vec![
+                    point.x(),
+                    point.y(),
+                    point.z(),
+                    tangent.x(),
+                    tangent.y(),
+                    tangent.z(),
+                ])
+            }
+            EdgeCurve::Circle(circle) => {
+                let point = circle.evaluate(t);
+                let tangent = circle.tangent(t);
+                Ok(vec![
+                    point.x(),
+                    point.y(),
+                    point.z(),
+                    tangent.x(),
+                    tangent.y(),
+                    tangent.z(),
+                ])
+            }
+            EdgeCurve::Ellipse(ellipse) => {
+                let point = ellipse.evaluate(t);
+                let tangent = ellipse.tangent(t);
                 Ok(vec![
                     point.x(),
                     point.y(),
@@ -2117,6 +2171,14 @@ impl BrepKernel {
                     result.push(p.z());
                 }
                 Ok(result)
+            }
+            EdgeCurve::Circle(circle) => {
+                let n = std::cmp::max(2, num_points as usize);
+                Ok(sample_full_period_curve(n, |t| circle.evaluate(t)))
+            }
+            EdgeCurve::Ellipse(ellipse) => {
+                let n = std::cmp::max(2, num_points as usize);
+                Ok(sample_full_period_curve(n, |t| ellipse.evaluate(t)))
             }
         }
     }
@@ -2358,16 +2420,35 @@ impl BrepKernel {
                 points.push(start);
             }
 
-            // For NURBS edges, sample interior points for better fidelity.
-            if let EdgeCurve::NurbsCurve(curve) = edge_data.curve() {
-                let (u0, u1) = curve.domain();
-                let n_samples = 4;
-                for i in 1..n_samples {
-                    #[allow(clippy::cast_precision_loss)]
-                    let frac = i as f64 / n_samples as f64;
-                    let u = u0 + frac * (u1 - u0);
-                    points.push(curve.evaluate(u));
+            // For non-line edges, sample interior points for better fidelity.
+            match edge_data.curve() {
+                EdgeCurve::NurbsCurve(curve) => {
+                    let (u0, u1) = curve.domain();
+                    let n_samples = 4;
+                    for i in 1..n_samples {
+                        #[allow(clippy::cast_precision_loss)]
+                        let frac = i as f64 / n_samples as f64;
+                        let u = u0 + frac * (u1 - u0);
+                        points.push(curve.evaluate(u));
+                    }
                 }
+                EdgeCurve::Circle(circle) => {
+                    let n_samples = 8;
+                    for i in 1..n_samples {
+                        #[allow(clippy::cast_precision_loss)]
+                        let t = std::f64::consts::TAU * (i as f64) / (n_samples as f64);
+                        points.push(circle.evaluate(t));
+                    }
+                }
+                EdgeCurve::Ellipse(ellipse) => {
+                    let n_samples = 8;
+                    for i in 1..n_samples {
+                        #[allow(clippy::cast_precision_loss)]
+                        let t = std::f64::consts::TAU * (i as f64) / (n_samples as f64);
+                        points.push(ellipse.evaluate(t));
+                    }
+                }
+                EdgeCurve::Line => {}
             }
 
             let end = self.topo.vertex(edge_data.end())?.point();
@@ -2557,7 +2638,7 @@ impl BrepKernel {
         let edge_id = self.resolve_edge(edge)?;
         let edge_data = self.topo.edge(edge_id)?;
         match edge_data.curve() {
-            EdgeCurve::Line => Ok(JsValue::NULL),
+            EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => Ok(JsValue::NULL),
             EdgeCurve::NurbsCurve(curve) => {
                 let cp_flat: Vec<f64> = curve
                     .control_points()
@@ -3074,7 +3155,11 @@ impl BrepKernel {
     pub fn get_compound_solids(&self, compound: u32) -> Result<Vec<u32>, JsError> {
         let compound_id = self.resolve_compound(compound)?;
         let compound_data = self.topo.compound(compound_id)?;
-        Ok(compound_data.solids().iter().map(|s| solid_id_to_u32(*s)).collect())
+        Ok(compound_data
+            .solids()
+            .iter()
+            .map(|s| solid_id_to_u32(*s))
+            .collect())
     }
 
     /// Get the face handles of a shell.
@@ -3088,7 +3173,11 @@ impl BrepKernel {
     pub fn get_shell_faces(&self, shell: u32) -> Result<Vec<u32>, JsError> {
         let shell_id = self.resolve_shell(shell)?;
         let shell_data = self.topo.shell(shell_id)?;
-        Ok(shell_data.faces().iter().map(|f| face_id_to_u32(*f)).collect())
+        Ok(shell_data
+            .faces()
+            .iter()
+            .map(|f| face_id_to_u32(*f))
+            .collect())
     }
 
     /// Get the edge handles of a wire.
@@ -3102,7 +3191,11 @@ impl BrepKernel {
     pub fn get_wire_edges(&self, wire: u32) -> Result<Vec<u32>, JsError> {
         let wire_id = self.resolve_wire(wire)?;
         let wire_data = self.topo.wire(wire_id)?;
-        Ok(wire_data.edges().iter().map(|oe| edge_id_to_u32(oe.edge())).collect())
+        Ok(wire_data
+            .edges()
+            .iter()
+            .map(|oe| edge_id_to_u32(oe.edge()))
+            .collect())
     }
 
     // ── Batch 3: Simple operations bindings ──────────────────────────
@@ -3807,7 +3900,7 @@ impl BrepKernel {
     ///
     /// Returns `"forward"` for all faces (brepkit faces don't have an
     /// independent orientation flag; the normal direction is canonical).
-            #[allow(clippy::unused_self)]
+    #[allow(clippy::unused_self)]
     #[must_use]
     #[wasm_bindgen(js_name = "getShapeOrientation")]
     pub fn get_shape_orientation(&self, _id: u32) -> String {
@@ -3866,10 +3959,12 @@ impl BrepKernel {
         let edge_data = self.topo.edge(edge_id)?;
         match edge_data.curve() {
             EdgeCurve::NurbsCurve(c) => Ok(c.clone()),
-            EdgeCurve::Line => Err(WasmError::InvalidInput {
-                reason: "edge is a line, not a NURBS curve".into(),
+            EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
+                Err(WasmError::InvalidInput {
+                    reason: "edge is not a NURBS curve".into(),
+                }
+                .into())
             }
-            .into()),
         }
     }
 
@@ -4166,7 +4261,9 @@ impl BrepKernel {
                 let edge_data = self.topo.edge(edge_id).map_err(|e| e.to_string())?;
                 let curve = match edge_data.curve() {
                     EdgeCurve::NurbsCurve(c) => c.clone(),
-                    EdgeCurve::Line => return Err("sweep path must be a NURBS edge".into()),
+                    EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
+                        return Err("sweep path must be a NURBS edge".into());
+                    }
                 };
                 let solid = sweep(&mut self.topo, face_id, &curve).map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))


### PR DESCRIPTION
## Summary

- Booleans between analytic primitives (box, cylinder, cone, sphere) now preserve exact surface types (`FaceSurface::Cylinder/Cone/Sphere`) instead of destroying them into tessellated triangles
- Adds `Circle(Circle3D)` and `Ellipse(Ellipse3D)` variants to `EdgeCurve` for exact circular/elliptical edge geometry
- Primitives (`make_cylinder`, `make_cone`) now use `EdgeCurve::Circle` for boundary circles
- `exact_plane_analytic()` computes closed-form intersection curves (Circle for perpendicular cuts, Ellipse for oblique cylinder cuts)
- Analytic boolean fast path tries exact geometry first, falls back gracefully to tessellated path
- Circle→Ellipse promotion under non-uniform scaling in copy/transform
- STEP writer emits proper `CIRCLE`/`ELLIPSE` entities
- All 12 match sites updated across measure, copy, transform, I/O, WASM

## Test plan

- [x] 726 tests passing (9 new analytic boolean tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo build -p brepkit-wasm --target wasm32-unknown-unknown` builds
- [x] `./scripts/check-boundaries.sh` layer deps valid
- [x] Pre-commit hooks (fmt + clippy + test) pass
- [x] Pre-push hooks (full test + cargo-deny) pass