### PR TITLE
feat(boolean_v2): NURBS surface support — step 4

### DIFF
--- a/crates/operations/src/boolean/boolean_v2.rs
+++ b/crates/operations/src/boolean/boolean_v2.rs
@@ -249,7 +249,8 @@ fn intersect_face_pair(
             }
             Ok(sections)
         }
-        // Any remaining NURBS pair (analytic-NURBS, NURBS-NURBS): general SSI.
+        // NURBS-NURBS pairs. Analytic-NURBS currently returns empty
+        // (TODO: convert analytic → NURBS for mixed pairs).
         _ if matches!(surf_a, FaceSurface::Nurbs(_)) || matches!(surf_b, FaceSurface::Nurbs(_)) => {
             intersect_nurbs_general_faces(topo, fa, fb, pipeline, tol)
         }
@@ -598,10 +599,10 @@ fn intersect_plane_nurbs_faces(
     Ok(result)
 }
 
-/// Intersect two faces where at least one is NURBS (general case).
+/// Intersect two NURBS-NURBS face pairs.
 ///
-/// Converts analytic surfaces to NURBS representation if needed, then
-/// uses `intersect_nurbs_nurbs` from the math crate.
+/// Currently only handles pairs where BOTH faces are NURBS. Mixed
+/// analytic-NURBS pairs return empty (TODO: convert analytic → NURBS).
 #[allow(clippy::too_many_lines)]
 fn intersect_nurbs_general_faces(
     topo: &Topology,
@@ -1126,7 +1127,7 @@ fn create_wire_from_edges_dedup(
 fn all_faces_supported(topo: &Topology, solid: SolidId) -> Result<bool, OperationsError> {
     let faces = collect_solid_faces(topo, solid)?;
     for fid in faces {
-        let surface = topo.face(fid)?.surface().clone();
+        let surface = topo.face(fid)?.surface();
         // Analytic (Plane, Cylinder, Cone, Sphere, Torus) + NURBS are supported.
         if !surface.is_analytic() && !matches!(surface, FaceSurface::Nurbs(_)) {
             return Ok(false);


### PR DESCRIPTION
## Summary
- Relax `all_faces_analytic` guard to accept NURBS faces (`all_faces_supported`)
- Add plane-NURBS intersection dispatch via `intersect_plane_nurbs` from math crate
- Add NURBS-NURBS intersection dispatch via `intersect_nurbs_nurbs` from math crate
- New tests: loft-box cut + loft-box intersect (4×4 NURBS prism through 10³ box)

## Architecture
Follows the same pattern as `intersect_plane_analytic_faces`:
1. Get intersection curves from math crate
2. Sample 3D points, trim to both face boundaries
3. Fit pcurves on both surfaces
4. Build SectionEdges

For NURBS-NURBS pairs, the general `intersect_nurbs_nurbs` marching algorithm is used. Analytic-NURBS pairs currently return empty (TODO: convert analytic → NURBS representation).

## Test plan
- [x] `boolean_v2_loft_box_cut` — 4×4 prism through 10³ box, volume 840±10%
- [x] `boolean_v2_loft_box_intersect` — prism ∩ box, volume 160±10%
- [x] All 37 boolean_v2 tests pass, 0 ignored (35 existing + 2 new)
- [x] Full workspace: all tests pass, 0 failures
- [x] Clippy clean