### PR TITLE
fix: prevent boolean hang on complex solids from unify_faces

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -133,14 +133,24 @@ pub fn boolean_with_options(
 
     // ── Mesh boolean guard for high face counts ─────────────────────
     // When either solid has many topology faces (e.g. from NURBS/torus
-    // tessellation in prior booleans), the chord-based path is O(N²).
-    // Fall back to mesh boolean (co-refinement, O(N log N)).
+    // tessellation in prior booleans or merged faces from unify_faces),
+    // the chord-based path is O(N²). Fall back to mesh boolean
+    // (co-refinement, O(N log N)).
+    //
+    // Two thresholds:
+    // - Per-solid: >100 faces (catches individual complex solids, e.g.
+    //   shelled+filleted geometry with merged faces)
+    // - Combined: >500 faces (catches pairs of moderate-complexity solids)
+    //
     // This check is O(1) and avoids the expensive collect_face_data
     // tessellation that would otherwise run first.
     {
         let count_a = topo.shell(topo.solid(a)?.outer_shell())?.faces().len();
         let count_b = topo.shell(topo.solid(b)?.outer_shell())?.faces().len();
-        if count_a + count_b > types::MESH_BOOLEAN_FACE_THRESHOLD {
+        if count_a > types::MESH_BOOLEAN_PER_SOLID_THRESHOLD
+            || count_b > types::MESH_BOOLEAN_PER_SOLID_THRESHOLD
+            || count_a + count_b > types::MESH_BOOLEAN_FACE_THRESHOLD
+        {
             log::debug!(
                 "boolean {op:?}: high face count ({count_a} + {count_b}), using mesh boolean"
             );

--- a/crates/operations/src/boolean/types.rs
+++ b/crates/operations/src/boolean/types.rs
@@ -36,6 +36,14 @@ pub(super) const DEFAULT_BOOLEAN_DEFLECTION: f64 = 0.1;
 /// sufficient for correct ray-crossing parity.
 pub(super) const CLASSIFIER_CYL_SEGMENTS: usize = 16;
 
+/// Per-solid face count above which the chord-based tessellated path is
+/// too expensive. If EITHER solid exceeds this, fall back to mesh boolean.
+///
+/// This catches individual complex solids (e.g. shelled geometry with merged
+/// faces from `unify_faces`) that would cause O(N²) intersection computation.
+/// Matches the v2.6.0 behavior that prevented hangs on gridfinity bins.
+pub(super) const MESH_BOOLEAN_PER_SOLID_THRESHOLD: usize = 100;
+
 /// Combined face count (A + B) above which the chord-based tessellated
 /// path is too expensive. Falls back to the mesh boolean (co-refinement
 /// on triangle meshes, O(N log N)).

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -840,6 +840,12 @@ fn uf_union(parent: &mut [usize], a: usize, b: usize) {
 /// Returns an error if topology lookups fail.
 #[allow(clippy::too_many_lines)]
 pub fn unify_faces(topo: &mut Topology, solid: SolidId) -> Result<usize, crate::OperationsError> {
+    /// Maximum boundary edges for a merged face. Groups whose boundary
+    /// exceeds this are skipped to prevent O(N²) slowdowns in subsequent
+    /// boolean intersection computations. 200 edges is generous for any
+    /// practical merged face (a merged rectangle has 4-20 edges).
+    const MAX_BOUNDARY_EDGES: usize = 200;
+
     let solid_data = topo.solid(solid)?;
     let shell_id = solid_data.outer_shell();
     let shell = topo.shell(shell_id)?;
@@ -942,6 +948,18 @@ pub fn unify_faces(topo: &mut Topology, solid: SolidId) -> Result<usize, crate::
                     boundary_edges.push(*oe);
                 }
             }
+        }
+
+        // Skip groups whose merged boundary would be too complex.
+        // A face with hundreds of boundary edges can cause O(N²) or worse
+        // performance in subsequent boolean intersection computations.
+        if boundary_edges.len() > MAX_BOUNDARY_EDGES {
+            log::debug!(
+                "unify_faces: skipping merge group with {} boundary edges (limit {})",
+                boundary_edges.len(),
+                MAX_BOUNDARY_EDGES
+            );
+            continue;
         }
 
         // Reorder boundary edges into closed loops.

--- a/crates/operations/src/tessellate.rs
+++ b/crates/operations/src/tessellate.rs
@@ -1880,7 +1880,10 @@ fn conforming_pass(
     cells: &mut Vec<AdaptiveCell>,
 ) {
     // Iterate until no more conforming subdivisions are needed.
-    loop {
+    // Safety: bound iterations to MAX_DEPTH to prevent infinite loops on
+    // degenerate surfaces. Each pass can only reduce the maximum level
+    // difference by 1, so MAX_DEPTH passes is a conservative upper bound.
+    for _pass in 0..MAX_DEPTH {
         // Collect leaf cells that need subdivision for conformity.
         let mut to_subdivide = Vec::new();
 
@@ -1996,6 +1999,11 @@ fn force_subdivide(
     cell_idx: usize,
 ) {
     let cell = &cells[cell_idx];
+    // Safety: never subdivide beyond MAX_DEPTH + 2 to prevent unbounded
+    // conforming subdivision cascades on degenerate surfaces.
+    if cell.depth >= MAX_DEPTH + 2 {
+        return;
+    }
     let u_min = cell.u_min;
     let u_max = cell.u_max;
     let v_min = cell.v_min;


### PR DESCRIPTION
## Summary

Fixes the infinite loop / extreme slowdown on gridfinity 1×1×3 standard-lip bins when `unify_faces` is true (v2.6.1+ regression). The hang occurs at the fillet or fuse step when the chord-based boolean path processes complex merged faces.

Three defense layers:

- **Restore per-solid mesh boolean threshold (>100 faces)** — The v2.6.0 guard caught individual complex solids before the O(N²) chord-based path. v2.6.1 removed it; v2.6.2 only restored a combined threshold (>500). The per-solid threshold prevents shelled/filleted geometry with merged faces from entering the chord path.

- **Bound `unify_faces` merge complexity (>200 boundary edges → skip)** — Prevents creating pathologically complex merged faces whose non-convex boundaries cause O(N²) intersection computation in subsequent booleans. 200 edges is generous for any practical merge (a merged rectangle has 4-20 edges).

- **Bound tessellation conforming pass (MAX_DEPTH iterations + depth cap)** — Replaces unbounded `loop {}` with bounded `for _ in 0..MAX_DEPTH`, and adds `MAX_DEPTH+2` cap to `force_subdivide`. Prevents infinite conforming subdivision on degenerate NURBS surfaces.

## Test plan

- [x] `cargo test --workspace` — 1577 passed, 0 failed, 5 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo build -p brepkit-wasm --target wasm32-unknown-unknown` — compiles
- [x] `./scripts/check-boundaries.sh` — all boundaries valid
- [x] All existing boolean, gridfinity, and unify_faces tests still pass