### PR TITLE
perf(wasm): copy-on-write checkpoints via Rc<Topology>

### DIFF
--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -107,9 +107,9 @@ impl BrepKernel {
     ) -> brepkit_topology::edge::EdgeId {
         let start = points[0];
         let end = points[points.len() - 1];
-        let v_start = self.topo.add_vertex(Vertex::new(start, TOL));
-        let v_end = self.topo.add_vertex(Vertex::new(end, TOL));
-        self.topo
+        let v_start = self.topo_mut().add_vertex(Vertex::new(start, TOL));
+        let v_end = self.topo_mut().add_vertex(Vertex::new(end, TOL));
+        self.topo_mut()
             .add_edge(Edge::new(v_start, v_end, EdgeCurve::NurbsCurve(curve)))
     }
 
@@ -120,9 +120,9 @@ impl BrepKernel {
     ) -> brepkit_topology::edge::EdgeId {
         let start = curve.evaluate(curve.knots()[0]);
         let end = curve.evaluate(*curve.knots().last().unwrap_or(&1.0));
-        let v_start = self.topo.add_vertex(Vertex::new(start, TOL));
-        let v_end = self.topo.add_vertex(Vertex::new(end, TOL));
-        self.topo.add_edge(Edge::new(
+        let v_start = self.topo_mut().add_vertex(Vertex::new(start, TOL));
+        let v_end = self.topo_mut().add_vertex(Vertex::new(end, TOL));
+        self.topo_mut().add_edge(Edge::new(
             v_start,
             v_end,
             EdgeCurve::NurbsCurve(curve.clone()),
@@ -145,12 +145,12 @@ impl BrepKernel {
         ];
         let verts: Vec<_> = corners
             .iter()
-            .map(|p| self.topo.add_vertex(Vertex::new(*p, TOL)))
+            .map(|p| self.topo_mut().add_vertex(Vertex::new(*p, TOL)))
             .collect();
         let n = verts.len();
         let edges: Vec<_> = (0..n)
             .map(|i| {
-                self.topo
+                self.topo_mut()
                     .add_edge(Edge::new(verts[i], verts[(i + 1) % n], EdgeCurve::Line))
             })
             .collect();
@@ -159,9 +159,9 @@ impl BrepKernel {
             .map(|&eid| OrientedEdge::new(eid, true))
             .collect();
         let wire = Wire::new(oriented, true)?;
-        let wid = self.topo.add_wire(wire);
+        let wid = self.topo_mut().add_wire(wire);
         let face_id = self
-            .topo
+            .topo_mut()
             .add_face(Face::new(wid, vec![], FaceSurface::Nurbs(surface)));
         Ok(face_id)
     }
@@ -178,14 +178,14 @@ impl BrepKernel {
                 let w = get_f64(args, "width")?;
                 let h = get_f64(args, "height")?;
                 let d = get_f64(args, "depth")?;
-                let solid = brepkit_operations::primitives::make_box(&mut self.topo, w, h, d)
+                let solid = brepkit_operations::primitives::make_box(self.topo_mut(), w, h, d)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
             "makeCylinder" => {
                 let r = get_f64(args, "radius")?;
                 let h = get_f64(args, "height")?;
-                let solid = brepkit_operations::primitives::make_cylinder(&mut self.topo, r, h)
+                let solid = brepkit_operations::primitives::make_cylinder(self.topo_mut(), r, h)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
@@ -193,7 +193,7 @@ impl BrepKernel {
                 let r = get_f64(args, "radius")?;
                 let segments = get_u32(args, "segments").unwrap_or(16);
                 let solid = brepkit_operations::primitives::make_sphere(
-                    &mut self.topo,
+                    self.topo_mut(),
                     r,
                     segments as usize,
                 )
@@ -204,7 +204,7 @@ impl BrepKernel {
                 let br = get_f64(args, "bottomRadius")?;
                 let tr = get_f64(args, "topRadius")?;
                 let h = get_f64(args, "height")?;
-                let solid = brepkit_operations::primitives::make_cone(&mut self.topo, br, tr, h)
+                let solid = brepkit_operations::primitives::make_cone(self.topo_mut(), br, tr, h)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
@@ -213,7 +213,7 @@ impl BrepKernel {
                 let minor = get_f64(args, "minorRadius")?;
                 let segments = get_u32(args, "segments").unwrap_or(16);
                 let solid = brepkit_operations::primitives::make_torus(
-                    &mut self.topo,
+                    self.topo_mut(),
                     major,
                     minor,
                     segments as usize,
@@ -228,10 +228,10 @@ impl BrepKernel {
                 if rx <= 0.0 || ry <= 0.0 || rz <= 0.0 {
                     return Err("rx, ry, rz must be positive".to_string());
                 }
-                let solid = brepkit_operations::primitives::make_sphere(&mut self.topo, 1.0, 16)
+                let solid = brepkit_operations::primitives::make_sphere(self.topo_mut(), 1.0, 16)
                     .map_err(|e| e.to_string())?;
                 let mat = brepkit_math::mat::Mat4::scale(rx, ry, rz);
-                transform_solid(&mut self.topo, solid, &mat).map_err(|e| e.to_string())?;
+                transform_solid(self.topo_mut(), solid, &mat).map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
             "fuse" => {
@@ -239,7 +239,7 @@ impl BrepKernel {
                 let b = get_u32(args, "solidB")?;
                 let a_id = self.resolve_solid(a).map_err(|e| e.to_string())?;
                 let b_id = self.resolve_solid(b).map_err(|e| e.to_string())?;
-                let result = boolean(&mut self.topo, BooleanOp::Fuse, a_id, b_id)
+                let result = boolean(self.topo_mut(), BooleanOp::Fuse, a_id, b_id)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
@@ -248,7 +248,7 @@ impl BrepKernel {
                 let b = get_u32(args, "solidB")?;
                 let a_id = self.resolve_solid(a).map_err(|e| e.to_string())?;
                 let b_id = self.resolve_solid(b).map_err(|e| e.to_string())?;
-                let result = boolean(&mut self.topo, BooleanOp::Cut, a_id, b_id)
+                let result = boolean(self.topo_mut(), BooleanOp::Cut, a_id, b_id)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
@@ -257,7 +257,7 @@ impl BrepKernel {
                 let b = get_u32(args, "solidB")?;
                 let a_id = self.resolve_solid(a).map_err(|e| e.to_string())?;
                 let b_id = self.resolve_solid(b).map_err(|e| e.to_string())?;
-                let result = boolean(&mut self.topo, BooleanOp::Intersect, a_id, b_id)
+                let result = boolean(self.topo_mut(), BooleanOp::Intersect, a_id, b_id)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
@@ -279,7 +279,7 @@ impl BrepKernel {
                     })
                     .collect::<Result<Vec<_>, String>>()?;
                 let result = boolean::compound_cut(
-                    &mut self.topo,
+                    self.topo_mut(),
                     target_id,
                     &tools,
                     boolean::BooleanOptions::default(),
@@ -309,7 +309,7 @@ impl BrepKernel {
                     .collect::<Result<_, _>>()?;
                 let rows = std::array::from_fn(|i| std::array::from_fn(|j| elems[i * 4 + j]));
                 let mat = Mat4(rows);
-                transform_solid(&mut self.topo, solid_id, &mat).map_err(|e| e.to_string())?;
+                transform_solid(self.topo_mut(), solid_id, &mat).map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid_id)))
             }
             "volume" => {
@@ -371,7 +371,7 @@ impl BrepKernel {
             "copySolid" => {
                 let s = get_u32(args, "solid")?;
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
-                let copy = brepkit_operations::copy::copy_solid(&mut self.topo, solid_id)
+                let copy = brepkit_operations::copy::copy_solid(self.topo_mut(), solid_id)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(copy)))
             }
@@ -398,7 +398,7 @@ impl BrepKernel {
                 let rows = std::array::from_fn(|i| std::array::from_fn(|j| elems[i * 4 + j]));
                 let mat = Mat4(rows);
                 let copy = brepkit_operations::copy::copy_and_transform_solid(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     &mat,
                 )
@@ -415,7 +415,7 @@ impl BrepKernel {
                 let face_id = self.resolve_face(f).map_err(|e| e.to_string())?;
                 let dir = Vec3::new(dx, dy, dz);
                 let solid =
-                    extrude(&mut self.topo, face_id, dir, dist).map_err(|e| e.to_string())?;
+                    extrude(self.topo_mut(), face_id, dir, dist).map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
             "revolve" => {
@@ -430,7 +430,7 @@ impl BrepKernel {
                 let face_id = self.resolve_face(f).map_err(|e| e.to_string())?;
                 // Convert degrees to radians to match the direct WASM binding.
                 let solid = revolve(
-                    &mut self.topo,
+                    self.topo_mut(),
                     face_id,
                     Point3::new(ox, oy, oz),
                     Vec3::new(ax, ay, az),
@@ -451,7 +451,7 @@ impl BrepKernel {
                         return Err("sweep path must be a NURBS edge".into());
                     }
                 };
-                let solid = sweep(&mut self.topo, face_id, &curve).map_err(|e| e.to_string())?;
+                let solid = sweep(self.topo_mut(), face_id, &curve).map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
             "chamfer" => {
@@ -470,9 +470,13 @@ impl BrepKernel {
                     .iter()
                     .map(|&h| self.resolve_edge(h).map_err(|e| e.to_string()))
                     .collect::<Result<Vec<_>, _>>()?;
-                let result =
-                    brepkit_operations::chamfer::chamfer(&mut self.topo, solid_id, &edge_ids, dist)
-                        .map_err(|e| e.to_string())?;
+                let result = brepkit_operations::chamfer::chamfer(
+                    self.topo_mut(),
+                    solid_id,
+                    &edge_ids,
+                    dist,
+                )
+                .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
             "fillet" => {
@@ -492,7 +496,7 @@ impl BrepKernel {
                     .map(|&h| self.resolve_edge(h).map_err(|e| e.to_string()))
                     .collect::<Result<Vec<_>, _>>()?;
                 let fillet_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    try_fillet(&mut self.topo, solid_id, &edge_ids, radius)
+                    try_fillet(self.topo_mut(), solid_id, &edge_ids, radius)
                 }));
                 let result = match fillet_result {
                     Ok(inner) => inner.map_err(|e| e.to_string())?,
@@ -543,7 +547,7 @@ impl BrepKernel {
                     edge_laws.push((edge_id, law));
                 }
                 let result = brepkit_operations::fillet::fillet_variable(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     &edge_laws,
                 )
@@ -567,7 +571,7 @@ impl BrepKernel {
                     .map(|&h| self.resolve_face(h).map_err(|e| e.to_string()))
                     .collect::<Result<Vec<_>, _>>()?;
                 let result = brepkit_operations::shell_op::shell(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     thickness,
                     &face_ids,
@@ -585,7 +589,7 @@ impl BrepKernel {
                 let nz = get_f64(args, "nz").unwrap_or(0.0);
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
                 let result = brepkit_operations::mirror::mirror(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     Point3::new(px, py, pz),
                     Vec3::new(nx, ny, nz),
@@ -596,7 +600,7 @@ impl BrepKernel {
             "unifyFaces" => {
                 let s = get_u32(args, "solid")?;
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
-                brepkit_operations::heal::unify_faces(&mut self.topo, solid_id)
+                brepkit_operations::heal::unify_faces(self.topo_mut(), solid_id)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid_id)))
             }
@@ -604,7 +608,7 @@ impl BrepKernel {
                 let s = get_u32(args, "solid")?;
                 let tol = get_f64(args, "tolerance").unwrap_or(1e-7);
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
-                brepkit_operations::heal::heal_solid(&mut self.topo, solid_id, tol)
+                brepkit_operations::heal::heal_solid(self.topo_mut(), solid_id, tol)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid_id)))
             }
@@ -612,7 +616,7 @@ impl BrepKernel {
                 let s = get_u32(args, "solid")?;
                 let tol = get_f64(args, "tolerance").unwrap_or(1e-7);
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
-                let report = brepkit_operations::heal::repair_solid(&mut self.topo, solid_id, tol)
+                let report = brepkit_operations::heal::repair_solid(self.topo_mut(), solid_id, tol)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!({
                     "solid": solid_id_to_u32(solid_id),
@@ -648,7 +652,7 @@ impl BrepKernel {
                     .iter()
                     .map(|&h| self.resolve_face(h).map_err(|e| e.to_string()))
                     .collect::<Result<Vec<_>, _>>()?;
-                let result = brepkit_operations::loft::loft(&mut self.topo, &face_ids)
+                let result = brepkit_operations::loft::loft(self.topo_mut(), &face_ids)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
@@ -665,7 +669,7 @@ impl BrepKernel {
                     .iter()
                     .map(|&h| self.resolve_face(h).map_err(|e| e.to_string()))
                     .collect::<Result<Vec<_>, _>>()?;
-                let result = brepkit_operations::loft::loft_smooth(&mut self.topo, &face_ids)
+                let result = brepkit_operations::loft::loft_smooth(self.topo_mut(), &face_ids)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
@@ -678,7 +682,7 @@ impl BrepKernel {
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
                 let axis = Vec3::new(ax, ay, az);
                 let compound = brepkit_operations::pattern::circular_pattern(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     axis,
                     count as usize,
@@ -700,7 +704,7 @@ impl BrepKernel {
                 let cy = get_u32(args, "countY")?;
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
                 let compound = brepkit_operations::pattern::grid_pattern(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     Vec3::new(dxx, dxy, dxz),
                     Vec3::new(dyx, dyy, dyz),
@@ -728,14 +732,14 @@ impl BrepKernel {
                     .map(|&h| self.resolve_face(h).map_err(|e| e.to_string()))
                     .collect::<Result<Vec<_>, _>>()?;
                 let result =
-                    brepkit_operations::defeature::defeature(&mut self.topo, solid_id, &face_ids)
+                    brepkit_operations::defeature::defeature(self.topo_mut(), solid_id, &face_ids)
                         .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
             "copyWire" => {
                 let w = get_u32(args, "wire")?;
                 let wire_id = self.resolve_wire(w).map_err(|e| e.to_string())?;
-                let copy = brepkit_operations::copy::copy_wire(&mut self.topo, wire_id)
+                let copy = brepkit_operations::copy::copy_wire(self.topo_mut(), wire_id)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(wire_id_to_u32(copy)))
             }
@@ -764,7 +768,7 @@ impl BrepKernel {
                 }
                 let rows = std::array::from_fn(|i| std::array::from_fn(|j| elems[i * 4 + j]));
                 let mat = Mat4(rows);
-                brepkit_operations::transform::transform_wire(&mut self.topo, wire_id, &mat)
+                brepkit_operations::transform::transform_wire(self.topo_mut(), wire_id, &mat)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(null))
             }
@@ -774,7 +778,7 @@ impl BrepKernel {
                 let samples = get_u32(args, "samples").unwrap_or(16);
                 let face_id = self.resolve_face(f).map_err(|e| e.to_string())?;
                 let result = brepkit_operations::offset_face::offset_face(
-                    &mut self.topo,
+                    self.topo_mut(),
                     face_id,
                     dist,
                     samples as usize,
@@ -787,7 +791,7 @@ impl BrepKernel {
                 let dist = get_f64(args, "distance")?;
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
                 let result =
-                    brepkit_operations::offset_solid::offset_solid(&mut self.topo, solid_id, dist)
+                    brepkit_operations::offset_solid::offset_solid(self.topo_mut(), solid_id, dist)
                         .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
@@ -801,7 +805,7 @@ impl BrepKernel {
                 let nz = get_f64(args, "nz").unwrap_or(1.0);
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
                 let result = brepkit_operations::section::section(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     Point3::new(px, py, pz),
                     Vec3::new(nx, ny, nz),
@@ -820,7 +824,7 @@ impl BrepKernel {
                 let nz = get_f64(args, "nz").unwrap_or(1.0);
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
                 let result = brepkit_operations::split::split(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     Point3::new(px, py, pz),
                     Vec3::new(nx, ny, nz),
@@ -845,7 +849,7 @@ impl BrepKernel {
                     .iter()
                     .map(|&h| self.resolve_face(h).map_err(|e| e.to_string()))
                     .collect::<Result<Vec<_>, _>>()?;
-                let solid = brepkit_operations::sew::sew_faces(&mut self.topo, &face_ids, tol)
+                let solid = brepkit_operations::sew::sew_faces(self.topo_mut(), &face_ids, tol)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
@@ -854,7 +858,7 @@ impl BrepKernel {
                 let thickness = get_f64(args, "thickness")?;
                 let face_id = self.resolve_face(f).map_err(|e| e.to_string())?;
                 let result =
-                    brepkit_operations::thicken::thicken(&mut self.topo, face_id, thickness)
+                    brepkit_operations::thicken::thicken(self.topo_mut(), face_id, thickness)
                         .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
@@ -870,7 +874,7 @@ impl BrepKernel {
                         return Err("pipe path must be a NURBS edge".into());
                     }
                 };
-                let solid = brepkit_operations::pipe::pipe(&mut self.topo, face_id, &curve, None)
+                let solid = brepkit_operations::pipe::pipe(self.topo_mut(), face_id, &curve, None)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
@@ -883,7 +887,7 @@ impl BrepKernel {
                 let count = get_u32(args, "count")?;
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
                 let compound = brepkit_operations::pattern::linear_pattern(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     Vec3::new(dx, dy, dz),
                     spacing,
@@ -917,7 +921,7 @@ impl BrepKernel {
                 let dir = Vec3::new(dx, dy, dz);
                 let neutral = Point3::new(npx, npy, npz);
                 let result = brepkit_operations::draft::draft(
-                    &mut self.topo,
+                    self.topo_mut(),
                     solid_id,
                     &face_ids,
                     dir,
@@ -976,7 +980,7 @@ impl BrepKernel {
                 let dist = get_f64(args, "distance")?;
                 let face_id = self.resolve_face(f).map_err(|e| e.to_string())?;
                 let wire_id =
-                    brepkit_operations::offset_wire::offset_wire(&mut self.topo, face_id, dist)
+                    brepkit_operations::offset_wire::offset_wire(self.topo_mut(), face_id, dist)
                         .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(wire_id_to_u32(wire_id)))
             }
@@ -990,7 +994,7 @@ impl BrepKernel {
                     super::operations::parse_join_type_str(jt_str).map_err(|e| e.to_string())?;
                 let face_id = self.resolve_face(f).map_err(|e| e.to_string())?;
                 let wire_id = brepkit_operations::offset_wire::offset_wire_with_join(
-                    &mut self.topo,
+                    self.topo_mut(),
                     face_id,
                     dist,
                     jt,

--- a/crates/wasm/src/bindings/booleans.rs
+++ b/crates/wasm/src/bindings/booleans.rs
@@ -27,7 +27,7 @@ impl BrepKernel {
     pub fn fuse(&mut self, a: u32, b: u32) -> Result<u32, JsError> {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
-        let result = boolean(&mut self.topo, BooleanOp::Fuse, a_id, b_id)?;
+        let result = boolean(self.topo_mut(), BooleanOp::Fuse, a_id, b_id)?;
         Ok(solid_id_to_u32(result))
     }
 
@@ -43,7 +43,7 @@ impl BrepKernel {
     pub fn cut(&mut self, a: u32, b: u32) -> Result<u32, JsError> {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
-        let result = boolean(&mut self.topo, BooleanOp::Cut, a_id, b_id)?;
+        let result = boolean(self.topo_mut(), BooleanOp::Cut, a_id, b_id)?;
         Ok(solid_id_to_u32(result))
     }
 
@@ -59,7 +59,7 @@ impl BrepKernel {
     pub fn intersect_solids(&mut self, a: u32, b: u32) -> Result<u32, JsError> {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
-        let result = boolean(&mut self.topo, BooleanOp::Intersect, a_id, b_id)?;
+        let result = boolean(self.topo_mut(), BooleanOp::Intersect, a_id, b_id)?;
         Ok(solid_id_to_u32(result))
     }
 
@@ -82,7 +82,7 @@ impl BrepKernel {
             .map(|&h| self.resolve_solid(h))
             .collect::<Result<Vec<_>, _>>()?;
         let result = brepkit_operations::boolean::compound_cut(
-            &mut self.topo,
+            self.topo_mut(),
             target_id,
             &tools,
             brepkit_operations::boolean::BooleanOptions::default(),
@@ -105,7 +105,7 @@ impl BrepKernel {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
         let (result, evo) = brepkit_operations::boolean::boolean_with_evolution(
-            &mut self.topo,
+            self.topo_mut(),
             BooleanOp::Fuse,
             a_id,
             b_id,
@@ -131,7 +131,7 @@ impl BrepKernel {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
         let (result, evo) = brepkit_operations::boolean::boolean_with_evolution(
-            &mut self.topo,
+            self.topo_mut(),
             BooleanOp::Cut,
             a_id,
             b_id,
@@ -157,7 +157,7 @@ impl BrepKernel {
         let a_id = self.resolve_solid(a)?;
         let b_id = self.resolve_solid(b)?;
         let (result, evo) = brepkit_operations::boolean::boolean_with_evolution(
-            &mut self.topo,
+            self.topo_mut(),
             BooleanOp::Intersect,
             a_id,
             b_id,

--- a/crates/wasm/src/bindings/checkpoint.rs
+++ b/crates/wasm/src/bindings/checkpoint.rs
@@ -1,5 +1,7 @@
 //! Checkpoint / restore bindings for [`BrepKernel`].
 
+use std::rc::Rc;
+
 use wasm_bindgen::prelude::*;
 
 use crate::kernel::BrepKernel;
@@ -18,7 +20,7 @@ impl BrepKernel {
     pub fn checkpoint(&mut self) -> u32 {
         let id = self.checkpoints.len();
         self.checkpoints.push(Checkpoint {
-            topo: self.topo.clone(),
+            topo: Rc::clone(&self.topo),
             assemblies: self.assemblies.clone(),
             sketches: self.sketches.clone(),
         });
@@ -44,7 +46,7 @@ impl BrepKernel {
             .checkpoints
             .get(idx)
             .ok_or_else(|| JsError::new(&format!("invalid checkpoint id: {checkpoint_id}")))?;
-        self.topo = cp.topo.clone();
+        self.topo = Rc::clone(&cp.topo);
         self.assemblies = cp.assemblies.clone();
         self.sketches = cp.sketches.clone();
         // Discard checkpoints created after the restored one

--- a/crates/wasm/src/bindings/heal.rs
+++ b/crates/wasm/src/bindings/heal.rs
@@ -28,7 +28,7 @@ impl BrepKernel {
             .iter()
             .map(|&h| self.resolve_face(h))
             .collect::<Result<_, _>>()?;
-        let solid = brepkit_operations::sew::sew_faces(&mut self.topo, &face_ids, tolerance)?;
+        let solid = brepkit_operations::sew::sew_faces(self.topo_mut(), &face_ids, tolerance)?;
         Ok(solid_id_to_u32(solid))
     }
 
@@ -44,7 +44,7 @@ impl BrepKernel {
             .map(|&h| self.resolve_face(h))
             .collect::<Result<_, _>>()?;
         let tolerance = brepkit_math::tolerance::Tolerance::new().linear;
-        let solid = brepkit_operations::sew::sew_faces(&mut self.topo, &face_ids, tolerance)?;
+        let solid = brepkit_operations::sew::sew_faces(self.topo_mut(), &face_ids, tolerance)?;
         Ok(solid_id_to_u32(solid))
     }
 
@@ -56,7 +56,7 @@ impl BrepKernel {
         let outer_wire = face_data.outer_wire();
         let surface = face_data.surface().clone();
         let new_face = Face::new(outer_wire, vec![], surface);
-        let fid = self.topo.add_face(new_face);
+        let fid = self.topo_mut().add_face(new_face);
         Ok(face_id_to_u32(fid))
     }
 
@@ -80,7 +80,7 @@ impl BrepKernel {
         } else {
             brepkit_math::tolerance::Tolerance::new().linear
         };
-        let solid = brepkit_operations::sew::sew_faces(&mut self.topo, &face_ids, tol)?;
+        let solid = brepkit_operations::sew::sew_faces(self.topo_mut(), &face_ids, tol)?;
         Ok(solid_id_to_u32(solid))
     }
 
@@ -94,7 +94,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "unifyFaces")]
     pub fn unify_faces(&mut self, solid: u32) -> Result<u32, JsError> {
         let solid_id = self.resolve_solid(solid)?;
-        let removed = brepkit_operations::heal::unify_faces(&mut self.topo, solid_id)?;
+        let removed = brepkit_operations::heal::unify_faces(self.topo_mut(), solid_id)?;
         #[allow(clippy::cast_possible_truncation)]
         Ok(removed as u32)
     }
@@ -105,7 +105,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "healSolid")]
     pub fn heal_solid(&mut self, solid: u32) -> Result<u32, JsError> {
         let solid_id = self.resolve_solid(solid)?;
-        let report = brepkit_operations::heal::heal_solid(&mut self.topo, solid_id, TOL)?;
+        let report = brepkit_operations::heal::heal_solid(self.topo_mut(), solid_id, TOL)?;
         #[allow(clippy::cast_possible_truncation)]
         Ok((report.vertices_merged
             + report.degenerate_edges_removed
@@ -126,7 +126,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "repairSolid")]
     pub fn repair_solid(&mut self, solid: u32) -> Result<u32, JsError> {
         let solid_id = self.resolve_solid(solid)?;
-        let report = brepkit_operations::heal::repair_solid(&mut self.topo, solid_id, TOL)?;
+        let report = brepkit_operations::heal::repair_solid(self.topo_mut(), solid_id, TOL)?;
         #[allow(clippy::cast_possible_truncation)]
         Ok(report.after.error_count() as u32)
     }
@@ -137,8 +137,11 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "removeDegenerateEdges")]
     pub fn remove_degenerate_edges(&mut self, solid: u32, tolerance: f64) -> Result<u32, JsError> {
         let solid_id = self.resolve_solid(solid)?;
-        let count =
-            brepkit_operations::heal::remove_degenerate_edges(&mut self.topo, solid_id, tolerance)?;
+        let count = brepkit_operations::heal::remove_degenerate_edges(
+            self.topo_mut(),
+            solid_id,
+            tolerance,
+        )?;
         #[allow(clippy::cast_possible_truncation)]
         Ok(count as u32)
     }
@@ -149,7 +152,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "fixFaceOrientations")]
     pub fn fix_face_orientations(&mut self, solid: u32) -> Result<u32, JsError> {
         let solid_id = self.resolve_solid(solid)?;
-        let count = brepkit_operations::heal::fix_face_orientations(&mut self.topo, solid_id)?;
+        let count = brepkit_operations::heal::fix_face_orientations(self.topo_mut(), solid_id)?;
         #[allow(clippy::cast_possible_truncation)]
         Ok(count as u32)
     }
@@ -168,7 +171,8 @@ impl BrepKernel {
             .iter()
             .map(|&h| self.resolve_face(h))
             .collect::<Result<Vec<_>, _>>()?;
-        let result = brepkit_operations::defeature::defeature(&mut self.topo, solid_id, &face_ids)?;
+        let result =
+            brepkit_operations::defeature::defeature(self.topo_mut(), solid_id, &face_ids)?;
         Ok(solid_id_to_u32(result))
     }
 

--- a/crates/wasm/src/bindings/io.rs
+++ b/crates/wasm/src/bindings/io.rs
@@ -126,7 +126,7 @@ impl BrepKernel {
             reason: format!("OBJ must be valid UTF-8: {e}"),
         })?;
         let mesh = brepkit_io::obj::read_obj(text)?;
-        let solid_id = brepkit_io::stl::import::import_mesh(&mut self.topo, &mesh, 1e-7)?;
+        let solid_id = brepkit_io::stl::import::import_mesh(self.topo_mut(), &mesh, 1e-7)?;
         #[allow(clippy::cast_possible_truncation)]
         Ok(solid_id.index() as u32)
     }
@@ -139,7 +139,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "importGlb")]
     pub fn import_glb(&mut self, data: &[u8]) -> Result<u32, JsError> {
         let mesh = brepkit_io::gltf::read_glb(data)?;
-        let solid_id = brepkit_io::stl::import::import_mesh(&mut self.topo, &mesh, 1e-7)?;
+        let solid_id = brepkit_io::stl::import::import_mesh(self.topo_mut(), &mesh, 1e-7)?;
         #[allow(clippy::cast_possible_truncation)]
         Ok(solid_id.index() as u32)
     }
@@ -155,7 +155,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "importStl")]
     pub fn import_stl(&mut self, data: &[u8]) -> Result<u32, JsError> {
         let mesh = brepkit_io::stl::reader::read_stl(data)?;
-        let solid_id = brepkit_io::stl::import::import_mesh(&mut self.topo, &mesh, TOL)?;
+        let solid_id = brepkit_io::stl::import::import_mesh(self.topo_mut(), &mesh, TOL)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -171,7 +171,7 @@ impl BrepKernel {
         let meshes = brepkit_io::threemf::reader::read_threemf(data)?;
         let mut handles = Vec::new();
         for mesh in &meshes {
-            let solid_id = brepkit_io::stl::import::import_mesh(&mut self.topo, mesh, TOL)?;
+            let solid_id = brepkit_io::stl::import::import_mesh(self.topo_mut(), mesh, TOL)?;
             handles.push(solid_id_to_u32(solid_id));
         }
         Ok(handles)
@@ -222,7 +222,7 @@ impl BrepKernel {
             indices: indices.to_vec(),
         };
 
-        let solid_id = brepkit_io::stl::import::import_mesh(&mut self.topo, &mesh, TOL)?;
+        let solid_id = brepkit_io::stl::import::import_mesh(self.topo_mut(), &mesh, TOL)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -251,7 +251,7 @@ impl BrepKernel {
     pub fn import_step(&mut self, data: &[u8]) -> Result<Vec<u32>, JsError> {
         let text = std::str::from_utf8(data)
             .map_err(|e| JsError::new(&format!("STEP data is not valid UTF-8: {e}")))?;
-        let solid_ids = brepkit_io::step::reader::read_step(text, &mut self.topo)?;
+        let solid_ids = brepkit_io::step::reader::read_step(text, self.topo_mut())?;
         Ok(solid_ids.iter().map(|id| solid_id_to_u32(*id)).collect())
     }
 
@@ -280,7 +280,7 @@ impl BrepKernel {
     pub fn import_iges(&mut self, data: &[u8]) -> Result<Vec<u32>, JsError> {
         let text = std::str::from_utf8(data)
             .map_err(|e| JsError::new(&format!("IGES data is not valid UTF-8: {e}")))?;
-        let solid_ids = brepkit_io::iges::reader::read_iges(text, &mut self.topo)?;
+        let solid_ids = brepkit_io::iges::reader::read_iges(text, self.topo_mut())?;
         Ok(solid_ids.iter().map(|id| solid_id_to_u32(*id)).collect())
     }
 }

--- a/crates/wasm/src/bindings/nurbs.rs
+++ b/crates/wasm/src/bindings/nurbs.rs
@@ -47,10 +47,10 @@ impl BrepKernel {
 
         let start = points[0];
         let end = points[points.len() - 1];
-        let v_start = self.topo.add_vertex(Vertex::new(start, TOL));
-        let v_end = self.topo.add_vertex(Vertex::new(end, TOL));
+        let v_start = self.topo_mut().add_vertex(Vertex::new(start, TOL));
+        let v_end = self.topo_mut().add_vertex(Vertex::new(end, TOL));
         let eid = self
-            .topo
+            .topo_mut()
             .add_edge(Edge::new(v_start, v_end, EdgeCurve::NurbsCurve(curve)));
         Ok(edge_id_to_u32(eid))
     }

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -74,7 +74,7 @@ impl BrepKernel {
         validate_finite(nz, "nz")?;
         let solid_id = self.resolve_solid(solid)?;
         let result = brepkit_operations::section::section(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             Point3::new(px, py, pz),
             Vec3::new(nx, ny, nz),
@@ -100,7 +100,7 @@ impl BrepKernel {
             .iter()
             .map(|&h| self.resolve_face(h))
             .collect::<Result<_, _>>()?;
-        let solid_id = brepkit_operations::loft::loft(&mut self.topo, &face_ids)?;
+        let solid_id = brepkit_operations::loft::loft(self.topo_mut(), &face_ids)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -123,7 +123,7 @@ impl BrepKernel {
             .iter()
             .map(|&h| self.resolve_face(h))
             .collect::<Result<_, _>>()?;
-        let solid_id = brepkit_operations::loft::loft_smooth(&mut self.topo, &face_ids)?;
+        let solid_id = brepkit_operations::loft::loft_smooth(self.topo_mut(), &face_ids)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -151,7 +151,7 @@ impl BrepKernel {
                 let x = sp[0].as_f64().unwrap_or(0.0);
                 let y = sp[1].as_f64().unwrap_or(0.0);
                 let z = sp[2].as_f64().unwrap_or(0.0);
-                let apex_face = create_apex_face(&mut self.topo, Point3::new(x, y, z), &face_ids)?;
+                let apex_face = create_apex_face(self.topo_mut(), Point3::new(x, y, z), &face_ids)?;
                 face_ids.insert(0, apex_face);
             }
         }
@@ -162,7 +162,7 @@ impl BrepKernel {
                 let x = ep[0].as_f64().unwrap_or(0.0);
                 let y = ep[1].as_f64().unwrap_or(0.0);
                 let z = ep[2].as_f64().unwrap_or(0.0);
-                let apex_face = create_apex_face(&mut self.topo, Point3::new(x, y, z), &face_ids)?;
+                let apex_face = create_apex_face(self.topo_mut(), Point3::new(x, y, z), &face_ids)?;
                 face_ids.push(apex_face);
             }
         }
@@ -173,9 +173,9 @@ impl BrepKernel {
             .unwrap_or(true);
 
         let solid_id = if ruled {
-            brepkit_operations::loft::loft(&mut self.topo, &face_ids)?
+            brepkit_operations::loft::loft(self.topo_mut(), &face_ids)?
         } else {
-            brepkit_operations::loft::loft_smooth(&mut self.topo, &face_ids)?
+            brepkit_operations::loft::loft_smooth(self.topo_mut(), &face_ids)?
         };
         Ok(solid_id_to_u32(solid_id))
     }
@@ -205,7 +205,7 @@ impl BrepKernel {
             .map(|&h| self.resolve_face(h))
             .collect::<Result<_, _>>()?;
         let result = brepkit_operations::shell_op::shell(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             thickness,
             &open_face_ids,
@@ -237,7 +237,7 @@ impl BrepKernel {
             .map(|&h| self.resolve_edge(h))
             .collect::<Result<_, _>>()?;
         let result =
-            brepkit_operations::chamfer::chamfer(&mut self.topo, solid_id, &edge_ids, distance)?;
+            brepkit_operations::chamfer::chamfer(self.topo_mut(), solid_id, &edge_ids, distance)?;
         Ok(solid_id_to_u32(result))
     }
 
@@ -273,7 +273,8 @@ impl BrepKernel {
         // WASM FFI boundary, which would abort the entire WASM instance.
         let result =
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> Result<u32, JsError> {
-                let solid = if let Ok(s) = try_fillet(&mut self.topo, solid_id, &edge_ids, radius) {
+                let solid = if let Ok(s) = try_fillet(self.topo_mut(), solid_id, &edge_ids, radius)
+                {
                     s
                 } else {
                     // Filter to edges where both adjacent faces are planar.
@@ -281,7 +282,7 @@ impl BrepKernel {
                     if planar_edges.is_empty() {
                         solid_id
                     } else {
-                        try_fillet(&mut self.topo, solid_id, &planar_edges, radius)
+                        try_fillet(self.topo_mut(), solid_id, &planar_edges, radius)
                             .map_err(|e| JsError::new(&e.to_string()))?
                     }
                 };
@@ -321,7 +322,7 @@ impl BrepKernel {
 
         let face_id = self.resolve_face(face)?;
         let direction = Vec3::new(dir_x, dir_y, dir_z);
-        let solid_id = extrude(&mut self.topo, face_id, direction, distance)?;
+        let solid_id = extrude(self.topo_mut(), face_id, direction, distance)?;
 
         Ok(solid_id_to_u32(solid_id))
     }
@@ -369,7 +370,7 @@ impl BrepKernel {
         let direction = Vec3::new(dx, dy, dz);
         let angle_radians = angle_degrees.to_radians();
 
-        let solid_id = revolve(&mut self.topo, face_id, origin, direction, angle_radians)?;
+        let solid_id = revolve(self.topo_mut(), face_id, origin, direction, angle_radians)?;
 
         Ok(solid_id_to_u32(solid_id))
     }
@@ -454,7 +455,7 @@ impl BrepKernel {
             path_weights,
         )?;
 
-        let solid_id = sweep(&mut self.topo, face_id, &path_curve)?;
+        let solid_id = sweep(self.topo_mut(), face_id, &path_curve)?;
 
         Ok(solid_id_to_u32(solid_id))
     }
@@ -517,7 +518,7 @@ impl BrepKernel {
         )?;
 
         let solid_id =
-            brepkit_operations::sweep::sweep_smooth(&mut self.topo, face_id, &path_curve)?;
+            brepkit_operations::sweep::sweep_smooth(self.topo_mut(), face_id, &path_curve)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -535,7 +536,7 @@ impl BrepKernel {
         validate_finite(distance, "distance")?;
         let face_id = self.resolve_face(face)?;
         let result = brepkit_operations::offset_face::offset_face(
-            &mut self.topo,
+            self.topo_mut(),
             face_id,
             distance,
             samples as usize,
@@ -576,7 +577,7 @@ impl BrepKernel {
         let axis_dir = brepkit_math::vec::Vec3::new(axis_dir_x, axis_dir_y, axis_dir_z);
 
         let solid_id = brepkit_operations::helix::helical_sweep(
-            &mut self.topo,
+            self.topo_mut(),
             face_id,
             origin,
             axis_dir,
@@ -617,7 +618,7 @@ impl BrepKernel {
         validate_finite(nz, "nz")?;
         let solid_id = self.resolve_solid(solid)?;
         let result = brepkit_operations::split::split(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             Point3::new(px, py, pz),
             Vec3::new(nx, ny, nz),
@@ -659,7 +660,7 @@ impl BrepKernel {
             .map(|&h| self.resolve_face(h))
             .collect::<Result<_, _>>()?;
         let result = brepkit_operations::draft::draft(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             &face_ids,
             Vec3::new(pull_x, pull_y, pull_z),
@@ -711,7 +712,7 @@ impl BrepKernel {
             path_weights,
         )?;
 
-        let solid_id = brepkit_operations::pipe::pipe(&mut self.topo, face_id, &path_curve, None)?;
+        let solid_id = brepkit_operations::pipe::pipe(self.topo_mut(), face_id, &path_curve, None)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -799,7 +800,7 @@ impl BrepKernel {
         let path_curve = brepkit_math::nurbs::fitting::interpolate(&points, degree)?;
 
         let face_id = self.resolve_face(face)?;
-        let solid_id = sweep(&mut self.topo, face_id, &path_curve)?;
+        let solid_id = sweep(self.topo_mut(), face_id, &path_curve)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -817,7 +818,7 @@ impl BrepKernel {
         validate_finite(distance, "distance")?;
         let solid_id = self.resolve_solid(solid)?;
         let result =
-            brepkit_operations::offset_solid::offset_solid(&mut self.topo, solid_id, distance)?;
+            brepkit_operations::offset_solid::offset_solid(self.topo_mut(), solid_id, distance)?;
         Ok(solid_id_to_u32(result))
     }
 
@@ -833,7 +834,7 @@ impl BrepKernel {
     pub fn thicken_face(&mut self, face: u32, thickness: f64) -> Result<u32, JsError> {
         validate_finite(thickness, "thickness")?;
         let face_id = self.resolve_face(face)?;
-        let result = brepkit_operations::thicken::thicken(&mut self.topo, face_id, thickness)?;
+        let result = brepkit_operations::thicken::thicken(self.topo_mut(), face_id, thickness)?;
         Ok(solid_id_to_u32(result))
     }
 
@@ -894,7 +895,7 @@ impl BrepKernel {
             edge_laws.push((edge_id, law));
         }
         let result =
-            brepkit_operations::fillet::fillet_variable(&mut self.topo, solid_id, &edge_laws)?;
+            brepkit_operations::fillet::fillet_variable(self.topo_mut(), solid_id, &edge_laws)?;
         Ok(solid_id_to_u32(result))
     }
 
@@ -977,7 +978,7 @@ impl BrepKernel {
         };
 
         let result = brepkit_operations::sweep::sweep_with_options(
-            &mut self.topo,
+            self.topo_mut(),
             face_id,
             &path_curve,
             &options,
@@ -1064,7 +1065,7 @@ impl BrepKernel {
             curves.push(points[offset..offset + l].to_vec());
             offset += l;
         }
-        let face_id = brepkit_operations::fill_face::fill_coons_patch(&mut self.topo, &curves)?;
+        let face_id = brepkit_operations::fill_face::fill_coons_patch(self.topo_mut(), &curves)?;
         Ok(face_id_to_u32(face_id))
     }
 
@@ -1120,7 +1121,7 @@ impl BrepKernel {
     pub fn offset_wire(&mut self, face: u32, distance: f64) -> Result<u32, JsError> {
         let face_id = self.resolve_face(face)?;
         let wire_id =
-            brepkit_operations::offset_wire::offset_wire(&mut self.topo, face_id, distance)?;
+            brepkit_operations::offset_wire::offset_wire(self.topo_mut(), face_id, distance)?;
         Ok(wire_id_to_u32(wire_id))
     }
 
@@ -1143,7 +1144,7 @@ impl BrepKernel {
         let face_id = self.resolve_face(face)?;
         let jt = parse_join_type_str(join_type)?;
         let wire_id = brepkit_operations::offset_wire::offset_wire_with_join(
-            &mut self.topo,
+            self.topo_mut(),
             face_id,
             distance,
             jt,
@@ -1190,14 +1191,14 @@ impl BrepKernel {
                 other => other.clone(),
             };
             let new_face = Face::new(outer_wire, inner_wires, new_surface);
-            let new_fid = self.topo.add_face(new_face);
+            let new_fid = self.topo_mut().add_face(new_face);
             return Ok(face_id_to_u32(new_fid));
         }
         // Try as edge
         if let Ok(edge_id) = self.resolve_edge(id) {
             let edge = self.topo.edge(edge_id)?;
             let new_edge = Edge::new(edge.end(), edge.start(), edge.curve().clone());
-            let new_eid = self.topo.add_edge(new_edge);
+            let new_eid = self.topo_mut().add_edge(new_edge);
             return Ok(edge_id_to_u32(new_eid));
         }
         Err(WasmError::InvalidInput {

--- a/crates/wasm/src/bindings/primitives.rs
+++ b/crates/wasm/src/bindings/primitives.rs
@@ -24,7 +24,7 @@ impl BrepKernel {
         validate_positive(dx, "dx")?;
         validate_positive(dy, "dy")?;
         validate_positive(dz, "dz")?;
-        let solid_id = brepkit_operations::primitives::make_box(&mut self.topo, dx, dy, dz)?;
+        let solid_id = brepkit_operations::primitives::make_box(self.topo_mut(), dx, dy, dz)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -40,7 +40,7 @@ impl BrepKernel {
         validate_positive(radius, "radius")?;
         validate_positive(height, "height")?;
         let solid_id =
-            brepkit_operations::primitives::make_cylinder(&mut self.topo, radius, height)?;
+            brepkit_operations::primitives::make_cylinder(self.topo_mut(), radius, height)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -54,8 +54,11 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "makeSphere")]
     pub fn make_sphere_solid(&mut self, radius: f64, segments: u32) -> Result<u32, JsError> {
         validate_positive(radius, "radius")?;
-        let solid_id =
-            brepkit_operations::primitives::make_sphere(&mut self.topo, radius, segments as usize)?;
+        let solid_id = brepkit_operations::primitives::make_sphere(
+            self.topo_mut(),
+            radius,
+            segments as usize,
+        )?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -77,7 +80,7 @@ impl BrepKernel {
         validate_finite(top_radius, "top_radius")?;
         validate_positive(height, "height")?;
         let solid_id = brepkit_operations::primitives::make_cone(
-            &mut self.topo,
+            self.topo_mut(),
             bottom_radius,
             top_radius,
             height,
@@ -102,7 +105,7 @@ impl BrepKernel {
         validate_positive(major_radius, "major_radius")?;
         validate_positive(minor_radius, "minor_radius")?;
         let solid_id = brepkit_operations::primitives::make_torus(
-            &mut self.topo,
+            self.topo_mut(),
             major_radius,
             minor_radius,
             segments as usize,
@@ -123,9 +126,9 @@ impl BrepKernel {
         validate_positive(ry, "ry")?;
         validate_positive(rz, "rz")?;
         // Create a unit sphere, then scale it non-uniformly.
-        let solid_id = brepkit_operations::primitives::make_sphere(&mut self.topo, 1.0, 16)?;
+        let solid_id = brepkit_operations::primitives::make_sphere(self.topo_mut(), 1.0, 16)?;
         let mat = brepkit_math::mat::Mat4::scale(rx, ry, rz);
-        transform_solid(&mut self.topo, solid_id, &mat)?;
+        transform_solid(self.topo_mut(), solid_id, &mat)?;
         Ok(solid_id_to_u32(solid_id))
     }
 }

--- a/crates/wasm/src/bindings/query.rs
+++ b/crates/wasm/src/bindings/query.rs
@@ -1225,7 +1225,7 @@ impl BrepKernel {
         }
 
         let new_face = Face::new(outer_wire, inner_wires, surface);
-        let fid = self.topo.add_face(new_face);
+        let fid = self.topo_mut().add_face(new_face);
         Ok(face_id_to_u32(fid))
     }
 
@@ -1828,7 +1828,7 @@ mod tests {
     #[test]
     fn to_brep_sphere_surface_params() {
         let mut k = crate::kernel::BrepKernel::new();
-        let id = brepkit_operations::primitives::make_sphere(&mut k.topo, 3.0, 16).unwrap();
+        let id = brepkit_operations::primitives::make_sphere(k.topo_mut(), 3.0, 16).unwrap();
         #[allow(clippy::cast_possible_truncation)]
         let solid = id.index() as u32;
         let brep = build_brep_json(&k, solid);
@@ -1853,7 +1853,7 @@ mod tests {
     #[test]
     fn to_brep_cone_surface_params() {
         let mut k = crate::kernel::BrepKernel::new();
-        let id = brepkit_operations::primitives::make_cone(&mut k.topo, 2.0, 0.5, 4.0).unwrap();
+        let id = brepkit_operations::primitives::make_cone(k.topo_mut(), 2.0, 0.5, 4.0).unwrap();
         #[allow(clippy::cast_possible_truncation)]
         let solid = id.index() as u32;
         let brep = build_brep_json(&k, solid);
@@ -1879,7 +1879,7 @@ mod tests {
     #[test]
     fn to_brep_torus_surface_params() {
         let mut k = crate::kernel::BrepKernel::new();
-        let id = brepkit_operations::primitives::make_torus(&mut k.topo, 5.0, 1.0, 16).unwrap();
+        let id = brepkit_operations::primitives::make_torus(k.topo_mut(), 5.0, 1.0, 16).unwrap();
         #[allow(clippy::cast_possible_truncation)]
         let solid = id.index() as u32;
         let brep = build_brep_json(&k, solid);

--- a/crates/wasm/src/bindings/shapes.rs
+++ b/crates/wasm/src/bindings/shapes.rs
@@ -135,7 +135,9 @@ impl BrepKernel {
         validate_finite(x, "x")?;
         validate_finite(y, "y")?;
         validate_finite(z, "z")?;
-        let id = self.topo.add_vertex(Vertex::new(Point3::new(x, y, z), TOL));
+        let id = self
+            .topo_mut()
+            .add_vertex(Vertex::new(Point3::new(x, y, z), TOL));
         Ok(vertex_id_to_u32(id))
     }
 
@@ -154,7 +156,7 @@ impl BrepKernel {
     ) -> Result<u32, JsError> {
         let start = Point3::new(x1, y1, z1);
         let end = Point3::new(x2, y2, z2);
-        let eid = brepkit_topology::builder::make_line_edge(&mut self.topo, start, end, TOL)?;
+        let eid = brepkit_topology::builder::make_line_edge(self.topo_mut(), start, end, TOL)?;
         Ok(edge_id_to_u32(eid))
     }
 
@@ -211,14 +213,14 @@ impl BrepKernel {
             reason: format!("invalid circle: {e}"),
         })?;
 
-        let v_start = self.topo.add_vertex(Vertex::new(start_pt, TOL));
+        let v_start = self.topo_mut().add_vertex(Vertex::new(start_pt, TOL));
         let v_end = if (start_pt - end_pt).length() < TOL * 100.0 {
             v_start
         } else {
-            self.topo.add_vertex(Vertex::new(end_pt, TOL))
+            self.topo_mut().add_vertex(Vertex::new(end_pt, TOL))
         };
         let eid = self
-            .topo
+            .topo_mut()
             .add_edge(Edge::new(v_start, v_end, EdgeCurve::Circle(circle)));
         Ok(edge_id_to_u32(eid))
     }
@@ -258,16 +260,16 @@ impl BrepKernel {
 
         let start_pt = Point3::new(start_x, start_y, start_z);
         let end_pt = Point3::new(end_x, end_y, end_z);
-        let v_start = self.topo.add_vertex(Vertex::new(start_pt, TOL));
+        let v_start = self.topo_mut().add_vertex(Vertex::new(start_pt, TOL));
         // When start ≈ end (closed curve), reuse the same vertex so
         // downstream code correctly identifies the edge as closed.
         let v_end = if (start_pt - end_pt).length() < TOL * 100.0 {
             v_start
         } else {
-            self.topo.add_vertex(Vertex::new(end_pt, TOL))
+            self.topo_mut().add_vertex(Vertex::new(end_pt, TOL))
         };
         let eid = self
-            .topo
+            .topo_mut()
             .add_edge(Edge::new(v_start, v_end, EdgeCurve::NurbsCurve(curve)));
         Ok(edge_id_to_u32(eid))
     }
@@ -385,7 +387,7 @@ impl BrepKernel {
                 let dist = (end_pos - start_pos).length();
                 if dist < tol.linear {
                     // Merge: replace the next edge's start with the current edge's end
-                    self.topo.edge_mut(edge_ids[next])?.set_start(end_vid);
+                    self.topo_mut().edge_mut(edge_ids[next])?.set_start(end_vid);
                 }
             }
         }
@@ -395,7 +397,7 @@ impl BrepKernel {
             .map(|&eid| OrientedEdge::new(eid, true))
             .collect();
         let wire = Wire::new(oriented, closed)?;
-        let wid = self.topo.add_wire(wire);
+        let wid = self.topo_mut().add_wire(wire);
         Ok(wire_id_to_u32(wid))
     }
 
@@ -405,7 +407,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "makeFaceFromWire")]
     pub fn make_face_from_wire(&mut self, wire: u32) -> Result<u32, JsError> {
         let wid = self.resolve_wire(wire)?;
-        let fid = brepkit_topology::builder::make_face_from_wire(&mut self.topo, wid)?;
+        let fid = brepkit_topology::builder::make_face_from_wire(self.topo_mut(), wid)?;
         Ok(face_id_to_u32(fid))
     }
 
@@ -416,7 +418,7 @@ impl BrepKernel {
     pub fn solid_from_shell(&mut self, shell: u32) -> Result<u32, JsError> {
         let shell_id = self.resolve_shell(shell)?;
         let solid = brepkit_topology::solid::Solid::new(shell_id, vec![]);
-        let sid = self.topo.add_solid(solid);
+        let sid = self.topo_mut().add_solid(solid);
         Ok(solid_id_to_u32(sid))
     }
 
@@ -432,7 +434,7 @@ impl BrepKernel {
             .collect::<Result<_, _>>()?;
         let compound = brepkit_topology::compound::Compound::new(solid_ids);
         #[allow(clippy::cast_possible_truncation)]
-        let cid = self.topo.add_compound(compound);
+        let cid = self.topo_mut().add_compound(compound);
         Ok(cid.index() as u32)
     }
 
@@ -471,7 +473,7 @@ impl BrepKernel {
             .into());
         }
 
-        let solid_id = brepkit_operations::primitives::make_convex_hull(&mut self.topo, &points)?;
+        let solid_id = brepkit_operations::primitives::make_convex_hull(self.topo_mut(), &points)?;
         Ok(solid_id_to_u32(solid_id))
     }
 
@@ -491,11 +493,11 @@ impl BrepKernel {
         let n = points.len();
         let verts: Vec<_> = points
             .iter()
-            .map(|p| self.topo.add_vertex(Vertex::new(*p, TOL)))
+            .map(|p| self.topo_mut().add_vertex(Vertex::new(*p, TOL)))
             .collect();
         let edges: Vec<_> = (0..n)
             .map(|i| {
-                self.topo
+                self.topo_mut()
                     .add_edge(Edge::new(verts[i], verts[(i + 1) % n], EdgeCurve::Line))
             })
             .collect();
@@ -504,7 +506,7 @@ impl BrepKernel {
             .map(|&eid| OrientedEdge::new(eid, true))
             .collect();
         let wire = Wire::new(oriented, true)?;
-        let wid = self.topo.add_wire(wire);
+        let wid = self.topo_mut().add_wire(wire);
         Ok(wire_id_to_u32(wid))
     }
 
@@ -521,7 +523,7 @@ impl BrepKernel {
             .into());
         }
         let wid = brepkit_topology::builder::make_regular_polygon_wire(
-            &mut self.topo,
+            self.topo_mut(),
             radius,
             n_sides as usize,
             TOL,
@@ -542,7 +544,7 @@ impl BrepKernel {
             .into());
         }
         let fid = brepkit_topology::builder::make_circle_face(
-            &mut self.topo,
+            self.topo_mut(),
             radius,
             segments as usize,
             TOL,

--- a/crates/wasm/src/bindings/transforms.rs
+++ b/crates/wasm/src/bindings/transforms.rs
@@ -47,7 +47,7 @@ impl BrepKernel {
         let rows = std::array::from_fn(|i| std::array::from_fn(|j| matrix[i * 4 + j]));
         let mat = Mat4(rows);
 
-        transform_solid(&mut self.topo, solid_id, &mat)?;
+        transform_solid(self.topo_mut(), solid_id, &mat)?;
         Ok(())
     }
 
@@ -98,7 +98,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "copySolid")]
     pub fn copy_solid(&mut self, solid: u32) -> Result<u32, JsError> {
         let solid_id = self.resolve_solid(solid)?;
-        let copy = brepkit_operations::copy::copy_solid(&mut self.topo, solid_id)?;
+        let copy = brepkit_operations::copy::copy_solid(self.topo_mut(), solid_id)?;
         Ok(solid_id_to_u32(copy))
     }
 
@@ -110,7 +110,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "copyWire")]
     pub fn copy_wire(&mut self, wire: u32) -> Result<u32, JsError> {
         let wire_id = self.resolve_wire(wire)?;
-        let copy = brepkit_operations::copy::copy_wire(&mut self.topo, wire_id)?;
+        let copy = brepkit_operations::copy::copy_wire(self.topo_mut(), wire_id)?;
         Ok(wire_id_to_u32(copy))
     }
 
@@ -145,7 +145,7 @@ impl BrepKernel {
         let wire_id = self.resolve_wire(wire)?;
         let rows = std::array::from_fn(|i| std::array::from_fn(|j| matrix[i * 4 + j]));
         let mat = Mat4(rows);
-        brepkit_operations::transform::transform_wire(&mut self.topo, wire_id, &mat)?;
+        brepkit_operations::transform::transform_wire(self.topo_mut(), wire_id, &mat)?;
         Ok(())
     }
 
@@ -188,7 +188,7 @@ impl BrepKernel {
         let mat = Mat4(rows);
 
         let copy =
-            brepkit_operations::copy::copy_and_transform_solid(&mut self.topo, solid_id, &mat)?;
+            brepkit_operations::copy::copy_and_transform_solid(self.topo_mut(), solid_id, &mat)?;
         Ok(solid_id_to_u32(copy))
     }
 
@@ -219,7 +219,7 @@ impl BrepKernel {
         validate_finite(nz, "nz")?;
         let solid_id = self.resolve_solid(solid)?;
         let result = brepkit_operations::mirror::mirror(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             Point3::new(px, py, pz),
             Vec3::new(nx, ny, nz),
@@ -251,7 +251,7 @@ impl BrepKernel {
         validate_positive(spacing, "spacing")?;
         let solid_id = self.resolve_solid(solid)?;
         let compound = brepkit_operations::pattern::linear_pattern(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             Vec3::new(dx, dy, dz),
             spacing,
@@ -291,7 +291,7 @@ impl BrepKernel {
         validate_positive(spacing_y, "spacing_y")?;
         let solid_id = self.resolve_solid(solid)?;
         let compound = brepkit_operations::pattern::grid_pattern(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             Vec3::new(dir_x_x, dir_x_y, dir_x_z),
             Vec3::new(dir_y_x, dir_y_y, dir_y_z),
@@ -318,7 +318,7 @@ impl BrepKernel {
         let solid_id = self.resolve_solid(solid)?;
         let axis = Vec3::new(ax, ay, az);
         let compound = brepkit_operations::pattern::circular_pattern(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             axis,
             count as usize,
@@ -337,7 +337,7 @@ impl BrepKernel {
     ) -> Result<u32, JsError> {
         let solid_id = self.resolve_solid(solid)?;
         let count = brepkit_operations::heal::merge_coincident_vertices(
-            &mut self.topo,
+            self.topo_mut(),
             solid_id,
             tolerance,
         )?;

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -14,6 +14,8 @@
     dead_code
 )]
 
+use std::rc::Rc;
+
 use brepkit_math::curves::{Circle3D, Ellipse3D};
 use brepkit_math::curves2d::Line2D;
 use brepkit_math::nurbs::curve::NurbsCurve;
@@ -40,7 +42,7 @@ use crate::state::{Checkpoint, SketchState};
 /// invokes methods to create, transform, and query geometry.
 #[wasm_bindgen]
 pub struct BrepKernel {
-    pub(crate) topo: Topology,
+    pub(crate) topo: Rc<Topology>,
     pub(crate) assemblies: Vec<brepkit_operations::assembly::Assembly>,
     pub(crate) sketches: Vec<SketchState>,
     pub(crate) checkpoints: Vec<Checkpoint>,
@@ -54,7 +56,7 @@ impl BrepKernel {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            topo: Topology::new(),
+            topo: Rc::new(Topology::new()),
             assemblies: Vec::new(),
             sketches: Vec::new(),
             checkpoints: Vec::new(),
@@ -72,6 +74,12 @@ impl Default for BrepKernel {
 // ── Private helpers ────────────────────────────────────────────────
 
 impl BrepKernel {
+    /// Returns a mutable reference to the topology, cloning if shared
+    /// with any checkpoints (copy-on-write).
+    pub(crate) fn topo_mut(&mut self) -> &mut Topology {
+        Rc::make_mut(&mut self.topo)
+    }
+
     /// Inner implementation for `make_tangent_arc_3d`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn make_tangent_arc_3d_impl(
@@ -118,10 +126,10 @@ impl BrepKernel {
         // Tangent parallel to chord means the points are collinear.
         let cross = t_norm.cross(chord);
         if cross.length() < 1e-10 * chord.length() {
-            let v_start = self.topo.add_vertex(Vertex::new(start, TOL));
-            let v_end = self.topo.add_vertex(Vertex::new(end, TOL));
+            let v_start = self.topo_mut().add_vertex(Vertex::new(start, TOL));
+            let v_end = self.topo_mut().add_vertex(Vertex::new(end, TOL));
             let eid = self
-                .topo
+                .topo_mut()
                 .add_edge(Edge::new(v_start, v_end, EdgeCurve::Line));
             return Ok(edge_id_to_u32(eid));
         }
@@ -148,14 +156,14 @@ impl BrepKernel {
             }
         })?;
 
-        let v_start = self.topo.add_vertex(Vertex::new(start, TOL));
+        let v_start = self.topo_mut().add_vertex(Vertex::new(start, TOL));
         let v_end = if (start - end).length() < TOL * 100.0 {
             v_start
         } else {
-            self.topo.add_vertex(Vertex::new(end, TOL))
+            self.topo_mut().add_vertex(Vertex::new(end, TOL))
         };
         let eid = self
-            .topo
+            .topo_mut()
             .add_edge(Edge::new(v_start, v_end, EdgeCurve::Circle(circle)));
         Ok(edge_id_to_u32(eid))
     }
@@ -242,10 +250,10 @@ impl BrepKernel {
                         reason: "degenerate line segment (start ≈ end)".into(),
                     });
                 }
-                let v_start = self.topo.add_vertex(Vertex::new(start_3d, TOL));
-                let v_end = self.topo.add_vertex(Vertex::new(end_3d, TOL));
+                let v_start = self.topo_mut().add_vertex(Vertex::new(start_3d, TOL));
+                let v_end = self.topo_mut().add_vertex(Vertex::new(end_3d, TOL));
                 let eid = self
-                    .topo
+                    .topo_mut()
                     .add_edge(Edge::new(v_start, v_end, EdgeCurve::Line));
                 Ok(edge_id_to_u32(eid))
             }
@@ -269,15 +277,15 @@ impl BrepKernel {
                 let end_3d = circle.evaluate(t_end);
 
                 let full_circle = (t_end - t_start).abs() >= std::f64::consts::TAU - 1e-10;
-                let v_start = self.topo.add_vertex(Vertex::new(start_3d, TOL));
+                let v_start = self.topo_mut().add_vertex(Vertex::new(start_3d, TOL));
                 let v_end = if full_circle {
                     v_start
                 } else {
-                    self.topo.add_vertex(Vertex::new(end_3d, TOL))
+                    self.topo_mut().add_vertex(Vertex::new(end_3d, TOL))
                 };
-                let eid = self
-                    .topo
-                    .add_edge(Edge::new(v_start, v_end, EdgeCurve::Circle(circle)));
+                let eid =
+                    self.topo_mut()
+                        .add_edge(Edge::new(v_start, v_end, EdgeCurve::Circle(circle)));
                 Ok(edge_id_to_u32(eid))
             }
             2 => {
@@ -307,15 +315,17 @@ impl BrepKernel {
                 let end_3d = ellipse.evaluate(t_end);
 
                 let full_ellipse = (t_end - t_start).abs() >= std::f64::consts::TAU - 1e-10;
-                let v_start = self.topo.add_vertex(Vertex::new(start_3d, TOL));
+                let v_start = self.topo_mut().add_vertex(Vertex::new(start_3d, TOL));
                 let v_end = if full_ellipse {
                     v_start
                 } else {
-                    self.topo.add_vertex(Vertex::new(end_3d, TOL))
+                    self.topo_mut().add_vertex(Vertex::new(end_3d, TOL))
                 };
-                let eid =
-                    self.topo
-                        .add_edge(Edge::new(v_start, v_end, EdgeCurve::Ellipse(ellipse)));
+                let eid = self.topo_mut().add_edge(Edge::new(
+                    v_start,
+                    v_end,
+                    EdgeCurve::Ellipse(ellipse),
+                ));
                 Ok(edge_id_to_u32(eid))
             }
             3 => {
@@ -369,15 +379,17 @@ impl BrepKernel {
                 let start_3d = curve.evaluate(t_start);
                 let end_3d = curve.evaluate(t_end);
 
-                let v_start = self.topo.add_vertex(Vertex::new(start_3d, TOL));
+                let v_start = self.topo_mut().add_vertex(Vertex::new(start_3d, TOL));
                 let v_end = if (start_3d - end_3d).length() < TOL * 100.0 {
                     v_start
                 } else {
-                    self.topo.add_vertex(Vertex::new(end_3d, TOL))
+                    self.topo_mut().add_vertex(Vertex::new(end_3d, TOL))
                 };
-                let eid =
-                    self.topo
-                        .add_edge(Edge::new(v_start, v_end, EdgeCurve::NurbsCurve(curve)));
+                let eid = self.topo_mut().add_edge(Edge::new(
+                    v_start,
+                    v_end,
+                    EdgeCurve::NurbsCurve(curve),
+                ));
                 Ok(edge_id_to_u32(eid))
             }
             _ => Err(WasmError::InvalidInput {
@@ -395,13 +407,13 @@ impl BrepKernel {
 
         let verts: Vec<_> = points
             .iter()
-            .map(|p| self.topo.add_vertex(Vertex::new(*p, TOL)))
+            .map(|p| self.topo_mut().add_vertex(Vertex::new(*p, TOL)))
             .collect();
 
         let edges: Vec<_> = (0..n)
             .map(|i| {
                 let next = (i + 1) % n;
-                self.topo
+                self.topo_mut()
                     .add_edge(Edge::new(verts[i], verts[next], EdgeCurve::Line))
             })
             .collect();
@@ -411,7 +423,7 @@ impl BrepKernel {
             .map(|&eid| OrientedEdge::new(eid, true))
             .collect();
         let wire = Wire::new(oriented, true)?;
-        let wid = self.topo.add_wire(wire);
+        let wid = self.topo_mut().add_wire(wire);
 
         let a = points[1] - points[0];
         let b = points[2] - points[0];
@@ -424,9 +436,9 @@ impl BrepKernel {
                 .mul_add(points[0].y(), normal.z() * points[0].z()),
         );
 
-        let face_id = self
-            .topo
-            .add_face(Face::new(wid, vec![], FaceSurface::Plane { normal, d }));
+        let face_id =
+            self.topo_mut()
+                .add_face(Face::new(wid, vec![], FaceSurface::Plane { normal, d }));
 
         Ok(face_id)
     }
@@ -571,7 +583,9 @@ impl BrepKernel {
                 .ok_or_else(|| WasmError::InvalidInput {
                     reason: "invalid vertex z coordinate".into(),
                 })?;
-            let vid = self.topo.add_vertex(Vertex::new(Point3::new(x, y, z), TOL));
+            let vid = self
+                .topo_mut()
+                .add_vertex(Vertex::new(Point3::new(x, y, z), TOL));
             vertex_map.insert(id, vid);
         }
 
@@ -753,7 +767,9 @@ impl BrepKernel {
                 }
             };
 
-            let eid = self.topo.add_edge(Edge::new(start_vid, end_vid, curve));
+            let eid = self
+                .topo_mut()
+                .add_edge(Edge::new(start_vid, end_vid, curve));
             edge_map.insert(id, eid);
         }
 
@@ -794,7 +810,7 @@ impl BrepKernel {
             }
 
             let wire = Wire::new(oriented_edges, true)?;
-            let wire_id = self.topo.add_wire(wire);
+            let wire_id = self.topo_mut().add_wire(wire);
 
             // Reconstruct surface
             let surface_type = f["surfaceType"].as_str().unwrap_or("plane");
@@ -1087,7 +1103,7 @@ impl BrepKernel {
                     }
                     if !inner_oriented.is_empty() {
                         let inner_wire = Wire::new(inner_oriented, true)?;
-                        inner_wire_ids.push(self.topo.add_wire(inner_wire));
+                        inner_wire_ids.push(self.topo_mut().add_wire(inner_wire));
                     }
                 }
             }
@@ -1097,7 +1113,7 @@ impl BrepKernel {
                 face.set_reversed(true);
             }
 
-            face_ids.push(self.topo.add_face(face));
+            face_ids.push(self.topo_mut().add_face(face));
         }
 
         // 4. Build shell and solid
@@ -1108,9 +1124,9 @@ impl BrepKernel {
         }
 
         let shell = brepkit_topology::shell::Shell::new(face_ids)?;
-        let shell_id = self.topo.add_shell(shell);
+        let shell_id = self.topo_mut().add_shell(shell);
         let solid = brepkit_topology::solid::Solid::new(shell_id, vec![]);
-        let solid_id = self.topo.add_solid(solid);
+        let solid_id = self.topo_mut().add_solid(solid);
 
         Ok(solid_id_to_u32(solid_id))
     }
@@ -1125,22 +1141,22 @@ pub(crate) mod test_fixtures {
 
     pub fn kernel_with_box() -> (BrepKernel, u32) {
         let mut k = BrepKernel::new();
-        let id = brepkit_operations::primitives::make_box(&mut k.topo, 1.0, 1.0, 1.0).unwrap();
+        let id = brepkit_operations::primitives::make_box(k.topo_mut(), 1.0, 1.0, 1.0).unwrap();
         #[allow(clippy::cast_possible_truncation)]
         (k, id.index() as u32)
     }
 
     pub fn kernel_with_two_boxes() -> (BrepKernel, u32, u32) {
         let mut k = BrepKernel::new();
-        let a = brepkit_operations::primitives::make_box(&mut k.topo, 2.0, 2.0, 2.0).unwrap();
-        let b = brepkit_operations::primitives::make_box(&mut k.topo, 1.0, 1.0, 1.0).unwrap();
+        let a = brepkit_operations::primitives::make_box(k.topo_mut(), 2.0, 2.0, 2.0).unwrap();
+        let b = brepkit_operations::primitives::make_box(k.topo_mut(), 1.0, 1.0, 1.0).unwrap();
         #[allow(clippy::cast_possible_truncation)]
         (k, a.index() as u32, b.index() as u32)
     }
 
     pub fn kernel_with_cylinder() -> (BrepKernel, u32) {
         let mut k = BrepKernel::new();
-        let id = brepkit_operations::primitives::make_cylinder(&mut k.topo, 1.0, 2.0).unwrap();
+        let id = brepkit_operations::primitives::make_cylinder(k.topo_mut(), 1.0, 2.0).unwrap();
         #[allow(clippy::cast_possible_truncation)]
         (k, id.index() as u32)
     }

--- a/crates/wasm/src/state.rs
+++ b/crates/wasm/src/state.rs
@@ -1,11 +1,13 @@
 //! Checkpoint and sketch state types used by [`super::kernel::BrepKernel`].
 
+use std::rc::Rc;
+
 use brepkit_topology::Topology;
 
 /// A saved snapshot of the kernel state that can be restored.
 #[derive(Clone)]
 pub struct Checkpoint {
-    pub topo: Topology,
+    pub topo: Rc<Topology>,
     pub assemblies: Vec<brepkit_operations::assembly::Assembly>,
     pub sketches: Vec<SketchState>,
 }


### PR DESCRIPTION
## Summary

Replace eager `Topology::clone()` in checkpoint/restore with `Rc`-based copy-on-write:

- `BrepKernel.topo` changed from `Topology` to `Rc<Topology>`
- New `topo_mut()` helper calls `Rc::make_mut()` for COW semantics
- `checkpoint()`: `Rc::clone` — O(1) refcount increment instead of O(entities) deep clone
- `restore()`: `Rc::clone` — O(1) instead of O(entities)
- First mutation after checkpoint triggers deferred clone via `Rc::make_mut()`
- Multiple checkpoints without intervening mutations share one allocation

13 files changed, ~230 insertions/200 deletions — mechanical `&mut self.topo` → `self.topo_mut()` replacement across all binding modules.

Performance roadmap item #13.

## Complexity analysis

| Operation | Before | After |
|-----------|--------|-------|
| `checkpoint()` | O(entities) clone | O(1) Rc::clone |
| `restore()` | O(entities) clone | O(1) Rc::clone |
| First mutation post-checkpoint | O(1) | O(entities) deferred clone |
| Multiple checkpoints (no mutations between) | N × O(entities) | N × O(1) |

Net: checkpoint+restore without mutations is O(1). Common try-then-rollback pattern eliminates one full clone.

## Test plan

- [x] All 154 WASM tests pass (including 12 checkpoint-specific tests)
- [x] Full workspace: 1556 tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] WASM target (`wasm32-unknown-unknown`) compiles