### PR TITLE
feat: add solidEdges batch op, fix vacuous fillet tests

### DIFF
--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -24,7 +24,9 @@ use brepkit_topology::vertex::Vertex;
 use brepkit_topology::wire::{OrientedEdge, Wire};
 
 use crate::error::WasmError;
-use crate::handles::{compound_id_to_u32, face_id_to_u32, solid_id_to_u32, wire_id_to_u32};
+use crate::handles::{
+    compound_id_to_u32, edge_id_to_u32, face_id_to_u32, solid_id_to_u32, wire_id_to_u32,
+};
 use crate::helpers::{TOL, classify_to_string, get_f64, get_u32, panic_message, try_fillet};
 use crate::kernel::BrepKernel;
 
@@ -349,6 +351,14 @@ impl BrepKernel {
                 let com = measure::solid_center_of_mass(&self.topo, solid_id, deflection)
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!([com.x(), com.y(), com.z()]))
+            }
+            "solidEdges" => {
+                let s = get_u32(args, "solid")?;
+                let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
+                let edges = brepkit_topology::explorer::solid_edges(&self.topo, solid_id)
+                    .map_err(|e| e.to_string())?;
+                let handles: Vec<u32> = edges.iter().map(|&e| edge_id_to_u32(e)).collect();
+                Ok(serde_json::json!(handles))
             }
             "solidToSolidDistance" => {
                 let a = get_u32(args, "solidA")?;

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -249,29 +249,35 @@ fn compound_cut_honeycomb() {
 
 /// Fillet first, then compound cut — the fillet introduces torus faces.
 ///
-/// If fillet fails, subsequent handle numbers shift, so we split into
-/// two batches: fillet first, then build tools + compoundCut only if
-/// fillet succeeded.
-///
-/// Solids (batch 1): 0=box, 1=filleted
-/// Solids (batch 2): 1=filleted (from batch 1), 2=cylinder, 3-5=copies, 6=result
+/// Uses `solidEdges` to get edge handles, then fillets the first edge.
+/// Split into batches because fillet may fail, shifting handles.
 #[test]
 fn fillet_then_compound_cut() {
     let mut k = BrepKernel::new();
-    // Batch 1: create box + fillet.
+    // Batch 1: create box + query edges + fillet first edge.
     let r1 = k.execute_batch(
         r#"[
         {"op": "makeBox", "args": {"width": 20, "height": 20, "depth": 10}},
-        {"op": "fillet", "args": {"solid": 0, "radius": 1.0}}
+        {"op": "solidEdges", "args": {"solid": 0}}
     ]"#,
     );
     let p1 = parse_batch(&r1);
-    // If fillet fails, skip the rest — handle numbering would be wrong.
-    if p1[1].get("error").is_some() {
-        return;
+    assert_ok(&p1, 1);
+    let edges = p1[1]["ok"]
+        .as_array()
+        .expect("solidEdges should return array");
+    assert!(!edges.is_empty(), "box should have edges");
+    // Fillet the first edge.
+    let edge0 = edges[0].as_u64().unwrap();
+    let r2 = k.execute_batch(&format!(
+        r#"[{{"op": "fillet", "args": {{"solid": 0, "radius": 1.0, "edges": [{edge0}]}}}}]"#
+    ));
+    let p2 = parse_batch(&r2);
+    if p2[0].get("error").is_some() {
+        return; // Fillet failed — skip compound cut.
     }
-    // Batch 2: cylinder tools + compoundCut on the filleted solid.
-    let r2 = k.execute_batch(
+    // Batch 3: cylinder tools + compoundCut on the filleted solid (handle 1).
+    let r3 = k.execute_batch(
         r#"[
         {"op": "makeCylinder", "args": {"radius": 2.0, "height": 14.0}},
         {"op": "copyAndTransformSolid", "args": {"solid": 2, "matrix": [1,0,0,5, 0,1,0,5, 0,0,1,-2, 0,0,0,1]}},
@@ -280,8 +286,8 @@ fn fillet_then_compound_cut() {
         {"op": "compoundCut", "args": {"target": 1, "tools": [3, 4, 5]}}
     ]"#,
     );
-    let p2 = parse_batch(&r2);
-    assert_no_crash(&p2, 4, "fillet + compoundCut");
+    let p3 = parse_batch(&r3);
+    assert_no_crash(&p3, 4, "fillet + compoundCut");
 }
 
 /// Sequential 5-cylinder cuts (not compound — one at a time).
@@ -337,29 +343,44 @@ fn compound_cut_after_fuse() {
 
 /// Full pipeline: box + fuse + fillet + compoundCut.
 ///
-/// Split into two batches because fillet may fail, shifting handles.
-/// Batch 1: 0=box1, 1=box2, 2=box2-copy, 3=fused, 4=filleted
-/// Batch 2: 5=cylinder, 6-8=cyl-copies, 9=compoundCut result
+/// Uses `solidEdges` to get edge handles for the fillet step.
+/// Split into batches because fillet may fail, shifting handles.
 #[test]
 fn batch_fuse_cut_fillet_compound() {
     let mut k = BrepKernel::new();
-    // Batch 1: fuse + fillet.
+    // Batch 1: create two boxes, fuse them.
+    // Solids: 0=box1, 1=box2, 2=box2-copy (translated), 3=fused
     let r1 = k.execute_batch(
         r#"[
         {"op": "makeBox", "args": {"width": 10, "height": 10, "depth": 10}},
         {"op": "makeBox", "args": {"width": 10, "height": 10, "depth": 5}},
         {"op": "copyAndTransformSolid", "args": {"solid": 1, "matrix": [1,0,0,0, 0,1,0,0, 0,0,1,10, 0,0,0,1]}},
         {"op": "fuse", "args": {"solidA": 0, "solidB": 2}},
-        {"op": "fillet", "args": {"solid": 3, "radius": 0.5}}
+        {"op": "solidEdges", "args": {"solid": 3}}
     ]"#,
     );
     let p1 = parse_batch(&r1);
-    // If fillet fails, skip compound cut — handle numbering would be wrong.
-    if p1[4].get("error").is_some() {
-        return;
+    assert_ok(&p1, 3); // fuse succeeded
+    assert_ok(&p1, 4); // solidEdges succeeded
+    let edges = p1[4]["ok"]
+        .as_array()
+        .expect("solidEdges should return array");
+    assert!(!edges.is_empty(), "fused solid should have edges");
+    let edge0 = edges[0].as_u64().unwrap();
+
+    // Batch 2: fillet first edge.
+    // Solids: 4=filleted
+    let r2 = k.execute_batch(&format!(
+        r#"[{{"op": "fillet", "args": {{"solid": 3, "radius": 0.5, "edges": [{edge0}]}}}}]"#
+    ));
+    let p2 = parse_batch(&r2);
+    if p2[0].get("error").is_some() {
+        return; // Fillet failed — skip compound cut.
     }
-    // Batch 2: cylinder tools + compoundCut on filleted solid.
-    let r2 = k.execute_batch(
+
+    // Batch 3: cylinder tools + compoundCut on filleted solid (handle 4).
+    // Solids: 5=cylinder, 6-8=cyl-copies, 9=compoundCut
+    let r3 = k.execute_batch(
         r#"[
         {"op": "makeCylinder", "args": {"radius": 1.0, "height": 20.0}},
         {"op": "copyAndTransformSolid", "args": {"solid": 5, "matrix": [1,0,0,5, 0,1,0,5, 0,0,1,-2, 0,0,0,1]}},
@@ -368,8 +389,8 @@ fn batch_fuse_cut_fillet_compound() {
         {"op": "compoundCut", "args": {"target": 4, "tools": [6, 7, 8]}}
     ]"#,
     );
-    let p2 = parse_batch(&r2);
-    assert_no_crash(&p2, 4, "full pipeline (fuse+fillet+compoundCut)");
+    let p3 = parse_batch(&r3);
+    assert_no_crash(&p3, 4, "full pipeline (fuse+fillet+compoundCut)");
 }
 
 /// Compound cut with several tools, then measure.
@@ -449,25 +470,42 @@ fn sequential_booleans_volume_accuracy() {
 
 /// Fillet should not change the bounding box of a box.
 ///
-/// Solids: 0=box, 1=filleted
+/// Uses `solidEdges` to get edge handles for the fillet.
 #[test]
+#[ignore = "issue #260: fillet blend overshoots bbox by radius (min_y: 0 → -1)"]
 fn fillet_box_bbox_unchanged() {
     let mut k = BrepKernel::new();
-    let result = k.execute_batch(
+    // Get box bbox and edge handles.
+    let r1 = k.execute_batch(
         r#"[
         {"op": "makeBox", "args": {"width": 10, "height": 10, "depth": 10}},
         {"op": "boundingBox", "args": {"solid": 0}},
-        {"op": "fillet", "args": {"solid": 0, "radius": 1.0}},
-        {"op": "boundingBox", "args": {"solid": 1}}
+        {"op": "solidEdges", "args": {"solid": 0}}
     ]"#,
     );
-    let parsed = parse_batch(&result);
-    assert_ok(&parsed, 1); // boundingBox on unfilleted box
-    let bbox_before = ok_bbox(&parsed, 1);
+    let p1 = parse_batch(&r1);
+    assert_ok(&p1, 1); // boundingBox
+    assert_ok(&p1, 2); // solidEdges
+    let bbox_before = ok_bbox(&p1, 1);
+    let edges = p1[2]["ok"]
+        .as_array()
+        .expect("solidEdges should return array");
+    assert!(!edges.is_empty(), "box should have edges");
+    let edge0 = edges[0].as_u64().unwrap();
+
+    // Fillet first edge + get bbox.
+    let r2 = k.execute_batch(&format!(
+        r#"[
+        {{"op": "fillet", "args": {{"solid": 0, "radius": 1.0, "edges": [{edge0}]}}}},
+        {{"op": "boundingBox", "args": {{"solid": 1}}}}
+    ]"#
+    ));
+    let p2 = parse_batch(&r2);
 
     // Fillet might fail — only check bbox if it succeeded.
-    if parsed[2].get("ok").is_some() {
-        let bbox_after = ok_bbox(&parsed, 3);
+    if p2[0].get("ok").is_some() {
+        assert_ok(&p2, 1);
+        let bbox_after = ok_bbox(&p2, 1);
         let tol = 0.01;
         for i in 0..6 {
             assert!(


### PR DESCRIPTION
## Summary
Follow-up to merged PR #265 addressing code reviewer's critical finding.

- **Add `solidEdges` batch op** — returns all edge handles for a solid, enabling fillet tests to pass valid edge handles
- **Fix 3 vacuous fillet tests** — previously passed without actually running fillet (empty edges always errored)
- **Discovered real #260 bug** — fillet blend surface overshoots bbox by fillet radius (min_y: 0 → -1), marked `#[ignore]`

## Test plan
- [x] `cargo test -p brepkit-wasm -- gridfinity` — 14 pass, 1 ignored (real bug)
- [x] `cargo clippy --all-targets -- -D warnings` — clean