### PR TITLE
fix(ci): add workflow_dispatch for manual npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ name: Release & Publish
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      publish_version:
+        description: "Manually publish this version (e.g. 0.4.1). Skips release-please."
+        required: true
 
 permissions:
   contents: read
@@ -56,7 +61,7 @@ jobs:
   publish:
     name: Build WASM & Publish
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -96,7 +101,7 @@ jobs:
           fi
           echo "Publishing brepkit-wasm@$PKG_VERSION"
         env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name || format('v{0}', github.event.inputs.publish_version) }}
 
       - name: Publish to npm
         working-directory: crates/wasm/pkg


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger with `publish_version` input for manual publishes
- Useful for retrying failed publishes without re-releasing

## Test plan
- [ ] Merge, then manually dispatch with version `0.4.1` to publish