### PR TITLE
feat: add checkpoint/restore for topology snapshots

### DIFF
--- a/crates/operations/src/assembly.rs
+++ b/crates/operations/src/assembly.rs
@@ -42,7 +42,7 @@ pub struct Component {
 /// - Instance sharing (same solid, different transforms)
 /// - Bounding box computation for the entire assembly
 /// - Flattening to a list of positioned solids
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Assembly {
     /// All components, indexed by their ID.
     components: HashMap<ComponentId, Component>,

--- a/crates/operations/src/sketch.rs
+++ b/crates/operations/src/sketch.rs
@@ -902,4 +902,66 @@ mod tests {
             sketch.points[p].x
         );
     }
+
+    #[test]
+    fn rectangle_30x20() {
+        // Build a 30x20 rectangle from 4 points with distance, horizontal,
+        // and vertical constraints. Pin one corner to the origin.
+        let mut sketch = Sketch::new();
+
+        // Four corners — start with rough initial guesses
+        let p0 = sketch.add_point(SketchPoint::new(0.0, 0.0)); // bottom-left
+        let p1 = sketch.add_point(SketchPoint::new(25.0, 1.0)); // bottom-right
+        let p2 = sketch.add_point(SketchPoint::new(26.0, 18.0)); // top-right
+        let p3 = sketch.add_point(SketchPoint::new(1.0, 17.0)); // top-left
+
+        // Pin p0 at origin
+        sketch.add_constraint(Constraint::FixX(p0, 0.0));
+        sketch.add_constraint(Constraint::FixY(p0, 0.0));
+
+        // Bottom edge: p0-p1 horizontal, length 30
+        sketch.add_constraint(Constraint::Horizontal(p0, p1));
+        sketch.add_constraint(Constraint::Distance(p0, p1, 30.0));
+
+        // Right edge: p1-p2 vertical, length 20
+        sketch.add_constraint(Constraint::Vertical(p1, p2));
+        sketch.add_constraint(Constraint::Distance(p1, p2, 20.0));
+
+        // Top edge: p2-p3 horizontal, length 30
+        sketch.add_constraint(Constraint::Horizontal(p2, p3));
+        sketch.add_constraint(Constraint::Distance(p2, p3, 30.0));
+
+        // Left edge: p3-p0 vertical, length 20
+        sketch.add_constraint(Constraint::Vertical(p3, p0));
+        sketch.add_constraint(Constraint::Distance(p3, p0, 20.0));
+
+        let result = sketch.solve(200, TOL).unwrap();
+        assert!(result.converged, "rectangle should converge");
+
+        // Verify corner positions
+        let eps = 1e-4;
+        assert!((sketch.points[p0].x).abs() < eps, "p0.x = 0");
+        assert!((sketch.points[p0].y).abs() < eps, "p0.y = 0");
+        assert!((sketch.points[p1].x - 30.0).abs() < eps, "p1.x = 30");
+        assert!((sketch.points[p1].y).abs() < eps, "p1.y = 0");
+        assert!((sketch.points[p2].x - 30.0).abs() < eps, "p2.x = 30");
+        assert!((sketch.points[p2].y - 20.0).abs() < eps, "p2.y = 20");
+        assert!((sketch.points[p3].x).abs() < eps, "p3.x = 0");
+        assert!((sketch.points[p3].y - 20.0).abs() < eps, "p3.y = 20");
+
+        // Verify edge lengths via Euclidean distance
+        let d01 = (sketch.points[p1].x - sketch.points[p0].x)
+            .hypot(sketch.points[p1].y - sketch.points[p0].y);
+        let d12 = (sketch.points[p2].x - sketch.points[p1].x)
+            .hypot(sketch.points[p2].y - sketch.points[p1].y);
+        let d23 = (sketch.points[p3].x - sketch.points[p2].x)
+            .hypot(sketch.points[p3].y - sketch.points[p2].y);
+        let d30 = (sketch.points[p0].x - sketch.points[p3].x)
+            .hypot(sketch.points[p0].y - sketch.points[p3].y);
+
+        assert!((d01 - 30.0).abs() < eps, "bottom edge = 30, got {d01}");
+        assert!((d12 - 20.0).abs() < eps, "right edge = 20, got {d12}");
+        assert!((d23 - 30.0).abs() < eps, "top edge = 30, got {d23}");
+        assert!((d30 - 20.0).abs() < eps, "left edge = 20, got {d30}");
+    }
 }

