### PR TITLE
fix(algo): closed-curve handling and disc classification

### DIFF
--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -118,7 +118,7 @@ fn apply_sd_selection(
 
         if same_ori_needed == pair.same_orientation {
             // Orientations match what the operation needs:
-            // - Fuse + same-ori: keep A (representative), discard B
+            // - Fuse + same-ori: keep A (representative) if on exterior, discard if internal
             // - Intersect + same-ori: keep A
             // - Cut + opposite-ori: depends on A's classification
             if op == BooleanOp::Cut {
@@ -130,6 +130,14 @@ fn apply_sd_selection(
                     });
                 }
                 // Overlapping: both faces cancel — discard both
+                continue;
+            }
+            // For Fuse/Intersect: if A is classified as Inside the opposing
+            // solid, this SD pair is an internal overlap (e.g., cylinder cap
+            // coincides with box face disc sub-face) — discard both faces.
+            if (op == BooleanOp::Fuse || op == BooleanOp::Intersect)
+                && sf_a.classification == FaceClass::Inside
+            {
                 continue;
             }
             selected.push(SelectedFace {

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -588,8 +588,11 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
             let dup_edge = topo.edge(dup)?;
             let dup_qs = quantize_point(topo.vertex(dup_edge.start())?.point(), tol);
             let dup_qe = quantize_point(topo.vertex(dup_edge.end())?.point(), tol);
-            // Detect reversed vertex order
-            let needs_flip = dup_qs == canon_qe && dup_qe == canon_qs;
+            // Detect reversed vertex order. For closed edges (start == end),
+            // qs == qe for both canonical and duplicate, so the flip condition
+            // would be trivially true. Never flip closed edges.
+            let is_closed = canon_qs == canon_qe;
+            let needs_flip = !is_closed && dup_qs == canon_qe && dup_qe == canon_qs;
             replacements.insert(dup, (canonical, needs_flip));
         }
     }

--- a/crates/algo/src/builder/face_splitter.rs
+++ b/crates/algo/src/builder/face_splitter.rs
@@ -1487,6 +1487,51 @@ fn split_face_with_internal_loops(
             }
         }
 
