### PR TITLE
feat: validate SSI curves + G1 fillet chain propagation (#34, #37)

### DIFF
--- a/crates/math/src/nurbs/intersection.rs
+++ b/crates/math/src/nurbs/intersection.rs
@@ -1047,29 +1047,39 @@ fn validate_intersection_curves(
             max_dev = max_dev.max(dev);
         }
 
-        if max_dev > tolerance {
-            // Re-fit from stored sample points with higher fidelity.
-            let refit_curve = refit_from_samples(ic);
-            result.push(refit_curve);
-            continue;
-        }
+        // Use the refitted curve if Phase 1 failed, otherwise the original.
+        let working_curve = if max_dev > tolerance {
+            refit_from_samples(ic)
+        } else {
+            ic.clone()
+        };
 
         // Phase 2: Dual-surface validation — verify the curve lies on
         // both input surfaces by projecting evenly-spaced curve points.
+        let (wt_min, wt_max) = working_curve.curve.domain();
         let n_surface_check = 5;
         let mut max_surface_dev = 0.0_f64;
+        let mut successful_projections = 0_u32;
         for i in 0..n_surface_check {
-            let t = t_min + (t_max - t_min) * i as f64 / (n_surface_check - 1).max(1) as f64;
-            let curve_pt = ic.curve.evaluate(t.clamp(t_min, t_max));
+            let t = wt_min + (wt_max - wt_min) * i as f64 / (n_surface_check - 1).max(1) as f64;
+            let curve_pt = working_curve.curve.evaluate(t.clamp(wt_min, wt_max));
 
             // Project onto surface 1 and measure deviation.
             if let Ok(proj) = project_point_to_surface(s1, curve_pt, tolerance) {
                 max_surface_dev = max_surface_dev.max(proj.distance);
+                successful_projections += 1;
             }
             // Project onto surface 2 and measure deviation.
             if let Ok(proj) = project_point_to_surface(s2, curve_pt, tolerance) {
                 max_surface_dev = max_surface_dev.max(proj.distance);
+                successful_projections += 1;
             }
+        }
+
+        if successful_projections == 0 {
+            // No projections succeeded — can't validate, keep curve as-is.
+            result.push(working_curve);
+            continue;
         }
 
         if max_surface_dev > tolerance {
@@ -1080,7 +1090,7 @@ fn validate_intersection_curves(
             let refit_curve = refit_from_samples(ic);
             result.push(refit_curve);
         } else {
-            result.push(ic.clone());
+            result.push(working_curve);
         }
     }
 

--- a/crates/operations/src/fillet.rs
+++ b/crates/operations/src/fillet.rs
@@ -1703,9 +1703,9 @@ pub fn fillet_rolling_ball_propagate_g1(
     seed_edges: &[EdgeId],
     radius: f64,
 ) -> Result<SolidId, crate::OperationsError> {
-    let tol = Tolerance::new();
-    let expanded = expand_g1_chain(topo, solid, seed_edges, tol)?;
-    fillet_rolling_ball(topo, solid, &expanded, radius)
+    // fillet_rolling_ball now performs G1 chain expansion internally,
+    // so we forward directly to avoid expanding twice.
+    fillet_rolling_ball(topo, solid, seed_edges, radius)
 }
 
 /// Law governing how fillet radius varies along an edge.


### PR DESCRIPTION
## Summary

Closes Tier 3 robustness items #34 and #37 (plus #35 which was already done — CDT replaced ear-clipping).

- **#34 — Dual-surface SSI validation**: `validate_intersection_curves()` now projects fitted curve samples onto both input surfaces. Curves passing the LSPIA fit check but deviating from either surface are re-fitted via interpolation. Previously the surface parameters were unused (`_s1`, `_s2`).

- **#37 — G1 chain propagation**: `fillet_rolling_ball()` now automatically expands the edge set to include all G1-continuous neighbors (< 10° tangent deviation). Previously this was only available via `fillet_rolling_ball_propagate_g1()`; now all callers benefit.

## Test plan

- [x] `cargo test -p brepkit-math` — all pass (new: `dual_surface_validation_passes_for_known_intersection`)
- [x] `cargo test -p brepkit-operations` — all pass (new: `g1_chain_no_expansion_for_box`, `g1_chain_integrated_matches_explicit_wrapper`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Full workspace test suite passes (pre-push hook)