--- a/crates/operations/tests/examples.rs
+++ b/crates/operations/tests/examples.rs
@@ -388,3 +388,45 @@ fn example_custom_profile_extrusion() {
         "mesh should have multiple triangles"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// Example 8: Checkpoint and Restore
+// ═══════════════════════════════════════════════════════════════════
+
+/// Snapshot topology before a boolean, then restore after a failed attempt.
+#[test]
+fn example_checkpoint_restore() {
+    let mut topo = Topology::new();
+
+    // Create a box
+    let box_id = brepkit_operations::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let box_vol = brepkit_operations::measure::solid_volume(&topo, box_id, 0.1).unwrap();
+    assert!((box_vol - 1000.0).abs() < 1.0);
+
+    // Take a checkpoint (clone the topology)
+    let snapshot = topo.clone();
+    let snapshot_vertex_count = snapshot.vertices.len();
+
+    // Perform a boolean that adds many entities
+    let cyl_id = brepkit_operations::primitives::make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+    let transform = Mat4::translation(5.0, 5.0, -5.0);
+    brepkit_operations::transform::transform_solid(&mut topo, cyl_id, &transform).unwrap();
+    let _result = brepkit_operations::boolean::boolean(
+        &mut topo,
+        brepkit_operations::boolean::BooleanOp::Cut,
+        box_id,
+        cyl_id,
+    )
+    .unwrap();
+
+    // Arena has grown significantly
+    assert!(topo.vertices.len() > snapshot_vertex_count + 10);
+
+    // Restore from snapshot — arena shrinks back
+    topo = snapshot;
+    assert_eq!(topo.vertices.len(), snapshot_vertex_count);
+
+    // Original box is still valid and unchanged
+    let restored_vol = brepkit_operations::measure::solid_volume(&topo, box_id, 0.1).unwrap();
+    assert!((restored_vol - 1000.0).abs() < 1.0);
+}

--- a/crates/topology/src/arena.rs
+++ b/crates/topology/src/arena.rs
@@ -56,7 +56,7 @@ impl<T> Id<T> {
 ///
 /// Stores values of type `T` in a contiguous `Vec` and hands out
 /// [`Id<T>`] handles for O(1) lookup.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Arena<T> {
     items: Vec<T>,
 }

--- a/crates/topology/src/topology.rs
+++ b/crates/topology/src/topology.rs
@@ -20,7 +20,7 @@ use crate::wire::{Wire, WireId};
 /// Fields are `pub` because every operation needs direct arena access for
 /// allocation and lookup; wrapping in getters would be pure boilerplate
 /// with no invariant to protect.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Topology {
     /// All vertices in the model.
     pub vertices: Arena<Vertex>,
@@ -139,6 +139,46 @@ mod tests {
             .vertices
             .alloc(Vertex::new(Point3::new(1.0, 2.0, 3.0), 1e-7));
 
+        let v = topo.vertex(vid).unwrap();
+        assert!((v.point().x() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn clone_preserves_entities() {
+        let mut topo = Topology::new();
+        let vid = topo
+            .vertices
+            .alloc(Vertex::new(Point3::new(1.0, 2.0, 3.0), 1e-7));
+
+        let snapshot = topo.clone();
+
+        // Add more entities after the snapshot
+        topo.vertices
+            .alloc(Vertex::new(Point3::new(4.0, 5.0, 6.0), 1e-7));
+        assert_eq!(topo.vertices.len(), 2);
+
+        // Snapshot still has exactly 1 vertex
+        assert_eq!(snapshot.vertices.len(), 1);
+        let v = snapshot.vertex(vid).unwrap();
+        assert!((v.point().x() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn restore_from_clone() {
+        let mut topo = Topology::new();
+        let vid = topo
+            .vertices
+            .alloc(Vertex::new(Point3::new(1.0, 2.0, 3.0), 1e-7));
+
+        let snapshot = topo.clone();
+
+        // Mutate after snapshot
+        topo.vertices
+            .alloc(Vertex::new(Point3::new(9.0, 9.0, 9.0), 1e-7));
+
+        // Restore from snapshot
+        topo = snapshot;
+        assert_eq!(topo.vertices.len(), 1);
         let v = topo.vertex(vid).unwrap();
         assert!((v.point().x() - 1.0).abs() < f64::EPSILON);
     }

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -48,10 +48,19 @@ pub struct BrepKernel {
     topo: Topology,
     assemblies: Vec<brepkit_operations::assembly::Assembly>,
     sketches: Vec<SketchState>,
+    checkpoints: Vec<Checkpoint>,
+}
+
+/// A saved snapshot of the kernel state that can be restored.
+#[derive(Clone)]
+struct Checkpoint {
+    topo: Topology,
+    assemblies: Vec<brepkit_operations::assembly::Assembly>,
+    sketches: Vec<SketchState>,
 }
 
 /// Internal state for an in-progress sketch.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct SketchState {
     points: Vec<brepkit_operations::sketch::SketchPoint>,
     constraints: Vec<brepkit_operations::sketch::Constraint>,
@@ -151,6 +160,7 @@ impl BrepKernel {
             topo: Topology::new(),
             assemblies: Vec::new(),
             sketches: Vec::new(),
+            checkpoints: Vec::new(),
         }
     }
 
@@ -3837,6 +3847,83 @@ impl BrepKernel {
             .collect();
 
         serde_json::Value::Array(results).to_string()
+    }
+}
+
+// ── Checkpoint / Restore ──────────────────────────────────────────
+
+#[wasm_bindgen]
+impl BrepKernel {
+    /// Save a snapshot of the current kernel state.
+    ///
+    /// Returns a checkpoint ID (zero-based index) that can be passed to
+    /// `restore` or `discardCheckpoint`.
+    ///
+    /// The snapshot is a clone of all topology, assembly, and sketch state.
+    /// Existing entity handles remain valid after restore.
+    #[wasm_bindgen(js_name = "checkpoint")]
+    pub fn checkpoint(&mut self) -> u32 {
+        let id = self.checkpoints.len();
+        self.checkpoints.push(Checkpoint {
+            topo: self.topo.clone(),
+            assemblies: self.assemblies.clone(),
+            sketches: self.sketches.clone(),
+        });
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            id as u32
+        }
+    }
+
+    /// Restore the kernel to a previously saved checkpoint.
+    ///
+    /// All state created after the checkpoint is discarded. The checkpoint
+    /// itself (and any earlier checkpoints) remain valid for future restores.
+    /// Checkpoints created after this one are discarded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `checkpoint_id` does not refer to a valid checkpoint.
+    #[wasm_bindgen(js_name = "restore")]
+    pub fn restore(&mut self, checkpoint_id: u32) -> Result<(), JsError> {
+        let idx = checkpoint_id as usize;
+        let cp = self
+            .checkpoints
+            .get(idx)
+            .ok_or_else(|| JsError::new(&format!("invalid checkpoint id: {checkpoint_id}")))?;
+        self.topo = cp.topo.clone();
+        self.assemblies = cp.assemblies.clone();
+        self.sketches = cp.sketches.clone();
+        // Discard checkpoints created after the restored one
+        self.checkpoints.truncate(idx + 1);
+        Ok(())
+    }
+
+    /// Discard a checkpoint and all checkpoints after it, freeing their memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `checkpoint_id` does not refer to a valid checkpoint.
+    #[wasm_bindgen(js_name = "discardCheckpoint")]
+    pub fn discard_checkpoint(&mut self, checkpoint_id: u32) -> Result<(), JsError> {
+        let idx = checkpoint_id as usize;
+        if idx >= self.checkpoints.len() {
+            return Err(JsError::new(&format!(
+                "invalid checkpoint id: {checkpoint_id}"
+            )));
+        }
+        self.checkpoints.truncate(idx);
+        Ok(())
+    }
+
+    /// Returns the number of saved checkpoints.
+    #[wasm_bindgen(js_name = "checkpointCount")]
+    #[must_use]
+    pub fn checkpoint_count(&self) -> u32 {
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            self.checkpoints.len() as u32
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Derive `Clone` on `Arena<T>`, `Topology`, `Assembly`, and `SketchState` — enables O(n) memcpy snapshots of the full kernel state
- Add `checkpoint()`, `restore()`, `discardCheckpoint()`, and `checkpointCount()` WASM bindings on `BrepKernel`
- Checkpoint preserves all entity handles (JS-side IDs remain valid after restore)
- Restore truncates checkpoints created after the restored one

This is the foundation for Brepd's undo/redo and command replay system (Spike 2 from the kernel spikes).

## Test plan

- [x] `topology::tests::clone_preserves_entities` — snapshot is independent of original
- [x] `topology::tests::restore_from_clone` — topology restores to snapshotted state
- [x] `example_checkpoint_restore` — full workflow: create box, snapshot, boolean+transform, restore, verify volume unchanged
- [x] `sketch::tests::rectangle_30x20` — GCS spike test (4-point rectangle with distance/alignment constraints)
- [x] All 1108+ existing tests pass
- [x] Clippy clean