### PR TITLE
fix: sphere-cylinder intersection and tangent-touch classification

### DIFF
--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -755,14 +755,36 @@ pub fn intersect_analytic_analytic(
     b: AnalyticSurface<'_>,
     grid_res: usize,
 ) -> Result<Vec<IntersectionCurve>, MathError> {
+    intersect_analytic_analytic_bounded(a, b, grid_res, None, None)
+}
+
+/// Intersect two analytic surfaces with optional v-range overrides.
+///
+/// When `v_range_hint_a` or `v_range_hint_b` is `Some((min, max))`, the
+/// marching algorithm searches that v-range instead of the hardcoded default.
+/// This is essential for cylinders and cones whose default v-range is small
+/// (-1..1 or 0.01..2) but whose actual face may extend much further.
+///
+/// # Errors
+///
+/// Returns `MathError` if algebraic intersection fails or marching diverges.
+pub fn intersect_analytic_analytic_bounded(
+    a: AnalyticSurface<'_>,
+    b: AnalyticSurface<'_>,
+    grid_res: usize,
+    v_range_hint_a: Option<(f64, f64)>,
+    v_range_hint_b: Option<(f64, f64)>,
+) -> Result<Vec<IntersectionCurve>, MathError> {
     // Try algebraic specialization for known surface pairs before falling
     // back to the general marching approach.
     if let Some(result) = try_algebraic_intersection(&a, &b)? {
         return Ok(result);
     }
 
-    let (surf_a, norm_a, u_range_a, v_range_a) = surface_closures(&a);
-    let (surf_b, norm_b, u_range_b, v_range_b) = surface_closures(&b);
+    let (surf_a, norm_a, u_range_a, default_v_a) = surface_closures(&a);
+    let (surf_b, norm_b, u_range_b, default_v_b) = surface_closures(&b);
+    let v_range_a = v_range_hint_a.unwrap_or(default_v_a);
+    let v_range_b = v_range_hint_b.unwrap_or(default_v_b);
 
     // Compute characteristic surface dimensions for adaptive parameters.
     let diag_a = {
@@ -780,6 +802,7 @@ pub fn intersect_analytic_analytic(
     // Sample surface A on a grid. For each grid point, project it
     // analytically onto surface B to find the closest point, then check
     // if the distance is below threshold (indicating near-intersection).
+    #[allow(clippy::type_complexity)]
     let mut seeds: Vec<(Point3, (f64, f64), (f64, f64))> = Vec::new();
     // Coarse threshold scales with the surface size — the distance from
     // a grid point on A to its projection on B can be large even near
@@ -931,8 +954,127 @@ fn try_algebraic_intersection(
             }
             Ok(None) // Non-coaxial: fall through to marching
         }
+        // Sphere-cylinder (both orderings).
+        (AnalyticSurface::Sphere(s), AnalyticSurface::Cylinder(c))
+        | (AnalyticSurface::Cylinder(c), AnalyticSurface::Sphere(s)) => {
+            algebraic_sphere_cylinder(s, c)
+        }
         _ => Ok(None),
     }
+}
+
+/// Algebraic sphere-cylinder intersection.
+///
+/// For a sphere of radius R centered at C and a cylinder of radius r with
+/// axis through O in direction A, the intersection is found by:
+///
+/// 1. Project the sphere center onto the cylinder axis.
+/// 2. Compute the perpendicular distance `d_perp` from center to axis.
+/// 3. If `d_perp + r > R` or `d_perp + R < r`: no intersection.
+/// 4. Otherwise, the intersection lies at axial positions where
+///    `sqrt(R² - z²) = r` for the coaxial case (d_perp = 0), giving
+///    two circles at `z = ±sqrt(R² - r²)`.
+/// 5. For the general case, solve a quartic for the axial position.
+///    Currently only handles the coaxial case analytically.
+fn algebraic_sphere_cylinder(
+    sphere: &SphericalSurface,
+    cyl: &CylindricalSurface,
+) -> Result<Option<Vec<IntersectionCurve>>, MathError> {
+    let sc = sphere.center();
+    let r_sphere = sphere.radius();
+    let co = cyl.origin();
+    let axis = cyl.axis();
+    let r_cyl = cyl.radius();
+
+    // Project sphere center onto the cylinder axis.
+    let delta = sc - co;
+    let delta_vec = Vec3::new(delta.x(), delta.y(), delta.z());
+    let along = delta_vec.dot(axis);
+    let perp_vec = delta_vec - axis * along;
+    let d_perp = perp_vec.length();
+
+    // Separation check.
+    if d_perp > r_sphere + r_cyl + 1e-10 {
+        return Ok(Some(vec![])); // Too far apart
+    }
+
+    // Currently only handle the coaxial/near-coaxial case.
+    // Non-coaxial sphere-cylinder intersections produce quartic curves;
+    // fall back to the general marching approach for those.
+    if d_perp > 1e-8 {
+        return Ok(None); // Fall through to marching
+    }
+
+    // Coaxial case: sphere center is on the cylinder axis.
+    // The intersection is at z = ±sqrt(R² - r²) relative to sphere center.
+    if r_cyl > r_sphere + 1e-10 {
+        return Ok(Some(vec![])); // Cylinder larger than sphere
+    }
+
+    let z_sq = r_sphere * r_sphere - r_cyl * r_cyl;
+    if z_sq < 0.0 {
+        return Ok(Some(vec![])); // No real intersection
+    }
+
+    let z = z_sq.sqrt();
+
+    // The intersection circles are centered on the axis at height ±z
+    // from the sphere center, with radius = r_cyl.
+    let center_axis_pt = Point3::new(
+        co.x() + axis.x() * along,
+        co.y() + axis.y() * along,
+        co.z() + axis.z() * along,
+    );
+
+    let mut curves = Vec::new();
+
+    // Build reference frame perpendicular to axis.
+    let ref_vec = if axis.x().abs() < 0.9 {
+        Vec3::new(1.0, 0.0, 0.0)
+    } else {
+        Vec3::new(0.0, 1.0, 0.0)
+    };
+    let u_dir = axis.cross(ref_vec).normalize()?;
+    let v_dir = axis.cross(u_dir);
+
+    for &z_offset in &[z, -z] {
+        let center = Point3::new(
+            center_axis_pt.x() + axis.x() * z_offset,
+            center_axis_pt.y() + axis.y() * z_offset,
+            center_axis_pt.z() + axis.z() * z_offset,
+        );
+
+        let n_samples = 33;
+        let mut points = Vec::with_capacity(n_samples);
+        let mut positions = Vec::with_capacity(n_samples);
+        #[allow(clippy::cast_precision_loss)]
+        for i in 0..n_samples {
+            let theta = TAU * i as f64 / (n_samples - 1) as f64;
+            let (sin_t, cos_t) = theta.sin_cos();
+            let pt = Point3::new(
+                center.x() + (u_dir.x() * cos_t + v_dir.x() * sin_t) * r_cyl,
+                center.y() + (u_dir.y() * cos_t + v_dir.y() * sin_t) * r_cyl,
+                center.z() + (u_dir.z() * cos_t + v_dir.z() * sin_t) * r_cyl,
+            );
+            positions.push(pt);
+            points.push(IntersectionPoint {
+                point: pt,
+                param1: (0.0, 0.0),
+                param2: (0.0, 0.0),
+            });
+        }
+
+        let degree = 3.min(positions.len() - 1);
+        let curve = interpolate(&positions, degree)?;
+        curves.push(IntersectionCurve { curve, points });
+    }
+
+    // If z is effectively 0, the two circles coincide (tangent case).
+    if z < 1e-10 {
+        curves.pop(); // Remove duplicate
+    }
+
+    Ok(Some(curves))
 }
 
 /// Algebraic sphere-sphere intersection.

