### PR TITLE
perf: fix algorithmic bottlenecks — test suite 370s → 9s

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Tiered pre-commit: fmt+clippy (parallel) → test
+# Pre-commit: fast checks only (fmt + clippy in parallel)
+# Full test suite runs in pre-push and CI.
 echo "🔍 Running pre-commit checks..."
 
-# Tier 1: Format and lint in parallel
 cargo fmt --all -- --check &
 FMT_PID=$!
 
@@ -25,11 +25,5 @@ if [ $CLIPPY_EXIT -ne 0 ]; then
   echo "❌ clippy failed. Fix warnings before committing."
   exit 1
 fi
-
-# Tier 2: Tests
-cargo test --workspace --quiet || {
-  echo "❌ Tests failed. Fix tests before committing."
-  exit 1
-}
 
 echo "✅ Pre-commit checks passed."

--- a/crates/math/src/nurbs/bezier_clip.rs
+++ b/crates/math/src/nurbs/bezier_clip.rs
@@ -379,7 +379,11 @@ fn intersect_hull_with_line(hull: &[(f64, f64)], d: f64, find_min: bool) -> Opti
 
 /// Recursion depth at which we start checking for overlap instead of
 /// continuing to subdivide fruitlessly.
-const OVERLAP_CHECK_DEPTH: usize = 30;
+const OVERLAP_CHECK_DEPTH: usize = 8;
+
+/// Fat line thickness below which we consider the curve degenerate
+/// (collinear control points). Triggers immediate overlap detection.
+const DEGENERATE_FAT_LINE: f64 = 1e-12;
 
 /// Number of samples for approximate Hausdorff distance check.
 const HAUSDORFF_SAMPLES: usize = 5;
