### PR TITLE
fix(validate): support genus-1+ solids in Euler characteristic check

### DIFF
--- a/crates/operations/src/validate.rs
+++ b/crates/operations/src/validate.rs
@@ -62,7 +62,7 @@ impl ValidationReport {
 /// Validate a solid, returning a report of all issues found.
 ///
 /// Checks performed:
-/// 1. **Euler characteristic**: V - E + F = 2 for a closed solid
+/// 1. **Euler-Poincaré**: V - E + F = 2(1 - g) for genus-g closed solid
 /// 2. **Manifold edges**: each edge shared by exactly 2 faces
 /// 3. **Boundary edges**: no edge shared by only 1 face (open shell)
 /// 4. **Degenerate faces**: each face has at least 3 vertices
@@ -81,13 +81,22 @@ pub fn validate_solid(
     // 1. Entity counts and Euler characteristic.
     let (f, e, v) = explorer::solid_entity_counts(topo, solid)?;
 
+    // Euler-Poincaré formula: V - E + F = 2(1 - g) for a closed orientable
+    // surface of genus g. Genus-0 (sphere-like) → 2, genus-1 (torus) → 0,
+    // genus-2 (double torus) → -2, etc.
+    //
+    // Rather than computing genus from inner wires (which is fragile),
+    // we check that the Euler characteristic is consistent: it must be an
+    // even integer ≤ 2, giving a non-negative integer genus.
     #[allow(clippy::cast_possible_wrap)]
     let euler = (v as i64) - (e as i64) + (f as i64);
-    if euler != 2 {
+    let genus_times_2 = 2 - euler;
+    if genus_times_2 < 0 || genus_times_2 % 2 != 0 {
         issues.push(ValidationIssue {
             severity: Severity::Error,
             description: format!(
-                "Euler characteristic V-E+F = {euler} (expected 2 for closed solid, got V={v}, E={e}, F={f})"
+                "Euler characteristic V-E+F = {euler} is invalid \
+                 (expected even value ≤ 2 for closed solid, got V={v}, E={e}, F={f})"
             ),
         });
     }
@@ -309,5 +318,107 @@ mod tests {
         // but should at least produce a report without panicking
         let _ = report.is_valid();
         let _ = report.error_count();
+    }
+
+    #[test]
+    fn hollow_revolve_is_valid() {
+        use brepkit_math::vec::{Point3, Vec3};
+        use brepkit_topology::face::{Face, FaceSurface};
+
+        let mut topo = Topology::new();
+
+        // Outer: 2×1 rectangle at x=1..3, y=0..1.
+        let outer_pts = vec![
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(3.0, 0.0, 0.0),
+            Point3::new(3.0, 1.0, 0.0),
+            Point3::new(1.0, 1.0, 0.0),
+        ];
+        let outer_wire =
+            brepkit_topology::builder::make_polygon_wire(&mut topo, &outer_pts).unwrap();
+
+        // Inner: 0.5×0.5 hole.
+        let inner_pts = vec![
+            Point3::new(1.5, 0.25, 0.0),
+            Point3::new(1.5, 0.75, 0.0),
+            Point3::new(2.5, 0.75, 0.0),
+            Point3::new(2.5, 0.25, 0.0),
+        ];
+        let inner_wire =
+            brepkit_topology::builder::make_polygon_wire(&mut topo, &inner_pts).unwrap();
+
+        let normal = Vec3::new(0.0, 0.0, 1.0);
+        let face = Face::new(
+            outer_wire,
+            vec![inner_wire],
+            FaceSurface::Plane { normal, d: 0.0 },
+        );
+        let face_id = topo.faces.alloc(face);
+
+        // Full revolution → genus-1 torus topology.
+        let solid = crate::revolve::revolve(
+            &mut topo,
+            face_id,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            2.0 * std::f64::consts::PI,
+        )
+        .unwrap();
+
+        let report = validate_solid(&topo, solid).unwrap();
+        assert!(
+            report.is_valid(),
+            "genus-1 hollow revolve should be valid, got {} error(s): {:?}",
+            report.error_count(),
+            report.issues
+        );
+    }
+
+    #[test]
+    fn extruded_hollow_box_is_valid() {
+        use brepkit_math::vec::{Point3, Vec3};
+        use brepkit_topology::face::{Face, FaceSurface};
+
+        let mut topo = Topology::new();
+
+        // Outer: 2×2 square.
+        let outer_pts = vec![
+            Point3::new(-1.0, -1.0, 0.0),
+            Point3::new(1.0, -1.0, 0.0),
+            Point3::new(1.0, 1.0, 0.0),
+            Point3::new(-1.0, 1.0, 0.0),
+        ];
+        let outer_wire =
+            brepkit_topology::builder::make_polygon_wire(&mut topo, &outer_pts).unwrap();
+
+        // Inner: 0.5×0.5 hole.
+        let inner_pts = vec![
+            Point3::new(-0.25, -0.25, 0.0),
+            Point3::new(-0.25, 0.25, 0.0),
+            Point3::new(0.25, 0.25, 0.0),
+            Point3::new(0.25, -0.25, 0.0),
+        ];
+        let inner_wire =
+            brepkit_topology::builder::make_polygon_wire(&mut topo, &inner_pts).unwrap();
+
+        let normal = Vec3::new(0.0, 0.0, 1.0);
+        let face = Face::new(
+            outer_wire,
+            vec![inner_wire],
+            FaceSurface::Plane { normal, d: 0.0 },
+        );
+        let face_id = topo.faces.alloc(face);
+
+        // Extrude → genus-0 (V-E+F=2) with inner walls.
+        let solid =
+            crate::extrude::extrude(&mut topo, face_id, Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+
+        let report = validate_solid(&topo, solid).unwrap();
+        assert!(
+            report.is_valid(),
+            "extruded hollow box should be valid, got {} error(s): {:?}",
+            report.error_count(),
+            report.issues
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a trust-breaking bug where the topology validator reported hollow revolution solids as invalid.

The validator hardcoded `V-E+F=2`, which is only correct for genus-0 (sphere-like) closed surfaces. Full-revolution hollow solids (e.g., revolve of a ring profile, as enabled by PR #36) produce genus-1 torus topology where `V-E+F=0`. The validator incorrectly flagged these with an Euler characteristic error.

**Impact**: Users who called `isValid()` on their own `revolve()` output with holes got `false`. The kernel produced the solid correctly but then declared it broken.

**Fix**: Replace the hardcoded `euler != 2` check with the Euler-Poincaré structural invariant: `(2 - V + E - F)` must be even and non-negative. This accepts all valid genus values (0=sphere, 1=torus, 2=double torus, etc.) without needing to explicitly compute genus from inner wires.

## Test plan

- [x] 807 tests pass (was 805)
- [x] Existing validation tests unchanged (genus-0 solids still pass)
- [x] New: hollow_revolve_is_valid (genus-1)
- [x] New: extruded_hollow_box_is_valid (genus-0 with inner walls)