+        // Compute the interior point for the disc sub-face.
+        // For closed section curves (circles) that form internal loops,
+        // the interior point on the plane can land ON the opposing solid's
+        // coplanar boundary face, causing ambiguous ray-cast classification.
+        // Offset the point slightly along the face normal to break the tie.
+        let disc_interior = {
+            // Sample 3D points along the circle to find its centroid.
+            let edge = &loop_edges[0];
+            let (t0, t1) = edge
+                .curve_3d
+                .domain_with_endpoints(edge.start_3d, edge.end_3d);
+            let n_samples = 16;
+            let mut sum = brepkit_math::vec::Vec3::new(0.0, 0.0, 0.0);
+            for k in 0..n_samples {
+                #[allow(clippy::cast_precision_loss)]
+                let t = t0 + (t1 - t0) * (k as f64 / n_samples as f64);
+                let pt = edge
+                    .curve_3d
+                    .evaluate_with_endpoints(t, edge.start_3d, edge.end_3d);
+                sum += brepkit_math::vec::Vec3::new(pt.x(), pt.y(), pt.z());
+            }
+            #[allow(clippy::cast_precision_loss)]
+            let centroid = Point3::new(
+                sum.x() / n_samples as f64,
+                sum.y() / n_samples as f64,
+                sum.z() / n_samples as f64,
+            );
+            // Offset along the face normal by a small amount to ensure
+            // the point is clearly inside the opposing solid (not on the
+            // coplanar boundary). Use the surface normal direction.
+            let normal_offset = match &surface {
+                FaceSurface::Plane { normal, .. } => {
+                    let n = if reversed { -*normal } else { *normal };
+                    // Offset INTO the solid (opposite to the face normal).
+                    brepkit_math::vec::Vec3::new(-n.x(), -n.y(), -n.z()) * 1e-6
+                }
+                _ => brepkit_math::vec::Vec3::new(0.0, 0.0, 0.0),
+            };
+            Point3::new(
+                centroid.x() + normal_offset.x(),
+                centroid.y() + normal_offset.y(),
+                centroid.z() + normal_offset.z(),
+            )
+        };
+
         // The loop as outer wire of the inside sub-face.
         result.push(SplitSubFace {
             surface: surface.clone(),
@@ -1495,7 +1540,7 @@ fn split_face_with_internal_loops(
             reversed,
             parent: face_id,
             rank,
-            precomputed_interior: None,
+            precomputed_interior: Some(disc_interior),
         });
 
         // Build reversed loop for the outside sub-face's hole.

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1034,29 +1034,21 @@ fn build_section_edges(
     for source in sources {
         match source {
             SectionSource::Curve(curve_idx) => {
+                use brepkit_math::vec::Point2;
                 // Use the COMPLETE intersection curve, not individual PBs.
                 // The face splitter needs whole curves to form proper loops.
-                let curve_ds = &arena.curves[*curve_idx];
+                let curve_ds = match arena.curves.get(*curve_idx) {
+                    Some(c) => c,
+                    None => continue,
+                };
 
-                // Find start/end 3D points from the curve's PaveBlocks
-                // (first PB's start vertex, last PB's end vertex).
-                // For a closed curve (circle), these will be the same point.
+                // Find start/end 3D points by evaluating the curve at its
+                // parametric endpoints. For closed curves (circles), start ≈ end.
                 let (start, end) = curve_endpoints(topo, arena, curve_ds);
                 let (start, end) = match (start, end) {
                     (Some(s), Some(e)) => (s, e),
                     _ => continue,
                 };
-
-                // For Line curves on planar faces, clip to face boundary.
-                let (start, end) =
-                    if matches!(&curve_ds.curve, brepkit_topology::edge::EdgeCurve::Line) {
-                        match clip_line_to_face_boundary(topo, face_id, start, end, tol) {
-                            Some(pair) => pair,
-                            None => continue,
-                        }
-                    } else {
-                        (start, end)
-                    };
 
                 let pcurve = super::pcurve_compute::compute_pcurve_on_surface(
                     &curve_ds.curve,
@@ -1067,8 +1059,48 @@ fn build_section_edges(
                     None,
                 );
 
-                let start_uv_pt = Some(pcurve.evaluate(0.0));
-                let end_uv_pt = Some(pcurve.evaluate(1.0));
+                // For closed curves on periodic surfaces (e.g. circle on cylinder),
+                // the pcurve wraps around and evaluate(0) ≈ evaluate(1). We need
+                // UV endpoints that span the full period so the face splitter
+                // sees the section edge as a full-width cut.
+                let is_closed = (start - end).length() < tol * 100.0;
+                let (u_per, _v_per) = super::pcurve_compute::surface_periods(face.surface());
+                let (start_uv_pt, end_uv_pt) = if is_closed && u_per.is_some() {
+                    let period = u_per.unwrap_or(std::f64::consts::TAU);
+                    // Project the start 3D point to UV.
+                    let start_uv = face.surface().project_point(start);
+                    if let Some((su, sv)) = start_uv {
+                        // Sample the curve at t=0.25 to determine winding direction.
+                        let (t0, t1) = curve_ds.curve.domain_with_endpoints(start, end);
+                        let mid_3d = curve_ds.curve.evaluate_with_endpoints(
+                            t0 + (t1 - t0) * 0.25,
+                            start,
+                            end,
+                        );
+                        let mid_uv = face.surface().project_point(mid_3d);
+                        if let Some((mu, _mv)) = mid_uv {
+                            // Determine winding: does the curve go in +u or -u
+                            // direction from start?
+                            let du = mu - su;
+                            // Normalize du to [-period/2, period/2].
+                            let du_norm = du - (du / period).round() * period;
+                            let end_u = if du_norm < 0.0 {
+                                su - period
+                            } else {
+                                su + period
+                            };
+                            (Some(Point2::new(su, sv)), Some(Point2::new(end_u, sv)))
+                        } else {
+                            let s = pcurve.evaluate(0.0);
+                            (Some(s), Some(Point2::new(s.x() - period, s.y())))
+                        }
+                    } else {
+                        // Plane surface — project via pcurve.
+                        (Some(pcurve.evaluate(0.0)), Some(pcurve.evaluate(1.0)))
+                    }
+                } else {
+                    (Some(pcurve.evaluate(0.0)), Some(pcurve.evaluate(1.0)))
+                };
 
                 sections.push(SectionEdge {
                     curve_3d: curve_ds.curve.clone(),
@@ -1172,55 +1204,23 @@ fn build_section_edges(
 
 /// Find the overall 3D start/end points of an intersection curve
 /// by evaluating at the curve's parametric endpoints.
+///
+/// This function is only called for non-Line curves (Circle, Ellipse, NURBS).
+/// For these types, `evaluate_with_endpoints` ignores the start/end reference
+/// points entirely — they dispatch to `ParametricCurve::evaluate(t)`.
 fn curve_endpoints(
-    topo: &Topology,
-    arena: &GfaArena,
+    _topo: &Topology,
+    _arena: &GfaArena,
     curve_ds: &crate::ds::IntersectionCurveDS,
 ) -> (Option<Point3>, Option<Point3>) {
     use brepkit_math::vec::Point3;
 
-    // First try: evaluate the curve directly at t_range endpoints.
-    // This works for all curve types and doesn't depend on PaveBlock split_edge.
     let (t0, t1) = curve_ds.t_range;
-
-    // For Line curves: we need a reference start/end point for evaluate_with_endpoints.
-    // Find any PB with a split_edge to get reference points.
-    let mut ref_start: Option<Point3> = None;
-    let mut ref_end: Option<Point3> = None;
-    for &pb_id in &curve_ds.pave_blocks {
-        let pb = match arena.pave_blocks.get(pb_id) {
-            Some(pb) => pb,
-            None => continue,
-        };
-        // Try the PB's original edge first (always present).
-        if let Ok(edge) = topo.edge(pb.original_edge) {
-            if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                ref_start = Some(sv.point());
-                ref_end = Some(ev.point());
-                break;
-            }
-        }
-        // Fall back to split_edge.
-        if let Some(eid) = pb.split_edge {
-            if let Ok(edge) = topo.edge(eid) {
-                if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                    ref_start = Some(sv.point());
-                    ref_end = Some(ev.point());
-                    break;
-                }
-            }
-        }
-    }
-
-    let (rs, re) = match (ref_start, ref_end) {
-        (Some(s), Some(e)) => (s, e),
-        _ => return (None, None),
-    };
-
-    // Evaluate the curve at its parametric endpoints.
-    let start_3d = curve_ds.curve.evaluate_with_endpoints(t0, rs, re);
-    let end_3d = curve_ds.curve.evaluate_with_endpoints(t1, rs, re);
-
+    // Non-Line curves evaluate directly at their parametric endpoints.
+    // The dummy reference points are unused by Circle/Ellipse/NURBS evaluation.
+    let dummy = Point3::new(0.0, 0.0, 0.0);
+    let start_3d = curve_ds.curve.evaluate_with_endpoints(t0, dummy, dummy);
+    let end_3d = curve_ds.curve.evaluate_with_endpoints(t1, dummy, dummy);
     (Some(start_3d), Some(end_3d))
 }
 

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -204,8 +204,26 @@ impl Builder {
 
         for (idx, sf) in self.sub_faces.iter_mut().enumerate() {
             if sd_indices.contains(&idx) {
-                sf.classification = FaceClass::On;
-                continue;
+                // Most SD faces stay "On" — ray-cast is unstable for
+                // coplanar boundary points. Exception: faces from internal
+                // circle loops (disc sub-faces from split_face_with_internal_loops)
+                // have offset interior points that classify reliably.
+                let is_disc_face = self
+                    .topo
+                    .face(sf.face_id)
+                    .ok()
+                    .and_then(|f| self.topo.wire(f.outer_wire()).ok())
+                    .is_some_and(|w| {
+                        w.edges().len() == 1
+                            && self.topo.edge(w.edges()[0].edge()).is_ok_and(|e| {
+                                !matches!(e.curve(), brepkit_topology::edge::EdgeCurve::Line)
+                            })
+                    });
+                if !is_disc_face {
+                    sf.classification = FaceClass::On;
+                    continue;
+                }
+                // Disc face — classify via ray-cast with offset interior point.
             }
 
             // Determine the opposing solid


### PR DESCRIPTION
## Summary
- Prevent false flip for closed edges in `merge_duplicate_edges`
- Compute disc sub-face interior point with normal offset to avoid coplanar ray-cast ambiguity
- Discard internal SD overlaps for Fuse/Intersect operations
- Simplify `curve_endpoints` for non-Line curves (no PB traversal needed)
- Full-period UV endpoints for closed curves on periodic surfaces
- Disc face exception in SD classification allows ray-cast with offset interior point

Follow-up review fixes for PR #487 (curve-level section edges for non-Line FF intersections).

## Test plan
- [x] All 65 algo tests pass
- [x] 622/642 operations tests pass (20 pre-existing failures on main, 0 regressions)
- [x] Pre-commit and pre-push hooks pass