### PR TITLE
fix: compute cylinder band normal from surface point, not centroid

### DIFF
--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -2852,19 +2852,23 @@ fn create_band_fragments(
         verts.extend(top_pts.into_iter().rev());
 
         // Compute representative normal and d for the band.
-        // Use the centroid's position and the average outward normal.
-        let centroid = verts.iter().fold(Point3::new(0.0, 0.0, 0.0), |acc, &p| {
-            acc + (p - Point3::new(0.0, 0.0, 0.0))
-        });
-        let centroid = Point3::new(
-            centroid.x() / verts.len() as f64,
-            centroid.y() / verts.len() as f64,
-            centroid.z() / verts.len() as f64,
-        );
-        let band_normal =
-            (centroid - cyl.origin() - cyl.axis() * cyl.axis().dot(centroid - cyl.origin()))
-                .normalize()
-                .unwrap_or(normal);
+        // Use a surface point (first vertex) for the outward normal, not
+        // the polygon centroid — the centroid of a full-circle band falls
+        // on the cylinder axis, making the radial direction degenerate.
+        let surface_point = verts[0];
+        let band_normal = (surface_point
+            - cyl.origin()
+            - cyl.axis() * cyl.axis().dot(surface_point - cyl.origin()))
+        .normalize()
+        .unwrap_or(normal);
+        #[allow(clippy::cast_precision_loss)]
+        let centroid = {
+            let (sx, sy, sz) = verts.iter().fold((0.0, 0.0, 0.0), |(ax, ay, az), v| {
+                (ax + v.x(), ay + v.y(), az + v.z())
+            });
+            let inv_n = 1.0 / verts.len() as f64;
+            Point3::new(sx * inv_n, sy * inv_n, sz * inv_n)
+        };
         let band_d = crate::dot_normal_point(band_normal, centroid);
 
         fragments.push(AnalyticFragment {

--- a/crates/operations/src/measure.rs
+++ b/crates/operations/src/measure.rs
@@ -1707,4 +1707,51 @@ mod tests {
             "box should have volume ~1000, got {vol}"
         );
     }
+
+    /// Boolean cut must reduce volume: cut(box, cylinder) < box volume.
+    ///
+    /// Regression test for the cylinder band classification bug: the analytic
+    /// boolean was computing the band normal from the polygon centroid, which
+    /// falls on the cylinder axis for full-circle bands, yielding a degenerate
+    /// zero-length direction. Ray-casting with this direction classified the
+    /// bore fragment as Outside instead of Inside, causing the cylinder bore
+    /// face to be dropped from the result.
+    #[test]
+    fn cut_box_cylinder_volume_decreases() {
+        use crate::boolean::{BooleanOp, boolean};
+        use crate::primitives::{make_box, make_cylinder};
+        use crate::transform::transform_solid;
+        use brepkit_math::mat::Mat4;
+
+        let mut topo = Topology::new();
+        let bx = make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let cyl = make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+        // Center cylinder in box so it fully passes through.
+        transform_solid(&mut topo, cyl, &Mat4::translation(5.0, 5.0, 0.0)).unwrap();
+        let cut = boolean(&mut topo, BooleanOp::Cut, bx, cyl).unwrap();
+
+        let box_vol = solid_volume(&topo, bx, 0.01).unwrap();
+        let cut_vol = solid_volume(&topo, cut, 0.01).unwrap();
+        // Expected: box volume minus full cylinder bore through box height.
+        let expected = 1000.0 - std::f64::consts::PI * 9.0 * 10.0;
+
+        // The result should have 7 faces: 6 planar (2 with holes) + 1 cylinder bore.
+        let s = topo.solid(cut).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        assert_eq!(
+            sh.faces().len(),
+            7,
+            "expected 7 faces (6 plane + 1 cylinder bore)"
+        );
+
+        assert!(
+            cut_vol < box_vol,
+            "cut volume ({cut_vol:.2}) must be less than box volume ({box_vol:.2})"
+        );
+        let rel_err = (cut_vol - expected).abs() / expected;
+        assert!(
+            rel_err < 0.02,
+            "cut volume ({cut_vol:.2}) should be close to expected ({expected:.2}), rel_err={rel_err:.4}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fix degenerate band normal in `create_band_fragments` that caused cylinder bore faces to be dropped from analytic boolean results
- The polygon centroid of a full-circle cylinder band falls on the cylinder axis, producing a zero-length radial direction for ray-casting classification
- Use a surface vertex (`verts[0]`) instead of the centroid to compute the outward normal
- Add regression test: `cut(box10, centered_cyl3)` verifies 7 faces and <2% volume error

**Before:** cut(box, cylinder) → 6 faces (no bore), volume 906 (26% error)
**After:** cut(box, cylinder) → 7 faces (with bore), volume 718 (0.13% error)

## Test plan

- [x] `cut_box_cylinder_volume_decreases` regression test passes
- [x] Full workspace test suite (924 tests pass, 0 failures)
- [x] Clippy clean
- [x] Pre-push hooks pass (including cargo-deny)