### PR TITLE
fix(algo): fix forward flag for new edges — un-ignore 5 tests (47→42)

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1520,8 +1520,12 @@ fn build_topology_face(
             // edges are shared across parent faces with different vertex caches.
             topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()))
         };
-        let forward = pcurve_edge.forward;
-        oriented_edges.push(OrientedEdge::new(edge_id, forward));
+        // The edge was created with start_vid at start_3d position and
+        // end_vid at end_3d position. These positions encode the wire's
+        // traversal direction (for reverse section edges, start_3d IS the
+        // reverse-direction start). So the edge is always in traversal
+        // order — use forward=true.
+        oriented_edges.push(OrientedEdge::new(edge_id, true));
     }
 
     if oriented_edges.is_empty() {

--- a/crates/operations/tests/boolean_stress.rs
+++ b/crates/operations/tests/boolean_stress.rs
@@ -271,7 +271,6 @@ fn fuse_overlap_y_axis() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn fuse_overlap_z_axis() {
     let mut topo = Topology::new();
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0);
@@ -540,7 +539,6 @@ fn fuse_asymmetric_boxes() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn cut_asymmetric_boxes() {
     let mut topo = Topology::new();
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 5.0, 3.0, 2.0);
@@ -749,7 +747,6 @@ fn cut_no_overlap_preserves_volume() {
 // ===========================================================================
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn l_shape_fuse() {
     // Create L-shape by fusing two boxes.
     let mut topo = Topology::new();
@@ -767,7 +764,6 @@ fn l_shape_fuse() {
 // ===========================================================================
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn t_shape_fuse() {
     // Create T-shape by fusing horizontal and vertical boxes.
     let mut topo = Topology::new();
@@ -785,7 +781,6 @@ fn t_shape_fuse() {
 // ===========================================================================
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn cross_shape_fuse() {
     let mut topo = Topology::new();
     let h = box_at(&mut topo, 0.0, 1.0, 0.0, 4.0, 2.0, 1.0);


### PR DESCRIPTION
## Summary
Fix the ±0.667 volume error on shape fuse booleans by using `forward=true` for all newly created edges.

## Root Cause
Edges in `build_topology_face` are created with `Edge::new(start_vid, end_vid)` where start_vid/end_vid are already in wire traversal order. Using `pcurve_edge.forward` as the `OrientedEdge` forward flag caused **double-negation** for reverse section edges: the edge was already in reverse order, and `forward=false` reversed it again.

## Impact
- **L-shape fuse**: 4.33 → 5.0 (correct)
- **T-shape fuse**: 9.33/10.67 → 10.0 (correct)
- **Cross-shape fuse**: 10.67/11.33 → 12.0 (correct)
- **fuse_overlap_z_axis**: now passes
- **cut_asymmetric_boxes**: now passes

## Test plan
- [x] 0 regressions (93 boolean + full operations suite)
- [x] 5 tests un-ignored (47→42 ignored)
- [x] Clippy clean