### PR TITLE
fix: exclude non-code paths from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,15 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         "crates/wasm/Cargo.toml"
+      ],
+      "exclude-paths": [
+        ".github",
+        "book",
+        "scripts",
+        "benches",
+        "bench-results",
+        "examples",
+        "bindings"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Add `exclude-paths` to release-please config so changes to CI, docs, scripts, benchmarks, and examples don't trigger npm releases
- Only changes to `crates/` and `tests/` (actual code) will trigger version bumps

## How release-please decides to release
1. Commit type: only `fix:` (patch) and `feat:` (minor) bump versions — `docs:`, `chore:`, `ci:` are changelog-only
2. File paths: with `exclude-paths`, even a `fix:` commit touching only excluded paths won't trigger a release
3. Both conditions must be met for a version bump

## Test plan
- [x] All tests pass
- [ ] Verify a `docs:` commit doesn't create a release PR
- [ ] Verify a `fix:` commit to `crates/` does create a release PR