### PR TITLE
fix(algo): SD selection for Cut + 7 tests un-ignored (62→55)

### DIFF
--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -110,7 +110,6 @@ fn apply_sd_selection(
 
     for pair in sd_pairs {
         let sf_a = &sub_faces[pair.idx_a];
-        let sf_b = &sub_faces[pair.idx_b];
 
         // Distinguish touching (face on boundary) from overlapping
         // (face inside opposing solid). Uses AABB containment check
@@ -141,24 +140,10 @@ fn apply_sd_selection(
             // Orientations DON'T match what the operation needs:
             // - Fuse + opposite-ori: internal faces — discard both
             // - Intersect + opposite-ori: discard both
-            // - Cut + same-ori: A's sub-face is being cut away,
-            //   B's face becomes inner cap (reversed)
-            if op == BooleanOp::Cut {
-                if is_touching {
-                    // Touching with same-ori: A's face on exterior — keep A
-                    selected.push(SelectedFace {
-                        face_id: sf_a.face_id,
-                        reversed: false,
-                    });
-                } else {
-                    // Overlapping: B becomes inner void cap
-                    selected.push(SelectedFace {
-                        face_id: sf_b.face_id,
-                        reversed: true,
-                    });
-                }
-            }
-            // For Fuse/Intersect with mismatched orientation: discard both
+            // - Cut + same-ori: discard both — the overlap region is
+            //   cut away from A, and B's cap is provided by the
+            //   B-Inside non-SD face from the regular selection.
+            // For Fuse/Intersect/Cut with mismatched orientation: discard both
         }
     }
 

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -183,7 +183,8 @@ pub fn detect_same_domain<S: BuildHasher>(
                 idx_a,
                 idx_b,
                 same_orientation,
-                // Edge-set matched faces have identical boundaries → touching, not contained
+                // Edge-set matched faces have identical boundaries.
+                // b_contained_in_a=false → touching (default for same-boundary faces).
                 b_contained_in_a: false,
             });
         }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -280,7 +280,6 @@ fn intersect_overlapping_cubes() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn cut_overlapping_cubes() {
     let mut topo = Topology::new();
     let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
@@ -2325,7 +2324,6 @@ fn test_boolean_convex_face_chord_clip_regression() {
 /// Verify boolean works correctly at 100m scale with scale-relative
 /// vertex merge resolution. Documents expected behavior for large models.
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn test_boolean_large_scale_vertex_merge() {
     let mut topo = Topology::new();
 

--- a/crates/operations/tests/boolean_invariants.rs
+++ b/crates/operations/tests/boolean_invariants.rs
@@ -143,7 +143,6 @@ fn intersect_commutativity() {
 // -- Cut complement -------------------------------------------------------
 
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn cut_complement_identity() {
     // V(A-B) = V(A) - V(A&B)
     let mut topo = Topology::new();
@@ -170,7 +169,6 @@ fn cut_complement_identity() {
 // -- Anti-commutativity ---------------------------------------------------
 
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn anti_commutativity_identity() {
     // V(A-B) + V(B-A) + 2*V(A&B) = V(A) + V(B)
     let mut topo = Topology::new();

--- a/crates/operations/tests/boolean_stress.rs
+++ b/crates/operations/tests/boolean_stress.rs
@@ -232,7 +232,6 @@ fn volume_fuse_overlapping_boxes() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn volume_cut_overlapping_boxes() {
     let mut topo = Topology::new();
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0);
@@ -709,7 +708,6 @@ fn half_overlap_fuse() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn half_overlap_cut() {
     let mut topo = Topology::new();
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0);

--- a/crates/operations/tests/proptest_operations.rs
+++ b/crates/operations/tests/proptest_operations.rs
@@ -145,7 +145,6 @@ proptest! {
 
     // 8. V(A-B) = V(A) - V(A&B)
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn prop_cut_complement(offset in 0.1f64..0.9) {
         let mut topo = Topology::new();
         let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);


### PR DESCRIPTION
## Summary
Fixes same-domain face selection for Cut operations. Same-orientation SD
pairs at the overlap should be discarded (both A and B). The B-Inside
non-SD face provides the cut cap. Previously kept A's overlap face →
wrong volume.

## Tests un-ignored (7)
- cut_overlapping_cubes, test_boolean_large_scale_vertex_merge
- half_overlap_cut, volume_cut_overlapping_boxes
- cut_complement_identity, anti_commutativity_identity
- prop_cut_complement

## Ignored count: 62 → 55

## Test plan
- [x] 0 regressions, 7 newly passing
- [x] clippy clean