### PR TITLE
docs: refine README voice and add licensing details

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ let step = write_step(&topo, &[drilled])?;
 
 ## Why build a CAD kernel?
 
-Building a solid modeling kernel from scratch is one of those problems measured in developer-careers, not sprints. Parasolid, ACIS, and OpenCascade represent decades of accumulated effort — surface-surface intersection, robust boolean classification, exact geometric predicates, degenerate case handling. Each is a research domain in its own right.
+CAD kernels are career-sized problems. Surface intersection, boolean classification, exact predicates, degenerate case handling. Each one is its own research rabbit hole. Parasolid, ACIS, and OpenCascade represent decades of work on these problems.
 
-brepkit grew out of building [gridfinitylayouttool.com](https://gridfinitylayouttool.com). I needed parametric CAD in the browser and the existing options were either proprietary or compiled-from-C++ with bridge overhead. OpenCascade works — [brepjs](https://github.com/andymai/brepjs) proves that — but performance ceilings and an 11 MB WASM bundle kept getting in the way.
+brepkit takes a crack at all of them in Rust, targeting WebAssembly from day one. I started it while building [gridfinitylayouttool.com](https://gridfinitylayouttool.com) and getting tired of OCCT's bridge overhead and 11 MB WASM bundle.
 
-brepkit is the answer to a simple question: what if the kernel was built for WebAssembly from day one? Rust's type system, no `unsafe`, no `unwrap`, no `panic` — all operations return `Result`. The WASM bundle is 1.8 MB.
+brepkit compiles to a 1.8 MB WASM bundle. Booleans run 3-30x faster than OpenCascade. No `unsafe`, no `unwrap`, no `panic`. All operations return `Result`. It's not finished, but it's fast and it's getting there.
 
 ## Status
 
-Core operations work and are fast: primitives, booleans, fillets, chamfers, extrude, revolve, sweep, loft, pipe, STEP I/O. The math layer — NURBS evaluation, exact geometric predicates, all analytic surface intersections — is mature. Booleans preserve analytic surfaces (cylinders stay cylinders) and handle compound operations efficiently.
+Core operations work and are fast: primitives, booleans, fillets, chamfers, extrude, revolve, sweep, loft, pipe, STEP I/O. The math layer (NURBS evaluation, exact geometric predicates, all analytic surface intersections) is mature. Booleans preserve analytic surfaces and handle compound operations efficiently.
 
-Still maturing: torus booleans fall back to the tessellated path, revolve/sweep/loft/pipe require planar profiles (extrude handles NURBS), and IGES round-trips lose analytic surface types.
+Still maturing: most sweeps need planar profiles (extrude handles NURBS), torus booleans use a slower tessellated path, and IGES round-trips lose analytic surface types.
 
-For production use today, [brepjs](https://github.com/andymai/brepjs) with the OpenCascade kernel is the stable path. brepkit is the faster replacement in progress — the kernel abstraction layer in brepjs means switching is a one-line change.
+For production use today, [brepjs](https://github.com/andymai/brepjs) with the OpenCascade kernel is the stable path. brepkit is the faster replacement in progress. The kernel abstraction layer in brepjs means switching is a one-line change.
 
 ## Features
 
@@ -79,12 +79,12 @@ Layered Cargo workspace. Each layer depends only on layers below it, with one ex
 | L0 | `brepkit-math` | Points, vectors, matrices, NURBS curves/surfaces, geometric predicates, CDT, convex hull |
 | L1 | `brepkit-topology` | Arena-allocated B-Rep: vertex, edge, wire, face, shell, solid. Half-edge adjacency graph |
 | L2 | `brepkit-operations` | Booleans, fillet, chamfer, extrude, revolve, sweep, loft, shell, measure |
-| L2 | `brepkit-io` | Import/export for 7 formats (2 B-Rep, 5 mesh). Uses operations for tessellation during mesh export |
+| L2 | `brepkit-io` | Import/export for 7 formats (2 B-Rep, 5 mesh) |
 | L3 | `brepkit-wasm` | JavaScript API via wasm-bindgen |
 
 ## Performance
 
-Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs/tree/main/benchmarks) (5 iterations, Node.js, Linux x86_64). WASM is single-threaded; native benchmarks use criterion with rayon.
+Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs/tree/main/benchmarks) (5 iterations, Node.js, Linux x86_64). WASM is single-threaded. Native benchmarks use criterion with rayon.
 
 | Operation | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
 |-----------|---------------|-------------|---------|-----------------|
@@ -97,7 +97,7 @@ Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs
 | mesh sphere (tol=0.01) | 20.0 ms | 61.3 ms | 3.1x | 1.8 ms |
 | exportSTEP (×10) | 0.9 ms | 19.2 ms | 21x | — |
 
-Booleans preserve analytic surfaces — cylinders and planes stay as exact geometry, keeping face counts low (72 vs ~7,000 for a 9-step compound boolean).
+Booleans preserve analytic surfaces, so cylinders and planes stay as exact geometry. This keeps face counts low (72 vs ~7,000 for a 9-step compound boolean).
 
 > Native benchmarks: `cargo bench -p brepkit-operations`. WASM comparison: `brepjs/benchmarks/`.
 


### PR DESCRIPTION
## Summary
- Rewrites README prose to match personal voice: shorter declarative sentences, fewer em dashes, commas for flow
- Adds adoption/community message to the preamble
- Expands License section with AGPL rationale and commercial licensing link

Follow-up to #186.

## Test plan
- [ ] Verify prose reads naturally and matches brepjs tone
- [ ] Confirm mailto link points to hi@andymai.com
- [ ] Check all factual claims unchanged from #186 (already verified)