### PR TITLE
fix(blend): respect face reversal for analytic fillet normals (#490)

### DIFF
--- a/crates/blend/src/fillet_builder.rs
+++ b/crates/blend/src/fillet_builder.rs
@@ -328,10 +328,24 @@ fn compute_stripe_for_edge(
     let radius = law.evaluate(0.5);
 
     // Try analytic fast path (only for constant radius).
+    // The analytic fillet expects INWARD-pointing normals (toward material).
+    // Compute inward normals from the surface normals and face reversal:
+    // - Not reversed: outward = surface_normal → inward = -surface_normal
+    // - Reversed: outward = -surface_normal → inward = surface_normal
     if matches!(law, RadiusLaw::Constant(_)) {
-        if let Some(result) =
-            analytic::try_analytic_fillet(&surf1, &surf2, &spine, topo, radius, face1, face2)?
-        {
+        let flipped1 = orient_plane_surface(&surf1);
+        let flipped2 = orient_plane_surface(&surf2);
+        let inward_surf1 = if face1_reversed { &surf1 } else { &flipped1 };
+        let inward_surf2 = if face2_reversed { &surf2 } else { &flipped2 };
+        if let Some(result) = analytic::try_analytic_fillet(
+            inward_surf1,
+            inward_surf2,
+            &spine,
+            topo,
+            radius,
+            face1,
+            face2,
+        )? {
             return Ok(result);
         }
     }

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -142,12 +142,12 @@ pub fn json_f64(val: &serde_json::Value, key: &str) -> Result<f64, JsError> {
 
 // ── Edge/face helpers ─────────────────────────────────────────────
 
-/// Attempt fillet with rolling-ball (primary), falling back to blend crate
-/// then flat bevel on failure.
+/// Attempt fillet using the blend crate's `FilletBuilder` (primary),
+/// falling back to rolling-ball then flat bevel on failure.
 ///
-/// The blend crate's `fillet_v2` has correct corner geometry for multi-edge
-/// fillets but is not yet fully validated for all single-edge cases.
-/// Once validated, it should become the primary path.
+/// The blend crate path has correct corner geometry (spherical triangle
+/// patches) for multi-edge fillets. Rolling-ball is kept as fallback
+/// for edge cases where `FilletBuilder` fails.
 #[allow(deprecated)]
 pub fn try_fillet(
     topo: &mut brepkit_topology::Topology,
@@ -155,13 +155,12 @@ pub fn try_fillet(
     edge_ids: &[brepkit_topology::edge::EdgeId],
     radius: f64,
 ) -> Result<brepkit_topology::solid::SolidId, brepkit_operations::OperationsError> {
-    // Primary path: rolling-ball (well-tested, correct bbox)
-    // TODO(#490): switch to fillet_v2 once its cylinder positioning is validated
-    brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edge_ids, radius)
-        // Fallback 1: blend crate FilletBuilder (correct corner patches)
+    // Primary path: blend crate FilletBuilder (correct corner geometry)
+    brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edge_ids, radius)
+        .map(|r| r.solid)
+        // Fallback 1: rolling-ball (legacy, known corner overlap issues)
         .or_else(|_| {
-            brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edge_ids, radius)
-                .map(|r| r.solid)
+            brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edge_ids, radius)
         })
         // Fallback 2: flat bevel (simplest)
         .or_else(|_| brepkit_operations::fillet::fillet(topo, solid_id, edge_ids, radius))


### PR DESCRIPTION
## Summary

Addresses review comments from PR #514 (now closed due to rebase conflict — this replaces it).

### Fixes

1. **P1: Respect face reversal for inward normals** (Greptile + Copilot)
   - Not reversed: outward = surface_normal → flip to inward
   - Reversed: outward = -surface_normal → surface_normal IS already inward
   - Previous code flipped unconditionally, which double-flipped reversed faces

2. **Doc comment updated** (Copilot)
   - `try_fillet` doc now correctly describes fillet_v2 as primary

3. **Switch try_fillet primary to fillet_v2** (the #490 milestone)

Closes #490 (with #507, #509, #511, #512).

## Test plan
- [x] `cargo test --workspace` — 1,883 tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `fillet_box_bbox_unchanged` passes with fillet_v2 as primary
- [x] All gridfinity tests pass