--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -122,6 +122,51 @@ fn analytic_face_normal_d(surface: &FaceSurface, verts: &[Point3]) -> (Vec3, f64
     }
 }
 
+/// Compute the v-range hint for an analytic surface based on face vertices.
+///
+/// Returns `Some((v_min, v_max))` if the surface has a non-trivial v
+/// parameterization that depends on the face extent (cylinder, cone).
+/// Returns `None` for surfaces where the default v_range is correct
+/// (sphere, torus).
+fn compute_v_range_hint(surface: &FaceSurface, verts: &[Point3]) -> Option<(f64, f64)> {
+    match surface {
+        FaceSurface::Cylinder(cyl) => {
+            // v = axial distance from origin. Compute from face vertices
+            // with padding to ensure intersections near the boundary are found.
+            cylinder_v_extent(cyl, verts).map(|(lo, hi)| {
+                let pad = (hi - lo) * 0.1;
+                (lo - pad, hi + pad)
+            })
+        }
+        FaceSurface::Cone(cone) => {
+            // v = distance from apex along the axis-radial direction.
+            // Compute from face vertices.
+            let axis = cone.axis();
+            let apex = cone.apex();
+            let half = cone.half_angle();
+            let (sin_a, cos_a) = half.sin_cos();
+            let mut v_min = f64::MAX;
+            let mut v_max = f64::MIN;
+            for &p in verts {
+                let d = p - apex;
+                let axial = d.dot(axis);
+                let radial_sq = d.dot(d) - axial * axial;
+                // v = sqrt(axial^2 + radial_sq) with correct sign
+                let v = axial * sin_a + radial_sq.sqrt() * cos_a;
+                v_min = v_min.min(v);
+                v_max = v_max.max(v);
+            }
+            if (v_max - v_min).abs() < 1e-10 {
+                None
+            } else {
+                let pad = (v_max - v_min) * 0.1;
+                Some(((v_min - pad).max(0.001), v_max + pad))
+            }
+        }
+        _ => None, // Sphere and torus have fixed parametric ranges
+    }
+}
+
 /// Compute the axial extent (v-range) of points projected onto a cylinder axis.
 ///
 /// Returns `None` if the extent is degenerate (< 1e-10).
