### PR TITLE
feat: add relative tolerance for scale-aware comparisons

### DIFF
--- a/crates/math/src/tolerance.rs
+++ b/crates/math/src/tolerance.rs
@@ -1,7 +1,12 @@
 //! Tolerance model for geometric comparisons.
 //!
 //! CAD kernels need well-defined tolerances for classifying geometric
-//! relationships. [`Tolerance`] bundles linear and angular thresholds.
+//! relationships. [`Tolerance`] bundles linear, angular, and relative
+//! thresholds.
+//!
+//! The [`approx_eq`](Tolerance::approx_eq) comparison is *scale-aware*:
+//! two values are equal when `|a - b| <= max(linear, relative * max(|a|, |b|))`.
+//! This prevents false negatives when comparing large coordinates.
 
 /// Tolerance thresholds for geometric comparisons.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -11,44 +16,67 @@ pub struct Tolerance {
     pub linear: f64,
     /// Absolute tolerance for angular (radian) comparisons.
     pub angular: f64,
+    /// Relative tolerance as a fraction of the larger operand.
+    ///
+    /// Used by [`approx_eq`](Self::approx_eq) to scale comparisons:
+    /// `|a - b| <= max(linear, relative * max(|a|, |b|))`.
+    pub relative: f64,
 }
 
 impl Tolerance {
-    /// Sensible defaults for CAD geometry: 1e-7 linear, 1e-12 angular.
+    /// Sensible defaults for CAD geometry.
+    ///
+    /// Linear: 1e-7, angular: 1e-12, relative: 1e-10.
     #[must_use]
     pub const fn new() -> Self {
         Self {
             linear: 1e-7,
             angular: 1e-12,
+            relative: 1e-10,
         }
     }
 
     /// A looser tolerance for visualization or rough checks.
     ///
-    /// Linear: 1e-4, angular: 1e-8.
+    /// Linear: 1e-4, angular: 1e-8, relative: 1e-6.
     #[must_use]
     pub const fn loose() -> Self {
         Self {
             linear: 1e-4,
             angular: 1e-8,
+            relative: 1e-6,
         }
     }
 
     /// A tighter tolerance for high-precision operations.
     ///
-    /// Linear: 1e-10, angular: 1e-15.
+    /// Linear: 1e-10, angular: 1e-15, relative: 1e-14.
     #[must_use]
     pub const fn tight() -> Self {
         Self {
             linear: 1e-10,
             angular: 1e-15,
+            relative: 1e-14,
         }
     }
 
-    /// Check whether two `f64` values are approximately equal within the
-    /// linear tolerance.
+    /// Scale-aware approximate equality.
+    ///
+    /// Returns `true` when `|a - b| <= max(linear, relative * max(|a|, |b|))`.
+    /// This ensures comparisons remain meaningful at any coordinate magnitude.
     #[must_use]
     pub fn approx_eq(self, a: f64, b: f64) -> bool {
+        let diff = (a - b).abs();
+        let scale = a.abs().max(b.abs());
+        diff <= self.linear.max(self.relative * scale)
+    }
+
+    /// Purely absolute approximate equality (ignores `relative`).
+    ///
+    /// Use this when comparing values that are *not* coordinates, e.g.
+    /// parameter-space values in `[0, 1]` where relative scaling is wrong.
+    #[must_use]
+    pub fn approx_eq_abs(self, a: f64, b: f64) -> bool {
         (a - b).abs() <= self.linear
     }
 
@@ -84,6 +112,7 @@ impl Default for Tolerance {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
 
     #[test]
@@ -91,18 +120,21 @@ mod tests {
         let tol = Tolerance::new();
         assert!((tol.linear - 1e-7).abs() < 1e-20);
         assert!((tol.angular - 1e-12).abs() < 1e-20);
+        assert!((tol.relative - 1e-10).abs() < 1e-20);
     }
 
     #[test]
     fn loose_tolerance() {
         let tol = Tolerance::loose();
         assert!(tol.linear > Tolerance::new().linear);
+        assert!(tol.relative > Tolerance::new().relative);
     }
 
     #[test]
     fn tight_tolerance() {
         let tol = Tolerance::tight();
         assert!(tol.linear < Tolerance::new().linear);
+        assert!(tol.relative < Tolerance::new().relative);
     }
 
     #[test]
@@ -124,6 +156,35 @@ mod tests {
         let tol = Tolerance::new();
         assert!(tol.approx_eq(42.0, 42.0));
         assert!(tol.approx_eq(0.0, 0.0));
+    }
+
+    #[test]
+    fn approx_eq_scales_with_magnitude() {
+        let tol = Tolerance {
+            linear: 1e-7,
+            angular: 1e-12,
+            relative: 1e-4, // 0.01%
+        };
+        // Near zero: absolute tolerance dominates
+        assert!(tol.approx_eq(0.0, 1e-8));
+        assert!(!tol.approx_eq(0.0, 1e-3));
+
+        // Large values: relative tolerance dominates
+        // 1e6 * 1e-4 = 100 → differences up to 100 are within tolerance
+        assert!(tol.approx_eq(1e6, 1e6 + 50.0));
+        assert!(!tol.approx_eq(1e6, 1e6 + 200.0));
+    }
+
+    #[test]
+    fn approx_eq_abs_ignores_relative() {
+        let tol = Tolerance {
+            linear: 1e-7,
+            angular: 1e-12,
+            relative: 1e-4,
+        };
+        // Even at large scale, abs only uses linear
+        assert!(!tol.approx_eq_abs(1e6, 1e6 + 1.0));
+        assert!(tol.approx_eq_abs(1e6, 1e6 + 1e-8));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a `relative` field to the `Tolerance` struct for scale-aware float comparisons
- `approx_eq` now uses `|a - b| <= max(linear, relative * max(|a|, |b|))` — adapts to coordinate magnitude
- Adds `approx_eq_abs` for parameter-space comparisons where relative scaling is inappropriate
- Default `relative: 1e-10` is conservative — behaviorally equivalent to the old absolute-only comparison for coordinates under ~1000

This is Phase 1 of roadmap item #33 (tolerance model refactor). It lays the foundation without changing any call sites — all 971 existing tests pass unchanged.

## Test plan
- [x] All 9 tolerance unit tests pass (including 2 new: `approx_eq_scales_with_magnitude`, `approx_eq_abs_ignores_relative`)
- [x] Full workspace test suite: 971 tests pass, 0 failures
- [x] Clippy clean (`-D warnings`)