### PR TITLE
chore: add CLA for dual licensing

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,61 @@
+# brepkit Contributor License Agreement
+
+Thank you for your interest in contributing to brepkit. This Contributor
+License Agreement ("Agreement") documents the rights granted by contributors
+to the brepkit project.
+
+By signing this Agreement, you accept and agree to the following terms and
+conditions for your present and future contributions submitted to brepkit.
+
+## 1. Definitions
+
+"You" means the individual copyright owner who submits a contribution.
+
+"Contribution" means any original work of authorship, including any
+modifications or additions to an existing work, that you intentionally submit
+to brepkit for inclusion in the project.
+
+"Submit" means any form of electronic, verbal, or written communication sent
+to the project, including but not limited to pull requests, issues, and
+comments on GitHub.
+
+## 2. Copyright Assignment
+
+You hereby assign to the brepkit project maintainer (Andy Mai) all right,
+title, and interest in and to the copyright of your contributions. This
+includes the right to license the contribution under any terms, including
+proprietary licenses.
+
+## 3. Patent License
+
+You hereby grant a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable patent license to make, have made, use, offer to
+sell, sell, import, and otherwise transfer your contributions, where such
+license applies only to those patent claims licensable by you that are
+necessarily infringed by your contribution alone or by combination of your
+contribution with the project.
+
+## 4. Representations
+
+You represent that:
+
+- Each contribution is your original creation.
+- You have the legal authority to enter into this agreement and assign
+  copyright.
+- Your contribution does not violate any third party's intellectual property
+  rights.
+- If your employer has rights to intellectual property that you create, you
+  have received permission to make contributions on behalf of that employer,
+  or your employer has waived such rights.
+
+## 5. No Obligation
+
+You understand that the decision to include your contribution in the project
+is entirely at the discretion of the project maintainer, and this agreement
+does not obligate the project to use your contribution.
+
+## 6. Agreement
+
+By commenting "I have read the CLA Document and I hereby sign the CLA" on a
+pull request, you agree to be bound by the terms of this Agreement for that
+contribution and all future contributions to brepkit.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,36 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+      || github.event_name == 'pull_request_target'
+    steps:
+      - uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: "signatures/cla.json"
+          path-to-document: "https://github.com/andymai/brepkit/blob/main/.github/CLA.md"
+          branch: "main"
+          allowlist: "dependabot[bot],renovate[bot]"
+          custom-notsigned-prcomment: >
+            Thank you for your contribution! Before we can merge this PR,
+            you need to sign the Contributor License Agreement.
+            To sign, please comment on this PR with exactly:
+            I have read the CLA Document and I hereby sign the CLA
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to brepkit
 
+## Contributor License Agreement
+
+All contributors must sign our [CLA](.github/CLA.md) before their first PR
+can be merged. When you open a PR, a bot will prompt you to sign by posting
+a comment. This is a one-time requirement.
+
 ## Getting Started
 
 1. Fork and clone the repository


### PR DESCRIPTION
## Summary
- Add `.github/CLA.md` with copyright assignment terms
- Add `.github/workflows/cla.yml` using [CLA Assistant](https://github.com/contributor-assistant/github-action) v2.6.1
- Update `CONTRIBUTING.md` with CLA requirement notice
- Bot auto-comments on first-time contributor PRs, stores signatures in `signatures/cla.json`
- Allowlisted: dependabot[bot], renovate[bot]

## Setup required after merge
- [ ] Create a GitHub Personal Access Token and add it as repo secret `CLA_TOKEN` (needed for the CLA bot to write signature commits)

## Test plan
- [ ] Open a test PR from a non-owner account to verify CLA bot comments
- [ ] Sign the CLA and verify the bot marks the check as passed