### PR TITLE
feat(chamfer,draft): support solids with non-planar faces

### DIFF
--- a/crates/operations/src/chamfer.rs
+++ b/crates/operations/src/chamfer.rs
@@ -15,7 +15,7 @@ use brepkit_topology::face::{FaceId, FaceSurface};
 use brepkit_topology::solid::SolidId;
 use brepkit_topology::vertex::VertexId;
 
-use crate::boolean::assemble_solid;
+use crate::boolean::{FaceSpec, assemble_solid_mixed};
 use crate::dot_normal_point;
 
 // ---------------------------------------------------------------------------
@@ -67,14 +67,6 @@ pub fn chamfer(
 
     for &face_id in &shell_face_ids {
         let face = topo.face(face_id)?;
-        let (normal, _d) = match face.surface() {
-            FaceSurface::Plane { normal, d } => (*normal, *d),
-            _ => {
-                return Err(crate::OperationsError::InvalidInput {
-                    reason: "chamfer on non-planar faces is not supported".into(),
-                });
-            }
-        };
 
         let wire = topo.wire(face.outer_wire())?;
         let mut vertex_ids = Vec::with_capacity(wire.edges().len());
@@ -97,6 +89,13 @@ pub fn chamfer(
                 .or_default()
                 .push(face_id);
         }
+
+        // Only build polygon data for planar faces. Non-planar faces
+        // will be passed through unchanged if they don't contain target edges.
+        let normal = match face.surface() {
+            FaceSurface::Plane { normal, .. } => *normal,
+            _ => continue, // Skip non-planar faces for polygon data
+        };
 
         face_polygons.insert(
             face_id.index(),
@@ -133,10 +132,19 @@ pub fn chamfer(
 
     // For each target edge, we collect the chamfer points from both faces.
     let mut chamfer_data: HashMap<usize, ChamferEdgeData> = HashMap::new();
-    let mut result_faces: Vec<(Vec<Point3>, Vec3, f64)> = Vec::new();
+    let mut result_specs: Vec<FaceSpec> = Vec::new();
 
     for &face_id in &shell_face_ids {
-        let poly = &face_polygons[&face_id.index()];
+        // Non-planar faces pass through unchanged.
+        let Some(poly) = face_polygons.get(&face_id.index()) else {
+            let face = topo.face(face_id)?;
+            let verts = crate::boolean::face_vertices(topo, face_id)?;
+            result_specs.push(FaceSpec::Surface {
+                vertices: verts,
+                surface: face.surface().clone(),
+            });
+            continue;
+        };
         let n = poly.positions.len();
         let mut new_verts: Vec<Point3> = Vec::with_capacity(n + target_set.len());
 
@@ -220,7 +228,11 @@ pub fn chamfer(
         // Recompute plane d from the (possibly shifted) polygon.
         // Normal stays the same since vertices only moved within the face plane.
         let new_d = dot_normal_point(poly.normal, new_verts[0]);
-        result_faces.push((new_verts, poly.normal, new_d));
+        result_specs.push(FaceSpec::Planar {
+            vertices: new_verts,
+            normal: poly.normal,
+            d: new_d,
+        });
     }
 
     // -- Phase 4: Build chamfer faces --
@@ -273,11 +285,15 @@ pub fn chamfer(
         };
 
         let d = dot_normal_point(normal, quad[0]);
-        result_faces.push((quad, normal, d));
+        result_specs.push(FaceSpec::Planar {
+            vertices: quad,
+            normal,
+            d,
+        });
     }
 
     // -- Phase 5: Assemble result solid --
-    assemble_solid(topo, &result_faces, tol)
+    assemble_solid_mixed(topo, &result_specs, tol)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/operations/src/draft.rs
+++ b/crates/operations/src/draft.rs
@@ -11,7 +11,7 @@ use brepkit_topology::Topology;
 use brepkit_topology::face::{FaceId, FaceSurface};
 use brepkit_topology::solid::SolidId;
 
-use crate::boolean::{assemble_solid, face_vertices};
+use crate::boolean::{FaceSpec, assemble_solid_mixed, face_vertices};
 use crate::dot_normal_point;
 
 /// Apply a draft angle to selected faces of a solid.
@@ -56,27 +56,42 @@ pub fn draft(
 
     let draft_set: HashSet<usize> = draft_faces.iter().map(|f| f.index()).collect();
 
-    let mut result_faces: Vec<(Vec<Point3>, Vec3, f64)> = Vec::new();
+    let mut result_specs: Vec<FaceSpec> = Vec::new();
 
     for &fid in &all_face_ids {
         let face = topo.face(fid)?;
-        let (face_normal, _face_d) = match face.surface() {
-            FaceSurface::Plane { normal, d } => (*normal, *d),
-            _ => {
-                return Err(crate::OperationsError::InvalidInput {
-                    reason: "draft on non-planar faces is not supported".into(),
-                });
-            }
-        };
-
         let verts = face_vertices(topo, fid)?;
 
         if !draft_set.contains(&fid.index()) {
-            // Non-draft face: keep as-is.
-            let d = dot_normal_point(face_normal, verts[0]);
-            result_faces.push((verts, face_normal, d));
+            // Non-draft face: keep as-is (supports any surface type).
+            match face.surface() {
+                FaceSurface::Plane { normal, .. } => {
+                    let d = dot_normal_point(*normal, verts[0]);
+                    result_specs.push(FaceSpec::Planar {
+                        vertices: verts,
+                        normal: *normal,
+                        d,
+                    });
+                }
+                other => {
+                    result_specs.push(FaceSpec::Surface {
+                        vertices: verts,
+                        surface: other.clone(),
+                    });
+                }
+            }
             continue;
         }
+
+        // Draft target face must be planar (vertex manipulation requires plane).
+        let _face_normal = match face.surface() {
+            FaceSurface::Plane { normal, .. } => *normal,
+            _ => {
+                return Err(crate::OperationsError::InvalidInput {
+                    reason: "draft target faces must be planar".into(),
+                });
+            }
+        };
 
         // Draft this face: for each vertex, compute its signed height
         // above the neutral plane, then offset it perpendicular to the
@@ -124,11 +139,15 @@ pub fn draft(
                         reason: "draft produced degenerate face geometry".into(),
                     })?;
             let new_d = dot_normal_point(new_normal, new_verts[0]);
-            result_faces.push((new_verts, new_normal, new_d));
+            result_specs.push(FaceSpec::Planar {
+                vertices: new_verts,
+                normal: new_normal,
+                d: new_d,
+            });
         }
     }
 
-    assemble_solid(topo, &result_faces, tol)
+    assemble_solid_mixed(topo, &result_specs, tol)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Chamfer and draft now work on solids containing non-planar faces. Non-target faces pass through unchanged with their original surface type. Target faces still require planar geometry (vertex manipulation). Uses FaceSpec + assemble_solid_mixed.

## Test plan
- [x] All existing chamfer/draft tests pass
- [x] 771 tests pass, clean clippy