### PR TITLE
docs: add 6-month product roadmap

### DIFF
--- a/.claude/agent-memory-local/researcher/MEMORY.md
+++ b/.claude/agent-memory-local/researcher/MEMORY.md
@@ -21,3 +21,12 @@
 - `robust` crate only has 2D; `robust-predicates` has all 4 Shewchuk predicates
 - Watertight ray-triangle (Woop-Benthin-Wald 2013) should replace Moller-Trumbore for classification
 - Graph-based decomposition is the standard for production constraint solvers (SolveSpace, PlaneGCS)
+
+## SSI / Boolean Deep Dive (2026-03-03) - see `ssi-boolean-research.md`
+- Canonical step size formula: h = sqrt(8*epsilon/kappa) from osculating circle deviation
+- GWN for trimmed NURBS: Spainhour et al. 2025 (arxiv 2504.11435), Stokes' theorem boundary integral
+- OCCT face splitting uses BOPAlgo_WireSplitter: min clockwise angle walk in 2D param space
+- brepkit march_intersection: fixed step + Newton corrector, no adaptive curvature step yet
+- Self-intersection NURBS: Li, Jia, Chen 2025 ACM TOG - algebraic signature approach
+- Topology-guaranteed SSI: Yang, Jia, Yan SIGGRAPH Asia 2023 (dl.acm.org/doi/10.1145/3618349)
+- Fast winding numbers (meshes): Barill et al. SIGGRAPH 2018 - BVH with multipole expansion

