### PR TITLE
fix(tessellate): tighter capacity bound for planar CDT output

### DIFF
--- a/crates/operations/src/tessellate.rs
+++ b/crates/operations/src/tessellate.rs
@@ -715,8 +715,8 @@ fn tessellate_planar_with_holes(
     let cdt_triangles = cdt.triangles();
     let cdt_verts = cdt.vertices();
     let num_tris = cdt_triangles.len();
-    let mut positions_out = Vec::with_capacity(num_tris);
-    let mut normals_out = Vec::with_capacity(num_tris);
+    let mut positions_out = Vec::with_capacity(cdt_verts.len());
+    let mut normals_out = Vec::with_capacity(cdt_verts.len());
     let mut indices_out = Vec::with_capacity(num_tris * 3);
 
     // Build O(1) reverse map: CDT vertex index → original position index.


### PR DESCRIPTION
## Summary

Address Greptile review on PR #238: use `cdt_verts.len()` instead of `num_tris` for `positions_out` and `normals_out` capacity in `tessellate_planar_with_holes()`.

CDT vertices is the correct upper bound for unique output vertices — triangle count over-allocates by ~2x since vertices are deduplicated during mesh construction.

## Test plan

- [x] Pre-commit checks pass