### PR TITLE
fix(ci): use OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,8 +71,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          node-version: 24
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary

- Bump Node.js 22 → 24 for npm OIDC trusted publishing support (npm >= 11.5.1)
- Remove `registry-url` from `setup-node` — it creates `.npmrc` with empty `NODE_AUTH_TOKEN` that overrides OIDC auto-detection
- `id-token: write` permission and `--provenance` flag were already configured

## Prerequisite

The `brepkit-wasm` package must have a trusted publisher configured on npmjs.com:
Settings → Trusted Publishers → GitHub Actions → repository: `andymai/brepkit`, workflow: `publish.yml`

## Test plan

- [ ] Merge this PR
- [ ] Re-run the failed Release & Publish workflow for v0.4.3 (`gh run rerun 22732571346`)
- [ ] Verify `brepkit-wasm@0.4.3` appears on npmjs.com