### PR TITLE
docs: add npm install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ graph TD
 
 ## Getting Started
 
+### npm (JavaScript / TypeScript)
+
+```bash
+npm install brepkit-wasm
+```
+
+```js
+import init, { BrepKernel } from "brepkit-wasm";
+
+await init();
+const kernel = new BrepKernel();
+const box = kernel.makeBox(10, 20, 30);
+```
+
+### Building from source
+
 ```bash
 # Build all crates
 cargo build --workspace


### PR DESCRIPTION
## Summary
- Adds npm install instructions (`npm install brepkit-wasm`) and a minimal usage example to the Getting Started section
- Reorganizes Getting Started into two subsections: **npm** (for JS/TS users) and **Building from source** (for Rust)

## Test plan
- [x] Verified `brepkit-wasm` is the correct published npm package name (v0.5.1)
- [ ] Visual check that README renders correctly on GitHub