@@ -1961,7 +2006,66 @@ fn classify_fragment(
     tol: Tolerance,
 ) -> FaceClass {
     let centroid = polygon_centroid(&frag.vertices);
-    classify_point(centroid, frag.normal, opposite, bvh, tol)
+    let class = classify_point(centroid, frag.normal, opposite, bvh, tol);
+    guard_tangent_coplanar(class, &frag.vertices, frag.normal, opposite, bvh, tol)
+}
+
+/// Guard against false coplanar classifications at tangent touch points.
+///
+/// When a face touches a curved surface tangentially, the centroid may lie
+/// exactly on the opposing surface with aligned normals, causing a false
+/// Coplanar classification. This function verifies coplanar results by
+/// checking whether most fragment vertices are also on the opposing face
+/// planes. If fewer than half are, it's a tangent touch — re-classify via
+/// ray-casting from a vertex that's clearly off the opposing surface.
+fn guard_tangent_coplanar(
+    class: FaceClass,
+    vertices: &[Point3],
+    normal: Vec3,
+    opposite: &FaceData,
+    bvh: Option<&Bvh>,
+    tol: Tolerance,
+) -> FaceClass {
+    if !matches!(class, FaceClass::CoplanarSame | FaceClass::CoplanarOpposite) || vertices.len() < 3
+    {
+        return class;
+    }
+
+    // Check how many vertices are on the same plane as any opposing face.
+    // Use plane distance only (not polygon containment) to avoid false
+    // negatives from vertices on polygon edges.
+    let mut on_plane_count = 0usize;
+    for v in vertices {
+        let on_any_plane = opposite.iter().any(|(_, _verts, n_opp, d_opp)| {
+            let dist = dot_normal_point(*n_opp, *v) - d_opp;
+            dist.abs() < tol.linear * 10.0
+        });
+        if on_any_plane {
+            on_plane_count += 1;
+        }
+    }
+
+    // If most vertices are on an opposing face plane, this is likely a true
+    // coplanar situation — keep the original classification. Only override
+    // when very few vertices (at most 1) are on any opposing plane, which
+    // indicates a tangent touch at a point or line.
+    if on_plane_count <= 1 {
+        // Find a vertex that's NOT on any opposing face for reliable ray-cast.
+        for v in vertices {
+            let on_any = opposite.iter().any(|(_, _verts, n_opp, d_opp)| {
+                let dist = dot_normal_point(*n_opp, *v) - d_opp;
+                dist.abs() < tol.linear * 10.0
+            });
+            if !on_any {
+                return classify_point(*v, normal, opposite, bvh, tol);
+            }
+        }
+        // All vertices near some opposing plane — use centroid ray-cast.
+        let centroid = polygon_centroid(vertices);
+        return classify_point_raycast(centroid, normal, opposite, bvh, tol);
+    }
+
+    class
 }
 
 /// Classify a point (centroid with a ray direction) relative to an opposite solid.
@@ -2089,6 +2193,81 @@ fn classify_point(
     }
 
     // Majority vote: inside if 2+ of 3 rays say inside.
