### PR TITLE
feat(wasm): feature-gate IO for core-only bundle <400KB

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -10,11 +10,15 @@ description = "WebAssembly bindings for brepkit"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["io"]
+io = ["dep:brepkit-io"]
+
 [dependencies]
 brepkit-math.workspace = true
 brepkit-topology.workspace = true
 brepkit-operations.workspace = true
-brepkit-io.workspace = true
+brepkit-io = { workspace = true, optional = true }
 wasm-bindgen.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -878,6 +878,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the solid handle is invalid or export fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "export3mf")]
     pub fn export_3mf(&self, solid: u32, deflection: f64) -> Result<Vec<u8>, JsError> {
         validate_positive(deflection, "deflection")?;
@@ -893,6 +894,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the solid handle is invalid or export fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "exportStl")]
     pub fn export_stl(&self, solid: u32, deflection: f64) -> Result<Vec<u8>, JsError> {
         validate_positive(deflection, "deflection")?;
@@ -911,6 +913,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the solid handle is invalid or tessellation fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "exportObj")]
     pub fn export_obj(&self, solid: u32, deflection: f64) -> Result<Vec<u8>, JsError> {
         validate_positive(deflection, "deflection")?;
@@ -924,6 +927,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the solid handle is invalid or tessellation fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "exportGlb")]
     pub fn export_glb(&self, solid: u32, deflection: f64) -> Result<Vec<u8>, JsError> {
         validate_positive(deflection, "deflection")?;
@@ -937,6 +941,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the solid handle is invalid or tessellation fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "exportPly")]
     pub fn export_ply(&self, solid: u32, deflection: f64) -> Result<Vec<u8>, JsError> {
         validate_positive(deflection, "deflection")?;
@@ -957,6 +962,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the file is malformed or mesh import fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "importObj")]
     pub fn import_obj(&mut self, data: &[u8]) -> Result<u32, JsError> {
         let text = std::str::from_utf8(data).map_err(|e| WasmError::InvalidInput {
@@ -973,6 +979,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the file is malformed or mesh import fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "importGlb")]
     pub fn import_glb(&mut self, data: &[u8]) -> Result<u32, JsError> {
         let mesh = brepkit_io::gltf::read_glb(data)?;
@@ -989,6 +996,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the STL data is malformed or empty.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "importStl")]
     pub fn import_stl(&mut self, data: &[u8]) -> Result<u32, JsError> {
         let mesh = brepkit_io::stl::reader::read_stl(data)?;
@@ -1003,6 +1011,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the 3MF data is malformed.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "import3mf")]
     pub fn import_3mf(&mut self, data: &[u8]) -> Result<Vec<u32>, JsError> {
         let meshes = brepkit_io::threemf::reader::read_threemf(data)?;
@@ -1021,6 +1030,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the solid handle is invalid or export fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "exportStep")]
     pub fn export_step(&self, solid: u32) -> Result<Vec<u8>, JsError> {
         let solid_id = self.resolve_solid(solid)?;
@@ -1035,6 +1045,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the STEP data is malformed.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "importStep")]
     pub fn import_step(&mut self, data: &[u8]) -> Result<Vec<u32>, JsError> {
         let text = std::str::from_utf8(data)
@@ -1077,6 +1088,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the solid handle is invalid or export fails.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "exportIges")]
     pub fn export_iges(&self, solid: u32) -> Result<Vec<u8>, JsError> {
         let solid_id = self.resolve_solid(solid)?;
@@ -1089,6 +1101,7 @@ impl BrepKernel {
     /// # Errors
     ///
     /// Returns an error if the IGES data is malformed.
+    #[cfg(feature = "io")]
     #[wasm_bindgen(js_name = "importIges")]
     pub fn import_iges(&mut self, data: &[u8]) -> Result<Vec<u32>, JsError> {
         let text = std::str::from_utf8(data)

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -8,6 +8,7 @@
 //! state and exposes shape creation, operations, and tessellation to JS.
 
 pub mod error;
+#[cfg(feature = "io")]
 pub mod io;
 pub mod kernel;
 pub mod operations;


### PR DESCRIPTION
## Summary
- Add optional `io` feature (default: enabled) to `brepkit-wasm`
- Gate all import/export WASM bindings behind `#[cfg(feature = "io")]`
- Building with `--no-default-features` excludes `brepkit-io` and dependencies (zip, quick-xml, miniz_oxide)

### Bundle Size Results

| Build | Raw | gzip'd | gzip'd + wasm-opt |
|-------|----:|-------:|------------------:|
| Full (default) | 1.95 MB | 613 KB | **516 KB** |
| Core-only (no IO) | 1.40 MB | 427 KB | **369 KB** |

Core-only + wasm-opt meets the <400 KB target from the roadmap.

### Usage
```bash
# Full build (default, includes all IO formats)
cargo build -p brepkit-wasm --target wasm32-unknown-unknown --release

# Core-only (no IO, smaller bundle)
cargo build -p brepkit-wasm --target wasm32-unknown-unknown --release --no-default-features

# Post-build optimization
wasm-opt -O3 --strip-debug -o output.wasm input.wasm
```

## Test plan
- [x] All 882 tests pass (default features)
- [x] Clippy clean
- [x] WASM builds with default features
- [x] WASM builds with `--no-default-features`