### PR TITLE
perf: speed up dev hooks from 10min to 14s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --workspace
+      - run: cargo nextest run --workspace --run-ignored all
       # nextest doesn't run doc tests, so run them separately
       - run: cargo test --workspace --doc
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Tiered pre-commit: fmt+clippy (parallel) → test
+# Pre-commit: fast checks only (fmt + clippy in parallel)
+# Full test suite runs in pre-push and CI.
 echo "🔍 Running pre-commit checks..."
 
-# Tier 1: Format and lint in parallel
 cargo fmt --all -- --check &
 FMT_PID=$!
 
@@ -25,11 +25,5 @@ if [ $CLIPPY_EXIT -ne 0 ]; then
   echo "❌ clippy failed. Fix warnings before committing."
   exit 1
 fi
-
-# Tier 2: Tests
-cargo test --workspace --quiet || {
-  echo "❌ Tests failed. Fix tests before committing."
-  exit 1
-}
 
 echo "✅ Pre-commit checks passed."

--- a/crates/math/src/nurbs/bezier_clip.rs
+++ b/crates/math/src/nurbs/bezier_clip.rs
@@ -918,6 +918,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "slow (~19s): collinear overlap detection is O(n²)"]
     fn overlapping_lines_detected() {
         // Two collinear lines that share the interval [0.5, 1.5] on x.
         // Line 1: (0,0,0) → (2,0,0)
@@ -940,6 +941,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "slow (~38s): identical-curve overlap detection is O(n²)"]
     fn identical_curves_full_overlap() {
         let c1 = make_line(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 0.0));
         let c2 = make_line(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 0.0));

--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -5157,6 +5157,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "slow (~300s): sphere fully containing box triggers expensive SSI"]
     fn cut_box_by_large_sphere_containment() {
         // Sphere (r=50) fully contains the box (10x10x10 at origin).
         // Cut should produce an empty result (error) or a very small volume.


### PR DESCRIPTION
## Summary
- Mark 3 slow tests as `#[ignore]` — they account for 364s of the 370s test suite wall time
- Remove `cargo test` from pre-commit hook — fmt + clippy is sufficient for commits
- CI runs `nextest --run-ignored all` to ensure ignored tests still run in CI

| Test | Time | Issue |
|------|------|-------|
| `cut_box_by_large_sphere_containment` | 307s | Expensive SSI for contained geometry |
| `identical_curves_full_overlap` | 38s | O(n²) overlap detection |
| `overlapping_lines_detected` | 19s | O(n²) collinear overlap |

**Before:** commit ~5min, push ~5min (10min total per commit+push cycle)
**After:** commit ~5s, push ~9s (14s total)

## Test plan
- [x] 968 tests pass, 4 ignored (3 new slow + 1 pre-existing)
- [x] Clippy clean
- [x] CI runs all tests including ignored via `--run-ignored all`