### PR TITLE
fix: correct nodejs WASM merge step in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,6 +111,7 @@ jobs:
             };
             pkg.main = "brepkit_wasm_node.js";
             pkg.module = "brepkit_wasm.js";
+            pkg.files = pkg.files || [];
             if (!pkg.files.includes("brepkit_wasm_node.js")) {
               pkg.files.push("brepkit_wasm_node.js");
             }


### PR DESCRIPTION
## Summary
Fix publish workflow from PR #78:
- nodejs wasm-pack target produces a single `brepkit_wasm.js` (no `_bg.js`)
- Add node entry to `files` array for npm tarball inclusion

## Test plan
- [x] Verified locally: `wasm-pack build --target nodejs` output files
- [x] Previous manual publish attempt failed on this exact `cp` command