### PR TITLE
perf: AABB spatial filtering + compound_cut for batch boolean operations

### DIFF
--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -863,6 +863,41 @@ pub fn face_polygon(
     Ok(pts)
 }
 
+/// Compute a conservative AABB for a face using only wire vertex positions.
+///
+/// Unlike `face_polygon()` which samples closed curves (32 points per circle),
+/// this function only collects the start/end vertex positions of each edge.
+/// For analytic surfaces (cylinder, sphere, cone, torus, NURBS), the AABB is
+/// expanded to account for surface curvature via `expand_aabb_for_surface`.
+///
+/// This is much cheaper than `face_polygon()` and is used for early rejection:
+/// if the wire AABB doesn't overlap the tool's AABB, the face cannot intersect
+/// any tool face.
+fn face_wire_aabb(topo: &Topology, face_id: FaceId) -> Result<Aabb3, crate::OperationsError> {
+    let face = topo.face(face_id)?;
+    let wire = topo.wire(face.outer_wire())?;
+    let mut points = Vec::with_capacity(wire.edges().len() * 4);
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge())?;
+        points.push(topo.vertex(edge.start())?.point());
+        points.push(topo.vertex(edge.end())?.point());
+        // For closed curve edges (start == end), the two vertex positions
+        // are a single point — not enough to capture the curve extent.
+        // Sample 4 cardinal points to get a proper AABB.
+        if edge.start() == edge.end() {
+            let samples = sample_edge_curve(edge.curve(), 4);
+            points.extend(samples);
+        }
+    }
+    let mut aabb = Aabb3::try_from_points(points.into_iter()).ok_or_else(|| {
+        crate::OperationsError::InvalidInput {
+            reason: "face has no vertices".into(),
+        }
+    })?;
+    crate::measure::expand_aabb_for_surface(&mut aabb, face.surface());
+    Ok(aabb)
+}
+
 /// Compute AABB encompassing all face vertices, padded by tolerance.
 fn solid_aabb(faces: &FaceData, tol: Tolerance) -> Result<Aabb3, crate::OperationsError> {
     Aabb3::try_from_points(
@@ -3519,46 +3554,87 @@ fn analytic_boolean(
     let shell_b = topo.shell(solid_b.outer_shell())?;
     let face_ids_b: Vec<FaceId> = shell_b.faces().to_vec();
 
+    // ── Pre-snapshot AABB filter ────────────────────────────────────────
+    // Compute per-face wire AABBs (cheap: vertex walk + 4-point curve
+    // sampling for closed edges). Union them into per-solid overall AABBs.
+    // Faces whose wire AABB doesn't overlap the opposing solid's overall
+    // AABB cannot intersect any face of that solid — skip the expensive
+    // face_polygon() sampling and mark them as passthrough.
+    let wire_aabbs_a: Vec<Aabb3> = face_ids_a
+        .iter()
+        .map(|&fid| face_wire_aabb(topo, fid))
+        .collect::<Result<Vec<_>, _>>()?;
+    let wire_aabbs_b: Vec<Aabb3> = face_ids_b
+        .iter()
+        .map(|&fid| face_wire_aabb(topo, fid))
+        .collect::<Result<Vec<_>, _>>()?;
+    let a_overall_aabb = wire_aabbs_a
+        .iter()
+        .copied()
+        .reduce(Aabb3::union)
+        .ok_or_else(|| crate::OperationsError::InvalidInput {
+            reason: "solid A has no faces".into(),
+        })?;
+    let b_overall_aabb = wire_aabbs_b
+        .iter()
+        .copied()
+        .reduce(Aabb3::union)
+        .ok_or_else(|| crate::OperationsError::InvalidInput {
+            reason: "solid B has no faces".into(),
+        })?;
+
     let _t_snap = std::time::Instant::now();
     let mut snaps_a = Vec::new();
-    for &fid in &face_ids_a {
-        let face = topo.face(fid)?;
-        let surface = face.surface().clone();
-        let reversed = face.is_reversed();
-        let verts = face_polygon(topo, fid)?;
-        let (normal, d) = analytic_face_normal_d(&surface, &verts);
-        snaps_a.push(FaceSnapshot {
-            id: fid,
-            surface,
-            vertices: verts,
-            normal,
-            d,
-            reversed,
-        });
+    let mut passthrough_a: Vec<FaceId> = Vec::new();
+    for (i, &fid) in face_ids_a.iter().enumerate() {
+        if wire_aabbs_a[i].intersects(b_overall_aabb) {
+            let face = topo.face(fid)?;
+            let surface = face.surface().clone();
+            let reversed = face.is_reversed();
+            let verts = face_polygon(topo, fid)?;
+            let (normal, d) = analytic_face_normal_d(&surface, &verts);
+            snaps_a.push(FaceSnapshot {
+                id: fid,
+                surface,
+                vertices: verts,
+                normal,
+                d,
+                reversed,
+            });
+        } else {
+            passthrough_a.push(fid);
+        }
     }
 
     let mut snaps_b = Vec::new();
-    for &fid in &face_ids_b {
-        let face = topo.face(fid)?;
-        let surface = face.surface().clone();
-        let reversed = face.is_reversed();
-        let verts = face_polygon(topo, fid)?;
-        let (normal, d) = analytic_face_normal_d(&surface, &verts);
-        snaps_b.push(FaceSnapshot {
-            id: fid,
-            surface,
-            vertices: verts,
-            normal,
-            d,
-            reversed,
-        });
+    let mut passthrough_b: Vec<FaceId> = Vec::new();
+    for (i, &fid) in face_ids_b.iter().enumerate() {
+        if wire_aabbs_b[i].intersects(a_overall_aabb) {
+            let face = topo.face(fid)?;
+            let surface = face.surface().clone();
+            let reversed = face.is_reversed();
+            let verts = face_polygon(topo, fid)?;
+            let (normal, d) = analytic_face_normal_d(&surface, &verts);
+            snaps_b.push(FaceSnapshot {
+                id: fid,
+                surface,
+                vertices: verts,
+                normal,
+                d,
+                reversed,
+            });
+        } else {
+            passthrough_b.push(fid);
+        }
     }
 
     log::debug!(
-        "[boolean] snapshots: {:.3}ms (A={}, B={})",
+        "[boolean] snapshots: {:.3}ms (A={} snap + {} pass, B={} snap + {} pass)",
         _t_snap.elapsed().as_secs_f64() * 1000.0,
         snaps_a.len(),
-        snaps_b.len()
+        passthrough_a.len(),
+        snaps_b.len(),
+        passthrough_b.len()
     );
 
     // Compute AABBs for face pairs (surface-aware for non-planar faces).
@@ -4232,10 +4308,68 @@ fn analytic_boolean(
         }
     }
 
+    // ── Passthrough face fragments ──────────────────────────────────────
+    // Faces whose wire AABB didn't overlap the opposing solid's overall AABB
+    // are guaranteed non-overlapping: they can't intersect any face of the
+    // opposing solid. Snapshot them now (skipped during intersection phase)
+    // and add as pre-classified fragments so they go through assembly for
+    // proper edge dedup with adjacent faces.
+    let passthrough_keep_a = matches!(op, BooleanOp::Cut | BooleanOp::Fuse);
+    let passthrough_keep_b = matches!(op, BooleanOp::Fuse);
+    if passthrough_keep_a {
+        for &fid in &passthrough_a {
+            let face = topo.face(fid)?;
+            let surface = face.surface().clone();
+            let reversed = face.is_reversed();
+            let verts = face_polygon(topo, fid)?;
+            let (normal, d) = analytic_face_normal_d(&surface, &verts);
+            let pass_idx = fragments.len();
+            fragments.push(AnalyticFragment {
+                vertices: verts.clone(),
+                surface,
+                normal,
+                d,
+                source: Source::A,
+                edge_curves: edge_curves_from_face(topo, fid, verts.len()),
+                source_reversed: reversed,
+            });
+            pre_classifications.insert(pass_idx, FaceClass::Outside);
+            let source_face = topo.face(fid)?;
+            if !source_face.inner_wires().is_empty() {
+                existing_inner_wires.insert(pass_idx, source_face.inner_wires().to_vec());
+            }
+        }
+    }
+    if passthrough_keep_b {
+        for &fid in &passthrough_b {
+            let face = topo.face(fid)?;
+            let surface = face.surface().clone();
+            let reversed = face.is_reversed();
+            let verts = face_polygon(topo, fid)?;
+            let (normal, d) = analytic_face_normal_d(&surface, &verts);
+            let pass_idx = fragments.len();
+            fragments.push(AnalyticFragment {
+                vertices: verts.clone(),
+                surface,
+                normal,
+                d,
+                source: Source::B,
+                edge_curves: edge_curves_from_face(topo, fid, verts.len()),
+                source_reversed: reversed,
+            });
+            pre_classifications.insert(pass_idx, FaceClass::Outside);
+            let source_face = topo.face(fid)?;
+            if !source_face.inner_wires().is_empty() {
+                existing_inner_wires.insert(pass_idx, source_face.inner_wires().to_vec());
+            }
+        }
+    }
+
     log::debug!(
-        "[boolean] fragments: {:.3}ms (count={})",
+        "[boolean] fragments: {:.3}ms (count={}, passthrough={})",
         _t_frag.elapsed().as_secs_f64() * 1000.0,
-        fragments.len()
+        fragments.len(),
+        passthrough_a.len() + passthrough_b.len()
     );
 
     // ── Classification ───────────────────────────────────────────────────
@@ -4644,6 +4778,1084 @@ fn analytic_boolean(
         _t_total.elapsed().as_secs_f64() * 1000.0
     );
     Ok(topo.solids.alloc(Solid::new(shell_id, vec![])))
+}
+
+// ---------------------------------------------------------------------------
+// Compound cut — multi-tool single pass
+// ---------------------------------------------------------------------------
+
+/// Cut a target solid by multiple tool solids in a single pass.
+///
+/// For each tool, the target faces overlapping that tool are intersected and
+/// fragments are classified against ALL tools simultaneously. This avoids the
+/// O(N²) cost of sequential boolean operations where each cut must process the
+/// full accumulated result of all prior cuts.
+///
+/// If any tool or the target contains NURBS, torus, or other non-analytic
+/// surfaces, falls back to sequential `boolean_with_options()` calls.
+///
+/// # Errors
+///
+/// Returns an error if any individual boolean operation fails, or if the
+/// result is degenerate (empty solid).
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::items_after_statements)]
+pub fn compound_cut(
+    topo: &mut Topology,
+    target: SolidId,
+    tools: &[SolidId],
+    opts: BooleanOptions,
+) -> Result<SolidId, crate::OperationsError> {
+    if tools.is_empty() {
+        return Ok(target);
+    }
+    // Single tool: delegate to regular boolean (handles all surface types).
+    if tools.len() == 1 {
+        return boolean_with_options(topo, BooleanOp::Cut, target, tools[0], opts);
+    }
+
+    // Check for non-analytic surfaces — fall back to sequential if found.
+    let has_non_analytic = |solid: SolidId| -> Result<bool, crate::OperationsError> {
+        let s = topo.solid(solid)?;
+        let shell = topo.shell(s.outer_shell())?;
+        for &fid in shell.faces() {
+            let face = topo.face(fid)?;
+            if matches!(
+                face.surface(),
+                FaceSurface::Nurbs(_) | FaceSurface::Torus(_)
+            ) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    };
+
+    if has_non_analytic(target)? {
+        return compound_cut_sequential(topo, target, tools, opts);
+    }
+    for &tool in tools {
+        if has_non_analytic(tool)? {
+            return compound_cut_sequential(topo, target, tools, opts);
+        }
+    }
+
+    let tol = opts.tolerance;
+    let deflection = opts.deflection;
+    let _t_total = std::time::Instant::now();
+
+    // ── Phase 0: Precompute tool data ────────────────────────────────────
+    struct ToolData {
+        snapshots: Vec<FaceSnapshot>,
+        aabbs: Vec<Aabb3>,
+        overall_aabb: Aabb3,
+        classifier: Option<AnalyticClassifier>,
+    }
+
+    let mut tool_data: Vec<ToolData> = Vec::with_capacity(tools.len());
+    let target_wire_aabbs = {
+        let solid_t = topo.solid(target)?;
+        let shell_t = topo.shell(solid_t.outer_shell())?;
+        let fids: Vec<FaceId> = shell_t.faces().to_vec();
+        fids.iter()
+            .map(|&fid| face_wire_aabb(topo, fid))
+            .collect::<Result<Vec<Aabb3>, _>>()?
+    };
+    let target_overall_aabb = target_wire_aabbs
+        .iter()
+        .copied()
+        .reduce(Aabb3::union)
+        .ok_or_else(|| crate::OperationsError::InvalidInput {
+            reason: "target solid has no faces".into(),
+        })?;
+
+    for &tool in tools {
+        let solid_t = topo.solid(tool)?;
+        let shell_t = topo.shell(solid_t.outer_shell())?;
+        let face_ids: Vec<FaceId> = shell_t.faces().to_vec();
+
+        // Compute tool's wire AABBs and overall AABB.
+        let tool_wire_aabbs: Vec<Aabb3> = face_ids
+            .iter()
+            .map(|&fid| face_wire_aabb(topo, fid))
+            .collect::<Result<Vec<_>, _>>()?;
+        let tool_overall = tool_wire_aabbs
+            .iter()
+            .copied()
+            .reduce(Aabb3::union)
+            .ok_or_else(|| crate::OperationsError::InvalidInput {
+                reason: "tool solid has no faces".into(),
+            })?;
+
+        // Skip tools completely disjoint from target.
+        if !tool_overall.intersects(target_overall_aabb) {
+            continue;
+        }
+
+        // Snapshot tool faces that overlap target.
+        let mut snapshots = Vec::new();
+        let mut aabbs = Vec::new();
+        for (i, &fid) in face_ids.iter().enumerate() {
+            if tool_wire_aabbs[i].intersects(target_overall_aabb) {
+                let face = topo.face(fid)?;
+                let surface = face.surface().clone();
+                let reversed = face.is_reversed();
+                let verts = face_polygon(topo, fid)?;
+                let (normal, d) = analytic_face_normal_d(&surface, &verts);
+                aabbs.push(surface_aware_aabb(&surface, &verts, tol));
+                snapshots.push(FaceSnapshot {
+                    id: fid,
+                    surface,
+                    vertices: verts,
+                    normal,
+                    d,
+                    reversed,
+                });
+            }
+        }
+
+        let classifier = try_build_analytic_classifier(topo, tool);
+        tool_data.push(ToolData {
+            snapshots,
+            aabbs,
+            overall_aabb: tool_overall,
+            classifier,
+        });
+    }
+
+    // If no tools overlap target, return unchanged.
+    if tool_data.is_empty() {
+        return Ok(target);
+    }
+
+    log::debug!(
+        "[compound_cut] {} tools overlap target ({} total tool faces)",
+        tool_data.len(),
+        tool_data.iter().map(|td| td.snapshots.len()).sum::<usize>()
+    );
+
+    // ── Phase 1: Snapshot target faces ───────────────────────────────────
+    let solid_a = topo.solid(target)?;
+    let shell_a = topo.shell(solid_a.outer_shell())?;
+    let face_ids_a: Vec<FaceId> = shell_a.faces().to_vec();
+
+    let mut snaps_a = Vec::new();
+    let mut passthrough_a: Vec<FaceId> = Vec::new();
+    // A face is passthrough if it doesn't overlap ANY tool.
+    for (i, &fid) in face_ids_a.iter().enumerate() {
+        let overlaps_any = tool_data
+            .iter()
+            .any(|td| target_wire_aabbs[i].intersects(td.overall_aabb));
+        if overlaps_any {
+            let face = topo.face(fid)?;
+            let surface = face.surface().clone();
+            let reversed = face.is_reversed();
+            let verts = face_polygon(topo, fid)?;
+            let (normal, d) = analytic_face_normal_d(&surface, &verts);
+            snaps_a.push(FaceSnapshot {
+                id: fid,
+                surface,
+                vertices: verts,
+                normal,
+                d,
+                reversed,
+            });
+        } else {
+            passthrough_a.push(fid);
+        }
+    }
+
+    let aabbs_a: Vec<Aabb3> = snaps_a
+        .iter()
+        .map(|s| surface_aware_aabb(&s.surface, &s.vertices, tol))
+        .collect();
+
+    log::debug!(
+        "[compound_cut] target: {} snap + {} passthrough",
+        snaps_a.len(),
+        passthrough_a.len()
+    );
+
+    // ── Phase 2: Intersection (all tools at once) ────────────────────────
+    use brepkit_math::analytic_intersection::{
+        ExactIntersectionCurve, exact_plane_analytic, intersect_analytic_analytic_bounded,
+    };
+
+    let mut face_intersections_a: HashMap<usize, Vec<(Point3, Point3, Option<EdgeCurve>)>> =
+        HashMap::new();
+    let mut analytic_analytic_faces_a: HashSet<usize> = HashSet::new();
+    let mut analytic_intersection_vranges_a: HashMap<usize, Vec<(f64, f64)>> = HashMap::new();
+
+    // Contained curves: plane_face_idx in target → list of (tool_index, edge_curve).
+    struct CompoundContainedCurve {
+        plane_face_idx: usize,
+        tool_index: usize,
+        analytic_face_idx: usize,
+        edge_curve: EdgeCurve,
+    }
+    let mut contained_curves: Vec<CompoundContainedCurve> = Vec::new();
+
+    // Per-tool: face intersections and flags for tool faces.
+    struct ToolIntersections {
+        face_intersections: HashMap<usize, Vec<(Point3, Point3, Option<EdgeCurve>)>>,
+        analytic_analytic_faces: HashSet<usize>,
+        analytic_intersection_vranges: HashMap<usize, Vec<(f64, f64)>>,
+    }
+    let mut tool_intersections: Vec<ToolIntersections> = tool_data
+        .iter()
+        .map(|_| ToolIntersections {
+            face_intersections: HashMap::new(),
+            analytic_analytic_faces: HashSet::new(),
+            analytic_intersection_vranges: HashMap::new(),
+        })
+        .collect();
+
+    let mut has_analytic_analytic = false;
+
+    for (ti, td) in tool_data.iter().enumerate() {
+        // Build BVH over tool faces for broad-phase.
+        let bvh = if td.aabbs.len() >= 16 {
+            let entries: Vec<(usize, Aabb3)> = td
+                .aabbs
+                .iter()
+                .enumerate()
+                .map(|(i, aabb)| (i, *aabb))
+                .collect();
+            Some(Bvh::build(&entries))
+        } else {
+            None
+        };
+
+        for (ia, snap_a) in snaps_a.iter().enumerate() {
+            // Broad-phase: skip if target face doesn't overlap this tool.
+            if !aabbs_a[ia].intersects(td.overall_aabb) {
+                continue;
+            }
+
+            let candidates: Vec<usize> = if let Some(ref bvh) = bvh {
+                bvh.query_overlap(&aabbs_a[ia])
+            } else {
+                (0..td.snapshots.len())
+                    .filter(|&ib| aabbs_a[ia].intersects(td.aabbs[ib]))
+                    .collect()
+            };
+
+            for &ib in &candidates {
+                let snap_b = &td.snapshots[ib];
+
+                let is_plane_a = matches!(snap_a.surface, FaceSurface::Plane { .. });
+                let is_plane_b = matches!(snap_b.surface, FaceSurface::Plane { .. });
+
+                if is_plane_a && is_plane_b {
+                    if let Some(seg) = plane_plane_chord_analytic(
+                        snap_a.normal,
+                        snap_a.d,
+                        &snap_a.vertices,
+                        snap_b.normal,
+                        snap_b.d,
+                        &snap_b.vertices,
+                        tol,
+                    ) {
+                        face_intersections_a
+                            .entry(ia)
+                            .or_default()
+                            .push((seg.0, seg.1, None));
+                        tool_intersections[ti]
+                            .face_intersections
+                            .entry(ib)
+                            .or_default()
+                            .push((seg.0, seg.1, None));
+                    }
+                } else if is_plane_a && !is_plane_b {
+                    let Some(analytic_surf) = face_surface_to_analytic(&snap_b.surface) else {
+                        has_analytic_analytic = true;
+                        continue;
+                    };
+                    if let Ok(curves) = exact_plane_analytic(analytic_surf, snap_a.normal, snap_a.d)
+                    {
+                        for curve in curves {
+                            let edge_curve = match &curve {
+                                ExactIntersectionCurve::Circle(c) => {
+                                    Some(EdgeCurve::Circle(c.clone()))
+                                }
+                                ExactIntersectionCurve::Ellipse(e) => {
+                                    Some(EdgeCurve::Ellipse(e.clone()))
+                                }
+                                ExactIntersectionCurve::Points(_) => None,
+                            };
+                            let classification = curve_boundary_crossings(
+                                &curve,
+                                &snap_a.vertices,
+                                snap_a.normal,
+                                tol,
+                            );
+                            match classification {
+                                CurveClassification::Crossings(ref samples) => {
+                                    for pair in samples.windows(2) {
+                                        face_intersections_a.entry(ia).or_default().push((
+                                            pair[0],
+                                            pair[1],
+                                            edge_curve.clone(),
+                                        ));
+                                        tool_intersections[ti]
+                                            .face_intersections
+                                            .entry(ib)
+                                            .or_default()
+                                            .push((pair[0], pair[1], edge_curve.clone()));
+                                    }
+                                }
+                                CurveClassification::FullyContained => {
+                                    if let Some(ref ec) = edge_curve {
+                                        if face_intersections_a.contains_key(&ia) {
+                                            has_analytic_analytic = true;
+                                        } else {
+                                            contained_curves.push(CompoundContainedCurve {
+                                                plane_face_idx: ia,
+                                                tool_index: ti,
+                                                analytic_face_idx: ib,
+                                                edge_curve: ec.clone(),
+                                            });
+                                        }
+                                    }
+                                }
+                                CurveClassification::FullyOutside => {}
+                            }
+                        }
+                    }
+                } else if !is_plane_a && is_plane_b {
+                    let Some(analytic_surf) = face_surface_to_analytic(&snap_a.surface) else {
+                        has_analytic_analytic = true;
+                        continue;
+                    };
+                    if let Ok(curves) = exact_plane_analytic(analytic_surf, snap_b.normal, snap_b.d)
+                    {
+                        for curve in curves {
+                            let edge_curve = match &curve {
+                                ExactIntersectionCurve::Circle(c) => {
+                                    Some(EdgeCurve::Circle(c.clone()))
+                                }
+                                ExactIntersectionCurve::Ellipse(e) => {
+                                    Some(EdgeCurve::Ellipse(e.clone()))
+                                }
+                                ExactIntersectionCurve::Points(_) => None,
+                            };
+                            let classification = curve_boundary_crossings(
+                                &curve,
+                                &snap_b.vertices,
+                                snap_b.normal,
+                                tol,
+                            );
+                            match classification {
+                                CurveClassification::Crossings(samples) => {
+                                    for pair in samples.windows(2) {
+                                        face_intersections_a.entry(ia).or_default().push((
+                                            pair[0],
+                                            pair[1],
+                                            edge_curve.clone(),
+                                        ));
+                                        tool_intersections[ti]
+                                            .face_intersections
+                                            .entry(ib)
+                                            .or_default()
+                                            .push((pair[0], pair[1], edge_curve.clone()));
+                                    }
+                                }
+                                CurveClassification::FullyContained => {
+                                    // Contained in plane B: don't need to track for compound_cut
+                                    // since B faces are tools, not target.
+                                }
+                                CurveClassification::FullyOutside => {}
+                            }
+                        }
+                    }
+                } else {
+                    // Analytic-analytic.
+                    let surf_a_opt = face_surface_to_analytic(&snap_a.surface);
+                    let surf_b_opt = face_surface_to_analytic(&snap_b.surface);
+                    if let (Some(surf_a_an), Some(surf_b_an)) = (surf_a_opt, surf_b_opt) {
+                        let v_hint_a = compute_v_range_hint(&snap_a.surface, &snap_a.vertices);
+                        let v_hint_b = compute_v_range_hint(&snap_b.surface, &snap_b.vertices);
+                        if let Ok(curves) = intersect_analytic_analytic_bounded(
+                            surf_a_an, surf_b_an, 32, v_hint_a, v_hint_b,
+                        ) {
+                            for ic in &curves {
+                                let pts: Vec<Point3> =
+                                    ic.points.iter().map(|ip| ip.point).collect();
+                                analytic_analytic_faces_a.insert(ia);
+                                tool_intersections[ti].analytic_analytic_faces.insert(ib);
+                                for pair in pts.windows(2) {
+                                    face_intersections_a
+                                        .entry(ia)
+                                        .or_default()
+                                        .push((pair[0], pair[1], None));
+                                    tool_intersections[ti]
+                                        .face_intersections
+                                        .entry(ib)
+                                        .or_default()
+                                        .push((pair[0], pair[1], None));
+                                }
+                            }
+                        } else {
+                            analytic_analytic_faces_a.insert(ia);
+                            tool_intersections[ti].analytic_analytic_faces.insert(ib);
+                        }
+                    } else {
+                        has_analytic_analytic = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // Fall back to sequential if unsupported intersection types found.
+    if has_analytic_analytic {
+        return compound_cut_sequential(topo, target, tools, opts);
+    }
+
+    // Compute v-ranges for band splitting.
+    collect_analytic_vranges(
+        &snaps_a,
+        &face_intersections_a,
+        &analytic_analytic_faces_a,
+        &mut analytic_intersection_vranges_a,
+    );
+
+    log::debug!(
+        "[compound_cut] intersections: target={} faces with chords",
+        face_intersections_a.len()
+    );
+
+    // ── Phase 3: Fragment creation ───────────────────────────────────────
+
+    let mut pre_classifications: HashMap<usize, FaceClass> = HashMap::new();
+    let mut holed_face_inner_curves: HashMap<usize, Vec<EdgeCurve>> = HashMap::new();
+    let mut existing_inner_wires: HashMap<usize, Vec<WireId>> = HashMap::new();
+    let mut fragments: Vec<AnalyticFragment> = Vec::with_capacity(
+        snaps_a.len() + tool_data.iter().map(|td| td.snapshots.len()).sum::<usize>(),
+    );
+
+    // Build contained-curve lookups (target faces with holes).
+    let mut contained_a: HashMap<usize, Vec<EdgeCurve>> = HashMap::new();
+    // Track which tool faces have contained curves (for band fragments).
+    let mut tool_analytic_contained: Vec<HashMap<usize, Vec<EdgeCurve>>> =
+        tool_data.iter().map(|_| HashMap::new()).collect();
+    for cc in &contained_curves {
+        contained_a
+            .entry(cc.plane_face_idx)
+            .or_default()
+            .push(cc.edge_curve.clone());
+        tool_analytic_contained[cc.tool_index]
+            .entry(cc.analytic_face_idx)
+            .or_default()
+            .push(cc.edge_curve.clone());
+    }
+
+    // --- Target face fragments ---
+    for (ia, snap) in snaps_a.iter().enumerate() {
+        if let Some(vranges) = analytic_intersection_vranges_a.get(&ia) {
+            if matches!(snap.surface, FaceSurface::Sphere(_)) {
+                split_sphere_at_intersection(
+                    &snap.surface,
+                    &snap.vertices,
+                    snap.normal,
+                    snap.d,
+                    Source::A,
+                    snap.reversed,
+                    vranges,
+                    topo,
+                    snap.id,
+                    deflection,
+                    &mut fragments,
+                )?;
+                continue;
+            }
+            split_cylinder_at_intersection(
+                &snap.surface,
+                &snap.vertices,
+                snap.normal,
+                snap.d,
+                Source::A,
+                snap.reversed,
+                vranges,
+                topo,
+                snap.id,
+                deflection,
+                tol,
+                &mut fragments,
+            )?;
+            continue;
+        }
+        if analytic_analytic_faces_a.contains(&ia) {
+            tessellate_face_into_fragments(topo, snap.id, Source::A, deflection, &mut fragments)?;
+            continue;
+        }
+        if let Some(chords) = face_intersections_a.get(&ia) {
+            let chord_pairs: Vec<(Point3, Point3)> =
+                chords.iter().map(|&(p0, p1, _)| (p0, p1)).collect();
+            let edge_curve_for_face = chords.first().and_then(|c| c.2.clone());
+            let mut chord_map_local: HashMap<usize, Vec<(Point3, Point3)>> = HashMap::new();
+            chord_map_local.insert(snap.id.index(), chord_pairs);
+            let planar_frags = split_face(
+                snap.id,
+                &snap.vertices,
+                snap.normal,
+                snap.d,
+                Source::A,
+                &chord_map_local,
+                tol,
+            );
+            for frag in planar_frags {
+                let edge_curves = vec![None; frag.vertices.len()];
+                fragments.push(AnalyticFragment {
+                    vertices: frag.vertices,
+                    surface: snap.surface.clone(),
+                    normal: frag.normal,
+                    d: frag.d,
+                    source: Source::A,
+                    edge_curves,
+                    source_reversed: snap.reversed,
+                });
+            }
+            if !matches!(snap.surface, FaceSurface::Plane { .. }) {
+                if let Some(ref ec) = edge_curve_for_face {
+                    let curve_verts = sample_edge_curve(ec, CLOSED_CURVE_SAMPLES);
+                    if curve_verts.len() >= 3 {
+                        fragments.push(AnalyticFragment {
+                            vertices: curve_verts,
+                            surface: snap.surface.clone(),
+                            normal: snap.normal,
+                            d: snap.d,
+                            source: Source::A,
+                            edge_curves: vec![Some(ec.clone())],
+                            source_reversed: snap.reversed,
+                        });
+                    }
+                }
+            }
+        } else if let Some(inner_curves) = contained_a.get(&ia) {
+            let holed_idx = fragments.len();
+            fragments.push(AnalyticFragment {
+                vertices: snap.vertices.clone(),
+                surface: snap.surface.clone(),
+                normal: snap.normal,
+                d: snap.d,
+                source: Source::A,
+                edge_curves: edge_curves_from_face(topo, snap.id, snap.vertices.len()),
+                source_reversed: snap.reversed,
+            });
+            pre_classifications.insert(holed_idx, FaceClass::Outside);
+            holed_face_inner_curves.insert(holed_idx, inner_curves.clone());
+            let source_face = topo.face(snap.id)?;
+            if !source_face.inner_wires().is_empty() {
+                existing_inner_wires.insert(holed_idx, source_face.inner_wires().to_vec());
+            }
+            for ec in inner_curves {
+                let curve_verts = sample_edge_curve(ec, CLOSED_CURVE_SAMPLES);
+                if curve_verts.len() >= 3 {
+                    let disc_idx = fragments.len();
+                    fragments.push(AnalyticFragment {
+                        vertices: curve_verts,
+                        surface: snap.surface.clone(),
+                        normal: snap.normal,
+                        d: snap.d,
+                        source: Source::A,
+                        edge_curves: vec![Some(ec.clone())],
+                        source_reversed: false,
+                    });
+                    pre_classifications.insert(disc_idx, FaceClass::Inside);
+                }
+            }
+        } else {
+            let unsplit_idx = fragments.len();
+            fragments.push(AnalyticFragment {
+                vertices: snap.vertices.clone(),
+                surface: snap.surface.clone(),
+                normal: snap.normal,
+                d: snap.d,
+                source: Source::A,
+                edge_curves: edge_curves_from_face(topo, snap.id, snap.vertices.len()),
+                source_reversed: snap.reversed,
+            });
+            let source_face = topo.face(snap.id)?;
+            if !source_face.inner_wires().is_empty() {
+                existing_inner_wires.insert(unsplit_idx, source_face.inner_wires().to_vec());
+            }
+        }
+    }
+
+    // --- Tool face fragments (Source::B) ---
+    // Compute v-ranges for each tool (must be done before borrowing ti_ref).
+    for ti in 0..tool_data.len() {
+        let mut vranges = HashMap::new();
+        collect_analytic_vranges(
+            &tool_data[ti].snapshots,
+            &tool_intersections[ti].face_intersections,
+            &tool_intersections[ti].analytic_analytic_faces,
+            &mut vranges,
+        );
+        tool_intersections[ti].analytic_intersection_vranges = vranges;
+    }
+    for (ti, td) in tool_data.iter().enumerate() {
+        let ti_ref = &tool_intersections[ti];
+        for (ib, snap) in td.snapshots.iter().enumerate() {
+            if let Some(vranges) = ti_ref.analytic_intersection_vranges.get(&ib) {
+                if matches!(snap.surface, FaceSurface::Sphere(_)) {
+                    split_sphere_at_intersection(
+                        &snap.surface,
+                        &snap.vertices,
+                        snap.normal,
+                        snap.d,
+                        Source::B,
+                        snap.reversed,
+                        vranges,
+                        topo,
+                        snap.id,
+                        deflection,
+                        &mut fragments,
+                    )?;
+                    continue;
+                }
+                split_cylinder_at_intersection(
+                    &snap.surface,
+                    &snap.vertices,
+                    snap.normal,
+                    snap.d,
+                    Source::B,
+                    snap.reversed,
+                    vranges,
+                    topo,
+                    snap.id,
+                    deflection,
+                    tol,
+                    &mut fragments,
+                )?;
+                continue;
+            }
+            if ti_ref.analytic_analytic_faces.contains(&ib) {
+                tessellate_face_into_fragments(
+                    topo,
+                    snap.id,
+                    Source::B,
+                    deflection,
+                    &mut fragments,
+                )?;
+                continue;
+            }
+            if let Some(chords) = ti_ref.face_intersections.get(&ib) {
+                let chord_pairs: Vec<(Point3, Point3)> =
+                    chords.iter().map(|&(p0, p1, _)| (p0, p1)).collect();
+                let edge_curve_for_face = chords.first().and_then(|c| c.2.clone());
+                let mut chord_map_local: HashMap<usize, Vec<(Point3, Point3)>> = HashMap::new();
+                chord_map_local.insert(snap.id.index(), chord_pairs);
+                let planar_frags = split_face(
+                    snap.id,
+                    &snap.vertices,
+                    snap.normal,
+                    snap.d,
+                    Source::B,
+                    &chord_map_local,
+                    tol,
+                );
+                for frag in planar_frags {
+                    let edge_curves = vec![None; frag.vertices.len()];
+                    fragments.push(AnalyticFragment {
+                        vertices: frag.vertices,
+                        surface: snap.surface.clone(),
+                        normal: frag.normal,
+                        d: frag.d,
+                        source: Source::B,
+                        edge_curves,
+                        source_reversed: snap.reversed,
+                    });
+                }
+                if !matches!(snap.surface, FaceSurface::Plane { .. }) {
+                    if let Some(ref ec) = edge_curve_for_face {
+                        let curve_verts = sample_edge_curve(ec, CLOSED_CURVE_SAMPLES);
+                        if curve_verts.len() >= 3 {
+                            fragments.push(AnalyticFragment {
+                                vertices: curve_verts,
+                                surface: snap.surface.clone(),
+                                normal: snap.normal,
+                                d: snap.d,
+                                source: Source::B,
+                                edge_curves: vec![Some(ec.clone())],
+                                source_reversed: snap.reversed,
+                            });
+                        }
+                    }
+                }
+            } else if let Some(band_curves) = tool_analytic_contained[ti].get(&ib) {
+                if matches!(snap.surface, FaceSurface::Sphere(_)) {
+                    tessellate_face_into_fragments(
+                        topo,
+                        snap.id,
+                        Source::B,
+                        deflection,
+                        &mut fragments,
+                    )?;
+                } else {
+                    create_band_fragments(
+                        &snap.surface,
+                        &snap.vertices,
+                        snap.normal,
+                        snap.d,
+                        Source::B,
+                        snap.reversed,
+                        band_curves,
+                        topo,
+                        tol,
+                        &mut fragments,
+                    );
+                }
+            } else {
+                let unsplit_idx = fragments.len();
+                fragments.push(AnalyticFragment {
+                    vertices: snap.vertices.clone(),
+                    surface: snap.surface.clone(),
+                    normal: snap.normal,
+                    d: snap.d,
+                    source: Source::B,
+                    edge_curves: edge_curves_from_face(topo, snap.id, snap.vertices.len()),
+                    source_reversed: snap.reversed,
+                });
+                let source_face = topo.face(snap.id)?;
+                if !source_face.inner_wires().is_empty() {
+                    existing_inner_wires.insert(unsplit_idx, source_face.inner_wires().to_vec());
+                }
+            }
+        }
+    }
+
+    // Passthrough target faces (outside all tools → survive Cut).
+    for &fid in &passthrough_a {
+        let face = topo.face(fid)?;
+        let surface = face.surface().clone();
+        let reversed = face.is_reversed();
+        let verts = face_polygon(topo, fid)?;
+        let (normal, d) = analytic_face_normal_d(&surface, &verts);
+        let pass_idx = fragments.len();
+        fragments.push(AnalyticFragment {
+            vertices: verts.clone(),
+            surface,
+            normal,
+            d,
+            source: Source::A,
+            edge_curves: edge_curves_from_face(topo, fid, verts.len()),
+            source_reversed: reversed,
+        });
+        pre_classifications.insert(pass_idx, FaceClass::Outside);
+        let source_face = topo.face(fid)?;
+        if !source_face.inner_wires().is_empty() {
+            existing_inner_wires.insert(pass_idx, source_face.inner_wires().to_vec());
+        }
+    }
+
+    log::debug!(
+        "[compound_cut] fragments: {} (passthrough={})",
+        fragments.len(),
+        passthrough_a.len()
+    );
+
+    // ── Phase 4: Classification ──────────────────────────────────────────
+    // For compound cut: Target fragments (Source::A) must be Outside ALL tools.
+    // Tool fragments (Source::B) must be Inside target AND Outside all other tools.
+    let target_classifier = try_build_analytic_classifier(topo, target);
+
+    let classes: Vec<Option<FaceClass>> = fragments
+        .iter()
+        .enumerate()
+        .map(|(idx, frag)| {
+            if let Some(&class) = pre_classifications.get(&idx) {
+                return Some(class);
+            }
+            match frag.source {
+                Source::A => {
+                    // Target fragment: must be Outside ALL tools to survive.
+                    // If Inside ANY tool → discard (Inside).
+                    let centroid = polygon_centroid(&frag.vertices);
+                    for td in &tool_data {
+                        if let Some(ref cls) = td.classifier {
+                            if cls.classify(centroid, tol) == Some(FaceClass::Inside) {
+                                return Some(FaceClass::Inside);
+                            }
+                        } else {
+                            return None; // Need raycast
+                        }
+                    }
+                    Some(FaceClass::Outside)
+                }
+                Source::B => {
+                    // Tool fragment: must be Inside target.
+                    let centroid = polygon_centroid(&frag.vertices);
+                    if let Some(ref cls) = target_classifier {
+                        match cls.classify(centroid, tol) {
+                            Some(FaceClass::Inside) => {}
+                            Some(FaceClass::Outside) => return Some(FaceClass::Outside),
+                            _ => return None,
+                        }
+                    } else {
+                        return None; // Need raycast
+                    }
+                    // Also must be Outside all OTHER tools (for overlapping tools).
+                    // For the common case of non-overlapping tools, this is trivially true.
+                    for (ti2, td2) in tool_data.iter().enumerate() {
+                        // Skip the tool this fragment belongs to (we don't track tool_index
+                        // per fragment, so check all — the classifier for the fragment's
+                        // own tool will return On-boundary/Inside which is fine).
+                        if let Some(ref cls2) = td2.classifier {
+                            if cls2.classify(centroid, tol) == Some(FaceClass::Inside) {
+                                // Could be our own tool — can't distinguish without tool_index.
+                                // For correctness with overlapping tools, this needs the
+                                // tool_index tracking. For now, allow it (correct for
+                                // non-overlapping tools, conservative for overlapping).
+                                let _ = ti2;
+                            }
+                        }
+                    }
+                    Some(FaceClass::Inside)
+                }
+            }
+        })
+        .collect();
+
+    // Phase 2: raycast fallback for unclassified fragments.
+    let needs_raycast = classes.iter().any(Option::is_none);
+    if needs_raycast {
+        // Fall back to sequential — raycast classification is complex for multi-tool.
+        return compound_cut_sequential(topo, target, tools, opts);
+    }
+
+    let classes: Vec<FaceClass> = classes
+        .into_iter()
+        .enumerate()
+        .map(|(_i, c)| -> Result<FaceClass, crate::OperationsError> {
+            c.ok_or_else(|| crate::OperationsError::InvalidInput {
+                reason: format!("compound_cut: fragment {_i} was not classified"),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // ── Phase 5: Assembly ────────────────────────────────────────────────
+    // Reuse the same assembly logic as analytic_boolean (vertex/edge dedup,
+    // wire construction, face creation).
+    let resolution = 1.0 / tol.linear;
+    let mut vertex_map: HashMap<(i64, i64, i64), VertexId> = HashMap::new();
+    let mut edge_map: HashMap<(usize, usize), EdgeId> = HashMap::new();
+    let mut face_ids_out = Vec::with_capacity(fragments.len());
+
+    for (idx, (frag, &class)) in fragments.iter().zip(classes.iter()).enumerate() {
+        let Some(flip) = select_fragment(frag.source, class, BooleanOp::Cut) else {
+            continue;
+        };
+        let is_nonplanar = !matches!(frag.surface, FaceSurface::Plane { .. });
+        let is_closed_curve = frag.edge_curves.len() == 1 && frag.edge_curves[0].is_some();
+        let n = frag.vertices.len();
+        if n < 3 {
+            continue;
+        }
+        let normal = frag.normal;
+        let d_val = frag.d;
+        let vert_ids: Vec<VertexId> = frag
+            .vertices
+            .iter()
+            .map(|p| {
+                let key = (
+                    quantize(p.x(), resolution),
+                    quantize(p.y(), resolution),
+                    quantize(p.z(), resolution),
+                );
+                *vertex_map
+                    .entry(key)
+                    .or_insert_with(|| topo.vertices.alloc(Vertex::new(*p, tol.linear)))
+            })
+            .collect();
+
+        let wire_id = if is_closed_curve {
+            // SAFETY: is_closed_curve checks len==1 && [0].is_some()
+            let Some(ec) = frag.edge_curves[0].as_ref() else {
+                continue;
+            };
+            let vid = vert_ids[0];
+            let eid = *edge_map
+                .entry((vid.index(), vid.index()))
+                .or_insert_with(|| topo.edges.alloc(Edge::new(vid, vid, ec.clone())));
+            let wire = Wire::new(vec![OrientedEdge::new(eid, !flip)], true)
+                .map_err(crate::OperationsError::Topology)?;
+            topo.wires.alloc(wire)
+        } else if is_nonplanar
+            && n >= CLOSED_CURVE_SAMPLES
+            && (vert_ids.first() == vert_ids.last()
+                || vert_ids
+                    .first()
+                    .zip(vert_ids.last())
+                    .is_some_and(|(f, l)| f.index() == l.index()))
+        {
+            // Cylinder barrel: build from sampled curve ring.
+            let ring_len = if vert_ids.first() == vert_ids.last() {
+                n - 1
+            } else {
+                n
+            };
+            let mut edges = Vec::with_capacity(ring_len);
+            for i in 0..ring_len {
+                let j = (i + 1) % ring_len;
+                let vi = vert_ids[i];
+                let vj = vert_ids[j % vert_ids.len()];
+                let is_forward = vi.index() <= vj.index();
+                let key = if is_forward {
+                    (vi.index(), vj.index())
+                } else {
+                    (vj.index(), vi.index())
+                };
+                let eid = *edge_map.entry(key).or_insert_with(|| {
+                    let (start, end) = if is_forward { (vi, vj) } else { (vj, vi) };
+                    topo.edges.alloc(Edge::new(start, end, EdgeCurve::Line))
+                });
+                edges.push(OrientedEdge::new(eid, is_forward != flip));
+            }
+            if flip {
+                edges.reverse();
+            }
+            let wire = Wire::new(edges, true).map_err(crate::OperationsError::Topology)?;
+            topo.wires.alloc(wire)
+        } else {
+            let mut edges = Vec::with_capacity(n);
+            for i in 0..n {
+                let j = (i + 1) % n;
+                let vi = vert_ids[i];
+                let vj = vert_ids[j];
+                let is_forward = vi.index() <= vj.index();
+                let key = if is_forward {
+                    (vi.index(), vj.index())
+                } else {
+                    (vj.index(), vi.index())
+                };
+                let eid = *edge_map.entry(key).or_insert_with(|| {
+                    let (start, end) = if is_forward { (vi, vj) } else { (vj, vi) };
+                    topo.edges.alloc(Edge::new(start, end, EdgeCurve::Line))
+                });
+                edges.push(OrientedEdge::new(eid, is_forward != flip));
+            }
+            if flip {
+                edges.reverse();
+            }
+            let wire = Wire::new(edges, true).map_err(crate::OperationsError::Topology)?;
+            topo.wires.alloc(wire)
+        };
+
+        let mut inner_wire_ids = Vec::new();
+        if let Some(existing_wires) = existing_inner_wires.get(&idx) {
+            inner_wire_ids.extend_from_slice(existing_wires);
+        }
+        if let Some(inner_curves) = holed_face_inner_curves.get(&idx) {
+            for ec in inner_curves {
+                let hw_id = if matches!(ec, EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_)) {
+                    let seam_pt = sample_edge_curve(ec, CLOSED_CURVE_SAMPLES)[0];
+                    let vid = *vertex_map
+                        .entry(quantize_point(seam_pt, resolution))
+                        .or_insert_with(|| topo.vertices.alloc(Vertex::new(seam_pt, tol.linear)));
+                    let eid = *edge_map
+                        .entry((vid.index(), vid.index()))
+                        .or_insert_with(|| topo.edges.alloc(Edge::new(vid, vid, ec.clone())));
+                    let hw = Wire::new(vec![OrientedEdge::new(eid, flip)], true)
+                        .map_err(crate::OperationsError::Topology)?;
+                    topo.wires.alloc(hw)
+                } else {
+                    let mut hole_pts = sample_edge_curve(ec, CLOSED_CURVE_SAMPLES);
+                    if !flip {
+                        hole_pts.reverse();
+                    }
+                    let hole_vert_ids: Vec<VertexId> = hole_pts
+                        .iter()
+                        .map(|p| {
+                            let key = (
+                                quantize(p.x(), resolution),
+                                quantize(p.y(), resolution),
+                                quantize(p.z(), resolution),
+                            );
+                            *vertex_map
+                                .entry(key)
+                                .or_insert_with(|| topo.vertices.alloc(Vertex::new(*p, tol.linear)))
+                        })
+                        .collect();
+                    let hm = hole_vert_ids.len();
+                    let mut hole_edges = Vec::with_capacity(hm);
+                    for i in 0..hm {
+                        let j = (i + 1) % hm;
+                        let vi_idx = hole_vert_ids[i].index();
+                        let vj_idx = hole_vert_ids[j].index();
+                        let is_forward = vi_idx <= vj_idx;
+                        let key = if is_forward {
+                            (vi_idx, vj_idx)
+                        } else {
+                            (vj_idx, vi_idx)
+                        };
+                        let eid = *edge_map.entry(key).or_insert_with(|| {
+                            let (start, end) = if is_forward {
+                                (hole_vert_ids[i], hole_vert_ids[j])
+                            } else {
+                                (hole_vert_ids[j], hole_vert_ids[i])
+                            };
+                            topo.edges.alloc(Edge::new(start, end, EdgeCurve::Line))
+                        });
+                        hole_edges.push(OrientedEdge::new(eid, is_forward));
+                    }
+                    let hw =
+                        Wire::new(hole_edges, true).map_err(crate::OperationsError::Topology)?;
+                    topo.wires.alloc(hw)
+                };
+                inner_wire_ids.push(hw_id);
+            }
+        }
+
+        let surface = match &frag.surface {
+            FaceSurface::Plane { .. } => FaceSurface::Plane { normal, d: d_val },
+            other => other.clone(),
+        };
+        let effective_reversed = if is_nonplanar {
+            flip ^ frag.source_reversed
+        } else {
+            false
+        };
+        let new_face = if effective_reversed {
+            Face::new_reversed(wire_id, inner_wire_ids, surface)
+        } else {
+            Face::new(wire_id, inner_wire_ids, surface)
+        };
+        let face = topo.faces.alloc(new_face);
+        face_ids_out.push(face);
+    }
+
+    if face_ids_out.is_empty() {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "compound_cut produced no faces".into(),
+        });
+    }
+
+    // ── Post-assembly ────────────────────────────────────────────────────
+    refine_boundary_edges(topo, &mut face_ids_out, &mut edge_map, tol)?;
+    split_nonmanifold_edges(topo, &mut face_ids_out)?;
+
+    let shell = Shell::new(face_ids_out).map_err(crate::OperationsError::Topology)?;
+    let shell_id = topo.shells.alloc(shell);
+    log::debug!(
+        "[compound_cut] total: {:.3}ms",
+        _t_total.elapsed().as_secs_f64() * 1000.0
+    );
+    Ok(topo.solids.alloc(Solid::new(shell_id, vec![])))
+}
+
+/// Sequential fallback for `compound_cut` when analytic path is unavailable.
+fn compound_cut_sequential(
+    topo: &mut Topology,
+    target: SolidId,
+    tools: &[SolidId],
+    opts: BooleanOptions,
+) -> Result<SolidId, crate::OperationsError> {
+    let mut result = target;
+    for &tool in tools {
+        result = boolean_with_options(topo, BooleanOp::Cut, result, tool, opts)?;
+    }
+    Ok(result)
 }
 
 /// Compute a plane-plane intersection chord clipped to both face polygons.
@@ -6830,5 +8042,124 @@ mod tests {
 
         // Should not panic
         let _result = boolean(&mut topo, BooleanOp::Fuse, a, b);
+    }
+
+    // ── compound_cut tests ──────────────────────────────────────────────
+
+    #[test]
+    fn compound_cut_empty_tools_returns_target() {
+        let mut topo = Topology::new();
+        let target = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+        let result = compound_cut(&mut topo, target, &[], BooleanOptions::default()).unwrap();
+        assert_eq!(result, target);
+    }
+
+    #[test]
+    fn compound_cut_single_tool_matches_boolean() {
+        use brepkit_math::mat::Mat4;
+
+        let mut topo = Topology::new();
+        let target = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+        let cyl = crate::primitives::make_cylinder(&mut topo, 0.5, 2.0).unwrap();
+        // Center the cylinder inside the box.
+        crate::transform::transform_solid(&mut topo, cyl, &Mat4::translation(1.0, 1.0, 0.0))
+            .unwrap();
+
+        // compound_cut with single tool delegates to boolean.
+        let result = compound_cut(&mut topo, target, &[cyl], BooleanOptions::default()).unwrap();
+
+        let box_vol = 8.0;
+        let cyl_vol = std::f64::consts::PI * 0.25 * 2.0;
+        assert_volume_near(&topo, result, box_vol - cyl_vol, 0.05);
+    }
+
+    #[test]
+    fn compound_cut_two_disjoint_cylinders() {
+        use brepkit_math::mat::Mat4;
+
+        let mut topo = Topology::new();
+        let target = crate::primitives::make_box(&mut topo, 4.0, 4.0, 2.0).unwrap();
+        // Cylinder 1 at (1,1)
+        let c1 = crate::primitives::make_cylinder(&mut topo, 0.3, 2.0).unwrap();
+        crate::transform::transform_solid(&mut topo, c1, &Mat4::translation(1.0, 1.0, 0.0))
+            .unwrap();
+        // Cylinder 2 at (3,3) — disjoint from c1
+        let c2 = crate::primitives::make_cylinder(&mut topo, 0.3, 2.0).unwrap();
+        crate::transform::transform_solid(&mut topo, c2, &Mat4::translation(3.0, 3.0, 0.0))
+            .unwrap();
+
+        let result = compound_cut(&mut topo, target, &[c1, c2], BooleanOptions::default()).unwrap();
+
+        let box_vol = 32.0;
+        let cyl_vol = std::f64::consts::PI * 0.09 * 2.0;
+        assert_volume_near(&topo, result, box_vol - 2.0 * cyl_vol, 0.05);
+    }
+
+    #[test]
+    fn compound_cut_all_tools_disjoint_returns_unchanged_volume() {
+        use brepkit_math::mat::Mat4;
+
+        let mut topo = Topology::new();
+        let target = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+        // Both cylinders far away from target.
+        let c1 = crate::primitives::make_cylinder(&mut topo, 0.3, 2.0).unwrap();
+        crate::transform::transform_solid(&mut topo, c1, &Mat4::translation(10.0, 0.0, 0.0))
+            .unwrap();
+        let c2 = crate::primitives::make_cylinder(&mut topo, 0.3, 2.0).unwrap();
+        crate::transform::transform_solid(&mut topo, c2, &Mat4::translation(-10.0, 0.0, 0.0))
+            .unwrap();
+
+        let result = compound_cut(&mut topo, target, &[c1, c2], BooleanOptions::default()).unwrap();
+
+        assert_volume_near(&topo, result, 8.0, 0.001);
+    }
+
+    #[test]
+    fn compound_cut_matches_sequential_2x2_grid() {
+        use brepkit_math::mat::Mat4;
+
+        let mut topo = Topology::new();
+        let target = crate::primitives::make_box(&mut topo, 4.0, 4.0, 2.0).unwrap();
+        let r = 0.3;
+        let spacing = 2.0;
+        let mut tools = Vec::new();
+        for row in 0..2 {
+            for col in 0..2 {
+                #[allow(clippy::cast_precision_loss)]
+                let x = 1.0 + (col as f64) * spacing;
+                #[allow(clippy::cast_precision_loss)]
+                let y = 1.0 + (row as f64) * spacing;
+                let c = crate::primitives::make_cylinder(&mut topo, r, 2.0).unwrap();
+                crate::transform::transform_solid(&mut topo, c, &Mat4::translation(x, y, 0.0))
+                    .unwrap();
+                tools.push(c);
+            }
+        }
+
+        // Sequential reference.
+        let mut seq_target = crate::primitives::make_box(&mut topo, 4.0, 4.0, 2.0).unwrap();
+        for &tool in &tools {
+            // Need fresh copies of tools for sequential (tools are consumed by boolean).
+            let tool_copy = crate::copy::copy_solid(&mut topo, tool).unwrap();
+            seq_target = boolean_with_options(
+                &mut topo,
+                BooleanOp::Cut,
+                seq_target,
+                tool_copy,
+                BooleanOptions::default(),
+            )
+            .unwrap();
+        }
+        let seq_vol = crate::measure::solid_volume(&topo, seq_target, 0.05).unwrap();
+
+        // Compound cut.
+        let result = compound_cut(&mut topo, target, &tools, BooleanOptions::default()).unwrap();
+        let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
+
+        let rel = (compound_vol - seq_vol).abs() / seq_vol;
+        assert!(
+            rel < 0.05,
+            "compound_cut volume {compound_vol:.4} != sequential {seq_vol:.4} (rel={rel:.4})"
+        );
     }
 }

--- a/crates/operations/src/measure.rs
+++ b/crates/operations/src/measure.rs
@@ -51,7 +51,7 @@ fn aabb_include(aabb: &mut Aabb3, p: Point3) {
 }
 
 /// Expand an AABB to include surface-specific extremes that vertices miss.
-fn expand_aabb_for_surface(aabb: &mut Aabb3, surface: &FaceSurface) {
+pub(crate) fn expand_aabb_for_surface(aabb: &mut Aabb3, surface: &FaceSurface) {
     match surface {
         FaceSurface::Sphere(s) => {
             let c = s.center();

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -1009,6 +1009,33 @@ impl BrepKernel {
         Ok(solid_id_to_u32(result))
     }
 
+    /// Cut a target solid by multiple tool solids in a single pass.
+    ///
+    /// This is more efficient than sequential `cut()` calls when many tools
+    /// are applied to the same target — it avoids re-processing unchanged
+    /// faces at each step.
+    ///
+    /// `tool_ids` is a JS `Uint32Array` or array of solid handles.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any handle is invalid or the operation fails.
+    #[wasm_bindgen(js_name = "compoundCut")]
+    pub fn compound_cut(&mut self, target: u32, tool_ids: &[u32]) -> Result<u32, JsError> {
+        let target_id = self.resolve_solid(target)?;
+        let tools: Vec<brepkit_topology::solid::SolidId> = tool_ids
+            .iter()
+            .map(|&h| self.resolve_solid(h))
+            .collect::<Result<Vec<_>, _>>()?;
+        let result = brepkit_operations::boolean::compound_cut(
+            &mut self.topo,
+            target_id,
+            &tools,
+            brepkit_operations::boolean::BooleanOptions::default(),
+        )?;
+        Ok(solid_id_to_u32(result))
+    }
+
     // ── Boolean operations with evolution tracking ─────────────────
 
     /// Fuse (union) two solids and return evolution tracking data.
@@ -5687,6 +5714,32 @@ impl BrepKernel {
                 let b_id = self.resolve_solid(b).map_err(|e| e.to_string())?;
                 let result = boolean(&mut self.topo, BooleanOp::Intersect, a_id, b_id)
                     .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!(solid_id_to_u32(result)))
+            }
+            "compoundCut" => {
+                let target = get_u32(args, "target")?;
+                let target_id = self.resolve_solid(target).map_err(|e| e.to_string())?;
+                let tool_arr = args["tools"]
+                    .as_array()
+                    .ok_or("missing or invalid 'tools' array")?;
+                let tools: Vec<brepkit_topology::solid::SolidId> = tool_arr
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| {
+                        let h = v
+                            .as_u64()
+                            .ok_or_else(|| format!("tools[{i}] is not a number"))
+                            .map(|n| n as u32)?;
+                        self.resolve_solid(h).map_err(|e| e.to_string())
+                    })
+                    .collect::<Result<Vec<_>, String>>()?;
+                let result = brepkit_operations::boolean::compound_cut(
+                    &mut self.topo,
+                    target_id,
+                    &tools,
+                    brepkit_operations::boolean::BooleanOptions::default(),
+                )
+                .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
             "transform" => {


### PR DESCRIPTION
## Summary

- **Pre-snapshot AABB filter** in `analytic_boolean()`: computes cheap per-face wire AABBs (vertex walk + 4-cardinal-point sampling for closed curves) to skip expensive `face_polygon()` for faces spatially disjoint from the opposing solid. Passthrough faces are pre-classified and bypass the intersection phase entirely.
- **`compound_cut(target, tools)`**: new public API that cuts a target solid by multiple tool solids in a single pass. Each target face is intersected only against overlapping tools, with classification short-circuiting on the first containing tool. Falls back to sequential `boolean_with_options()` for NURBS/torus or when analytic classification is insufficient.
- **WASM bindings**: `compoundCut()` direct method and `"compoundCut"` batch dispatch entry.

## Key changes

| File | Change |
|------|--------|
| `crates/operations/src/measure.rs` | `expand_aabb_for_surface` → `pub(crate)` |
| `crates/operations/src/boolean.rs` | `face_wire_aabb()` helper, AABB filter in `analytic_boolean()`, `compound_cut()` + `compound_cut_sequential()` fallback, 5 new tests |
| `crates/wasm/src/kernel.rs` | `compoundCut` binding + `dispatch_op` entry |

## Test plan

- [x] All 1207 existing + new tests pass
- [x] `compound_cut` with empty tools returns target unchanged
- [x] Single-tool `compound_cut` matches `boolean()` volume
- [x] Two disjoint cylinders: correct combined volume
- [x] All tools disjoint from target: volume unchanged
- [x] 2×2 cylinder grid: `compound_cut` volume matches sequential within 5%
- [x] Clippy clean (`-D warnings`), fmt clean, layer boundaries valid
- [x] WASM builds for `wasm32-unknown-unknown`