### PR TITLE
test: un-ignore 8 tests passing with cylinder fix

### DIFF
--- a/crates/operations/tests/boolean_edge_cases.rs
+++ b/crates/operations/tests/boolean_edge_cases.rs
@@ -265,7 +265,6 @@ fn test_sequential_cuts_volume() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn test_sequential_boolean_vertex_drift() {
     // Perform 10 fuse+cut cycles. Volume should return to original each time.
     let mut topo = Topology::new();

--- a/crates/operations/tests/boolean_stress.rs
+++ b/crates/operations/tests/boolean_stress.rs
@@ -73,7 +73,6 @@ fn coplanar_fuse_shared_face() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn coplanar_cut_shared_face() {
     let mut topo = Topology::new();
     let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
@@ -563,7 +562,6 @@ fn cut_asymmetric_boxes() {
 // ===========================================================================
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn self_fuse() {
     // Fusing a solid with a copy of itself.
     let mut topo = Topology::new();
@@ -576,7 +574,6 @@ fn self_fuse() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn self_intersect() {
     let mut topo = Topology::new();
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0);
@@ -828,7 +825,6 @@ fn fuse_two_cylinders() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn cut_cylinder_from_cylinder() {
     let mut topo = Topology::new();
     let a = make_cylinder(&mut topo, 2.0, 3.0).unwrap();
@@ -844,7 +840,6 @@ fn cut_cylinder_from_cylinder() {
 // ===========================================================================
 
 #[test]
-#[ignore = "post-BOP edge merge regression — tiny overlap solid not found"]
 fn volume_tiny_overlap() {
     let mut topo = Topology::new();
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 5.0, 5.0, 5.0);

--- a/crates/wasm/src/bindings/booleans.rs
+++ b/crates/wasm/src/bindings/booleans.rs
@@ -475,7 +475,6 @@ mod tests {
     // ── boolean volume check ─────────────────────────────────────────
 
     #[test]
-    #[ignore = "BuilderSolid regression — GFA shell assembly changes Euler check outcome"]
     fn cut_reduces_volume() {
         let mut k = BrepKernel::new();
         let r = k.execute_batch(

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -406,7 +406,6 @@ fn batch_fuse_cut_fillet_compound() {
 ///
 /// Solids: 0=box, 1=cylinder, 2-5=copies, 6=compoundCut result
 #[test]
-#[ignore = "GFA pipeline limitation — containment cut not yet supported"]
 fn compound_cut_then_measure() {
     let mut k = BrepKernel::new();
     let result = k.execute_batch(


### PR DESCRIPTION
## Summary
Un-ignores 8 tests that now pass after PR #409 (cylinder-box boolean fix).

**Operations stress (5):**
- self_fuse, self_intersect, cut_cylinder_from_cylinder
- coplanar_cut_shared_face, volume_tiny_overlap

**Operations integration (1):**
- test_sequential_boolean_vertex_drift

**WASM (2):**
- cut_reduces_volume (booleans)
- compound_cut_then_measure (gridfinity — first Category D gridfinity test!)

## Test plan
- [x] All workspace tests pass (0 failures)