### PR TITLE
test: un-ignore 2 tests passing with edge-set SD + VV canonicalization

### DIFF
--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1639,7 +1639,6 @@ fn fuse_ring_inside_shelled_cylinder() {
 /// Test fuse with ring partially overlapping shell wall height
 /// (simulates lip extension below wall top).
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn fuse_ring_overlapping_shelled_box_height() {
     let mut topo = Topology::new();
 

--- a/crates/operations/tests/boolean_invariants.rs
+++ b/crates/operations/tests/boolean_invariants.rs
@@ -122,7 +122,6 @@ fn fuse_commutativity() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn intersect_commutativity() {
     let mut topo = Topology::new();
     let a1 = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);


### PR DESCRIPTION
## Summary

- Un-ignore `fuse_ring_overlapping_shelled_box_height` (stable 5/5 runs)
- Un-ignore `intersect_commutativity` (stable 5/5 runs)

Both pass reliably after PRs #414 (edge-set SD detection) and #415 (VV vertex canonicalization).

## Test plan

- [x] 607 operations tests pass (was 606, +1 from un-ignore)
- [x] 32 ignored tests (was 33, -1)
- [x] Full workspace passes
- [x] Both tests verified stable across 5 consecutive runs