### PR TITLE
fix(ops): remove both_complex guard from boolean dispatch

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -214,69 +214,12 @@ pub fn boolean_with_options(
         let no_torus = !has_torus(topo, a)? && !has_torus(topo, b)?;
         both_analytic && no_torus
     };
-    // Detect when BOTH inputs have complex topology (shelled + hollow).
-    // The analytic assembly creates non-manifold edges when fusing a
-    // shelled box (inner wires on rim face) with a hollow solid (reversed
-    // curved faces from boolean cut, e.g., lip frustum).
-    // Skip analytic only when BOTH conditions are present simultaneously.
-    let both_complex = {
-        // Detect polygonal inner wires (shell rim) vs circular (boolean hole).
-        let has_polygonal_inner_wire = |solid: SolidId| -> Result<bool, crate::OperationsError> {
-            let s = topo.solid(solid)?;
-            let sh = topo.shell(s.outer_shell())?;
-            for &fid in sh.faces() {
-                for &iw_id in topo.face(fid)?.inner_wires() {
-                    let iw = topo.wire(iw_id)?;
-                    let all_lines = iw.edges().iter().all(|oe| {
-                        topo.edge(oe.edge()).is_ok_and(|e| {
-                            matches!(e.curve(), brepkit_topology::edge::EdgeCurve::Line)
-                        })
-                    });
-                    if all_lines && iw.edges().len() >= 3 {
-                        return Ok(true);
-                    }
-                }
-            }
-            Ok(false)
-        };
-        let has_reversed_curved = |solid: SolidId| -> Result<bool, crate::OperationsError> {
-            let s = topo.solid(solid)?;
-            let sh = topo.shell(s.outer_shell())?;
-            for &fid in sh.faces() {
-                let f = topo.face(fid)?;
-                if f.is_reversed()
-                    && !matches!(
-                        f.surface(),
-                        brepkit_topology::face::FaceSurface::Plane { .. }
-                    )
-                {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
-        };
-        // Check if one input is shelled and the other is hollow, or either is both.
-        let a_wires = has_polygonal_inner_wire(a)?;
-        let b_wires = has_polygonal_inner_wire(b)?;
-        let a_curved = has_reversed_curved(a)?;
-        let b_curved = has_reversed_curved(b)?;
-        // Trigger when one input has reversed curved faces (hollow frustum)
-        // and EITHER the other has polygonal inner wires (shelled)
-        // OR the other has many faces (complex result from prior booleans).
-        let a_faces = topo.shell(topo.solid(a)?.outer_shell())?.faces().len();
-        let b_faces = topo.shell(topo.solid(b)?.outer_shell())?.faces().len();
-        // A solid is "structurally complex" if it has polygonal inner wires
-        // (shelled) OR reversed curved faces (from boolean cut of hollow shapes).
-        // "Large" means many faces (from prior booleans or mesh tessellation).
-        // Skip analytic only when one input has reversed CURVED faces (from
-        // boolean cut producing hollow frustums) AND the other is large.
-        // Inner wires alone (from shell) work correctly with the analytic path.
-        let _ = a_wires;
-        let _ = b_wires;
-        let a_large = a_faces > 6;
-        let b_large = b_faces > 6;
-        (a_curved && b_large) || (b_curved && a_large)
-    };
+    // The analytic path handles all analytic surface combinations.
+    // Previously, a `both_complex` guard skipped the analytic path for
+    // solids with inner wires + reversed curved faces, but the root cause
+    // (unify_faces merging opposite-normal faces) is now fixed by the
+    // normal direction pre-check in unify_faces.
+    let both_complex = false;
 
     let mut analytic_fallback: Option<SolidId> = None;
 


### PR DESCRIPTION
## Summary

Removes the `both_complex` guard that prevented the analytic boolean from running on solids with complex topology (inner wires + reversed curved faces). This guard was a workaround for non-manifold assembly issues, but with the `unify_faces` normal pre-check (#314) now in place, it's no longer needed.

**Impact:** No regressions (24/24 gridfinity pass, full workspace clean). The simplified D4 repro test now passes through the analytic path correctly.

The full D4 WASM test still fails (analytic assembly produces non-manifold edges at lofted curved face junctions — separate assembly bug).

## Test plan
- [x] `cargo test --workspace` — 0 failures
- [x] Gridfinity: 24/24 pass (D4 still ignored)