### PR TITLE
fix: enable unify_faces for intermediate compound booleans

### DIFF
--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -354,6 +354,13 @@ pub(super) fn validate_boolean_result(
         });
     }
 
+    // Euler characteristic diagnostic: V - E + F should be 2 for a closed solid.
+    #[allow(clippy::cast_possible_wrap)]
+    let euler = (v as i64) - (e as i64) + (f as i64);
+    if euler != 2 {
+        log::warn!("boolean result: Euler V-E+F = {euler} (expected 2; V={v}, E={e}, F={f})");
+    }
+
     // Full topological validation: Euler characteristic, manifold edges,
     // boundary edges, wire closure, degenerate faces.
     // Logged as warnings rather than hard errors — many boolean results have

--- a/crates/operations/src/boolean/compound.rs
+++ b/crates/operations/src/boolean/compound.rs
@@ -1360,7 +1360,19 @@ fn compound_cut_sequential(
     let _t = timer_now();
     let mut result = target;
     let mut skipped = 0usize;
-    for &tool in tools {
+
+    // For many-tool sequences, enable unify_faces on intermediate results to
+    // prevent topology explosion from multiplicative chord splitting.
+    // The final tool uses the caller's original options.
+    let intermediate_opts = if tools.len() > 3 {
+        let mut o = opts;
+        o.unify_faces = true;
+        o
+    } else {
+        opts
+    };
+
+    for (i, &tool) in tools.iter().enumerate() {
         // AABB pre-filter: skip tools that don't overlap the current target.
         let target_aabb = crate::measure::solid_bounding_box(topo, result)?;
         let tool_aabb = crate::measure::solid_bounding_box(topo, tool)?;
@@ -1368,7 +1380,12 @@ fn compound_cut_sequential(
             skipped += 1;
             continue;
         }
-        result = boolean_with_options(topo, BooleanOp::Cut, result, tool, opts)?;
+        let use_opts = if i < tools.len() - 1 {
+            intermediate_opts
+        } else {
+            opts
+        };
+        result = boolean_with_options(topo, BooleanOp::Cut, result, tool, use_opts)?;
     }
     log::debug!(
         "[compound_cut_sequential] {} tools, {} skipped (disjoint), {:.1}ms",

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -2717,3 +2717,55 @@ fn boolean_fuse_overlapping_boxes_positive_volume() {
         "fused overlapping boxes should have positive volume: {vol}"
     );
 }
+
+/// Sequential compound cut with many tools should produce a valid solid
+/// with bounded face count (unify_faces prevents explosion).
+#[test]
+fn compound_cut_sequential_preserves_volume() {
+    let mut topo = Topology::new();
+    let target = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let original_vol = crate::measure::solid_volume(&topo, target, 0.01).unwrap();
+
+    // Create 5 cylinder tools at different positions along X.
+    let mut tools = Vec::new();
+    for i in 0..5 {
+        let cyl = crate::primitives::make_cylinder(&mut topo, 0.5, 12.0).unwrap();
+        let offset = 2.0 * (i as f64) + 1.0;
+        let t = brepkit_math::mat::Mat4::translation(offset, 5.0, 0.0);
+        crate::transform::transform_solid(&mut topo, cyl, &t).unwrap();
+        tools.push(cyl);
+    }
+
+    let result = compound_cut(&mut topo, target, &tools, BooleanOptions::default());
+    assert!(
+        result.is_ok(),
+        "compound_cut with 5 tools should succeed: {:?}",
+        result.err()
+    );
+    let result_id = result.unwrap();
+
+    // Volume must be positive and less than original.
+    let vol = crate::measure::solid_volume(&topo, result_id, 0.01).unwrap();
+    assert!(
+        vol > 0.0 && vol < original_vol,
+        "volume should decrease: original={original_vol}, result={vol}"
+    );
+
+    // Face count should be bounded (unify_faces prevents explosion).
+    let s = topo.solid(result_id).unwrap();
+    let shell = topo.shell(s.outer_shell()).unwrap();
+    let face_count = shell.faces().len();
+    assert!(
+        face_count < 500,
+        "face count should be bounded: got {face_count}"
+    );
+}
+
+/// Euler characteristic function should return 2 for valid simple solids.
+#[test]
+fn euler_characteristic_box_is_two() {
+    let mut topo = Topology::new();
+    let solid = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+    let euler = crate::validate::euler_characteristic(&topo, solid).unwrap();
+    assert_eq!(euler, 2, "box Euler V-E+F should be 2, got {euler}");
+}

--- a/crates/operations/src/validate.rs
+++ b/crates/operations/src/validate.rs
@@ -82,6 +82,25 @@ impl Default for ValidationOptions {
     }
 }
 
+/// Compute the Euler characteristic (V - E + F) for a solid.
+///
+/// A closed, manifold solid should have Euler characteristic 2.
+/// Values other than 2 indicate topological defects (missing faces,
+/// non-manifold edges, etc.).
+///
+/// # Errors
+///
+/// Returns an error if topology lookups fail.
+pub fn euler_characteristic(
+    topo: &Topology,
+    solid: SolidId,
+) -> Result<i64, crate::OperationsError> {
+    let (f, e, v) = explorer::solid_entity_counts(topo, solid)?;
+    #[allow(clippy::cast_possible_wrap)]
+    let euler = (v as i64) - (e as i64) + (f as i64);
+    Ok(euler)
+}
+
 /// Validate a solid, returning a report of all issues found.
 ///
 /// Checks performed:

--- a/crates/wasm/src/bindings/booleans.rs
+++ b/crates/wasm/src/bindings/booleans.rs
@@ -473,4 +473,30 @@ mod tests {
             "cut must reduce volume: {vol_before} -> {vol_after}"
         );
     }
+
+    // ── compound_cut volume regression ───────────────────────────────
+
+    #[test]
+    fn compound_cut_volume_decreases() {
+        let mut k = BrepKernel::new();
+        // Target: 10x10x10 box at origin. Tool: 1x1x1 box at origin.
+        // The tool overlaps one corner, so volume decreases.
+        let r = k.execute_batch(
+            r#"[
+                {"op": "makeBox", "args": {"width": 10, "height": 10, "depth": 10}},
+                {"op": "makeBox", "args": {"width": 1, "height": 1, "depth": 1}},
+                {"op": "volume", "args": {"solid": 0}},
+                {"op": "compoundCut", "args": {"target": 0, "tools": [1]}},
+                {"op": "volume", "args": {"solid": 2}}
+            ]"#,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+        let vol_before = parsed[2]["ok"].as_f64().unwrap();
+        assert!(batch_has_ok(&r, 3), "compoundCut must succeed: {r}");
+        let vol_after = parsed[4]["ok"].as_f64().unwrap();
+        assert!(
+            vol_after < vol_before && vol_after > 0.0,
+            "compound_cut must reduce volume: {vol_before} -> {vol_after}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Enable `unify_faces` on intermediate boolean results in `compound_cut_sequential` when tool count > 3, preventing multiplicative face fragmentation from chord splitting
- Add Euler characteristic diagnostic logging (`V-E+F`) in `validate_boolean_result` — logs a warning when Euler != 2
- Add public `euler_characteristic()` convenience function in `validate.rs`

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New test: `compound_cut_sequential_preserves_volume` — 5 cylinder tools, verifies volume decreases and face count < 500
- [x] New test: `euler_characteristic_box_is_two` — unit box has Euler = 2
- [x] New test: `compound_cut_volume_decreases` (WASM contract test)

Closes #260