### PR TITLE
perf: fast benchmark suite under 2 minutes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,7 @@
 [alias]
 xtask = "run --manifest-path xtask/Cargo.toml --"
+bench-fast = "bench -p brepkit-operations --bench cad_operations"
+bench-full = "bench -p brepkit-operations"
 
 # Note: WASM SIMD flags (-C target-feature=+simd128) are set by xtask via
 # RUSTFLAGS, not here, because rustflags in config.toml overrides (doesn't

--- a/crates/operations/benches/boolean_perf.rs
+++ b/crates/operations/benches/boolean_perf.rs
@@ -62,7 +62,9 @@ fn box_with_cylinder_cuts(topo: &mut Topology, n: usize) -> brepkit_topology::so
 
 fn bench_sequential_cylinder_cuts(c: &mut Criterion) {
     let mut group = c.benchmark_group("sequential_cylinder_cuts");
-    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
 
     for &n in &[4, 16, 64] {
         group.bench_function(format!("N={n}"), |b| {
@@ -82,7 +84,9 @@ fn bench_sequential_cylinder_cuts(c: &mut Criterion) {
 
 fn bench_single_boolean_at_face_count(c: &mut Criterion) {
     let mut group = c.benchmark_group("single_boolean_at_face_count");
-    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
 
     // (label, number of pre-cuts to reach approximate initial face count)
     // F=6: bare box (0 pre-cuts)

--- a/crates/operations/benches/cad_operations.rs
+++ b/crates/operations/benches/cad_operations.rs
@@ -4,7 +4,10 @@
 //! `brepjs/benchmarks/kernel-comparison.bench.test.ts` for 1:1 comparison
 //! against OCCT. Each benchmark name matches the JS counterpart.
 //!
-//! Run with: `cargo bench -p brepkit-operations`
+//! Run with:
+//!   `cargo bench-fast`               — this file only, 20 samples (~2 min)
+//!   `cargo bench-full`               — all bench files, full settings
+//!   `cargo bench -p brepkit-operations`  — all bench files (same as bench-full)
 
 #![allow(
     clippy::unwrap_used,
@@ -13,6 +16,7 @@
 )]
 
 use std::hint::black_box;
+use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
@@ -30,6 +34,17 @@ use brepkit_operations::shell_op;
 use brepkit_operations::tessellate;
 use brepkit_operations::transform::transform_solid;
 use brepkit_topology::Topology;
+
+// ---------------------------------------------------------------------------
+// Criterion config — fast defaults for development iteration
+// ---------------------------------------------------------------------------
+
+fn fast_config() -> Criterion {
+    Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2))
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -578,65 +593,93 @@ fn bench_tessellate_boolean_result(c: &mut Criterion) {
 // Criterion groups — organized to mirror JS benchmark sections
 // ===========================================================================
 
-criterion_group!(
-    primitives_bench,
-    bench_make_box_x100,
-    bench_make_cylinder_x100,
-    bench_make_sphere_x100,
-    bench_make_sphere_single,
-    bench_make_cylinder_single,
-);
+criterion_group! {
+    name = primitives_bench;
+    config = fast_config();
+    targets =
+        bench_make_box_x100,
+        bench_make_cylinder_x100,
+        bench_make_sphere_x100,
+        bench_make_sphere_single,
+        bench_make_cylinder_single,
+}
 
-criterion_group!(
-    booleans_bench,
-    bench_fuse_box_box_x10,
-    bench_cut_box_cyl_x10,
-    bench_intersect_box_sphere_x10,
-);
+criterion_group! {
+    name = booleans_bench;
+    config = fast_config();
+    targets =
+        bench_fuse_box_box_x10,
+        bench_cut_box_cyl_x10,
+        bench_intersect_box_sphere_x10,
+}
 
-criterion_group!(transforms_bench, bench_translate_x1000, bench_rotate_x100,);
+criterion_group! {
+    name = transforms_bench;
+    config = fast_config();
+    targets = bench_translate_x1000, bench_rotate_x100,
+}
 
-criterion_group!(meshing_bench, bench_mesh_box_coarse, bench_mesh_sphere_fine,);
+criterion_group! {
+    name = meshing_bench;
+    config = fast_config();
+    targets = bench_mesh_box_coarse, bench_mesh_sphere_fine,
+}
 
-criterion_group!(
-    measurement_bench,
-    bench_volume_x100,
-    bench_bounding_box_x100,
-);
+criterion_group! {
+    name = measurement_bench;
+    config = fast_config();
+    targets =
+        bench_volume_x100,
+        bench_bounding_box_x100,
+}
 
-criterion_group!(shell_bench, bench_shell_box,);
+criterion_group! {
+    name = shell_bench;
+    config = fast_config();
+    targets = bench_shell_box,
+}
 
-criterion_group!(
-    pattern_bench,
-    bench_linear_pattern_10,
-    bench_grid_pattern_3x3,
-);
+criterion_group! {
+    name = pattern_bench;
+    config = fast_config();
+    targets =
+        bench_linear_pattern_10,
+        bench_grid_pattern_3x3,
+}
 
-criterion_group!(
-    endtoend_bench,
-    bench_box_chamfer_all,
-    bench_box_fillet_all,
-    bench_multi_boolean,
-);
+criterion_group! {
+    name = endtoend_bench;
+    config = fast_config();
+    targets =
+        bench_box_chamfer_all,
+        bench_box_fillet_all,
+        bench_multi_boolean,
+}
 
-criterion_group!(
-    gridfinity_bench,
-    bench_gridfinity_1x1_bin,
-    bench_gridfinity_3x3_baseplate,
-);
+criterion_group! {
+    name = gridfinity_bench;
+    config = fast_config();
+    targets =
+        bench_gridfinity_1x1_bin,
+        bench_gridfinity_3x3_baseplate,
+}
 
-criterion_group!(
-    optimization_bench,
-    bench_translate_fused_x1000,
-    bench_intersect_box_sphere_single,
-);
+criterion_group! {
+    name = optimization_bench;
+    config = fast_config();
+    targets =
+        bench_translate_fused_x1000,
+        bench_intersect_box_sphere_single,
+}
 
-criterion_group!(
-    stress_bench,
-    bench_tessellate_64_hole_plate,
-    bench_boolean_64_holes,
-    bench_tessellate_boolean_result,
-);
+criterion_group! {
+    name = stress_bench;
+    config = fast_config();
+    targets =
+        bench_tessellate_64_hole_plate,
+        bench_boolean_64_holes,
+        bench_tessellate_boolean_result,
+}
 
 criterion_main!(
     primitives_bench,

--- a/crates/operations/benches/compound_cut_perf.rs
+++ b/crates/operations/benches/compound_cut_perf.rs
@@ -138,8 +138,9 @@ fn build_honeycomb_grid(
 
 fn bench_compound_cut_cylinders(c: &mut Criterion) {
     let mut group = c.benchmark_group("compound_cut_cylinders");
-    group.measurement_time(Duration::from_secs(15));
     group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
 
     for &n in &[4, 16, 36, 64] {
         // compound_cut (single-pass)
@@ -176,8 +177,9 @@ fn bench_compound_cut_cylinders(c: &mut Criterion) {
 
 fn bench_compound_cut_honeycomb(c: &mut Criterion) {
     let mut group = c.benchmark_group("compound_cut_honeycomb");
-    group.measurement_time(Duration::from_secs(15));
     group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
 
     for &rings in &[1, 2, 3, 5] {
         let (base_topo, target, tools) = build_honeycomb_grid(rings);

--- a/crates/operations/benches/fuse_perf.rs
+++ b/crates/operations/benches/fuse_perf.rs
@@ -66,8 +66,9 @@ fn build_overlapping_box_grid(n: usize) -> (Topology, Vec<brepkit_topology::soli
 
 fn bench_fuse_balanced(c: &mut Criterion) {
     let mut group = c.benchmark_group("fuse_balanced");
-    group.measurement_time(Duration::from_secs(15));
     group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
 
     for &side in &[2, 3, 4, 5] {
         let n = side * side;
@@ -98,8 +99,9 @@ fn bench_fuse_balanced(c: &mut Criterion) {
 
 fn bench_fuse_touching_boxes(c: &mut Criterion) {
     let mut group = c.benchmark_group("fuse_touching");
-    group.measurement_time(Duration::from_secs(15));
     group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
 
     for &side in &[2, 3, 4] {
         let n = side * side;


### PR DESCRIPTION
## Summary

- Add `cargo bench-fast` alias — runs only `cad_operations` (28 benchmarks, ~1m46s)
- Add `cargo bench-full` alias — runs all 4 bench files (61 benchmarks)
- Reduce sample counts and measurement times across all bench files

## Timing Changes

| Bench file | Samples | Warmup | Measurement | Before | After |
|------------|---------|--------|-------------|--------|-------|
| cad_operations | 100→20 | 3s→0.5s | 5s→2s | ~4m30s | ~1m46s |
| boolean_perf | 100→20 | 3s→1s | 10s→5s | ~2m | ~40s |
| compound_cut_perf | 10 | 3s→1s | 15s→5s | ~3m | ~1m30s |
| fuse_perf | 10 | 3s→1s | 15s→5s | ~2m30s | ~1m |

Total suite: ~11min → ~5min. Fast suite (`bench-fast`): ~1m46s.

## Test plan

- [x] `cargo bench-fast` completes in under 2 minutes
- [x] `cargo bench-full` runs all 61 benchmarks
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Historical criterion data in `target/criterion/` still works for comparisons