### PR TITLE
fix(algo): Line-only forward=true + un-ignore 9 tests (47→38)

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -25,7 +25,7 @@ const VERTEX_DEDUP_SCALE: f64 = 1e10;
 use brepkit_math::tolerance::Tolerance;
 use brepkit_math::vec::Point3;
 use brepkit_topology::Topology;
-use brepkit_topology::edge::{Edge, EdgeId};
+use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
 use brepkit_topology::face::{Face, FaceId, FaceSurface};
 use brepkit_topology::vertex::Vertex;
 use brepkit_topology::wire::{OrientedEdge, Wire};
@@ -1520,12 +1520,13 @@ fn build_topology_face(
             // edges are shared across parent faces with different vertex caches.
             topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()))
         };
-        // The edge was created with start_vid at start_3d position and
-        // end_vid at end_3d position. These positions encode the wire's
-        // traversal direction (for reverse section edges, start_3d IS the
-        // reverse-direction start). So the edge is always in traversal
-        // order — use forward=true.
-        oriented_edges.push(OrientedEdge::new(edge_id, true));
+        // For Line edges: start_vid at start_3d, end_vid at end_3d encode
+        // the traversal direction directly — always use forward=true.
+        // For curved edges (Circle, Ellipse, etc.): the curve has its own
+        // parameterization that may differ from start_3d→end_3d order.
+        // Use pcurve_edge.forward to preserve the intended traversal.
+        let forward = matches!(pcurve_edge.curve_3d, EdgeCurve::Line) || pcurve_edge.forward;
+        oriented_edges.push(OrientedEdge::new(edge_id, forward));
     }
 
     if oriented_edges.is_empty() {

--- a/crates/operations/src/validate.rs
+++ b/crates/operations/src/validate.rs
@@ -1311,7 +1311,6 @@ mod tests {
     // ── Boolean result validation ──────────────────────
 
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn boolean_fuse_result_validates() {
         let mut topo = Topology::new();
         let a = brepkit_topology::test_utils::make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
@@ -1329,7 +1328,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn boolean_cut_result_validates() {
         let mut topo = Topology::new();
         let a = brepkit_topology::test_utils::make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
@@ -1347,7 +1345,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn boolean_intersect_result_validates() {
         let mut topo = Topology::new();
         let a = brepkit_topology::test_utils::make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);

--- a/crates/operations/tests/golden_regression.rs
+++ b/crates/operations/tests/golden_regression.rs
@@ -243,7 +243,6 @@ fn golden_tessellation_sphere() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn golden_boolean_fuse_two_boxes() {
     let mut topo = Topology::new();
     let a = make_box(&mut topo, 6.0, 6.0, 6.0).unwrap();

--- a/tests/golden/data/boolean_fuse_two_boxes.golden
+++ b/tests/golden/data/boolean_fuse_two_boxes.golden
@@ -1,6 +1,6 @@
 # fuse box [0,6]^3 with box [3,0,0]+[6,6,6]
-vertices: 24
-triangles: 44
+vertices: 16
+triangles: 28
 volume: 324.000000
 bbox_min: (0.000000, 0.000000, 0.000000)
 bbox_max: (9.000000, 6.000000, 6.000000)


### PR DESCRIPTION
## Summary
Refine forward=true fix for Line edges only + un-ignore 4 more tests.

## Details
The forward=true fix from PR #473 applied to ALL edge types. Curved edges
(Circle, Ellipse) have their own parameterization that may differ from the
start_3d→end_3d order, so they need pcurve_edge.forward preserved.

Also un-ignores 4 additional tests:
- 3 validate boolean tests (fuse/cut/intersect result validates)
- 1 golden fuse test (updated golden data: 24→16 vertices)

Combined with PR #473: **47→38 ignored tests** (9 un-ignored total).

## Test plan
- [x] 0 regressions (full operations suite)
- [x] Clippy clean
- [x] Golden tests pass with updated data