### PR TITLE
test: un-ignore 11 tests that now pass

### DIFF
--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1396,7 +1396,7 @@ fn compound_cut_all_tools_disjoint_returns_unchanged_volume() {
 }
 
 #[test]
-#[ignore = "flaky — SD refactor non-determinism causes ~25% failure rate"]
+#[ignore = "flaky ~25% — SD non-determinism at coplanar boundaries"]
 fn compound_cut_matches_sequential_2x2_grid() {
     use brepkit_math::mat::Mat4;
 

--- a/crates/operations/tests/boolean_edge_cases.rs
+++ b/crates/operations/tests/boolean_edge_cases.rs
@@ -185,7 +185,6 @@ fn test_boolean_thin_slab() {
 }
 
 #[test]
-#[ignore = "flaky — SD refactor non-determinism at coplanar boundaries"]
 fn test_boolean_near_tangent() {
     // Two boxes with tiny overlap: A (0,0,0)-(1,1,1), B (0.999,0,0)-(2,1,1).
     let mut topo = Topology::new();

--- a/crates/operations/tests/boolean_stress.rs
+++ b/crates/operations/tests/boolean_stress.rs
@@ -206,7 +206,6 @@ fn thin_wall_cut() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn thin_wall_intersect() {
     // Intersection producing a thin slab.
     let mut topo = Topology::new();
@@ -325,7 +324,6 @@ fn fuse_commutative() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn intersect_commutative() {
     let mut topo = Topology::new();
     let a1 = box_at(&mut topo, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0);

--- a/crates/operations/tests/proptest_operations.rs
+++ b/crates/operations/tests/proptest_operations.rs
@@ -71,7 +71,6 @@ proptest! {
 
     // 3. rotation + translation preserves volume
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn prop_transform_preserves_volume(theta in 0.0f64..std::f64::consts::TAU, tx in -10.0f64..10.0) {
         let mut topo = Topology::new();
         let solid = make_box(&mut topo, 2.0, 3.0, 4.0).unwrap();
@@ -87,7 +86,6 @@ proptest! {
 
     // 4. copy produces identical volume
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn prop_copy_produces_equal_volume(dx in 0.5f64..5.0, dy in 0.5f64..5.0, dz in 0.5f64..5.0) {
         let mut topo = Topology::new();
         let original = make_box(&mut topo, dx, dy, dz).unwrap();
@@ -102,7 +100,6 @@ proptest! {
 
     // 5. all tessellation triangles have positive area
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn prop_tessellate_positive_area(r in 0.5f64..5.0, h in 0.5f64..5.0) {
         let mut topo = Topology::new();
         let cyl = make_cylinder(&mut topo, r, h).unwrap();
@@ -126,7 +123,6 @@ proptest! {
 
     // 6. box volume matches dx*dy*dz exactly
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn prop_box_volume_exact(dx in 0.1f64..100.0, dy in 0.1f64..100.0, dz in 0.1f64..100.0) {
         let mut topo = Topology::new();
         let solid = make_box(&mut topo, dx, dy, dz).unwrap();
@@ -139,7 +135,6 @@ proptest! {
 
     // 7. cylinder volume matches pi*r^2*h within 1%
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn prop_cylinder_volume(r in 0.5f64..5.0, h in 0.5f64..5.0) {
         let mut topo = Topology::new();
         let cyl = make_cylinder(&mut topo, r, h).unwrap();
@@ -179,7 +174,6 @@ proptest! {
 
     // 9. tessellation produces watertight mesh (every edge has a matching reverse)
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn prop_tessellate_watertight_box(dx in 0.5f64..10.0, dy in 0.5f64..10.0, dz in 0.5f64..10.0) {
         let mut topo = Topology::new();
         let solid = make_box(&mut topo, dx, dy, dz).unwrap();

--- a/crates/wasm/src/bindings/booleans.rs
+++ b/crates/wasm/src/bindings/booleans.rs
@@ -358,7 +358,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "GFA pipeline limitation"]
     fn compound_cut_multiple_tools() {
         let mut k = BrepKernel::new();
         let r = k.execute_batch(

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -1075,7 +1075,6 @@ fn gridfinity_d1a1c_octagon_cut() {
 ///
 /// Tests coplanar face handling when inner box shares Z planes with outer.
 #[test]
-#[ignore = "Euler=0 — boolean coplanar face classification keeps both solid faces"]
 fn gridfinity_d1a2_concentric_box_coplanar() {
     let mut k = BrepKernel::new();
     // Outer box: 20×20×10, inner box: 14×14×10 centered (coplanar top & bottom)


### PR DESCRIPTION
## Summary
- Un-ignores 13 tests, reduces ignored count from 99 to 86
- Fixes 3 bugs: miter sweep edge sharing, miter sweep test geometry, quantization scale mismatch

## Fixes

### 1. Miter sweep edge sharing (code bug)
Duplicate edges at miter joints — `miter_ring_edges` for transition faces and new `ring_edges[0]` for segment side faces connected the same vertices but were distinct entities. Fix: hoist and reuse `miter_ring_edges`.

### 2. Miter sweep test paths (test bug)
L-shaped and U-shaped paths were coplanar with the XY-plane profile, collapsing the cross-section to a line. Changed paths to go along +Z/+X.

### 3. Quantization scale mismatch (latent bug)
`vv_vertex_seed` was built at tolerance scale (1e7) but looked up at `VERTEX_DEDUP_SCALE` (1e10), making seed entries unreachable. Unified all quantization to `VERTEX_DEDUP_SCALE`.

## Tests un-ignored (13)
- `thin_wall_intersect`, `intersect_commutative` — boolean stress
- `test_boolean_near_tangent` — boolean edge cases
- `prop_box_volume_exact`, `prop_cylinder_volume`, `prop_copy_produces_equal_volume`, `prop_transform_preserves_volume`, `prop_tessellate_watertight_box`, `prop_tessellate_positive_area` — proptest
- `compound_cut_multiple_tools` — WASM booleans
- `gridfinity_d1a2_concentric_box_coplanar` — gridfinity
- `sweep_miter_l_shaped_path`, `sweep_miter_l_shaped_volume_correct` — miter sweep

## Test plan
- [x] All 13 un-ignored tests pass
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean