### PR TITLE
fix(deps): migrate tsify-next to tsify (RUSTSEC-2025-0048)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rayon = "1.11"
 
 # WASM
 wasm-bindgen = "=0.2.114"  # Pinned: must match wasm-bindgen-cli in CI
-tsify-next = { version = "0.5", features = ["js"] }
+tsify = { version = "0.5", features = ["js"] }
 serde-wasm-bindgen = "0.6"
 
 # Testing

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -27,7 +27,7 @@ thiserror.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tsify-next.workspace = true
+tsify.workspace = true
 serde-wasm-bindgen.workspace = true
 
 [lints]

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -3,7 +3,7 @@
 //! Types annotated with `Tsify` automatically generate TypeScript definitions
 //! and can be serialized via `serde-wasm-bindgen` for zero-copy JS interop.
 
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 /// Typed result for `tessellateSolidGrouped`.
 #[derive(serde::Serialize, Tsify)]

--- a/deny.toml
+++ b/deny.toml
@@ -7,12 +7,8 @@ allow = [
   "AGPL-3.0-only",
   "Apache-2.0",
   "MIT",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "ISC",
   "Zlib",
   "Unicode-3.0",
-  "Unicode-DFS-2016",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary
- Migrate from unmaintained `tsify-next` to the now-maintained `tsify` crate (RUSTSEC-2025-0048)
- Remove 4 unused license allowances from `deny.toml` (BSD-2-Clause, BSD-3-Clause, ISC, Unicode-DFS-2016)

This unblocks `Cargo Deny` CI on `main` and the release-please PR #222.

## Test plan
- [x] `cargo deny check` passes (advisories ok, licenses ok)
- [x] `cargo build -p brepkit-wasm` compiles
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean