### PR TITLE
feat(boolean_v2): fix sphere-cap and cone face-crossing tests — step 3d

### DIFF
--- a/crates/operations/src/boolean/boolean_v2.rs
+++ b/crates/operations/src/boolean/boolean_v2.rs
@@ -1652,24 +1652,30 @@ fn face_uv_polygon(topo: &Topology, face_id: FaceId, surface: &FaceSurface) -> V
         // For closed circle edges (start ≈ end), evaluate starting from the
         // vertex angle instead of the Circle3D's parametric origin. This keeps
         // the UV samples aligned with seam edge endpoints.
-        let is_closed_circle = matches!(edge.curve(), EdgeCurve::Circle(_))
-            && (start_v - end_v).length() < Tolerance::new().linear;
+        // For closed circle edges (start ≈ end), pre-compute the vertex angle
+        // so we evaluate starting from the boundary vertex, not the Circle3D's
+        // parametric origin. Hoisted outside the sample loop.
+        let closed_circle_angle = if matches!(edge.curve(), EdgeCurve::Circle(_))
+            && (start_v - end_v).length() < Tolerance::new().linear
+        {
+            if let EdgeCurve::Circle(circle) = edge.curve() {
+                Some((circle, circle.project(start_v)))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         #[allow(clippy::cast_precision_loss)]
         for i in 0..SAMPLES_PER_EDGE {
             let t = i as f64 / SAMPLES_PER_EDGE as f64;
-            let p3d = if is_closed_circle {
-                if let EdgeCurve::Circle(circle) = edge.curve() {
-                    // Find the angle of the vertex on the circle.
-                    let vertex_angle = circle.project(start_v);
-                    let angle = if oe.is_forward() {
-                        vertex_angle + std::f64::consts::TAU * t
-                    } else {
-                        vertex_angle - std::f64::consts::TAU * t
-                    };
-                    circle.evaluate(angle)
+            let p3d = if let Some((circle, vertex_angle)) = closed_circle_angle {
+                let angle = if oe.is_forward() {
+                    vertex_angle + std::f64::consts::TAU * t
                 } else {
-                    evaluate_edge_at_t(edge.curve(), start_v, end_v, t)
-                }
+                    vertex_angle - std::f64::consts::TAU * t
+                };
+                circle.evaluate(angle)
             } else {
                 evaluate_edge_at_t(edge.curve(), start_v, end_v, t)
             };

--- a/crates/operations/src/boolean/face_splitter.rs
+++ b/crates/operations/src/boolean/face_splitter.rs
@@ -470,7 +470,12 @@ pub fn interior_point_3d(sub_face: &SubFace, frame: Option<&PlaneFrame>) -> Poin
                         })
                         .map(|e| e.start_uv);
                     if let Some(uv) = best {
-                        interior_uv = uv;
+                        // Nudge slightly toward the centroid so the point
+                        // is strictly interior, not on the boundary vertex.
+                        interior_uv = Point2::new(
+                            uv.x() * 0.95 + interior_uv.x() * 0.05,
+                            uv.y() * 0.95 + interior_uv.y() * 0.05,
+                        );
                     }
                     break;
                 }
@@ -1102,6 +1107,26 @@ fn split_sphere_face_direct(
 
     if cap_edges.is_empty() {
         // No valid section edges — return the face unsplit.
+        return vec![SubFace {
+            surface: surface.clone(),
+            outer_wire: boundary_edges.to_vec(),
+            inner_wires: Vec::new(),
+            reversed,
+            parent: face_id,
+            source,
+        }];
+    }
+
+    // Validate: cap edges must form a single closed loop (last end ≈ first start).
+    // If the topology is unexpected (multiple loops, open chain), fall back to unsplit.
+    let loop_gap = (cap_edges
+        .last()
+        .map_or(Point3::new(0.0, 0.0, 0.0), |e| e.end_3d)
+        - cap_edges
+            .first()
+            .map_or(Point3::new(0.0, 0.0, 0.0), |e| e.start_3d))
+    .length();
+    if loop_gap > brepkit_math::tolerance::Tolerance::new().linear * 100.0 {
         return vec![SubFace {
             surface: surface.clone(),
             outer_wire: boundary_edges.to_vec(),


### PR DESCRIPTION
## Summary

- Fix sphere-cap cut test: hemisphere UV polygon was degenerate (zero-area strip), now extended with pole vertices
- Fix cone-through-box intersect test: closed Circle edge evaluation started at wrong parametric origin, creating self-intersecting UV polygons
- Fix interior point computation for sphere cap and ring sub-faces landing on solid boundaries
- Add `split_sphere_face_direct()` to bypass wire builder for sphere hemisphere faces (no seam edges)
- Steinmetz (cylinder-cylinder) remains ignored — needs deeper analytic-analytic pipeline work

## Test plan

- [x] `boolean_v2_sphere_cap_cut` passes (was: vol=1000 no intersection found)
- [x] `boolean_v2_cone_through_box_intersect` passes (was: "disjoint solids" error)
- [x] All 34 boolean_v2 tests pass, 0 regressions
- [x] Full workspace: all tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `./scripts/check-boundaries.sh` passes