### PR TITLE
refactor: replace manual coordinate arithmetic with operators

### DIFF
--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -524,7 +524,7 @@ pub fn intersect_plane_cone(
         let n_dot_apex = dot_np(normal, apex);
         // dir(u) = P(u,1) - apex
         let p1 = cone.evaluate(u, 1.0);
-        let dir = Vec3::new(p1.x() - apex.x(), p1.y() - apex.y(), p1.z() - apex.z());
+        let dir = p1 - apex;
         let n_dot_dir = normal.dot(dir);
 
         if n_dot_dir.abs() < 1e-12 {

--- a/crates/math/src/convex_hull.rs
+++ b/crates/math/src/convex_hull.rs
@@ -83,7 +83,7 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
         let signed = signed_distance(face, centroid);
         if signed > 0.0 {
             // Normal points inward — flip.
-            face.normal = Vec3::new(-face.normal.x(), -face.normal.y(), -face.normal.z());
+            face.normal = -face.normal;
             face.d = -face.d;
             face.verts.swap(1, 2);
         }

--- a/crates/operations/src/boolean.rs
+++ b/crates/operations/src/boolean.rs
@@ -4307,11 +4307,7 @@ fn split_nonmanifold_edges(
             };
 
             // If face is reversed, flip the effective normal for sorting.
-            let effective_normal = if face.is_reversed() {
-                Vec3::new(-normal.x(), -normal.y(), -normal.z())
-            } else {
-                normal
-            };
+            let effective_normal = if face.is_reversed() { -normal } else { normal };
 
             // Project normal onto perpendicular plane and compute angle.
             let proj_u = effective_normal.dot(u_axis);

--- a/crates/operations/src/classify.rs
+++ b/crates/operations/src/classify.rs
@@ -334,7 +334,7 @@ fn count_3d_polygon_crossings(
     // extends into the opposite side of the boundary plane.
     let face = topo.face(face_id)?;
     if face.is_reversed() {
-        normal = normal * -1.0;
+        normal = -normal;
     }
     // A reference point on the boundary plane.
     let ref_pt = verts[0];

--- a/crates/operations/src/distance.rs
+++ b/crates/operations/src/distance.rs
@@ -338,10 +338,10 @@ fn closest_point_on_segment(point: Point3, a: Point3, b: Point3) -> Point3 {
     if len_sq < 1e-30 {
         return a;
     }
-    let ap = Vec3::new(point.x() - a.x(), point.y() - a.y(), point.z() - a.z());
+    let ap = point - a;
     let t = ap.dot(ab) / len_sq;
     let t = t.clamp(0.0, 1.0);
-    Point3::new(a.x() + t * ab.x(), a.y() + t * ab.y(), a.z() + t * ab.z())
+    a + ab * t
 }
 
 /// Compute the distance from a point to a single face, dispatching by type.

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -524,7 +524,7 @@ pub fn extrude(
 
     let bottom_surface = match &input_surface {
         FaceSurface::Plane { normal, .. } => {
-            let bottom_normal = Vec3::new(-normal.x(), -normal.y(), -normal.z());
+            let bottom_normal = -*normal;
             let bottom_d = dot_normal_point(bottom_normal, input_positions[0]);
             FaceSurface::Plane {
                 normal: bottom_normal,

--- a/crates/operations/src/fillet.rs
+++ b/crates/operations/src/fillet.rs
@@ -1260,7 +1260,7 @@ pub fn fillet_rolling_ball(
             // Normal should point away from the original vertex
             let to_vertex = v_pos - centroid;
             if to_vertex.dot(blend_normal) > 0.0 {
-                Vec3::new(-blend_normal.x(), -blend_normal.y(), -blend_normal.z())
+                -blend_normal
             } else {
                 blend_normal
             }

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -399,7 +399,7 @@ pub fn fix_face_orientations(
     for (fid, normal, d) in faces_to_flip {
         let face = topo.face_mut(fid)?;
         face.set_surface(FaceSurface::Plane {
-            normal: Vec3::new(-normal.x(), -normal.y(), -normal.z()),
+            normal: -normal,
             d: -d,
         });
     }

--- a/crates/operations/src/measure.rs
+++ b/crates/operations/src/measure.rs
@@ -174,8 +174,7 @@ pub fn face_area(
                 let u_vals: Vec<f64> = positions
                     .iter()
                     .map(|p| {
-                        let rel =
-                            Vec3::new(p.x() - origin.x(), p.y() - origin.y(), p.z() - origin.z());
+                        let rel = *p - origin;
                         let along = axis.dot(rel);
                         let radial = rel - axis * along;
                         radial.y().atan2(radial.x())


### PR DESCRIPTION
## Summary
- Replace manual component-wise arithmetic with Vec3/Point3 operators across 9 files
- `Vec3::new(a.x()-b.x(), ...)` → `a - b` (3 sites)
- `Point3::new(a.x()+t*v.x(), ...)` → `a + v * t` (1 site)  
- `Vec3::new(-v.x(), -v.y(), -v.z())` → `-v` (6 sites)
- `v * -1.0` → `-v` (1 site)
- Net -5 lines

## Test plan
- [x] All 19 test suites pass
- [x] Clippy clean with all features