### PR TITLE
fix(math): harden GCS entity snapshot and QR norm downdate

### DIFF
--- a/crates/math/src/gcs/constraint.rs
+++ b/crates/math/src/gcs/constraint.rs
@@ -73,14 +73,24 @@ pub struct EntitySnapshot {
 
 impl EntitySnapshot {
     /// Look up a point's (x, y) by handle.
+    ///
+    /// Returns `(NaN, NaN)` for stale/missing handles. NaN propagates
+    /// through residual and Jacobian arithmetic, causing the solver to
+    /// detect non-convergence rather than silently using wrong values.
     fn point(&self, id: PointId) -> (f64, f64) {
-        self.points.get(&id).copied().unwrap_or((0.0, 0.0))
+        self.points
+            .get(&id)
+            .copied()
+            .unwrap_or((f64::NAN, f64::NAN))
     }
 
     /// Look up a line's endpoint IDs.
+    ///
+    /// Returns dummy IDs for stale handles. When those IDs are subsequently
+    /// looked up via [`Self::point`], NaN is returned, poisoning downstream
+    /// arithmetic.
     fn line(&self, id: LineId) -> (PointId, PointId) {
         self.lines.get(&id).copied().unwrap_or_else(|| {
-            // Should never happen if constraints are validated
             let dummy = PointId::dummy();
             (dummy, dummy)
         })
@@ -88,7 +98,10 @@ impl EntitySnapshot {
 }
 
 impl Handle<PointData> {
-    /// Create a dummy handle (only for unreachable fallback paths).
+    /// Create a dummy handle for unreachable fallback paths.
+    ///
+    /// Looking up a dummy handle in [`EntitySnapshot::point`] returns NaN,
+    /// which propagates through the solver to signal an error.
     fn dummy() -> Self {
         Self {
             index: u32::MAX,

--- a/crates/math/src/gcs/qr.rs
+++ b/crates/math/src/gcs/qr.rs
@@ -111,13 +111,27 @@ impl QrResult {
                 }
             }
 
-            // Update remaining column norms (downdate)
+            // Update remaining column norms (downdate).
+            // Periodic recomputation prevents accumulated rounding errors
+            // from corrupting pivot selection in large systems.
+            let recompute_interval = (k / 4).max(1);
+            let needs_recompute = (step + 1) % recompute_interval == 0;
+
             for j in (step + 1)..n {
-                let v = data[step * n + j];
-                col_norms[j] -= v * v;
-                // Clamp to avoid negative due to rounding
-                if col_norms[j] < 0.0 {
-                    col_norms[j] = 0.0;
+                if needs_recompute {
+                    // Full recomputation from the sub-column below the diagonal
+                    let mut s = 0.0;
+                    for i in (step + 1)..m {
+                        let v = data[i * n + j];
+                        s += v * v;
+                    }
+                    col_norms[j] = s;
+                } else {
+                    let v = data[step * n + j];
+                    col_norms[j] -= v * v;
+                    if col_norms[j] < 0.0 {
+                        col_norms[j] = 0.0;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- **E1 fix**: `EntitySnapshot::point()` now returns `(NaN, NaN)` for stale/missing handles instead of `(0.0, 0.0)`. NaN propagates through residual and Jacobian arithmetic, causing the solver to detect non-convergence rather than silently computing with wrong values.
- **E2 fix**: QR column-norm downdate now recomputes norms from scratch every `k/4` steps (minimum 1) to prevent accumulated rounding errors from corrupting pivot selection in large constraint systems.

## Test plan
- [x] All 384 math tests pass
- [x] Clippy clean with all features
- [x] No signature changes — backward compatible