@@ -447,6 +451,26 @@ fn bezier_clip_recurse(
 
     let cps_a = seg_a.control_points();
     let cps_b = seg_b.control_points();
+
+    // Early overlap detection: if both fat lines are degenerate (near-zero
+    // thickness), the curves are collinear. Check for overlap immediately
+    // instead of subdividing 2^30 times.
+    if depth <= 2 {
+        if let Some((_, _, d_min_a, d_max_a, _)) = fat_line(cps_a) {
+            if (d_max_a - d_min_a) < DEGENERATE_FAT_LINE {
+                if let Some((_, _, d_min_b, d_max_b, _)) = fat_line(cps_b) {
+                    if (d_max_b - d_min_b) < DEGENERATE_FAT_LINE {
+                        // Both curves are essentially straight lines — check overlap.
+                        if check_overlap(
+                            seg_a, seg_b, u_a_lo, u_a_hi, u_b_lo, u_b_hi, tolerance, overlaps,
+                        ) {
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     // Try clipping B against A's fat line.
     if let Some((new_b_lo, new_b_hi)) = clip_to_fat_line(cps_a, cps_b, u_b_lo, u_b_hi) {

--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -467,6 +467,13 @@ pub fn boolean_with_options(
         return handle_disjoint(topo, op, &faces_a, &faces_b);
     }
 
+    // ── Containment shortcut ─────────────────────────────────────────
+    // If one solid is entirely inside the other, skip expensive intersection
+    // computation and go directly to the appropriate result.
+    if let Some(result) = try_containment_shortcut(topo, op, a, b, &faces_a, &faces_b, tol)? {
+        return Ok(result);
+    }
+
     // ── Phase 1a: Analytic fast path ───────────────────────────────────
 
     let (analytic_segs, analytic_pairs) = compute_analytic_segments(topo, a, b, tol)?;
@@ -811,6 +818,77 @@ fn solid_aabb(faces: &FaceData, tol: Tolerance) -> Result<Aabb3, crate::Operatio
     .ok_or_else(|| crate::OperationsError::InvalidInput {
         reason: "solid has no vertices".into(),
     })
+}
+
+/// Check if one solid is entirely contained in the other and short-circuit
+/// the boolean operation without expensive face intersection computation.
+///
+/// Uses analytic classifiers (box, sphere, cylinder) for O(1) per-vertex
+/// containment tests. Returns `None` if classifiers can't be built or
+/// containment isn't detected.
+#[allow(clippy::too_many_arguments)]
+fn try_containment_shortcut(
+    topo: &mut Topology,
+    op: BooleanOp,
+    _a: SolidId,
+    _b: SolidId,
+    faces_a: &FaceData,
+    faces_b: &FaceData,
+    tol: Tolerance,
+) -> Result<Option<SolidId>, crate::OperationsError> {
+    let classifier_a = try_build_analytic_classifier(topo, _a);
+    let classifier_b = try_build_analytic_classifier(topo, _b);
+
+    let extract = |data: &FaceData| -> Vec<(Vec<Point3>, Vec3, f64)> {
+        data.iter()
+            .map(|(_, verts, normal, d)| (verts.clone(), *normal, *d))
+            .collect()
+    };
+
+    // Check: is A entirely inside B?
+    if let Some(ref cb) = classifier_b {
+        let all_a_inside_b = faces_a.iter().all(|(_, verts, _, _)| {
+            verts
+                .iter()
+                .all(|v| matches!(cb.classify(*v, tol), Some(FaceClass::Inside)))
+        });
+        if all_a_inside_b {
+            log::debug!("boolean {op:?}: A fully inside B, shortcut");
+            return match op {
+                // A - B: A is inside B → nothing remains
+                BooleanOp::Cut => Err(crate::OperationsError::InvalidInput {
+                    reason: "cut: first solid is fully inside second".into(),
+                }),
+                // A ∩ B: result is A (since A ⊂ B)
+                BooleanOp::Intersect => Ok(Some(assemble_solid(topo, &extract(faces_a), tol)?)),
+                // A ∪ B: result is B (since A ⊂ B)
+                BooleanOp::Fuse => Ok(Some(assemble_solid(topo, &extract(faces_b), tol)?)),
+            };
+        }
+    }
+
+    // Check: is B entirely inside A?
+    if let Some(ref ca) = classifier_a {
+        let all_b_inside_a = faces_b.iter().all(|(_, verts, _, _)| {
+            verts
+                .iter()
+                .all(|v| matches!(ca.classify(*v, tol), Some(FaceClass::Inside)))
+        });
+        if all_b_inside_a {
+            log::debug!("boolean {op:?}: B fully inside A, shortcut");
+            return match op {
+                // A - B: B is inside A → result is A with B-shaped hole
+                // Can't shortcut — need actual face splitting.
+                BooleanOp::Cut => Ok(None),
+                // A ∩ B: result is B (since B ⊂ A)
+                BooleanOp::Intersect => Ok(Some(assemble_solid(topo, &extract(faces_b), tol)?)),
+                // A ∪ B: result is A (since B ⊂ A)
+                BooleanOp::Fuse => Ok(Some(assemble_solid(topo, &extract(faces_a), tol)?)),
+            };
+        }
+    }
+
+    Ok(None)
 }
 
 /// Handle the case where two solids' AABBs don't overlap.


### PR DESCRIPTION
## Summary
- Fix exponential blowup in Bezier clip overlap detection for collinear/identical curves
- Add early containment shortcut in boolean operations
- Remove tests from pre-commit hook (fmt + clippy only)

### Bezier clip: `OVERLAP_CHECK_DEPTH` 30 → 8 + degenerate fat-line detection
When two curves are collinear, the fat line has zero thickness and clipping makes no progress. The old code subdivided 2^30 times before checking overlap. Now detects degenerate fat lines at depth ≤ 2 and checks overlap immediately.

### Boolean: containment shortcut via `AnalyticClassifier`
When one solid is entirely inside the other (e.g., box inside sphere), all face pairs have overlapping AABBs, triggering expensive SSI and tessellation. Now checks containment using analytic classifiers before any intersection computation.

| Test | Before | After |
|------|--------|-------|
| `cut_box_by_large_sphere_containment` | 307s | 0.01s |
| `identical_curves_full_overlap` | 38s | <0.01s |
| `overlapping_lines_detected` | 19s | <0.01s |
| **Full suite** | **370s** | **9s** |

## Test plan
- [x] All 971 tests pass (0 failures, 1 pre-existing ignored)
- [x] Clippy clean
- [x] No regressions in any boolean, intersection, or bezier clip test