### PR TITLE
perf(wasm): enable simd128 by default (perf #2)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [alias]
 xtask = "run --manifest-path xtask/Cargo.toml --"
 
-# Note: WASM SIMD flags (-C target-feature=+simd128) are set by xtask via
-# RUSTFLAGS, not here, because rustflags in config.toml overrides (doesn't
-# append to) env RUSTFLAGS, and CI sets RUSTFLAGS=-Dwarnings globally.
+# Note: WASM SIMD flags (-C target-feature=+simd128) are enabled by default
+# via xtask (disable with --no-simd). Not set here because rustflags in
+# config.toml overrides (doesn't append to) env RUSTFLAGS, and CI sets
+# RUSTFLAGS=-Dwarnings globally.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,9 +96,13 @@ jobs:
 
       - name: Build WASM (bundler target for browsers)
         run: wasm-pack build crates/wasm --target bundler --release --out-dir pkg
+        env:
+          RUSTFLAGS: "-Dwarnings -C target-feature=+simd128"
 
       - name: Build WASM (nodejs target for Node.js/vitest)
         run: wasm-pack build crates/wasm --target nodejs --release --out-dir pkg-node
+        env:
+          RUSTFLAGS: "-Dwarnings -C target-feature=+simd128"
 
       - name: Merge dual targets into single package
         working-directory: crates/wasm

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,9 +13,9 @@ struct Cli {
 enum Command {
     /// Build WASM package with dual targets, merge, and validate.
     WasmBuild {
-        /// Enable SIMD optimizations (wasm simd128).
+        /// Disable SIMD optimizations (simd128 is enabled by default).
         #[arg(long)]
-        simd: bool,
+        no_simd: bool,
 
         /// Skip wasm-opt optimization pass.
         #[arg(long)]
@@ -28,9 +28,9 @@ enum Command {
         #[arg(long)]
         dry_run: bool,
 
-        /// Enable SIMD optimizations.
+        /// Disable SIMD optimizations (simd128 is enabled by default).
         #[arg(long)]
-        simd: bool,
+        no_simd: bool,
     },
 }
 
@@ -38,9 +38,9 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::WasmBuild { simd, skip_opt } => {
+        Command::WasmBuild { no_simd, skip_opt } => {
             wasm::check_tools()?;
-            wasm::build_both_targets(simd)?;
+            wasm::build_both_targets(!no_simd)?;
             if !skip_opt {
                 wasm::run_wasm_opt()?;
             }
@@ -49,9 +49,9 @@ fn main() -> anyhow::Result<()> {
             println!("\n✅ WASM build complete. Run smoke test with:");
             println!("   node scripts/test-wasm-smoke.mjs");
         }
-        Command::WasmPublish { dry_run, simd } => {
+        Command::WasmPublish { dry_run, no_simd } => {
             wasm::check_tools()?;
-            wasm::build_both_targets(simd)?;
+            wasm::build_both_targets(!no_simd)?;
             wasm::run_wasm_opt()?;
             wasm::merge_packages()?;
             wasm::validate_output()?;


### PR DESCRIPTION
## Summary

- Flip xtask CLI from opt-in `--simd` to opt-out `--no-simd`, making SIMD128 the default
- Add `RUSTFLAGS="-Dwarnings -C target-feature=+simd128"` to publish workflow wasm-pack steps
- Update `.cargo/config.toml` comment to reflect new default

## WASM Binary Size

| | Size |
|--|------|
| Without SIMD | 1.90 MB |
| With SIMD (now default) | 1.82 MB |
| Delta | **-4%** |

SIMD instructions are more compact than the scalar equivalents they replace.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo xtask wasm-build --skip-opt` works (SIMD by default)
- [x] `cargo xtask wasm-build --no-simd --skip-opt` works (opt-out)
- [x] `node scripts/test-wasm-smoke.mjs` passes