### PR TITLE
chore(wasm): package metadata for npm publish

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -5,7 +5,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "WebAssembly bindings for brepkit"
+description = "WebAssembly bindings for brepkit — browser-native B-Rep solid modeling"
+keywords = ["cad", "brep", "wasm", "geometry", "solid-modeling"]
+categories = ["wasm", "mathematics", "science"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Summary
- Add crates.io keywords: `cad`, `brep`, `wasm`, `geometry`, `solid-modeling`
- Add categories: `wasm`, `mathematics`, `science`
- Improve description to highlight browser-native B-Rep value prop

Publishing infrastructure already in place:
- release-please auto-generates CHANGELOG
- publish.yml builds WASM + publishes to npm with provenance
- Apache-2.0 license configured

## Test plan
- [x] All 892 tests pass
- [x] Clippy clean