### PR TITLE
docs: rewrite README with status matrix and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ let step = write_step(&topo, &[drilled])?;
 
 ## Why build a CAD kernel?
 
-I needed parametric CAD in the browser for [gridfinitylayouttool.com](https://gridfinitylayouttool.com). The existing options were proprietary or compiled from C++.
-
 brepkit is a from-scratch B-Rep kernel in Rust targeting WebAssembly. `unsafe` is forbidden, `unwrap` and `panic` are denied by default. Every public operation returns `Result`.
+
+The project grew out of building [gridfinitylayouttool.com](https://gridfinitylayouttool.com), where the existing options for parametric CAD in the browser were proprietary or compiled from C++.
 
 ## Status
 


### PR DESCRIPTION
## Summary

- Replace prose Status + Features sections with a Stable/Beta/Planned feature matrix (24 rows)
- Add Mermaid architecture diagram showing all 10 crates with dependency arrows
- Add directional roadmap section (6 items, no dates)
- Rewrite origin story to be concise and factual
- Name OCCT in benchmark comparison with methodology footnote (opencascade.js link)
- Specify STEP AP203 in status and data exchange tables
- Add unsafe-forbidden badge, crates.io note, cargo doc hint

## Test plan

- [x] No code changes, README only
- [x] Mermaid syntax valid
- [x] All links verified (opencascade.js → donalffons/opencascade.js)
- [x] Pre-commit hooks pass