### PR TITLE
feat(boolean_v2): wire builder band formation — step 3c

### DIFF
--- a/crates/operations/src/boolean/boolean_v2.rs
+++ b/crates/operations/src/boolean/boolean_v2.rs
@@ -321,17 +321,18 @@ fn intersect_plane_analytic_faces(
 
             if is_closed {
                 // Closed intersection curve (full circle). Split into two
-                // arcs at the surface's u=0 seam and the u=π antipodal point.
+                // arcs at the face's topological seam and its antipodal point.
                 //
-                // Strategy: project ALL samples to the analytic surface's UV,
-                // find the seam (u≈0) and antipodal (u≈π) samples, then build
-                // arcs by collecting samples sorted by INCREASING u. This
-                // avoids depending on the circle's traversal direction.
+                // The seam u-value is where the boundary vertex sits (NOT
+                // necessarily u=0 in the surface parameterization). We detect
+                // it by projecting a boundary vertex onto the surface.
+                let seam_u = detect_topological_seam_u(topo, analytic_face_id, analytic_surface);
                 let closed_sections = build_seam_split_sections(
                     &samples[seg_start..=seg_end],
                     &curve_3d,
                     analytic_surface,
                     frame_plane,
+                    seam_u,
                 );
                 result.extend(closed_sections);
             } else if (end_3d - start_3d).length() >= tol.linear {
@@ -1324,6 +1325,44 @@ fn fit_pcurve_from_3d_samples(
     }
 }
 
+/// Detect the topological seam u-value for a periodic face.
+///
+/// Projects the first boundary vertex onto the surface to find the u-angle
+/// where the seam edge (Line edge connecting top and bottom circles) sits.
+/// Falls back to u=0 if the face or surface can't be queried.
+fn detect_topological_seam_u(topo: &Topology, face_id: FaceId, surface: &FaceSurface) -> f64 {
+    let face = match topo.face(face_id) {
+        Ok(f) => f,
+        Err(_) => return 0.0,
+    };
+    let wire = match topo.wire(face.outer_wire()) {
+        Ok(w) => w,
+        Err(_) => return 0.0,
+    };
+    // Find a Line edge in the wire — this is the seam.
+    for oe in wire.edges() {
+        let edge = match topo.edge(oe.edge()) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if !matches!(edge.curve(), EdgeCurve::Line) {
+            continue;
+        }
+        let vid = if oe.is_forward() {
+            edge.start()
+        } else {
+            edge.end()
+        };
+        let vertex = match topo.vertex(vid) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let (u, _v) = surface.project_point(vertex.point()).unwrap_or((0.0, 0.0));
+        return u;
+    }
+    0.0
+}
+
 /// Build two seam-split section edges from a closed intersection curve.
 ///
 /// Projects all 3D samples to the analytic surface's UV, finds the seam (u≈0)
@@ -1339,6 +1378,7 @@ fn build_seam_split_sections(
     curve_3d: &EdgeCurve,
     analytic_surface: &FaceSurface,
     frame_plane: &PlaneFrame,
+    seam_u: f64,
 ) -> Vec<SectionEdge> {
     use super::pcurve_compute::surface_periods;
     use std::f64::consts::TAU;
@@ -1359,32 +1399,26 @@ fn build_seam_split_sections(
     let (u_period, _v_period) = surface_periods(analytic_surface);
     let period = u_period.unwrap_or(TAU);
 
-    // Find the seam sample: the one with raw u closest to 0 (or period).
+    // Find the seam sample: the one with raw u closest to the topological seam.
     let seam_idx = raw_uv
         .iter()
         .enumerate()
         .min_by(|(_, a), (_, b)| {
-            let da = a
-                .x()
-                .rem_euclid(period)
-                .min(period - a.x().rem_euclid(period));
-            let db = b
-                .x()
-                .rem_euclid(period)
-                .min(period - b.x().rem_euclid(period));
+            let da = angular_distance(a.x(), seam_u, period);
+            let db = angular_distance(b.x(), seam_u, period);
             da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
         })
         .map(|(i, _)| i)
         .unwrap_or(0);
 
-    // Find the antipodal sample: raw u closest to π.
-    let target_u = std::f64::consts::PI;
+    // Find the antipodal sample: raw u closest to seam + π.
+    let target_u = (seam_u + std::f64::consts::PI).rem_euclid(period);
     let anti_idx = raw_uv
         .iter()
         .enumerate()
         .min_by(|(_, a), (_, b)| {
-            let da = (a.x().rem_euclid(period) - target_u).abs();
-            let db = (b.x().rem_euclid(period) - target_u).abs();
+            let da = angular_distance(a.x(), target_u, period);
+            let db = angular_distance(b.x(), target_u, period);
             da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
         })
         .map(|(i, _)| i)
@@ -1395,21 +1429,24 @@ fn build_seam_split_sections(
     let seam_v = raw_uv[seam_idx].y();
     let anti_v = raw_uv[anti_idx].y();
 
-    // Classify each sample into arc 1 (u ∈ [0, π]) or arc 2 (u ∈ [π, 2π])
-    // using the RAW u coordinate (in [0, 2π)).
-    let mut arc1_indexed: Vec<(usize, f64)> = Vec::new(); // (idx, raw_u)
+    // Classify each sample into arc 1 (seam → antipodal in +u direction)
+    // or arc 2 (antipodal → seam+period). Use angular distance from seam_u.
+    let mut arc1_indexed: Vec<(usize, f64)> = Vec::new(); // (idx, angular_offset_from_seam)
     let mut arc2_indexed: Vec<(usize, f64)> = Vec::new();
+    let half = std::f64::consts::PI;
     for (i, uv) in raw_uv.iter().enumerate() {
         let u = uv.x().rem_euclid(period);
-        if u <= target_u + 0.05 {
-            arc1_indexed.push((i, u));
+        // Angular offset from seam in [0, period).
+        let offset = (u - seam_u).rem_euclid(period);
+        if offset <= half + 0.05 {
+            arc1_indexed.push((i, offset));
         }
-        if u >= target_u - 0.05 {
-            arc2_indexed.push((i, u));
+        if offset >= half - 0.05 {
+            arc2_indexed.push((i, offset));
         }
     }
 
-    // Sort by raw u.
+    // Sort by angular offset from seam.
     arc1_indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
     arc2_indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
@@ -1428,8 +1465,8 @@ fn build_seam_split_sections(
             end: anti_3d,
             start_uv_a: None,
             end_uv_a: None,
-            start_uv_b: Some(Point2::new(0.0, seam_v)),
-            end_uv_b: Some(Point2::new(std::f64::consts::PI, anti_v)),
+            start_uv_b: Some(Point2::new(seam_u, seam_v)),
+            end_uv_b: Some(Point2::new(seam_u + std::f64::consts::PI, anti_v)),
         });
     }
 
@@ -1448,8 +1485,8 @@ fn build_seam_split_sections(
             end: seam_3d,
             start_uv_a: None,
             end_uv_a: None,
-            start_uv_b: Some(Point2::new(std::f64::consts::PI, anti_v)),
-            end_uv_b: Some(Point2::new(period, seam_v)),
+            start_uv_b: Some(Point2::new(seam_u + std::f64::consts::PI, anti_v)),
+            end_uv_b: Some(Point2::new(seam_u + period, seam_v)),
         });
     }
 
@@ -1485,6 +1522,12 @@ fn split_closed_segment(
 }
 
 /// Find the 3D point where a circle crosses a periodic surface's u=0 seam.
+/// Angular distance between two u-values on a periodic surface.
+fn angular_distance(u1: f64, u2: f64, period: f64) -> f64 {
+    let d = (u1 - u2).rem_euclid(period);
+    d.min(period - d)
+}
+
 /// Fit a 2D pcurve from 3D sample points projected onto a surface's UV space.
 ///
 /// Like [`fit_pcurve_from_3d_samples`] but projects via `surface.project_point()`
@@ -2312,7 +2355,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
     fn boolean_v2_cylinder_through_box_cut() {
         // Cylinder r=2, h=20 centered at (5,5) goes through box [0,10]³.
         // Cut = box minus cylinder slice within box.
@@ -2335,7 +2377,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
     fn boolean_v2_cylinder_through_box_intersect() {
         // Same geometry: intersect = cylinder slice within box.
         let mut topo = Topology::new();
@@ -2355,7 +2396,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
     fn boolean_v2_cylinder_through_box_fuse() {
         // Fuse = box + cylinder - overlap.
         let mut topo = Topology::new();
@@ -2377,7 +2417,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
     fn boolean_v2_cylinder_partially_through_box_cut() {
         // Cylinder r=2, base at z=2, top at z=17 — exits top face only.
         // Overlap: z ∈ [2, 10], h_overlap = 8, vol_overlap = π·4·8 ≈ 100.53.
@@ -2399,7 +2438,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
+    #[ignore = "Sphere intersection with non-horizontal plane needs different seam handling"]
     fn boolean_v2_sphere_cap_cut() {
         // Sphere r=5 centered at (5, 5, 10) — top face of box.
         // Spherical cap height h = 5 (sphere center at box top).
@@ -2421,7 +2460,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
+    #[ignore = "Cone seam splitting needs surface-specific UV mapping"]
     fn boolean_v2_cone_through_box_intersect() {
         // Frustum r₁=3, r₂=1, h=20 through box [0,10]³.
         // Frustum slice z∈[0,10]: r varies linearly from r₁ to midpoint.
@@ -2452,7 +2491,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
     fn boolean_v2_offset_cylinder_through_box_cut() {
         // Cylinder off-center at (3, 7) to avoid seam alignment with box faces.
         let mut topo = Topology::new();
@@ -2472,7 +2510,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires periodic UV seam splitting for cylinder lateral face (step 4)"]
+    #[ignore = "Steinmetz (cylinder-cylinder) needs analytic-analytic seam splitting"]
     fn boolean_v2_two_cylinders_intersect() {
         // Two perpendicular cylinders (Steinmetz-like).
         // Cylinder A along z-axis, Cylinder B along x-axis, both r=3.

--- a/crates/operations/src/boolean/face_splitter.rs
+++ b/crates/operations/src/boolean/face_splitter.rs
@@ -73,7 +73,7 @@ pub fn split_face_2d(
     let (u_periodic, v_periodic) = info.map_or((false, false), SurfaceInfo::periodicity);
 
     // Convert boundary edges to OrientedPCurveEdge.
-    let boundary_edges = if is_plane {
+    let mut boundary_edges = if is_plane {
         boundary_edges_to_pcurve(topo, face.outer_wire(), &surface, &wire_pts, Some(frame))
     } else {
         boundary_edges_to_pcurve(topo, face.outer_wire(), &surface, &wire_pts, None)
@@ -94,16 +94,64 @@ pub fn split_face_2d(
     // Stage 2: Split boundary edges at section edge endpoints (3D matching).
     let mut split_pts_3d: Vec<Point3> = sections.iter().flat_map(|s| [s.start, s.end]).collect();
 
-    // For periodic faces with seam-split section edges, also split closed
-    // boundary edges (full circles) at the ANTIPODAL point (u=π). Without
-    // this, closed circles form 1-edge self-loops after periodic quantization,
-    // preventing the wire builder from forming proper bands.
+    // For periodic faces, align closed boundary edge UV with seam edge UV.
+    // The same 3D vertex projects to u=0 (from circle unwrapping) and u=seam
+    // (from Line edge projection). Shift the circle UV so it starts at seam_u.
+    if u_periodic {
+        let seam_u_opt = boundary_edges.iter().find_map(|e| {
+            if matches!(e.curve_3d, EdgeCurve::Line) {
+                surface.project_point(e.start_3d).map(|(u, _)| u)
+            } else {
+                None
+            }
+        });
+        if let Some(seam_u) = seam_u_opt {
+            for edge in &mut boundary_edges {
+                if (edge.start_3d - edge.end_3d).length() < 1e-10 {
+                    // Closed edge: shift UV so start_uv.x() == seam_u.
+                    let shift = seam_u - edge.start_uv.x();
+                    if shift.abs() > 0.01 {
+                        edge.start_uv = Point2::new(edge.start_uv.x() + shift, edge.start_uv.y());
+                        edge.end_uv = Point2::new(edge.end_uv.x() + shift, edge.end_uv.y());
+                    }
+                }
+            }
+        }
+    }
+
+    // For periodic faces with section edges, split closed boundary edges
+    // (full circles) at the point diametrically opposite the seam vertex
+    // in the surface's UV parameterization (u = seam_u + π).
+    //
+    // The seam vertex (where the boundary circle starts/ends) is shared
+    // with the seam Line edge. Splitting the circle at the UV-antipodal
+    // point creates half-arcs whose endpoints match the seam edge vertices,
+    // enabling the wire builder to form proper rectangular bands.
     if u_periodic && !sections.is_empty() {
+        // Find the seam Line edge's vertex UV to determine seam_u.
+        let seam_u = {
+            let mut su = 0.0_f64;
+            for edge in &boundary_edges {
+                if matches!(edge.curve_3d, EdgeCurve::Line) {
+                    if let Some((u, _)) = surface.project_point(edge.start_3d) {
+                        su = u;
+                        break;
+                    }
+                }
+            }
+            su
+        };
+        let anti_u = (seam_u + std::f64::consts::PI).rem_euclid(std::f64::consts::TAU);
+
         for edge in &boundary_edges {
             if (edge.start_3d - edge.end_3d).length() < 1e-10 {
-                // Closed edge: find the antipodal point at u=π via sampling.
-                let mid_3d = evaluate_edge_at_t(&edge.curve_3d, edge.start_3d, edge.end_3d, 0.5);
-                split_pts_3d.push(mid_3d);
+                // Closed edge: find the 3D point at u = seam_u + π on the surface.
+                // Project the boundary vertex to get v, then evaluate surface at (anti_u, v).
+                if let Some((_, v)) = surface.project_point(edge.start_3d) {
+                    if let Some(anti_pt) = surface.evaluate(anti_u, v) {
+                        split_pts_3d.push(anti_pt);
+                    }
+                }
             }
         }
     }
@@ -115,6 +163,19 @@ pub fn split_face_2d(
         &surface,
         tol.linear,
     );
+
+    // Reorder boundary edges: Line (seam) edges first, then curved (circle)
+    // edges. This ensures the wire builder starts loops from seam edges,
+    // forming rectangular bands before circle arcs can self-close.
+    let boundary_edges = if u_periodic && !sections.is_empty() {
+        let (mut lines, curves): (Vec<_>, Vec<_>) = boundary_edges
+            .into_iter()
+            .partition(|e| matches!(e.curve_3d, EdgeCurve::Line));
+        lines.extend(curves);
+        lines
+    } else {
+        boundary_edges
+    };
 
     // Convert section edges to OrientedPCurveEdge (both orientations).
     let mut all_edges = boundary_edges;
@@ -204,18 +265,51 @@ pub fn split_face_2d(
     let mut outers: Vec<(Vec<OrientedPCurveEdge>, f64)> = Vec::new();
     let mut holes: Vec<Vec<OrientedPCurveEdge>> = Vec::new();
 
+    let u_per_opt = if u_periodic {
+        Some(std::f64::consts::TAU)
+    } else {
+        None
+    };
+    let v_per_opt = if v_periodic {
+        Some(std::f64::consts::TAU)
+    } else {
+        None
+    };
+
+    // For periodic faces with section edges, use structural classification
+    // instead of signed area. Band loops (containing seam + section edges)
+    // are outer wires. Circle-only self-loops are holes. Signed area on
+    // periodic surfaces is unreliable because UV wraps around the period.
+    let use_structural_classification = u_periodic && !sections.is_empty();
+
     for wire_loop in loops {
-        let pts = sample_wire_loop_uv(&wire_loop);
-        let area = signed_area_2d(&pts);
-        if area > 0.0 {
-            outers.push((wire_loop, area));
+        if use_structural_classification {
+            // Structural: a loop containing both Line edges (seam) and
+            // non-Line edges (section arcs / circles) is a band = outer.
+            let has_line = wire_loop
+                .iter()
+                .any(|e| matches!(e.curve_3d, EdgeCurve::Line));
+            let has_nonline = wire_loop
+                .iter()
+                .any(|e| !matches!(e.curve_3d, EdgeCurve::Line));
+            if has_line && has_nonline {
+                outers.push((wire_loop, 1.0)); // area placeholder
+            } else {
+                holes.push(wire_loop);
+            }
         } else {
-            holes.push(wire_loop);
+            let pts = sample_wire_loop_uv_periodic(&wire_loop, u_per_opt, v_per_opt);
+            let area = signed_area_2d(&pts);
+            if area > 0.0 {
+                outers.push((wire_loop, area));
+            } else {
+                holes.push(wire_loop);
+            }
         }
     }
 
     // If all loops are CW (negative area), the winding is reversed.
-    if outers.is_empty() && !holes.is_empty() {
+    if !use_structural_classification && outers.is_empty() && !holes.is_empty() {
         for hole in &mut holes {
             hole.reverse();
             for edge in hole.iter_mut() {
@@ -312,14 +406,33 @@ pub fn interior_point_3d(sub_face: &SubFace, frame: Option<&PlaneFrame>) -> Poin
 /// true curve shape in UV. This is critical for signed area computation
 /// and point-in-polygon tests on loops with curved edges.
 fn sample_wire_loop_uv(wire: &[OrientedPCurveEdge]) -> Vec<Point2> {
+    sample_wire_loop_uv_periodic(wire, None, None)
+}
+
+/// Sample UV points along a wire loop with optional periodic unwrapping.
+///
+/// When `u_period`/`v_period` is set, unwraps consecutive points so the
+/// UV path is continuous (no jumps of ~2π between edges connected via
+/// periodic quantization).
+fn sample_wire_loop_uv_periodic(
+    wire: &[OrientedPCurveEdge],
+    u_period: Option<f64>,
+    v_period: Option<f64>,
+) -> Vec<Point2> {
     use brepkit_math::curves2d::Curve2D;
     const CURVE_SAMPLES: usize = 8;
 
     let mut pts = Vec::new();
+    let has_period = u_period.is_some() || v_period.is_some();
     for edge in wire {
         match &edge.pcurve {
             Curve2D::Line(_) => {
+                // For periodic surfaces, push both start and end to enable
+                // proper unwrapping across periodic jumps at seam vertices.
                 pts.push(edge.start_uv);
+                if has_period {
+                    pts.push(edge.end_uv);
+                }
             }
             Curve2D::Nurbs(nurbs) => {
                 let knots = nurbs.knots();
@@ -358,6 +471,12 @@ fn sample_wire_loop_uv(wire: &[OrientedPCurveEdge]) -> Vec<Point2> {
             }
         }
     }
+
+    // Unwrap periodic UV jumps between consecutive points.
+    if pts.len() >= 2 {
+        super::pcurve_compute::unwrap_periodic_params_pub(&mut pts, u_period, v_period);
+    }
+
     pts
 }
 


### PR DESCRIPTION
## Summary

Fixes 3 issues preventing proper face splitting on cylinder lateral faces:

- **Topological seam detection**: `detect_topological_seam_u` finds the actual seam u-value from the boundary vertex (was hardcoded u=0, but `make_cylinder` places it at u=3π/2)
- **Boundary circle UV alignment**: shift closed circle edge UV so `start_uv` matches the seam Line edge's UV (was mismatched from independent unwrapping)
- **Structural loop classification**: use edge-type analysis (Line+Circle = band = outer) instead of signed area, which wraps unreliably on periodic UV
- **Edge reordering**: Line (seam) edges come first so the wire builder forms bands before circle arcs self-close

## Results

**5 face-crossing tests unignored and passing:**
- `boolean_v2_cylinder_through_box_cut` — vol ≈ 874 (expected 874) ✓
- `boolean_v2_cylinder_through_box_intersect` — vol ≈ 126 (expected 126) ✓
- `boolean_v2_cylinder_through_box_fuse` — vol ≈ 1126 (expected 1126) ✓
- `boolean_v2_cylinder_partially_through_box_cut` — vol ≈ 900 (expected 900) ✓
- `boolean_v2_offset_cylinder_through_box_cut` — vol ≈ 874 (expected 874) ✓

**3 tests remain ignored** (need surface-specific seam handling):
- Sphere-cap cut (non-horizontal plane intersection)
- Cone-through-box (cone seam UV mapping)
- Steinmetz cylinders (cylinder-cylinder analytic-analytic seam)

## Test plan

- [x] 32 boolean_v2 tests pass, 0 fail, 3 ignored
- [x] Full workspace passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean