### PR TITLE
fix(wasm): use npm-expected repository URL format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
-repository = "https://github.com/andymai/brepkit"
+repository = "git+https://github.com/andymai/brepkit.git"
 
 [workspace.dependencies]
 # Math


### PR DESCRIPTION
## Summary
- Updates `repository` URL in workspace `Cargo.toml` to use `git+https://...git` format
- Fixes `npm warn publish` auto-correction warning during `wasm-pack` publish

## Test plan
- [x] All 897 tests pass
- [x] `cargo clippy` clean