### PR TITLE
feat(boolean): mixed-surface solid assembly (FaceSpec + assemble_solid_mixed)

### DIFF
--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -938,12 +938,62 @@ fn quantize(v: f64, resolution: f64) -> i64 {
     (v * resolution).round() as i64
 }
 
-/// Assemble a solid from a set of face polygons with normals.
+/// Assemble a solid from a set of planar face polygons with normals.
 ///
 /// Uses spatial hashing for vertex dedup and edge sharing.
+/// This is a convenience wrapper around [`assemble_solid_mixed`] for the
+/// common case where all faces are planar.
 pub(crate) fn assemble_solid(
     topo: &mut Topology,
     faces: &[(Vec<Point3>, Vec3, f64)],
+    tol: Tolerance,
+) -> Result<SolidId, crate::OperationsError> {
+    let specs: Vec<FaceSpec> = faces
+        .iter()
+        .map(|(verts, normal, d)| FaceSpec::Planar {
+            vertices: verts.clone(),
+            normal: *normal,
+            d: *d,
+        })
+        .collect();
+    assemble_solid_mixed(topo, &specs, tol)
+}
+
+/// A face specification for mixed-surface solid assembly.
+///
+/// Used by [`assemble_solid_mixed`] to build solids with faces of any
+/// surface type — not just planar.
+#[derive(Clone)]
+pub enum FaceSpec {
+    /// A planar face defined by vertex positions and plane equation.
+    Planar {
+        /// Vertex positions (at least 3).
+        vertices: Vec<Point3>,
+        /// Outward-facing normal.
+        normal: Vec3,
+        /// Plane equation signed distance (n · p = d).
+        d: f64,
+    },
+    /// A face with a pre-built surface and vertex positions for the boundary wire.
+    Surface {
+        /// Vertex positions for the outer wire (at least 3).
+        vertices: Vec<Point3>,
+        /// The surface geometry.
+        surface: FaceSurface,
+    },
+}
+
+/// Assemble a solid from a set of face specifications with mixed surface types.
+///
+/// Like [`assemble_solid`], but supports faces with NURBS, analytic, or any
+/// other surface type. Uses the same spatial-hashing vertex dedup and edge
+/// sharing as the planar variant.
+///
+/// This is the general-purpose solid assembly function that unblocks operations
+/// on non-planar faces.
+pub(crate) fn assemble_solid_mixed(
+    topo: &mut Topology,
+    face_specs: &[FaceSpec],
     tol: Tolerance,
 ) -> Result<SolidId, crate::OperationsError> {
     let resolution = 1e7;
@@ -951,9 +1001,24 @@ pub(crate) fn assemble_solid(
     let mut vertex_map: HashMap<(i64, i64, i64), VertexId> = HashMap::new();
     let mut edge_map: HashMap<(usize, usize), brepkit_topology::edge::EdgeId> = HashMap::new();
 
-    let mut face_ids = Vec::with_capacity(faces.len());
+    let mut face_ids = Vec::with_capacity(face_specs.len());
 
-    for (verts, normal, d) in faces {
+    for spec in face_specs {
+        let (verts, surface) = match spec {
+            FaceSpec::Planar {
+                vertices,
+                normal,
+                d,
+            } => (
+                vertices.clone(),
+                FaceSurface::Plane {
+                    normal: *normal,
+                    d: *d,
+                },
+            ),
+            FaceSpec::Surface { vertices, surface } => (vertices.clone(), surface.clone()),
+        };
+
         let n = verts.len();
         if n < 3 {
             continue;
@@ -995,28 +1060,19 @@ pub(crate) fn assemble_solid(
 
         let wire = Wire::new(oriented_edges, true).map_err(crate::OperationsError::Topology)?;
         let wire_id = topo.wires.alloc(wire);
-        let face = topo.faces.alloc(Face::new(
-            wire_id,
-            vec![],
-            FaceSurface::Plane {
-                normal: *normal,
-                d: *d,
-            },
-        ));
+        let face = topo.faces.alloc(Face::new(wire_id, vec![], surface));
         face_ids.push(face);
     }
 
     if face_ids.is_empty() {
         return Err(crate::OperationsError::InvalidInput {
-            reason: "boolean operation produced no faces".into(),
+            reason: "solid assembly produced no faces".into(),
         });
     }
 
     let shell = Shell::new(face_ids).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.shells.alloc(shell);
-    let solid = topo.solids.alloc(Solid::new(shell_id, vec![]));
-
-    Ok(solid)
+    Ok(topo.solids.alloc(Solid::new(shell_id, vec![])))
 }
 
 // ---------------------------------------------------------------------------
@@ -2183,5 +2239,139 @@ mod tests {
             }
         }
         assert!(has_circle, "cone should have Circle edges");
+    }
+
+    // ── Mixed-surface assembly tests ────────────────────
+
+    #[test]
+    fn assemble_mixed_planar_only() {
+        // Planar-only via FaceSpec should produce the same result as assemble_solid.
+        let mut topo = Topology::new();
+        let specs = vec![
+            FaceSpec::Planar {
+                vertices: vec![
+                    Point3::new(0.0, 0.0, 0.0),
+                    Point3::new(1.0, 0.0, 0.0),
+                    Point3::new(1.0, 1.0, 0.0),
+                    Point3::new(0.0, 1.0, 0.0),
+                ],
+                normal: Vec3::new(0.0, 0.0, -1.0),
+                d: 0.0,
+            },
+            FaceSpec::Planar {
+                vertices: vec![
+                    Point3::new(0.0, 0.0, 1.0),
+                    Point3::new(1.0, 0.0, 1.0),
+                    Point3::new(1.0, 1.0, 1.0),
+                    Point3::new(0.0, 1.0, 1.0),
+                ],
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: 1.0,
+            },
+            FaceSpec::Planar {
+                vertices: vec![
+                    Point3::new(0.0, 0.0, 0.0),
+                    Point3::new(1.0, 0.0, 0.0),
+                    Point3::new(1.0, 0.0, 1.0),
+                    Point3::new(0.0, 0.0, 1.0),
+                ],
+                normal: Vec3::new(0.0, -1.0, 0.0),
+                d: 0.0,
+            },
+            FaceSpec::Planar {
+                vertices: vec![
+                    Point3::new(0.0, 1.0, 0.0),
+                    Point3::new(1.0, 1.0, 0.0),
+                    Point3::new(1.0, 1.0, 1.0),
+                    Point3::new(0.0, 1.0, 1.0),
+                ],
+                normal: Vec3::new(0.0, 1.0, 0.0),
+                d: 1.0,
+            },
+            FaceSpec::Planar {
+                vertices: vec![
+                    Point3::new(0.0, 0.0, 0.0),
+                    Point3::new(0.0, 1.0, 0.0),
+                    Point3::new(0.0, 1.0, 1.0),
+                    Point3::new(0.0, 0.0, 1.0),
+                ],
+                normal: Vec3::new(-1.0, 0.0, 0.0),
+                d: 0.0,
+            },
+            FaceSpec::Planar {
+                vertices: vec![
+                    Point3::new(1.0, 0.0, 0.0),
+                    Point3::new(1.0, 1.0, 0.0),
+                    Point3::new(1.0, 1.0, 1.0),
+                    Point3::new(1.0, 0.0, 1.0),
+                ],
+                normal: Vec3::new(1.0, 0.0, 0.0),
+                d: 1.0,
+            },
+        ];
+
+        let solid = assemble_solid_mixed(&mut topo, &specs, Tolerance::new()).unwrap();
+        let s = topo.solid(solid).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        assert_eq!(
+            sh.faces().len(),
+            6,
+            "mixed assembly box should have 6 faces"
+        );
+    }
+
+    #[test]
+    fn assemble_mixed_with_nurbs() {
+        use brepkit_math::nurbs::surface::NurbsSurface;
+
+        let mut topo = Topology::new();
+
+        // Create a mix of planar and NURBS faces.
+        let nurbs = NurbsSurface::new(
+            1,
+            1,
+            vec![0.0, 0.0, 1.0, 1.0],
+            vec![0.0, 0.0, 1.0, 1.0],
+            vec![
+                vec![Point3::new(0.0, 0.0, 1.0), Point3::new(1.0, 0.0, 1.0)],
+                vec![Point3::new(0.0, 1.0, 1.0), Point3::new(1.0, 1.0, 1.0)],
+            ],
+            vec![vec![1.0, 1.0], vec![1.0, 1.0]],
+        )
+        .unwrap();
+
+        let specs = vec![
+            FaceSpec::Planar {
+                vertices: vec![
+                    Point3::new(0.0, 0.0, 0.0),
+                    Point3::new(1.0, 0.0, 0.0),
+                    Point3::new(1.0, 1.0, 0.0),
+                    Point3::new(0.0, 1.0, 0.0),
+                ],
+                normal: Vec3::new(0.0, 0.0, -1.0),
+                d: 0.0,
+            },
+            FaceSpec::Surface {
+                vertices: vec![
+                    Point3::new(0.0, 0.0, 1.0),
+                    Point3::new(1.0, 0.0, 1.0),
+                    Point3::new(1.0, 1.0, 1.0),
+                    Point3::new(0.0, 1.0, 1.0),
+                ],
+                surface: FaceSurface::Nurbs(nurbs),
+            },
+        ];
+
+        let solid = assemble_solid_mixed(&mut topo, &specs, Tolerance::new()).unwrap();
+        let s = topo.solid(solid).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        assert_eq!(sh.faces().len(), 2, "mixed assembly should have 2 faces");
+
+        // Verify the NURBS face exists.
+        let has_nurbs = sh
+            .faces()
+            .iter()
+            .any(|&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)));
+        assert!(has_nurbs, "mixed assembly should contain a NURBS face");
     }
 }