+    if inside_votes >= 2 {
+        FaceClass::Inside
+    } else {
+        FaceClass::Outside
+    }
+}
+
+/// Ray-cast only classification — skips the coplanar check.
+///
+/// Used when the coplanar check has been determined unreliable (e.g. tangent
+/// touch) and we need a direct Inside/Outside answer via ray-casting.
+fn classify_point_raycast(
+    point: Point3,
+    normal: Vec3,
+    opposite: &FaceData,
+    bvh: Option<&Bvh>,
+    tol: Tolerance,
+) -> FaceClass {
+    let ray_dirs = {
+        let perp = if normal.x().abs() < 0.9 {
+            Vec3::new(1.0, 0.0, 0.0)
+        } else {
+            Vec3::new(0.0, 1.0, 0.0)
+        };
+        let cross_vec = normal.cross(perp);
+        let axis_len = cross_vec.length();
+        if axis_len < 1e-12 {
+            [normal, normal, normal]
+        } else {
+            let inv = 1.0 / axis_len;
+            let axis = Vec3::new(
+                cross_vec.x() * inv,
+                cross_vec.y() * inv,
+                cross_vec.z() * inv,
+            );
+            let rodrigues = |cos_a: f64, sin_a: f64| -> Vec3 {
+                let dot = axis.dot(normal);
+                let cross = axis.cross(normal);
+                Vec3::new(
+                    normal.x().mul_add(
+                        cos_a,
+                        cross.x().mul_add(sin_a, axis.x() * dot * (1.0 - cos_a)),
+                    ),
+                    normal.y().mul_add(
+                        cos_a,
+                        cross.y().mul_add(sin_a, axis.y() * dot * (1.0 - cos_a)),
+                    ),
+                    normal.z().mul_add(
+                        cos_a,
+                        cross.z().mul_add(sin_a, axis.z() * dot * (1.0 - cos_a)),
+                    ),
+                )
+            };
+            [normal, rodrigues(0.574, 0.819), rodrigues(0.574, -0.819)]
+        }
+    };
+
+    let mut inside_votes = 0u8;
+    for ray_dir in &ray_dirs {
+        let mut crossings = 0i32;
+        if let Some(bvh) = bvh {
+            for idx in bvh.query_ray(point, *ray_dir) {
+                let (_, ref verts, n_opp, d_opp) = opposite[idx];
+                crossings += ray_face_crossing(point, *ray_dir, verts, n_opp, d_opp, tol);
+            }
+        } else {
+            for &(_, ref verts, n_opp, d_opp) in opposite {
+                crossings += ray_face_crossing(point, *ray_dir, verts, n_opp, d_opp, tol);
+            }
+        }
+        if crossings != 0 {
+            inside_votes += 1;
+        }
+    }
+
     if inside_votes >= 2 {
         FaceClass::Inside
     } else {
@@ -3311,7 +3490,7 @@ fn analytic_boolean(
     deflection: f64,
 ) -> Result<SolidId, crate::OperationsError> {
     use brepkit_math::analytic_intersection::{
-        ExactIntersectionCurve, exact_plane_analytic, intersect_analytic_analytic,
+        ExactIntersectionCurve, exact_plane_analytic, intersect_analytic_analytic_bounded,
     };
 
     // Collect face info for both solids.
@@ -3559,7 +3738,11 @@ fn analytic_boolean(
                 let surf_b_opt = face_surface_to_analytic(&snap_b.surface);
 
                 if let (Some(surf_a_an), Some(surf_b_an)) = (surf_a_opt, surf_b_opt) {
-                    if let Ok(curves) = intersect_analytic_analytic(surf_a_an, surf_b_an, 32) {
+                    let v_hint_a = compute_v_range_hint(&snap_a.surface, &snap_a.vertices);
+                    let v_hint_b = compute_v_range_hint(&snap_b.surface, &snap_b.vertices);
+                    if let Ok(curves) = intersect_analytic_analytic_bounded(
+                        surf_a_an, surf_b_an, 32, v_hint_a, v_hint_b,
+                    ) {
                         for ic in &curves {
                             let pts: Vec<Point3> = ic.points.iter().map(|ip| ip.point).collect();
 
@@ -4024,14 +4207,41 @@ fn analytic_boolean(
             if let Some(&class) = pre_classifications.get(&idx) {
                 return Some(class);
             }
+            let classifier = match frag.source {
+                Source::A => analytic_cls_b.as_ref(),
+                Source::B => analytic_cls_a.as_ref(),
+            };
+            let classifier = match classifier {
+                Some(c) => c,
+                None => return None,
+            };
             let centroid = polygon_centroid(&frag.vertices);
-            match frag.source {
-                Source::A => analytic_cls_b
-                    .as_ref()
-                    .and_then(|c| c.classify(centroid, tol)),
-                Source::B => analytic_cls_a
-                    .as_ref()
-                    .and_then(|c| c.classify(centroid, tol)),
+            if let Some(class) = classifier.classify(centroid, tol) {
+                return Some(class);
+            }
+            // Centroid is on the boundary of a curved solid (sphere/cylinder/
+            // cone). Phase 2 ray-casting from a point ON a curved surface is
+            // unreliable (ray may graze the surface), so resolve using vertex
+            // majority voting. For box classifiers, defer to Phase 2 — ray-
+            // casting from a point on a flat face is reliable.
+            if matches!(classifier, AnalyticClassifier::Box { .. }) {
+                return None;
+            }
+            let mut inside = 0u32;
+            let mut outside = 0u32;
+            for v in &frag.vertices {
+                match classifier.classify(*v, tol) {
+                    Some(FaceClass::Inside) => inside += 1,
+                    Some(FaceClass::Outside) => outside += 1,
+                    _ => {}
+                }
+            }
+            if outside > inside && outside > 0 {
+                Some(FaceClass::Outside)
+            } else if inside > outside && inside > 0 {
+                Some(FaceClass::Inside)
+            } else {
+                None // Truly ambiguous — defer to Phase 2
             }
         })
         .collect();
@@ -4054,7 +4264,17 @@ fn analytic_boolean(
                 Source::B => (&face_data_a, bvh_a.as_ref()),
             };
             let centroid = polygon_centroid(&frag.vertices);
-            *class = Some(classify_point(centroid, frag.normal, opposite, bvh, tol));
+            let raw = classify_point(centroid, frag.normal, opposite, bvh, tol);
+            // Apply tangent guard: verify coplanar classifications
+            // using fragment vertices to catch tangent-touch false positives.
+            *class = Some(guard_tangent_coplanar(
+                raw,
+                &frag.vertices,
+                frag.normal,
+                opposite,
+                bvh,
+                tol,
+            ));
         }
     }
 

--- a/crates/operations/tests/boolean_edge_cases.rs
+++ b/crates/operations/tests/boolean_edge_cases.rs
@@ -138,7 +138,6 @@ fn test_kissing_boxes_cut() {
 }
 
 #[test]
-#[ignore = "bug: tangent cylinder-box fuse produces incorrect volume"]
 fn test_kissing_cylinder_box() {
     // Cylinder radius 1, height 2. Box with left face tangent at x=1.
     let mut topo = Topology::new();
@@ -317,7 +316,6 @@ fn test_alternating_union_cut() {
 // ── Mixed surfaces ──────────────────────────────────────────────────
 
 #[test]
-#[ignore = "bug: sphere-cylinder cut produces degenerate result (1 face)"]
 fn test_boolean_sphere_cylinder() {
     // Sphere radius 2. Cylinder radius 0.5, height 6 through center.
     let mut topo = Topology::new();


### PR DESCRIPTION
## Summary

- **Sphere-cylinder boolean**: Add algebraic sphere-cylinder intersection for coaxial case (two circles at z = ±√(R²-r²)). Previously, SSI marching failed because the hardcoded v_range (-1..1) was too small for the actual face extent. Now uses `intersect_analytic_analytic_bounded()` with v_range hints computed from face vertex positions.

- **Tangent cylinder-box fuse**: When a face centroid lies exactly on a curved opposing surface (tangent touch), the analytic classifier returns `None` (boundary) and Phase 2 ray-casting from that on-surface point gives unreliable Inside/Outside results. Fix: vertex majority voting for curved-surface classifiers when centroid is on boundary. Also adds a tangent-coplanar guard that verifies Coplanar classifications by checking whether fragment vertices lie on opposing face planes — if very few do, it's a tangent touch (not true coplanarity) and falls through to ray-casting from a reliable off-surface point.

Un-ignores `test_boolean_sphere_cylinder` and `test_kissing_cylinder_box` (2 of 3 ignored boolean tests). The remaining `test_boolean_cone_cylinder` has a deeper classification issue with many fragments.

## Test plan

- [x] `cargo test --workspace` — all 1105 tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `test_boolean_sphere_cylinder` — passes (was ignored)
- [x] `test_kissing_cylinder_box` — passes (was ignored)
- [x] `fuse_overlapping_cubes` — still passes (regression guard)
- [x] `test_tessellate_boolean_result_watertight` — still passes
- [x] `boolean_fuse_result_validates` — still passes