### PR TITLE
fix: address PR #263 review comments

### DIFF
--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -359,13 +359,6 @@ pub(super) fn validate_boolean_result(
         });
     }
 
-    // Euler characteristic diagnostic: V - E + F should be 2 for a closed solid.
-    #[allow(clippy::cast_possible_wrap)]
-    let euler = (v as i64) - (e as i64) + (f as i64);
-    if euler != 2 {
-        log::warn!("boolean result: Euler V-E+F = {euler} (expected 2; V={v}, E={e}, F={f})");
-    }
-
     // Full topological validation: Euler characteristic, manifold edges,
     // boundary edges, wire closure, degenerate faces.
     // Logged as warnings rather than hard errors — many boolean results have

--- a/crates/operations/src/boolean/compound.rs
+++ b/crates/operations/src/boolean/compound.rs
@@ -1361,18 +1361,7 @@ fn compound_cut_sequential(
     let mut result = target;
     let mut skipped = 0usize;
 
-    // For many-tool sequences, enable unify_faces on intermediate results to
-    // prevent topology explosion from multiplicative chord splitting.
-    // The final tool uses the caller's original options.
-    let intermediate_opts = if tools.len() > 3 {
-        let mut o = opts;
-        o.unify_faces = true;
-        o
-    } else {
-        opts
-    };
-
-    for (i, &tool) in tools.iter().enumerate() {
+    for &tool in tools {
         // AABB pre-filter: skip tools that don't overlap the current target.
         let target_aabb = crate::measure::solid_bounding_box(topo, result)?;
         let tool_aabb = crate::measure::solid_bounding_box(topo, tool)?;
@@ -1380,12 +1369,7 @@ fn compound_cut_sequential(
             skipped += 1;
             continue;
         }
-        let use_opts = if i < tools.len() - 1 {
-            intermediate_opts
-        } else {
-            opts
-        };
-        result = boolean_with_options(topo, BooleanOp::Cut, result, tool, use_opts)?;
+        result = boolean_with_options(topo, BooleanOp::Cut, result, tool, opts)?;
     }
 
     // Post-pass: unify co-surface faces when many tools cause fragmentation.

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -2721,7 +2721,7 @@ fn boolean_fuse_overlapping_boxes_positive_volume() {
 /// Sequential compound cut with many tools should produce a valid solid
 /// with bounded face count (unify_faces prevents explosion).
 #[test]
-fn compound_cut_sequential_preserves_volume() {
+fn compound_cut_sequential_reduces_volume() {
     let mut topo = Topology::new();
     let target = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
     let original_vol = crate::measure::solid_volume(&topo, target, 0.01).unwrap();

--- a/crates/operations/src/validate.rs
+++ b/crates/operations/src/validate.rs
@@ -82,11 +82,12 @@ impl Default for ValidationOptions {
     }
 }
 
-/// Compute the Euler characteristic (V - E + F) for a solid.
+/// Compute the raw Euler characteristic (V - E + F) for a solid.
 ///
-/// A closed, manifold solid should have Euler characteristic 2.
-/// Values other than 2 indicate topological defects (missing faces,
-/// non-manifold edges, etc.).
+/// Returns the unmodified V - E + F value. For a genus-0 closed manifold
+/// solid without inner wire loops this equals 2. Solids with through-holes
+/// (genus > 0) or inner loops will have different values — use
+/// [`validate_solid`] for a full topological check that accounts for these.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
## Summary
Follow-up to merged PR #263. Addresses review comments:

- **Remove redundant Euler warning** in `assembly.rs` — `validate_solid()` already checks Euler-Poincaré correctly with genus and inner loops
- **Update `euler_characteristic()` docs** — clarify it returns raw V-E+F; 2 only expected for genus-0 solids without inner wire loops
- **Rename misleading test** — `compound_cut_sequential_preserves_volume` → `compound_cut_sequential_reduces_volume` (cuts remove material)
- **Fix `unify_faces` opts-leak** — replace per-step `intermediate_opts` with post-pass `unify_faces` to prevent leaking `unify_faces=true` when trailing tools are AABB-skipped

## Test plan
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean