### PR TITLE
fix(ops): correct volume for GFA boolean results — un-ignores fuse_overlapping_cubes

### DIFF
--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -73,7 +73,6 @@ fn intersect_disjoint_returns_error() {
 /// 2 overshared edges. Root cause is incomplete face coverage from
 /// missing SD representative replacement, not edge merging failure.
 #[test]
-#[ignore = "GFA pipeline limitation — SD face replacement not yet implemented"]
 fn diagnose_fuse_overlapping_cubes_edges() {
     use std::collections::HashMap;
 
@@ -259,7 +258,6 @@ fn gfa_direct_fuse_overlapping_manifold() {
 // ── 1D overlapping tests (offset on one axis) ───────────────────────
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn fuse_overlapping_cubes() {
     let mut topo = Topology::new();
     let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -1729,7 +1729,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn unify_boolean_box_reduces_faces() {
         // Two overlapping boxes: the boolean result has coplanar face fragments
         // on the shared cutting plane. Use unify_faces=false so the fragments

--- a/crates/operations/src/measure.rs
+++ b/crates/operations/src/measure.rs
@@ -758,7 +758,10 @@ pub fn solid_volume(
             .faces()
             .iter()
             .all(|&fid| topo.face(fid).is_ok_and(|f| f.inner_wires().is_empty()));
-        if no_inner_wires {
+        // Skip planar polygon volume for solids with 10+ faces — these are
+        // likely GFA boolean results where merge_duplicate_edges may have
+        // created crossed polygon winding. Use tessellation instead.
+        if no_inner_wires && sh.faces().len() <= 8 {
             if let Ok(v) = volume_from_planar_polygons(topo, solid, deflection) {
                 return Ok(v);
             }


### PR DESCRIPTION
## Summary
Fixes the volume computation for GFA boolean results by skipping the
`volume_from_planar_polygons` path for solids with >8 faces. This path
uses Newell area which gives wrong results when `merge_duplicate_edges`
creates crossed polygon winding on shared edges.

## MILESTONE: fuse_overlapping_cubes PASSES
For the first time, a GFA boolean fuse of two overlapping unit cubes
produces both correct manifold topology (V=16, Euler=2, 0 NM edges)
AND correct volume (1.5).

## Tests un-ignored (3)
- `diagnose_fuse_overlapping_cubes_edges` — manifold check
- `fuse_overlapping_cubes` — volume + manifold
- `unify_boolean_box_reduces_faces` — post-boolean healing

## Root cause
The reference implementation never creates duplicate edges — they're
shared from the start via the PaveBlock system. brepkit creates per-face
edges and merges them retroactively in `merge_duplicate_edges`. This
merge creates correct manifold topology but introduces crossed polygon
winding that makes the Newell area computation give wrong results.
Tessellation-based volume handles this correctly.

## Test plan
- [x] 0 regressions, 3 newly passing tests
- [x] clippy clean