### PR TITLE
fix: add brepkit[bot] to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,7 @@ jobs:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/andymai/brepkit/blob/main/.github/CLA.md"
           branch: "cla-signatures"
-          allowlist: "dependabot[bot],renovate[bot]"
+          allowlist: "dependabot[bot],renovate[bot],brepkit[bot]"
           custom-notsigned-prcomment: >
             Thank you for your contribution! Before we can merge this PR,
             you need to sign the Contributor License Agreement.


### PR DESCRIPTION
## Summary
- Adds `brepkit[bot]` to the CLA allowlist so release-please PRs aren't blocked

## Problem
PR #157 (release 0.10.0) has a failing CLA check because `brepkit[bot]` isn't in the allowlist.

## Test plan
- [ ] After merge, comment `recheck` on PR #157 — CLA should pass