### PR TITLE
fix(algo): deterministic face rebuild order in merge_duplicate_edges

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -605,13 +605,23 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
 
     // Step 3: Rebuild faces that have replaced edges.
     // Snapshot face data, then create new faces.
+    //
+    // Sort the face indices before iterating so that `topo.add_wire` and
+    // `topo.add_face` are called in a deterministic order. Iterating the
+    // HashSet directly picks up a random per-process iteration order,
+    // which assigns different underlying WireId/FaceId values to
+    // structurally identical wires across runs. Downstream flood-fill in
+    // `perform_loops` can be sensitive to those ID orderings at
+    // near-degenerate geometry, so fix the order here.
     let faces_to_rebuild: HashSet<usize> = entries
         .iter()
         .filter(|e| replacements.contains_key(&e.edge_id))
         .map(|e| e.face_idx)
         .collect();
+    let mut faces_to_rebuild_sorted: Vec<usize> = faces_to_rebuild.into_iter().collect();
+    faces_to_rebuild_sorted.sort_unstable();
 
-    for &fi in &faces_to_rebuild {
+    for &fi in &faces_to_rebuild_sorted {
         let fid = face_ids[fi];
 
         // Snapshot
@@ -687,7 +697,7 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
 
     log::debug!(
         "merge_duplicate_edges: merged {merge_count} duplicate edges across {} faces",
-        faces_to_rebuild.len()
+        faces_to_rebuild_sorted.len()
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Defensive hardening follow-up to #520. `merge_duplicate_edges` iterates `faces_to_rebuild: HashSet<usize>` to call `topo.add_wire()` and `topo.add_face()` for each face that needs rebuilding. Because HashSet iteration uses a random per-process seed, structurally identical wires get different underlying `WireId`/`FaceId` values across runs. Downstream `perform_loops` flood-fill may be sensitive to those ID orderings at near-degenerate geometry.

This is the same class of nondeterminism bug fixed in #520 (`fill_images_faces.rs:184` — HashMap iteration driving `topo.add_vertex`). The same file family was audited after #520 was identified; this is the only other site where local `HashMap`/`HashSet` iteration drives topology mutation.

## Honest caveat

Unlike #520, **this site is not currently a confirmed cause of a flaky test.** I ran a 60-iteration stress loop of `compound_cut_sequential_reduces_volume` on origin/main with only this fix applied (no #520) and reproduced the 2/60 flake rate that #520 eliminates. So this PR does not fix an observed failure — it closes a clear determinism hole in the same file family before it surfaces in a future test.

## Why ship it anyway

1. The pattern (`HashSet → topo.add_*` inside a loop) is *exactly* the same as the one that caused #520's flake.
2. The fix is three lines: sort by `usize` before iterating.
3. It eliminates a latent class of failures at near-degenerate geometry where flood-fill visitation order matters.

## Test plan

- [x] \`cargo test -p brepkit-operations --lib boolean::\`: 65/65 pass
- [x] \`cargo clippy -p brepkit-algo --all-targets -- -D warnings\`: clean
- [x] Pre-push full test suite: green

## Other audit findings (not fixed here)

The audit covered all \`HashMap\`/\`HashSet\` iteration sites in \`crates/algo/src/\`. Beyond #520 and this PR, the only other risk sites are in \`same_domain.rs\` (lines 109, 143, 159) where HashMap iteration feeds a UnionFind and builds \`Vec<SameDomainPair>\`. Downstream consumption is mostly order-insensitive (collects into HashSet of indices), but there is a thin possibility of propagating non-determinism into \`apply_sd_selection\`'s \`selected: Vec<SelectedFace>\` ordering. Not addressed here — would be worth a more thorough trace if a future SD-related flake appears.