### PR TITLE
fix: cone nappe, non-manifold edges, and cylinder test geometry

### DIFF
--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -169,7 +169,11 @@ fn exact_plane_cone(
         let n_dot_apex = dot_np(normal, cone.apex());
         let t = (d - n_dot_apex) / n_dot_axis;
 
-        if t < 1e-10 {
+        // t is the signed distance from apex to plane along the axis.
+        // The cone surface can extend in either direction from the apex
+        // (positive or negative v), so use |t| for the radius.
+        // |t| ≈ 0 means the plane passes through the apex → degenerate point.
+        if t.abs() < 1e-10 {
             return Ok(vec![]);
         }
 
@@ -178,7 +182,7 @@ fn exact_plane_cone(
             cone.apex().y() + t * axis.y(),
             cone.apex().z() + t * axis.z(),
         );
-        let circle_r = t * half_angle.tan();
+        let circle_r = t.abs() * half_angle.tan();
         if circle_r < 1e-15 {
             return Ok(vec![]);
         }
@@ -535,7 +539,8 @@ pub fn intersect_plane_cone(
         }
 
         let v = (d - n_dot_apex) / n_dot_dir;
-        if v > 0.0 && v < 100.0 {
+        // Allow negative v — the cone surface extends in both directions from the apex.
+        if v.abs() > 1e-10 && v.abs() < 100.0 {
             let pt = cone.evaluate(u, v);
             points_3d.push(pt);
             ipoints.push(IntersectionPoint {

--- a/crates/operations/src/primitives.rs
+++ b/crates/operations/src/primitives.rs
@@ -145,9 +145,9 @@ pub fn make_box(
 
 // ── Cylinder ───────────────────────────────────────────────────────
 
-/// Create a cylinder solid centered at the origin, with its axis along +Z.
+/// Create a cylinder solid with its axis along +Z, base at the origin.
 ///
-/// The cylinder extends from `z = -height/2` to `z = height/2`.
+/// The cylinder extends from `z = 0` to `z = height` (OCCT convention).
 /// Built with one `CylindricalSurface` lateral face and two planar cap faces.
 ///
 /// # Errors

--- a/crates/operations/tests/boolean_stress.rs
+++ b/crates/operations/tests/boolean_stress.rs
@@ -842,16 +842,15 @@ fn volume_large_boxes() {
 // ===========================================================================
 
 #[test]
-#[ignore = "known deep boolean algorithm issue — tracked separately"]
 fn cut_cylinder_from_box_volume() {
-    // Box 4×4×4 at origin (z=0..4), cylinder r=1, h=6 centered at origin
-    // (z=-3..3), translated to (2,2,2) → z=-1..5, fully through box.
+    // Box 4×4×4 at origin (z=0..4), cylinder r=1, h=6 at z=0..6
+    // (make_cylinder places base at z=0), translated to (2,2,-1) → z=-1..5.
     // Overlap height = 4 (clamped to box z=0..4).
     // Expected: box_vol - π·r²·h = 64 - π·1²·4 ≈ 64 - 12.566 ≈ 51.434
     let mut topo = Topology::new();
     let base = box_at(&mut topo, 0.0, 0.0, 0.0, 4.0, 4.0, 4.0);
     let cyl = make_cylinder(&mut topo, 1.0, 6.0).unwrap();
-    transform_solid(&mut topo, cyl, &Mat4::translation(2.0, 2.0, 2.0)).unwrap();
+    transform_solid(&mut topo, cyl, &Mat4::translation(2.0, 2.0, -1.0)).unwrap();
 
     let result = boolean(&mut topo, BooleanOp::Cut, base, cyl).unwrap();
     check_manifold(&topo, result);


### PR DESCRIPTION
## Summary

### Cone nappe direction fix
- Fix `exact_plane_cone` to handle cones extending in negative axis direction from apex (use `|t|` instead of rejecting negative `t`)
- Fix `intersect_plane_cone` to allow negative `v` parameters

### Non-manifold edge splitting
- Add `split_nonmanifold_edges()` post-assembly pass that detects edges shared by >2 faces and duplicates them
- Faces are sorted by angular ordering around the edge direction, then paired consecutively
- Each pair gets its own edge copy, restoring manifold topology
- Fixes L-shaped junctions where two solids share an edge or vertex exactly

### Test geometry fix
- Fix `cut_cylinder_from_box_volume`: `make_cylinder` places base at z=0 (not centered), so `translation(2,2,2)` placed the cylinder at z=2..8 with only 2 units of overlap instead of intended 4
- Fix `make_cylinder` doc comment: said "z=-h/2 to z=h/2" but actual behavior is z=0 to z=height

### Un-ignored tests (4 total)
- `cut_cylinder_from_box_volume` — test geometry was wrong, not algorithm
- `test_boolean_shared_edge` — two boxes sharing an edge
- `test_boolean_near_tangent` — boxes with near-tangent intersection  
- `test_boolean_at_mm_scale` — boolean at 0.1-unit scale

Ignored tests: 12 → 8

## Test plan
- [x] `cargo test --workspace` — 1100 tests pass (was 1097)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — formatted