### PR TITLE
perf: switch release opt-level from "z" to 3 (perf #1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ cast_lossless = "allow"
 [profile.release]
 lto = true
 codegen-units = 1
-opt-level = "z"
+opt-level = 3
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
## Summary

- Change `[profile.release]` `opt-level` from `"z"` (minimize size) to `3` (maximize speed)
- One-line change in root `Cargo.toml`

## Native Benchmarks (before → after)

| Benchmark | opt-level "z" | opt-level 3 | Speedup |
|-----------|--------------|-------------|---------|
| fuse(box,box) x10 | 3.12 ms | 1.62 ms | **1.9x** |
| cut(box,cyl) x10 | 2.36 ms | 1.04 ms | **2.3x** |
| intersect(box,sphere) x10 | 24.6 ms | 11.5 ms | **2.1x** |
| boolean 64 cuts | 16.7 ms | 7.59 ms | **2.2x** |
| tessellate 64-hole | 95.0 ms | 40.2 ms | **2.4x** |
| mesh sphere (tol=0.01) | 2.97 ms | 546 µs | **5.4x** |
| mesh box (tol=0.1) | 38.5 µs | 17.5 µs | **2.2x** |
| makeCylinder x100 | 55.4 µs | 16.9 µs | **3.3x** |
| volume x100 | 5.34 ms | 2.53 ms | **2.1x** |

## WASM Binary Size

| | Size |
|--|------|
| Before (opt-level "z") | 1.90 MB |
| After (opt-level 3) | 2.49 MB |
| Delta | +31% |

Still under the 2.5 MB target.

## Test plan

- [x] `cargo test --workspace` passes
- [x] WASM smoke test passes
- [x] WASM binary under 2.5 MB