### PR TITLE
fix: use OIDC provenance for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,5 +70,3 @@ jobs:
       - name: Publish to npm
         working-directory: crates/wasm/pkg
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove redundant `NPM_TOKEN` secret — npm publish uses OIDC provenance via `id-token: write` permission + `--provenance` flag

## Test plan
- [x] All tests pass
- [ ] Verify npm publish works via OIDC on next release