### PR TITLE
fix: store CLA signatures on unprotected branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/andymai/brepkit/blob/main/.github/CLA.md"
-          branch: "main"
+          branch: "cla-signatures"
           allowlist: "dependabot[bot],renovate[bot]"
           custom-notsigned-prcomment: >
             Thank you for your contribution! Before we can merge this PR,


### PR DESCRIPTION
## Summary
- CLA bot cannot commit `signatures/cla.json` to `main` because branch protection requires PRs and the "CI Pass" status check
- Created `cla-signatures` orphan branch (unprotected) for storing signatures
- Changed `branch: "main"` → `branch: "cla-signatures"` in the CLA workflow

## Test plan
- [x] `cla-signatures` branch created and pushed
- [ ] After merge, trigger CLA recheck on PR #147 to verify signatures can be written