--- a/.claude/agent-memory-local/researcher/ssi-boolean-research.md
+++ b/.claude/agent-memory-local/researcher/ssi-boolean-research.md
@@ -1,0 +1,162 @@
+# SSI and Boolean Operations Research (2026-03-03)
+
+## Topic 1: NURBS SSI Marching Algorithms
+
+### ODE Formulation (Patrikalakis-Maekawa)
+- The intersection curve satisfies a first-order ODE: dX/ds = t where t = N1 x N2 / |N1 x N2|
+- Source: MIT hyperbook https://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/node118.html
+- For tangential intersection (N1 || N2), second-order analysis of curvature difference tensor applies
+- brepkit already implements this in `singular_tangent_direction()` via `second_order_tangent()`
+
+### Adaptive Step Size Formula
+- Standard formula: h = sqrt(8 * epsilon / kappa) where epsilon = chord-height tolerance, kappa = curvature of intersection curve
+- Derivation: from osculating circle, chord height = h^2 * kappa / 8; solving for h gives the formula
+- Source: Barnhill-Kersey 1990 CAGD and confirmed in multiple references
+- brepkit current state: fixed step (march_step parameter), NO curvature adaptation
+
+### Predictor-Corrector Structure
+1. Predictor: Euler step along tangent t = N1 x N2 (or RK4 for better accuracy)
+2. Corrector: Newton iteration in (u1,v1,u2,v2) to snap back to intersection
+3. Step acceptance: compare predicted vs corrected 3D position; if error > tolerance, halve step
+- brepkit uses this pattern in `march_direction()` but with fixed step (no error-controlled resizing)
+
+### 2023/2025 State of Art
+- Yang, Jia, Yan (SIGGRAPH Asia 2023): "Topology Guaranteed B-Spline SSI"
+  URL: https://dl.acm.org/doi/10.1145/3618349
+  Hybrid: interval algebraic topology analysis → subdivision for seeds → forward marching
+  Classifies 4 fundamental topological cases (transversal, tangent point, tangent curve, cusp)
+- "Topology guaranteed and error controlled curve tracing" (CAGD 2025, ScienceDirect pii/S0167839625000214)
+  SRS-BFS: Dixon matrix + breadth-first search for branch points
+- Mukundan et al. 2004: validated ODE (interval arithmetic) eliminates straying/looping
+  URL: https://diglib.eg.org/handle/10.2312/sm20041397
+
+## Topic 2: Boolean Face Splitting and Trim Reconstruction
+
+### OCCT Algorithm (BOPAlgo)
+Source: https://old.opencascade.com/doc/occt-7.4.0/overview/html/occt_user_guides__boolean_operations.html
+
+Pipeline:
+1. Intersection Part: compute Face/Face interferences → curves stored as pave blocks
+2. BOPDS_PaveBlock: (edge, pave1, pave2, shrunkData, commonBlock)
+3. BOPDS_InterfFF: (tolR3D, tolR2D, curves[], points[])
+4. BOPAlgo_BuilderFace:
+   a. Collect all split edges for face Fi (ESPij) + section edges SEk
+   b. BOPAlgo_WireSplitter: trace wires using min-clockwise-angle walk in 2D parameter space
+   c. Build split face topology from closed wires
+5. Classification via FaceInfo: IN, ON, SC states
+6. Result extraction: union=IN+ON, cut=IN_A+ON_A, intersect=IN+ON
+
+### Correct Trim Wire Reconstruction Algorithm
+The key is the min-clockwise-angle walk in 2D (parameter space):
+- Project all edges to 2D parameter space of parent face
+- At each vertex, pick the outgoing edge that makes the smallest clockwise turn
+- This naturally finds the minimal (innermost) loop at each step
+- Handles multiple wires including holes
+
+### brepkit gap
+- brepkit CDT splits produce triangles but don't reassemble into oriented trim loops
+- Need: wire reconstruction from intersection edges using the OCCT WireSplitter approach
+
+## Topic 3: Robust Face Classification
+
+### Single-ray (current brepkit approach)
+- Cast ray from face centroid, count intersections with opposing solid
+- Problem: ray tangency, numerical near-misses near edges
+
+### Multi-ray consensus
+- Cast N rays in different directions, majority vote
+- Handles individual ray failures but O(N) cost
+
+### Generalized Winding Numbers (GWN) - recommended upgrade path
+
+#### For triangle meshes (Jacobson 2013, Barill 2018)
+- w(p) = (1/4pi) * sum of signed solid angles of each triangle
+- BVH with multipole expansion for far-field (O(log n) per query)
+- Barill et al. 2018: https://www.dgp.toronto.edu/projects/fast-winding-numbers/
+- SideFX open source: https://github.com/sideeffects/WindingNumber
+
+#### For trimmed NURBS directly (Spainhour et al. 2025)
+- Reduces surface integral to boundary integral via Stokes' theorem
+- Uses adaptive Gauss-Legendre quadrature on boundary curves
+- 3 spatial regimes: far-field (direct), near-field (intersection test), edge-case (disk extraction)
+- Performance: ~0.15-1.3 ms per query depending on model complexity
+- Handles non-watertight models robustly
+- arxiv: https://arxiv.org/abs/2504.11435
+
+#### For parametric curves in 2D (Spainhour 2024)
+- GWN without quadrature for rational parametric curves
+- arxiv: https://arxiv.org/html/2403.17371v1
+
+### Face state (ON vs IN vs OUT) vs winding number
+- w ~ 1.0: inside solid
+- w ~ 0.0: outside solid
+- w ~ 0.5: on boundary (use smaller epsilon)
+- Non-integer values indicate non-watertight geometry
+
+## Topic 4: NURBS Bounding Volume Computation
+
+### Convex Hull Property
+- NURBS surface is contained within convex hull of control points (this is exact)
+- AABB of control points is a valid (loose) bound
+- Source: standard NURBS theory, confirmed by Piegl-Tiller "The NURBS Book"
+
+### Tight AABB via Subdivision
+Algorithm:
+1. Decompose NURBS into Bezier patches (Bezier extraction)
+2. For each Bezier patch, AABB of control polygon is a valid bound
+3. Recursively subdivide patch until AABB of control polygon is "tight enough"
+   - Termination: max(patch_diagonal) < tolerance OR flatness criterion
+4. Union of all leaf AABBs is tight bound for whole surface
+
+### OBB via PCA
+- Apply PCA to control points to find principal axes
+- Build OBB in those axes
+- Tighter than AABB but more expensive
+- OCCT provides Bnd_OBB for shapes: https://dev.opencascade.org/doc/refman/html/class_bnd___o_b_b.html
+- CGAL 5.2+ has optimal OBB: https://doc.cgal.org/5.2.4/Optimal_bounding_box/index.html
+
+### Refinement via Curvature
+- Evaluate surface on a regular grid and expand AABB based on surface curvature
+- GPU-accelerated: Pabst et al. "Ray Casting of Trimmed NURBS Surfaces on the GPU"
+  URL: https://www.uni-weimar.de/fileadmin/user/fak/medien/professuren/Virtual_Reality/documents/publications/Ray_Casting_of_Trimmed_NURBS_Surfaces_on_the_GPU.pdf
+
+### Self-intersection detection (2025 state-of-art)
+- Li, Jia, Chen (ACM TOG 2025): "Fast Determination and Computation of Self-intersections for NURBS Surfaces"
+  URL: https://dl.acm.org/doi/10.1145/3727620
+  Key: algebraic signature whose non-negativity proves absence of self-intersections
+  Recursive subdivision using this signature for fast determination
+
+## Topic 5: Curvature-Adaptive Marching
+
+### Standard Formula (widely cited since Barnhill-Kersey 1990)
+h_new = sqrt(8 * epsilon_chord / kappa)
+where:
+  epsilon_chord = allowed chord-height deviation (user tolerance, e.g. 1e-3)
+  kappa = curvature of intersection curve at current point
+
+### Computing kappa from surface data
+At intersection point with params (u1,v1,u2,v2):
+1. Get surface normals N1, N2
+2. tangent t = N1 x N2 (normalized)
+3. Curvature of intersection curve:
+   kappa = |t' / |t|| where t' is derivative of tangent w.r.t. arc length
+4. Approximate from second-order data:
+   kappa ≈ |dt/ds| computed from second-order SSI ODE (uses second derivatives of surfaces)
+
+### Practical implementation
+- Compute kappa from the osculating circle fit to 3 consecutive marching points
+- Update h: h_new = min(h_max, max(h_min, sqrt(8*epsilon/kappa)))
+- Typical: h_min = 1e-5, h_max = 0.1, epsilon = linear_tolerance / 10
+
+### Step rejection
+- Compare predicted point (Euler) vs corrected point (Newton)
+- err = |predicted_3D - corrected_3D|
+- If err > tolerance: reject, halve h, retry
+- If err < tolerance/4: accept, double h for next step (up to h_max)
+- This is the embedded RKF45 pattern adapted for constrained manifold tracing
+
+### brepkit current state
+- `march_intersection()` uses fixed step_size parameter
+- No curvature computation
+- No step rejection/adaptation
+- Improvement opportunity: add curvature estimation from 2nd derivatives and adapt h per step

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,315 @@
+# brepkit — Product Roadmap (Q1–Q3 2026)
+
+> **Vision**: The browser-native B-Rep geometry SDK. Exact solid modeling
+> in any web app — no server, no legacy C++ dependencies.
+>
+> **Dogfood**: [gridfinity-layout-tool](https://github.com/andymai/gridfinity-layout-tool) —
+> parametric gridfinity bin generator. Migrating from `brepjs-opencascade` to
+> [brepjs](https://github.com/andymai/brepjs) + [brepkit-wasm](https://github.com/andymai/brepkit/tree/main/crates/wasm).
+>
+> **License**: Free non-commercial. Commercial license required for products.
+
+---
+
+## Current State (March 2026)
+
+| Metric         | Value                                            |
+|----------------|--------------------------------------------------|
+| Tests          | 807+ passing                                     |
+| WASM bindings  | ~145                                             |
+| CAD operations | ~25 + helpers                                    |
+| I/O formats    | 7 (STEP, IGES, STL, 3MF, OBJ, PLY, glTF)        |
+| PRs merged     | 38                                               |
+| WASM binary    | 1.9 MB raw / 602 KB gzip'd (release, no wasm-opt)|
+| Public release | [brepjs](https://github.com/andymai/brepjs) on npm (stable API); brepkit not yet published |
+
+### Known Gaps
+
+| Gap                                    | Severity | Phase |
+|----------------------------------------|----------|-------|
+| Adapter drops sweep options (`withContact`) | Critical | P1.1  |
+| Adapter drops loft options (`ruled: true`) | Critical | P1.1  |
+| Adapter drops boolean options (`commonFace`) | Critical | P1.1 |
+| OpenCascade → brepkit migration        | Critical | P1.2  |
+| Fillet vertex blending (3-edge corners)| High     | P2.2  |
+| Boolean coplanar face handling         | Medium   | P2.1  |
+| `meshEdges()` returns stub (no edge viz) | Medium | P1.1  |
+| NURBS tessellation (no boundary conformance) | Medium | —  |
+| WASM bundle size (602 KB over target)  | Medium   | P3.2  |
+| STL per-face tessellation (non-manifold) | Medium | P1.3 |
+| No 2D grid pattern                     | Low      | P1.4  |
+
+### Release Strategy
+
+- **Cadence**: Continuous semver via npm
+- **Versioning**: brepjs semver; brepkit crates version-locked internally
+- **Distribution**: npm (primary), crates.io deferred
+- **Docs**: TypeDoc API reference + curated examples
+
+---
+
+## Phase 1: Migration & Quick Wins (March–April 2026)
+
+Get gridfinity-layout-tool running on brepkit with watertight export and a performance baseline. Fillet corners deferred — bins ship with chamfers initially.
+
+### Dependencies
+
+```
+P1.1 (adapter audit) → P1.2 (migration) → P1.5 (integration tests)
+P1.3 (STL fix) ─────────────────────────────→ P1.5
+P1.4 (grid pattern) ────────────────────────→ P1.5
+P1.6 (perf baseline) ── parallel with all ──→
+```
+
+### P1.1 — brepjs Adapter Audit
+
+The adapter silently drops unsupported options. `sweepPipeShell` ignores `withContact`, `frenet`, `correction` — stacking lip geometry will be wrong.
+
+- [ ] Audit every adapter method for silently ignored options (grep for `_options`, unused params)
+- [ ] Catalog pass-through vs. dropped options
+- [ ] Fix critical adapter gaps used by gridfinity-layout-tool:
+  - `sweepPipeShell` — `withContact` (stacking lip), `correction` (profile alignment)
+  - `loftAdvanced` — `ruled: true` (socket tapers, baseplate pockets, connector chamfers — 5 call sites)
+  - `fuse`/`fuseAll` — `optimisation: 'commonFace'` (6 call sites — won't break geometry but leaves redundant faces)
+  - `meshEdges` — currently returns stub (edge visualization missing)
+  - `fillet` — verify edge selection via `iterShapes` + `getBounds`
+  - `shell` — verify open-top-box case (remove top face, offset inward)
+  - `edgeFinder`/`faceFinder` — verify `getBounds`, face normals
+- [ ] Add adapter integration tests for each fixed method
+
+### P1.2 — OpenCascade → brepkit Migration
+
+6 non-test files reference OpenCascade directly; generator files import from brepjs. Migration is primarily swapping WASM init.
+
+- [ ] Replace `brepjs-opencascade` WASM init with brepkit WASM init in `wasmInstantiator.ts`
+- [ ] Update `wasmPreload.ts` and `wasmCapabilities.ts` (remove SharedArrayBuffer/pthread logic)
+- [ ] Remove `brepjs-opencascade` from `package.json`
+- [ ] Run all generator tests against brepkit backend
+- [ ] Visual diff: same bin spec → compare meshes for regressions
+
+### P1.3 — STL Watertight Export
+
+- [ ] Switch STL writer to `tessellate_solid()` (shared-edge tessellator)
+- [ ] Maintain backward compat for ASCII/binary modes
+- [ ] Test: box STL → 0 boundary edges in MeshLab
+
+### P1.4 — Grid Pattern (2D)
+
+- [ ] Add `grid_pattern(solid, dir_x, dir_y, spacing_x, spacing_y, count_x, count_y)`
+- [ ] Return `Compound` of positioned copies
+- [ ] WASM binding: `gridPattern()`
+
+### P1.5 — Gridfinity Integration Testing
+
+Validates full pipeline: brepjs API → brepkit-wasm → STL/3MF. Depends on P1.1 and P1.2.
+
+- [ ] Integration test: 2×1×3u bin with stacking lip
+- [ ] Integration test: 3×3 baseplate with magnet holes
+- [ ] Verify printability: import STL into PrusaSlicer, check for manifold errors
+- [ ] Measure boolean pass rate on gridfinity-specific operations
+
+### P1.6 — Performance Baseline
+
+Can run in parallel with other Phase 1 work.
+
+- [ ] Benchmark suite: primitive creation, boolean cut, fillet, shell, tessellation, pattern
+- [ ] Gridfinity benchmarks: 1×1 bin gen, 3×3 baseplate gen
+- [ ] In-browser measurement via `performance.now()` around brepjs calls
+- [ ] Record WASM load time, peak memory, wall-clock per operation
+
+### Phase 1 Exit Criteria
+
+| Metric                                   | Target                                          |
+|------------------------------------------|--------------------------------------------------|
+| gridfinity-layout-tool runs on brepkit   | No `brepjs-opencascade` in `package.json`        |
+| Generator tests pass                     | All existing tests green on brepkit backend      |
+| Stacking lip geometry correct            | Visual match with OpenCascade output             |
+| STL export watertight                    | 0 boundary edges on test solids                  |
+| Performance baseline documented          | Numbers recorded for all key operations          |
+
+---
+
+## Phase 2: Robustness (May–June 2026)
+
+Harden booleans and add fillet corner blending. Pick **one** of P2.2 or P2.3 — both are multi-week research efforts. P2.4 is a stretch goal.
+
+### Dependencies
+
+```
+P2.1 (boolean campaign) → P2.4 (healing, stretch)
+P2.2 (vertex blending) ─or─ P2.3 (non-planar fillet)  ← pick one
+```
+
+### P2.1 — Boolean Reliability Campaign
+
+The try-and-fallback design silently degrades to tessellated approximation.
+
+- [ ] Build 100-case stress-test suite (categories: coplanar, tangent, thin-wall, near-miss)
+- [ ] Add telemetry: log which path was taken (analytic / NURBS / tessellated fallback)
+- [ ] Fix coplanar face classification (CoplanarSame/Opposite dropping fragments)
+- [ ] Make tessellated fallback deflection configurable (currently hardcoded at 1.0)
+- [ ] Explicit error on degenerate result (empty solid, isolated face)
+- [ ] Target: <5% fallback-to-tessellation rate on the test suite
+
+### P2.2 — Fillet Vertex Blending (Convex Corners)
+
+Scoped to convex 3-edge corners only (box-like shapes). Concave corners and n-edge vertices deferred.
+
+- [ ] Spherical vertex blend patches at convex 3-edge junctions
+- [ ] Watertight stitching between blend patch and adjacent fillet surfaces
+- [ ] Test: fillet all 12 edges of a box → 0 boundary edges
+- [ ] Stretch: concave 3-edge corners if convex ships early
+
+### P2.3 — Non-Planar Fillet *(alternative if vertex blending is blocked)*
+
+Both `fillet()` and `fillet_rolling_ball()` reject non-planar faces.
+
+- [ ] Rolling-ball algorithm for cylinder–plane junctions
+- [ ] Cylinder–cylinder junctions (common at bin corners)
+- [ ] Test: fillet edges of a cylinder → smooth blend between cap and wall
+
+### P2.4 — Healing & Validation Hardening *(stretch goal)*
+
+- [ ] `repair_solid()` convenience function chaining healing passes
+- [ ] Auto-heal small gaps (< tolerance) in wire closure
+- [ ] Detect and warn on degenerate faces (area < tolerance²)
+- [ ] Opt-in `validate_solid()` pass (behind feature flag to avoid perf overhead)
+
+### Phase 2 Exit Criteria
+
+| Metric                          | Target                                        |
+|---------------------------------|-----------------------------------------------|
+| Boolean pass rate               | > 95% on 100-case stress suite                |
+| Fillet box edges                | 0 boundary edges (if P2.2 completed)          |
+| Fillet cylinder edges           | Smooth cap-to-wall blend (if P2.3 completed)  |
+| No silent boolean degradation   | Telemetry logs path for every boolean call    |
+
+---
+
+## Phase 3: Performance & Polish (July–August 2026)
+
+Optimize for interactive web apps and prepare for public launch.
+
+### Dependencies
+
+```
+P3.1 (perf) depends on P1.6 (baseline)
+P3.2 (bundle) ── parallel with P3.1
+P3.3 (docs) ──→ P3.4 (npm publish)
+```
+
+### P3.1 — Performance Optimization
+
+- [ ] Profile WASM execution against Phase 1 baseline
+- [ ] Optimize hot paths identified in baseline
+- [ ] Target: 1×1×1 gridfinity bin < 100ms in browser
+- [ ] Target: 4×4 baseplate with magnet holes < 500ms
+
+### P3.2 — WASM Bundle Optimization
+
+Current: 1.9 MB raw / 602 KB gzip'd.
+
+- [ ] `wasm-opt -O3 --strip-debug` for release builds
+- [ ] Dead code elimination via `cargo features` gating (e.g., IGES behind feature flag)
+- [ ] Evaluate core + io bundle split
+- [ ] Target: < 400 KB gzip'd for core-only bundle
+
+### P3.3 — API Reference & Examples
+
+- [ ] TypeDoc API reference for [brepjs](https://github.com/andymai/brepjs)
+- [ ] 10 curated examples:
+  - Basic box with fillet
+  - Gridfinity bin (showcase)
+  - Boolean operations (union, cut, intersect)
+  - Sweep along a path
+  - STEP import → modify → STL export
+  - Pattern (linear, circular, grid)
+  - Measurement (volume, area, center of mass)
+  - Transform and mirror
+  - Multi-solid assembly
+  - Custom profile extrusion
+- [ ] Static site with copy-paste code snippets (live WASM playground deferred)
+- [ ] README badges (npm version, bundle size, license)
+
+### P3.4 — npm Package Preparation
+
+- [ ] Finalize dual-license text + LICENSE file
+- [ ] `package.json` metadata (description, keywords, repository)
+- [ ] CHANGELOG.md with semver history
+- [ ] Publish v1.0.0-beta.1 to npm
+
+### Phase 3 Exit Criteria
+
+| Metric            | Target                                  |
+|-------------------|-----------------------------------------|
+| Bin generation    | < 100ms for 1×1 bin (vs. Phase 1 baseline) |
+| WASM bundle size  | < 400 KB gzip'd (core-only)             |
+| npm published     | v1.0.0-beta.x with TypeDoc reference    |
+| Examples live     | 10 examples on static site              |
+
+---
+
+## Out of Scope (This Cycle)
+
+| Item                                      | Reason                                              |
+|-------------------------------------------|------------------------------------------------------|
+| Mesh-only workflows (sculpting, subdiv)   | Not B-Rep; different audience                        |
+| Desktop/native distribution (crates.io)   | Focus on npm/WASM                                    |
+| Simulation (FEA/CFD)                      | Different product category                           |
+| Parametric history / feature tree         | Can be built at brepjs layer later                   |
+| General NURBS-to-NURBS fillet             | Convex corners + cylinder junctions cover gridfinity |
+| BREP/SAT import                           | STEP covers interop needs                            |
+| Concave vertex blending                   | After convex case proves out                         |
+
+---
+
+## Success Criteria (September 2026)
+
+| Metric                        | Target                                             |
+|-------------------------------|----------------------------------------------------|
+| gridfinity-layout-tool on brepkit | Live, generating printable bins (no OpenCascade) |
+| Boolean pass rate             | > 95% on 100-case stress suite                     |
+| npm published                 | v1.0.0-beta.x with docs                           |
+| First external user           | >= 1 developer building with brepjs                |
+| WASM bundle size              | < 400 KB gzip'd (core-only)                       |
+| Bin generation perf           | < 100ms for 1×1 bin in browser                    |
+| Gridfinity operation coverage | All 14 operations in appendix at Ready status      |
+
+---
+
+## Risk Register
+
+| Risk                                          | Likelihood | Impact   | Mitigation                                                           |
+|-----------------------------------------------|------------|----------|----------------------------------------------------------------------|
+| Stacking lip sweep (`withContact`) wrong geometry | High   | Critical | P1.1 audit; implement `withContact` in brepkit if needed             |
+| Ruled lofts produce wrong surface (smooth not ruled) | High | High | P1.1 audit; pass `ruled` through adapter to brepkit `loft()` |
+| `shell` fails on gridfinity box geometry      | Medium     | Critical | Test shell(open-top box) early in P1.1; boolean-cut fallback         |
+| Fillet vertex blending harder than expected    | High       | High     | Scope to convex 3-edge only; ship with chamfers until ready          |
+| Adapter drops more options than cataloged      | High       | High     | Systematic P1.1 audit with per-method integration tests              |
+| Boolean coplanar handling causes regressions   | Medium     | High     | Comprehensive test suite before changing                             |
+| WASM bundle still >500 KB after optimization   | Medium     | Medium   | Feature-gate I/O modules; offer core-only bundle                     |
+| Non-commercial license deters adoption         | Low        | Medium   | Clear license FAQ; fast response on commercial inquiries             |
+| Solo capacity bottleneck                       | High       | Medium   | AI-assisted dev; prioritize ruthlessly; P2.2 vs P2.3 is pick-one    |
+
+---
+
+## Appendix: Gridfinity Operation Map
+
+Operations required by [gridfinity-layout-tool](https://github.com/andymai/gridfinity-layout-tool):
+
+| Gridfinity Feature             | brepkit Operation                        | Status       | Notes                                        |
+|--------------------------------|------------------------------------------|--------------|----------------------------------------------|
+| Bin body (rounded box)         | `make_box` + `fillet`                    | Partial | Vertex blending missing (P2.2)               |
+| Stacking lip profile           | `sweepSketch` with `withContact`         | At Risk | Adapter drops `withContact` (P1.1)           |
+| Shell (hollow box)             | `shell` (remove top face, offset inward) | Unverified | Open-top-box case untested                   |
+| Base foot (chamfered step)     | `chamfer` or `extrude` + `boolean cut`   | Ready   | —                                            |
+| Magnet pockets                 | `make_cylinder` + `boolean cut`          | Ready   | —                                            |
+| Screw holes                    | `make_cylinder` + `boolean cut`          | Ready   | —                                            |
+| Internal dividers              | `make_box` + `boolean cut`               | Ready   | —                                            |
+| Label slot (45 deg cut)        | `extrude` + `boolean cut`                | Ready   | —                                            |
+| Scoop (cylindrical cut)        | `make_cylinder` + `boolean cut`          | Ready   | —                                            |
+| Baseplate grid                 | `grid_pattern` (P1.4)                    | Planned | Currently requires two `linear_pattern` calls|
+| STL export                     | `write_stl`                              | Fix in P1.3 | Switching to shared-edge tessellation        |
+| Socket/pocket ruled lofts      | `loftWith({ ruled: true })`              | At Risk | Adapter drops `ruled` option (P1.1)          |
+| Edge visualization             | `meshEdges()`                            | Broken  | Adapter returns stub (P1.1)                  |
+| 3MF export                     | `write_3mf`                              | Ready   | Watertight                                   |


### PR DESCRIPTION
## Summary
- Three-phase roadmap (Q1–Q3 2026) grounded in gridfinity-layout-tool as the dogfood product
- **Phase 1** (Mar–Apr): brepjs adapter audit, OpenCascade→brepkit migration, STL watertight fix, grid pattern, perf baseline
- **Phase 2** (May–Jun): Boolean reliability campaign (95% pass target), fillet vertex blending or non-planar fillet (pick one)
- **Phase 3** (Jul–Aug): WASM bundle optimization (<400KB gzip), TypeDoc + examples, npm beta publish

Key findings from codebase analysis:
- brepjs adapter silently drops critical options: `withContact` (sweep), `ruled` (loft), `commonFace` (boolean) — 3 Critical gaps
- 14-operation gridfinity capability map with per-operation status (7 Ready, 4 At Risk/Broken, 3 Partial/Planned)
- WASM binary measured at 602 KB gzip'd (before wasm-opt)
- Per-phase exit criteria and dependency graphs included

## Test plan
- [ ] Review roadmap accuracy against codebase
- [ ] Verify all GitHub URLs resolve correctly
- [ ] Confirm appendix operation count matches success criteria (14)