### PR TITLE
fix(fillet): correct vertex blend spherical cap geometry (#25, closes #26)

### DIFF
--- a/crates/operations/src/fillet.rs
+++ b/crates/operations/src/fillet.rs
@@ -1393,8 +1393,9 @@ pub fn fillet_rolling_ball(
                     // v=1 boundary degenerates to single point p2.
                     //
                     // Weight grid — per-edge weights on each boundary arc,
-                    // apex weight in the interior, 1.0 at corners, 1.0 on
-                    // the degenerate row (p2, p2, p2).
+                    // apex weight in the interior, 1.0 at corners.
+                    // Column 2 (degenerate, all CPs = p2) uses 1.0
+                    // for symmetric interior parametrization.
                     let cap_surface = NurbsSurface::new(
                         2,
                         2,
@@ -1403,7 +1404,7 @@ pub fn fillet_rolling_ball(
                         vec![vec![p0, m20, p2], vec![m01, apex, p2], vec![p1, m12, p2]],
                         vec![
                             vec![1.0, w20, 1.0],
-                            vec![w01, w_apex, w12],
+                            vec![w01, w_apex, 1.0],
                             vec![1.0, w12, 1.0],
                         ],
                     )


### PR DESCRIPTION
## Summary

- **Fix vertex blend sphere center** (#25): replaced `centroid + normal * R` (outside the solid) with `vertex - R * Σ(face_normals)` (correct offset-plane intersection inside the solid)
- **Fix edge midpoint control points**: changed from on-sphere points to tangent-intersection positions (`r/cos(θ/2)` from center), as required by rational quadratic Bézier circular arcs
- **Fix weight computation**: replaced single shared `w_edge` with per-edge `cos(θ/2)` weights and product apex weight
- **Close #26** (offset surface sample-and-refit): already resolved by adaptive curvature refinement + SSI trimming in `offset_face.rs`/`offset_trim.rs` — verified 38 offset tests pass

Before: sphere deviation 0.13 (larger than fillet radius R=0.1).
After: sphere deviation 0.002 (< 2.5% of R).

Completes Tier 2 of the robustness roadmap (14/16 → 16/16).

## Test plan

- [x] `vertex_blend_is_curved_not_flat` — blend surface points lie on correct sphere (deviation < 5% R)
- [x] `vertex_blend_sphere_center_inside_solid` — surface points within unit cube bounds (± R margin)
- [x] All 7 vertex blend tests pass
- [x] All 43 fillet tests pass
- [x] All 38 offset tests pass
- [x] All 1466 workspace tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #25
Closes #26