--- a/crates/operations/src/fillet.rs
+++ b/crates/operations/src/fillet.rs
@@ -24,14 +24,12 @@ use brepkit_math::nurbs::surface::NurbsSurface;
 use brepkit_math::tolerance::Tolerance;
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
-use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
-use brepkit_topology::face::{Face, FaceId, FaceSurface};
-use brepkit_topology::shell::Shell;
-use brepkit_topology::solid::{Solid, SolidId};
-use brepkit_topology::vertex::{Vertex, VertexId};
-use brepkit_topology::wire::{OrientedEdge, Wire};
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::face::{FaceId, FaceSurface};
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::vertex::VertexId;
 
-use crate::boolean::assemble_solid;
+use crate::boolean::{FaceSpec, assemble_solid};
 use crate::dot_normal_point;
 
 /// Fillet one or more edges of a solid with a constant radius.
@@ -428,67 +426,15 @@ pub fn fillet_rolling_ball(
         planar_faces.push((new_verts, poly.normal, new_d));
     }
 
-    // Phase 4: Build NURBS fillet surfaces.
-    // First, assemble the planar faces (trimmed original faces).
-    let mut all_face_ids: Vec<FaceId> = Vec::new();
-
-    // Create planar faces using the same vertex-dedup approach as assemble_solid.
-    let resolution = 1e7;
-    let mut vertex_map: HashMap<(i64, i64, i64), VertexId> = HashMap::new();
-    let mut edge_map: HashMap<(usize, usize), EdgeId> = HashMap::new();
-
-    for (verts, normal, d) in &planar_faces {
-        let n = verts.len();
-        if n < 3 {
-            continue;
-        }
-
-        let vert_ids: Vec<VertexId> = verts
-            .iter()
-            .map(|p| {
-                let key = (
-                    quantize(p.x(), resolution),
-                    quantize(p.y(), resolution),
-                    quantize(p.z(), resolution),
-                );
-                *vertex_map
-                    .entry(key)
-                    .or_insert_with(|| topo.vertices.alloc(Vertex::new(*p, tol.linear)))
-            })
-            .collect();
-
-        let mut oriented_edges = Vec::with_capacity(n);
-        for i in 0..n {
-            let j = (i + 1) % n;
-            let vi = vert_ids[i].index();
-            let vj = vert_ids[j].index();
-            let (key_min, key_max) = if vi <= vj { (vi, vj) } else { (vj, vi) };
-            let is_forward = vi <= vj;
-
-            let edge_id = *edge_map.entry((key_min, key_max)).or_insert_with(|| {
-                let (start, end) = if vi <= vj {
-                    (vert_ids[i], vert_ids[j])
-                } else {
-                    (vert_ids[j], vert_ids[i])
-                };
-                topo.edges.alloc(Edge::new(start, end, EdgeCurve::Line))
-            });
-
-            oriented_edges.push(OrientedEdge::new(edge_id, is_forward));
-        }
-
-        let wire = Wire::new(oriented_edges, true).map_err(crate::OperationsError::Topology)?;
-        let wire_id = topo.wires.alloc(wire);
-        let face = topo.faces.alloc(Face::new(
-            wire_id,
-            vec![],
-            FaceSurface::Plane {
-                normal: *normal,
-                d: *d,
-            },
-        ));
-        all_face_ids.push(face);
-    }
+    // Phase 4: Build face specs for mixed-surface assembly.
+    let mut all_specs: Vec<FaceSpec> = planar_faces
+        .iter()
+        .map(|(verts, normal, d)| FaceSpec::Planar {
+            vertices: verts.clone(),
+            normal: *normal,
+            d: *d,
+        })
+        .collect();
 
     // Phase 5: Build NURBS fillet faces for each target edge.
     for &edge_id in edges {
@@ -607,111 +553,16 @@ pub fn fillet_rolling_ball(
         )
         .map_err(crate::OperationsError::Math)?;
 
-        // Create topology for the fillet face.
-        // 4 corner vertices of the fillet patch.
-        let v_c1s = lookup_or_create_vertex(
-            topo,
-            &mut vertex_map,
-            contact1_start,
-            resolution,
-            tol.linear,
-        );
-        let v_c1e =
-            lookup_or_create_vertex(topo, &mut vertex_map, contact1_end, resolution, tol.linear);
-        let v_c2s = lookup_or_create_vertex(
-            topo,
-            &mut vertex_map,
-            contact2_start,
-            resolution,
-            tol.linear,
-        );
-        let v_c2e =
-            lookup_or_create_vertex(topo, &mut vertex_map, contact2_end, resolution, tol.linear);
-
-        // 4 edges of the fillet patch boundary.
-        let e_bottom = get_or_create_edge(topo, &mut edge_map, v_c1s, v_c2s); // u=const, v=0
-        let e_top = get_or_create_edge(topo, &mut edge_map, v_c1e, v_c2e); // u=const, v=1
-        let e_left = get_or_create_edge(topo, &mut edge_map, v_c1s, v_c1e); // v varies, u=0
-        let e_right = get_or_create_edge(topo, &mut edge_map, v_c2s, v_c2e); // v varies, u=1
-
-        let fillet_wire = Wire::new(
-            vec![
-                OrientedEdge::new(e_bottom, v_c1s.index() <= v_c2s.index()),
-                OrientedEdge::new(e_right, v_c2s.index() <= v_c2e.index()),
-                OrientedEdge::new(e_top, v_c1e.index() > v_c2e.index()),
-                OrientedEdge::new(e_left, v_c1s.index() > v_c1e.index()),
-            ],
-            true,
-        )
-        .map_err(crate::OperationsError::Topology)?;
-        let fillet_wid = topo.wires.alloc(fillet_wire);
-        let fillet_face = topo.faces.alloc(Face::new(
-            fillet_wid,
-            vec![],
-            FaceSurface::Nurbs(fillet_surface),
-        ));
-
-        all_face_ids.push(fillet_face);
-    }
-
-    // Phase 6: Assemble the solid from all faces.
-    if all_face_ids.is_empty() {
-        return Err(crate::OperationsError::InvalidInput {
-            reason: "fillet operation produced no faces".into(),
+        // Add the fillet face as a Surface FaceSpec.
+        // Boundary vertices: contact1_start → contact2_start → contact2_end → contact1_end
+        all_specs.push(FaceSpec::Surface {
+            vertices: vec![contact1_start, contact2_start, contact2_end, contact1_end],
+            surface: FaceSurface::Nurbs(fillet_surface),
         });
     }
 
-    let shell = Shell::new(all_face_ids).map_err(crate::OperationsError::Topology)?;
-    let shell_id = topo.shells.alloc(shell);
-    Ok(topo.solids.alloc(Solid::new(shell_id, vec![])))
-}
-
-/// Quantize a coordinate for vertex deduplication.
-fn quantize(v: f64, resolution: f64) -> i64 {
-    #[allow(clippy::cast_possible_truncation)]
-    {
-        (v * resolution).round() as i64
-    }
-}
-
-/// Look up or create a vertex at the given position.
-fn lookup_or_create_vertex(
-    topo: &mut Topology,
-    vertex_map: &mut HashMap<(i64, i64, i64), VertexId>,
-    pos: Point3,
-    resolution: f64,
-    tol_linear: f64,
-) -> VertexId {
-    let key = (
-        quantize(pos.x(), resolution),
-        quantize(pos.y(), resolution),
-        quantize(pos.z(), resolution),
-    );
-    *vertex_map
-        .entry(key)
-        .or_insert_with(|| topo.vertices.alloc(Vertex::new(pos, tol_linear)))
-}
-
-/// Look up or create an edge between two vertices.
-fn get_or_create_edge(
-    topo: &mut Topology,
-    edge_map: &mut HashMap<(usize, usize), EdgeId>,
-    v1: VertexId,
-    v2: VertexId,
-) -> EdgeId {
-    let (key_min, key_max) = if v1.index() <= v2.index() {
-        (v1.index(), v2.index())
-    } else {
-        (v2.index(), v1.index())
-    };
-    *edge_map.entry((key_min, key_max)).or_insert_with(|| {
-        let (start, end) = if v1.index() <= v2.index() {
-            (v1, v2)
-        } else {
-            (v2, v1)
-        };
-        topo.edges.alloc(Edge::new(start, end, EdgeCurve::Line))
-    })
+    // Phase 6: Assemble the solid using mixed-surface assembly.
+    crate::boolean::assemble_solid_mixed(topo, &all_specs, tol)
 }
 
 // ── Internal data structures ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `assemble_solid_mixed()` — a general-purpose solid assembly function that accepts faces with **any surface type** (Plane, NURBS, Cylinder, Cone, Sphere, Torus). This is the foundational infrastructure that unblocks all planar-only operations from supporting curved surfaces.

### Architecture

```rust
pub enum FaceSpec {
    Planar { vertices, normal, d },     // Existing planar case
    Surface { vertices, surface },       // Any FaceSurface type
}

pub fn assemble_solid_mixed(topo, face_specs, tol) -> Result<SolidId>
```

The existing `assemble_solid` now delegates to `assemble_solid_mixed`, eliminating code duplication.

### Impact

This PR provides the building block for converting the remaining 9 planar-only operations (chamfer, draft, shell_op, split, defeature, etc.) to support curved surfaces. The `fillet_rolling_ball` function is refactored as the first consumer, reducing ~50 lines of redundant vertex/edge construction code.

### Call sites using `assemble_solid` (all now benefit from the shared infrastructure)

| Operation | File | Status |
|-----------|------|--------|
| boolean | boolean.rs | Via assemble_solid → mixed |
| fillet | fillet.rs | Refactored to use FaceSpec directly |
| fillet_rolling_ball | fillet.rs | ✅ Now uses assemble_solid_mixed |
| chamfer | chamfer.rs | Via assemble_solid → mixed |
| draft | draft.rs | Via assemble_solid → mixed |
| shell_op | shell_op.rs | Via assemble_solid → mixed |
| split | split.rs | Via assemble_solid → mixed |
| defeature | defeature.rs | Via assemble_solid → mixed |
| offset_solid | offset_solid.rs | Via assemble_solid → mixed |

## Test plan

- [x] Mixed assembly with all-planar faces: correct 6-face box
- [x] Mixed assembly with NURBS + planar faces: NURBS face preserved
- [x] All existing tests pass (768 total, 2 new)
- [x] Clean clippy