### PR TITLE
fix(algo,ops): restore PB cache fix + Euler gate (missed in #450 squash)

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -107,87 +107,26 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
         seed
     };
 
-    // ── Per-rank fresh-vertex pools ─────────────────────────────────
-    // For each input solid (rank), create FRESH vertices at all leaf
-    // PaveBlock endpoint positions. Keyed by quantized position within
-    // each rank. Different solids at the same position get SEPARATE
-    // fresh vertices, preventing cross-solid topology contamination.
-    let rank_vertex_pools: HashMap<
-        Rank,
-        BTreeMap<(i64, i64, i64), brepkit_topology::vertex::VertexId>,
-    > = {
-        let scale = VERTEX_DEDUP_SCALE;
-        let q = |p: Point3| -> (i64, i64, i64) {
-            (
-                (p.x() * scale).round() as i64,
-                (p.y() * scale).round() as i64,
-                (p.z() * scale).round() as i64,
-            )
-        };
-        // Count face references per (rank, resolved_vid). Only vertices
-        // referenced by 3+ faces within the same rank are true solid
-        // corners that benefit from sharing. Vertices in <3 faces
-        // (shelled box internal edges, etc.) stay per-face.
-        let mut rank_vid_count: HashMap<(Rank, usize), (Point3, usize)> = HashMap::new();
-        for (&face_id, &rank) in face_ranks {
-            if let Ok(face) = topo.face(face_id) {
-                if let Ok(wire) = topo.wire(face.outer_wire()) {
-                    for oe in wire.edges() {
-                        if let Ok(edge) = topo.edge(oe.edge()) {
-                            for &vid in &[edge.start(), edge.end()] {
-                                let rv = arena.resolve_vertex(vid);
-                                if let Ok(v) = topo.vertex(rv) {
-                                    let pt = v.point();
-                                    let entry = rank_vid_count
-                                        .entry((rank, rv.index()))
-                                        .or_insert_with(|| (pt, 0));
-                                    entry.1 += 1;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        // Create fresh vertices for vertices in 3+ faces per rank.
-        let mut pools: HashMap<Rank, BTreeMap<_, _>> = HashMap::new();
-        for ((rank, _), (pt, count)) in &rank_vid_count {
-            if *count >= 3 {
-                let pool = pools.entry(*rank).or_default();
-                pool.entry(q(*pt))
-                    .or_insert_with(|| topo.add_vertex(Vertex::new(*pt, tol.linear)));
-            }
-        }
-        pools
+    // Shared quantization helper for vertex position dedup.
+    let qpos = |p: Point3| -> (i64, i64, i64) {
+        (
+            (p.x() * VERTEX_DEDUP_SCALE).round() as i64,
+            (p.y() * VERTEX_DEDUP_SCALE).round() as i64,
+            (p.z() * VERTEX_DEDUP_SCALE).round() as i64,
+        )
     };
 
-    // PB vertex registry: populated by PaveBlock (CommonBlock) vertex
-    // resolution, consulted by ALL faces' fallback vertex creation.
-    // Only authoritative shared vertices enter this registry — boundary
-    // edge vertices do NOT, preventing cross-face contamination.
+    // PB vertex registry: cross-face pool of FRESH vertices at CB positions.
     let mut pb_vertex_registry: BTreeMap<(i64, i64, i64), brepkit_topology::vertex::VertexId> =
         BTreeMap::new();
 
     // ── CommonBlock vertex pre-pass ─────────────────────────────────
-    // Create FRESH vertices at CommonBlock split edge positions and
-    // register them in the cross-face pool. These fresh vertices are
-    // shared across all faces' boundary edges at intersection positions
-    // WITHOUT creating topology connections to the CB split_edges
-    // (which would corrupt solid_entity_counts traversal).
+    // Create FRESH vertices at CommonBlock split edge positions.
     {
-        let q = |p: Point3| -> (i64, i64, i64) {
-            (
-                (p.x() * VERTEX_DEDUP_SCALE).round() as i64,
-                (p.y() * VERTEX_DEDUP_SCALE).round() as i64,
-                (p.z() * VERTEX_DEDUP_SCALE).round() as i64,
-            )
-        };
-        // Snapshot positions first (can't borrow topo immutably and mutably).
         let cb_positions: Vec<Point3> = arena
             .common_blocks
             .iter()
-            .map(|(_, cb)| cb)
-            .filter_map(|cb| {
+            .filter_map(|(_, cb)| {
                 let eid = cb.split_edge?;
                 let e = topo.edge(eid).ok()?;
                 let mut pts = Vec::new();
@@ -203,10 +142,64 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
             .collect();
         for pt in cb_positions {
             pb_vertex_registry
-                .entry(q(pt))
+                .entry(qpos(pt))
                 .or_insert_with(|| topo.add_vertex(Vertex::new(pt, tol.linear)));
         }
     }
+
+    // ── Per-rank fresh-vertex pools ─────────────────────────────────
+    // For each input solid (rank), create FRESH vertices at positions
+    // of face vertices shared by 2+ unique faces within that rank.
+    // This covers box corners (3 faces) and shared edge endpoints
+    // (2 faces). Different solids get SEPARATE pools to prevent
+    // cross-solid contamination. Vertices in <2 faces (e.g.
+    // shelled-box internal edges) stay per-face.
+    let rank_vertex_pools: HashMap<
+        Rank,
+        BTreeMap<(i64, i64, i64), brepkit_topology::vertex::VertexId>,
+    > = {
+        // Count UNIQUE faces per (rank, resolved_vid).
+        let mut rank_vid_faces: HashMap<(Rank, usize), (Point3, std::collections::HashSet<usize>)> =
+            HashMap::new();
+        for (&face_id, &rank) in face_ranks {
+            if let Ok(face) = topo.face(face_id) {
+                if let Ok(wire) = topo.wire(face.outer_wire()) {
+                    for oe in wire.edges() {
+                        if let Ok(edge) = topo.edge(oe.edge()) {
+                            for &vid in &[edge.start(), edge.end()] {
+                                let rv = arena.resolve_vertex(vid);
+                                if let Ok(v) = topo.vertex(rv) {
+                                    let entry =
+                                        rank_vid_faces.entry((rank, rv.index())).or_insert_with(
+                                            || (v.point(), std::collections::HashSet::new()),
+                                        );
+                                    entry.1.insert(face_id.index());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Create fresh vertices for vertices in 2+ unique faces per rank.
+        // Reuse CB pre-pass vertex if available at this position.
+        let mut pools: HashMap<Rank, BTreeMap<_, _>> = HashMap::new();
+        for ((rank, _), (pt, faces)) in &rank_vid_faces {
+            if faces.len() >= 2 {
+                let pool = pools.entry(*rank).or_default();
+                let key = qpos(*pt);
+                pool.entry(key).or_insert_with(|| {
+                    pb_vertex_registry
+                        .get(&key)
+                        .copied()
+                        .unwrap_or_else(|| topo.add_vertex(Vertex::new(*pt, tol.linear)))
+                });
+            }
+        }
+        pools
+    };
+
+    // (pb_vertex_registry and CB pre-pass moved above rank pool)
 
     // Pre-compute which faces have section edges from which curves
     let section_map = build_section_map(arena);
@@ -1165,23 +1158,30 @@ fn resolve_edge_vertices(
                         if fwd_match {
                             let qs = quantize(edge.start_3d);
                             let qe = quantize(edge.end_3d);
-                            cache.entry(qs).or_insert(se_start);
-                            cache.entry(qe).or_insert(se_end);
-                            // Register in cross-face PB registry so other
-                            // faces' boundary edges at these positions
-                            // reuse the same vertices.
-                            pb_registry.entry(qs).or_insert(se_start);
-                            pb_registry.entry(qe).or_insert(se_end);
-                            return (se_start, se_end);
+                            // Use fresh vertex from cache/registry if available
+                            // (from rank pool or CB pre-pass). Fall back to
+                            // the split_edge's actual vertex only if no fresh
+                            // vertex exists. This prevents topology connections
+                            // between the GFA result and the PaveFiller's
+                            // intermediate split edges.
+                            let vs = *cache
+                                .entry(qs)
+                                .or_insert_with(|| *pb_registry.entry(qs).or_insert(se_start));
+                            let ve = *cache
+                                .entry(qe)
+                                .or_insert_with(|| *pb_registry.entry(qe).or_insert(se_end));
+                            return (vs, ve);
                         }
                         if rev_match {
                             let qs = quantize(edge.start_3d);
                             let qe = quantize(edge.end_3d);
-                            cache.entry(qs).or_insert(se_end);
-                            cache.entry(qe).or_insert(se_start);
-                            pb_registry.entry(qs).or_insert(se_end);
-                            pb_registry.entry(qe).or_insert(se_start);
-                            return (se_end, se_start);
+                            let vs = *cache
+                                .entry(qs)
+                                .or_insert_with(|| *pb_registry.entry(qs).or_insert(se_end));
+                            let ve = *cache
+                                .entry(qe)
+                                .or_insert_with(|| *pb_registry.entry(qe).or_insert(se_start));
+                            return (vs, ve);
                         }
                     }
                 }

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -207,9 +207,17 @@ pub fn boolean(
                 .unwrap_or(0);
             if result_faces > 0 {
                 let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
-                for _ in 0..3 {
-                    if crate::heal::unify_faces(topo, result)? == 0 {
-                        break;
+                // Check Euler before unify_faces — if already valid, skip
+                // unify to avoid its face-merging bugs (non-manifold edges).
+                let (f_pre, e_pre, v_pre) =
+                    brepkit_topology::explorer::solid_entity_counts(topo, result)?;
+                #[allow(clippy::cast_possible_wrap)]
+                let euler_pre = (v_pre as i64) - (e_pre as i64) + (f_pre as i64);
+                if euler_pre != 2 {
+                    for _ in 0..3 {
+                        if crate::heal::unify_faces(topo, result)? == 0 {
+                            break;
+                        }
                     }
                 }
                 let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(topo, result)?;


### PR DESCRIPTION
## Summary
PR #450's squash merge only included the first 2 of 5 commits. This restores the missing 3:

1. **Euler-gated unify_faces** — skip face merging when Euler=2 pre-unify
2. **PB cache fix** — section edges use cache/registry vertices (V: 32→24)
3. **Review cleanup** — deduplicated quantize, fixed face counting

## Impact
- V reduced from 32 to **24** for overlapping box fuse (was 38 baseline)
- 8 remaining duplicates are at far corners of each box

## Test plan
- [x] 0 regressions across 612 tests
- [x] `cargo clippy --all-targets -- -D warnings` — clean