### PR TITLE
fix(algo): reduce VERTEX_DEDUP_SCALE from 1e12 to 1e10

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -13,11 +13,14 @@ type CbEdgeKey = ((i64, i64, i64), (i64, i64, i64));
 
 /// Scale for vertex deduplication in the face splitter.
 ///
-/// Uses 1e12 so only BIT-IDENTICAL positions share keys.
-/// GFA duplicate vertices are from the same computation path (d=0.0).
-/// Topologically-distinct vertices at the same modeling-tolerance
-/// position but different bit patterns remain separate.
-const VERTEX_DEDUP_SCALE: f64 = 1e12;
+/// Uses 1e10 to match vertices from the same computation path that
+/// may differ by floating-point noise (~1e-14). This is coarser than
+/// bit-identical (1e12) but much tighter than modeling tolerance (1e7).
+/// Vertices from the same plane-plane intersection that land on
+/// different face splits will share VertexIds, reducing the Euler
+/// vertex count. Geometrically distinct vertices (>1e-10 apart)
+/// remain separate.
+const VERTEX_DEDUP_SCALE: f64 = 1e10;
 
 use brepkit_math::tolerance::Tolerance;
 use brepkit_math::vec::Point3;


### PR DESCRIPTION
## Summary
- Reduces `VERTEX_DEDUP_SCALE` in `fill_images_faces.rs` from `1e12` to `1e10`
- The old `1e12` scale only matched bit-identical positions, but split vertices from different faces at the "same" position differ by floating-point noise (~1e-14)
- The new `1e10` scale matches vertices from the same intersection computation while keeping geometrically distinct vertices (differ by >1e-7) separate

## Test plan
- [x] 0 regressions across full test suite
- [x] 2 previously-ignored tests now pass (`fuse_ring_inside_shelled_cylinder` already un-ignored in prior PR)
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes