### PR TITLE
feat(algo): coincident-face boolean corpus + Torus same-domain detection

### DIFF
--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -304,7 +304,18 @@ impl UnionFind {
 /// Returns `Some(true)` for same-direction normals (CoplanarSame),
 /// `Some(false)` for opposite normals (CoplanarOpposite), or
 /// `None` if not the same domain.
-pub fn surfaces_same_domain(a: &FaceSurface, b: &FaceSurface, tol: Tolerance) -> Option<bool> {
+///
+/// Visible to `crate::diagnostic` (the boolean preflight API). The
+/// `redundant_pub_crate` allow is required because the enclosing
+/// `builder` module is private — clippy folds `pub(crate)` to `pub`
+/// in that scope, but we keep `pub(crate)` to make the intent
+/// explicit in the source.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn surfaces_same_domain(
+    a: &FaceSurface,
+    b: &FaceSurface,
+    tol: Tolerance,
+) -> Option<bool> {
     match (a, b) {
         (FaceSurface::Plane { normal: na, d: da }, FaceSurface::Plane { normal: nb, d: db }) => {
             let dot = na.dot(*nb);

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -304,7 +304,7 @@ impl UnionFind {
 /// Returns `Some(true)` for same-direction normals (CoplanarSame),
 /// `Some(false)` for opposite normals (CoplanarOpposite), or
 /// `None` if not the same domain.
-fn surfaces_same_domain(a: &FaceSurface, b: &FaceSurface, tol: Tolerance) -> Option<bool> {
+pub fn surfaces_same_domain(a: &FaceSurface, b: &FaceSurface, tol: Tolerance) -> Option<bool> {
     match (a, b) {
         (FaceSurface::Plane { normal: na, d: da }, FaceSurface::Plane { normal: nb, d: db }) => {
             let dot = na.dot(*nb);
@@ -358,6 +358,23 @@ fn surfaces_same_domain(a: &FaceSurface, b: &FaceSurface, tol: Tolerance) -> Opt
                 return None;
             }
             let dist = (ca.apex() - cb.apex()).length();
+            if dist > tol.linear {
+                return None;
+            }
+            Some(axis_dot > 0.0)
+        }
+        (FaceSurface::Torus(ta), FaceSurface::Torus(tb)) => {
+            if (ta.major_radius() - tb.major_radius()).abs() > tol.linear {
+                return None;
+            }
+            if (ta.minor_radius() - tb.minor_radius()).abs() > tol.linear {
+                return None;
+            }
+            let axis_dot = ta.z_axis().dot(tb.z_axis());
+            if axis_dot.abs() < 1.0 - tol.angular {
+                return None;
+            }
+            let dist = (ta.center() - tb.center()).length();
             if dist > tol.linear {
                 return None;
             }
@@ -427,6 +444,201 @@ mod tests {
         let b = FaceSurface::Sphere(
             brepkit_math::surfaces::SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), 1.0)
                 .expect("valid sphere"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), None);
+    }
+
+    #[test]
+    fn cones_same_domain_same_direction() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Cone(
+            brepkit_math::surfaces::ConicalSurface::with_ref_dir(
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+                std::f64::consts::FRAC_PI_6,
+                Vec3::new(1.0, 0.0, 0.0),
+            )
+            .expect("valid cone"),
+        );
+        let b = FaceSurface::Cone(
+            brepkit_math::surfaces::ConicalSurface::with_ref_dir(
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+                std::f64::consts::FRAC_PI_6,
+                Vec3::new(0.0, 1.0, 0.0),
+            )
+            .expect("valid cone"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), Some(true));
+    }
+
+    #[test]
+    fn cones_different_half_angle_not_same_domain() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Cone(
+            brepkit_math::surfaces::ConicalSurface::with_ref_dir(
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+                std::f64::consts::FRAC_PI_6,
+                Vec3::new(1.0, 0.0, 0.0),
+            )
+            .expect("valid cone"),
+        );
+        let b = FaceSurface::Cone(
+            brepkit_math::surfaces::ConicalSurface::with_ref_dir(
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+                std::f64::consts::FRAC_PI_4,
+                Vec3::new(1.0, 0.0, 0.0),
+            )
+            .expect("valid cone"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), None);
+    }
+
+    #[test]
+    fn torus_same_domain_same_direction_ignores_ref_dir() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        // Same surface, but constructed with a different ref direction —
+        // x_axis/y_axis differ but z_axis matches, so this is the same surface.
+        let b = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis_and_ref_dir(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+                Vec3::new(0.0, 1.0, 0.0),
+            )
+            .expect("valid torus"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), Some(true));
+    }
+
+    #[test]
+    fn torus_same_domain_opposite_direction() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(1.0, 2.0, 3.0),
+                5.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        let b = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(1.0, 2.0, 3.0),
+                5.0,
+                1.0,
+                Vec3::new(0.0, 0.0, -1.0),
+            )
+            .expect("valid torus"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), Some(false));
+    }
+
+    #[test]
+    fn torus_different_major_radius_not_same_domain() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        let b = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                4.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), None);
+    }
+
+    #[test]
+    fn torus_different_minor_radius_not_same_domain() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        let b = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                0.5,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), None);
+    }
+
+    #[test]
+    fn torus_different_center_not_same_domain() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        let b = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(1.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        assert_eq!(surfaces_same_domain(&a, &b, tol), None);
+    }
+
+    #[test]
+    fn torus_skew_axes_not_same_domain() {
+        let tol = Tolerance::new();
+        let a = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(0.0, 0.0, 1.0),
+            )
+            .expect("valid torus"),
+        );
+        let b = FaceSurface::Torus(
+            brepkit_math::surfaces::ToroidalSurface::with_axis(
+                Point3::new(0.0, 0.0, 0.0),
+                3.0,
+                1.0,
+                Vec3::new(1.0, 0.0, 0.0),
+            )
+            .expect("valid torus"),
         );
         assert_eq!(surfaces_same_domain(&a, &b, tol), None);
     }

--- a/crates/algo/src/diagnostic.rs
+++ b/crates/algo/src/diagnostic.rs
@@ -1,0 +1,285 @@
+//! Boolean preflight diagnostics.
+//!
+//! Lightweight checks that callers can run BEFORE invoking a boolean
+//! operation, to detect input configurations that are likely to
+//! exercise the same-domain detector or known boolean robustness
+//! gaps. The diagnostic does NOT run the full GFA pipeline — it only
+//! compares the underlying face surfaces and AABBs.
+
+use brepkit_math::aabb::Aabb3;
+use brepkit_math::tolerance::Tolerance;
+use brepkit_topology::Topology;
+use brepkit_topology::face::FaceId;
+use brepkit_topology::solid::SolidId;
+
+use crate::builder::same_domain::surfaces_same_domain;
+
+/// One detected pair of same-domain faces between two solids.
+///
+/// "Same-domain" here is the surface-level relationship: the two
+/// faces lie on the same underlying analytic surface (e.g., the same
+/// plane, or two cylinders with matching axis and radius). It does
+/// NOT guarantee that the faces overlap geometrically — see
+/// `aabb_overlap` for a coarse geometric filter.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CoincidentFacePair {
+    /// Face from solid A.
+    pub face_a: FaceId,
+    /// Face from solid B.
+    pub face_b: FaceId,
+    /// `true` if the surface normals point the same direction at
+    /// corresponding parametric points; `false` if they point opposite.
+    pub same_orientation: bool,
+    /// `true` if the face AABBs overlap (geometric overlap candidate).
+    /// Pairs with `aabb_overlap = false` are same-domain on the surface
+    /// but geometrically disjoint (will not interact in a boolean).
+    pub aabb_overlap: bool,
+}
+
+/// Detect surface-level same-domain face pairs between two solids.
+///
+/// Walks each face of `solid_a` against each face of `solid_b` and
+/// reports pairs whose underlying surfaces are same-domain (per the
+/// rules in `same_domain.rs`). For each pair we also compute the
+/// AABB overlap so callers can filter pairs that won't actually
+/// interact during a boolean.
+///
+/// This is O(|A.faces| × |B.faces|) — fine for typical CAD shapes
+/// (tens to a few hundred faces) but should not be called in tight
+/// rendering loops on large assemblies.
+///
+/// # Errors
+///
+/// Returns an error if `solid_a` or `solid_b` cannot be found in
+/// `topo`, or if face data is missing.
+pub fn detect_coincident_faces(
+    topo: &Topology,
+    solid_a: SolidId,
+    solid_b: SolidId,
+    tol: Tolerance,
+) -> Result<Vec<CoincidentFacePair>, crate::error::AlgoError> {
+    use brepkit_topology::explorer;
+
+    let faces_a = explorer::solid_faces(topo, solid_a)
+        .map_err(|_| crate::error::AlgoError::AssemblyFailed("solid_a not found".into()))?;
+    let faces_b = explorer::solid_faces(topo, solid_b)
+        .map_err(|_| crate::error::AlgoError::AssemblyFailed("solid_b not found".into()))?;
+
+    let mut pairs = Vec::new();
+    for &fa in &faces_a {
+        let face_a = topo
+            .face(fa)
+            .map_err(|_| crate::error::AlgoError::AssemblyFailed("face_a not found".into()))?;
+        let aabb_a = face_aabb(topo, fa)?;
+        for &fb in &faces_b {
+            let face_b = topo
+                .face(fb)
+                .map_err(|_| crate::error::AlgoError::AssemblyFailed("face_b not found".into()))?;
+            if let Some(same_orientation) =
+                surfaces_same_domain(face_a.surface(), face_b.surface(), tol)
+            {
+                let aabb_b = face_aabb(topo, fb)?;
+                pairs.push(CoincidentFacePair {
+                    face_a: fa,
+                    face_b: fb,
+                    same_orientation,
+                    aabb_overlap: aabbs_overlap(&aabb_a, &aabb_b, tol.linear),
+                });
+            }
+        }
+    }
+    Ok(pairs)
+}
+
+/// Compute a face AABB from its boundary vertex positions.
+fn face_aabb(topo: &Topology, fid: FaceId) -> Result<Aabb3, crate::error::AlgoError> {
+    use brepkit_math::vec::Point3;
+    let face = topo
+        .face(fid)
+        .map_err(|_| crate::error::AlgoError::AssemblyFailed("face not found".into()))?;
+    let outer = topo
+        .wire(face.outer_wire())
+        .map_err(|_| crate::error::AlgoError::AssemblyFailed("wire not found".into()))?;
+
+    let mut min = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+    let mut max = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+    let mut any = false;
+
+    for oe in outer.edges() {
+        let edge = topo
+            .edge(oe.edge())
+            .map_err(|_| crate::error::AlgoError::AssemblyFailed("edge not found".into()))?;
+        for vid in [edge.start(), edge.end()] {
+            let v = topo
+                .vertex(vid)
+                .map_err(|_| crate::error::AlgoError::AssemblyFailed("vertex not found".into()))?;
+            let p = v.point();
+            min = Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
+            max = Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
+            any = true;
+        }
+    }
+    if !any {
+        // Empty wire — give a degenerate AABB at origin.
+        min = Point3::new(0.0, 0.0, 0.0);
+        max = Point3::new(0.0, 0.0, 0.0);
+    }
+    Ok(Aabb3 { min, max })
+}
+
+fn aabbs_overlap(a: &Aabb3, b: &Aabb3, slack: f64) -> bool {
+    a.min.x() <= b.max.x() + slack
+        && a.max.x() + slack >= b.min.x()
+        && a.min.y() <= b.max.y() + slack
+        && a.max.y() + slack >= b.min.y()
+        && a.min.z() <= b.max.z() + slack
+        && a.max.z() + slack >= b.min.z()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use brepkit_math::vec::Point3;
+    use brepkit_math::vec::Vec3;
+    use brepkit_topology::edge::{Edge, EdgeCurve};
+    use brepkit_topology::face::{Face, FaceSurface};
+    use brepkit_topology::shell::Shell;
+    use brepkit_topology::solid::Solid;
+    use brepkit_topology::vertex::Vertex;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    fn make_box(topo: &mut Topology, min: [f64; 3], max: [f64; 3]) -> SolidId {
+        let [x0, y0, z0] = min;
+        let [x1, y1, z1] = max;
+        let v = [
+            topo.add_vertex(Vertex::new(Point3::new(x0, y0, z0), 1e-7)),
+            topo.add_vertex(Vertex::new(Point3::new(x1, y0, z0), 1e-7)),
+            topo.add_vertex(Vertex::new(Point3::new(x1, y1, z0), 1e-7)),
+            topo.add_vertex(Vertex::new(Point3::new(x0, y1, z0), 1e-7)),
+            topo.add_vertex(Vertex::new(Point3::new(x0, y0, z1), 1e-7)),
+            topo.add_vertex(Vertex::new(Point3::new(x1, y0, z1), 1e-7)),
+            topo.add_vertex(Vertex::new(Point3::new(x1, y1, z1), 1e-7)),
+            topo.add_vertex(Vertex::new(Point3::new(x0, y1, z1), 1e-7)),
+        ];
+        let mut edge = |a: usize, b: usize| topo.add_edge(Edge::new(v[a], v[b], EdgeCurve::Line));
+        let e01 = edge(0, 1);
+        let e12 = edge(1, 2);
+        let e23 = edge(2, 3);
+        let e30 = edge(3, 0);
+        let e45 = edge(4, 5);
+        let e56 = edge(5, 6);
+        let e67 = edge(6, 7);
+        let e74 = edge(7, 4);
+        let e04 = edge(0, 4);
+        let e15 = edge(1, 5);
+        let e26 = edge(2, 6);
+        let e37 = edge(3, 7);
+        let fwd = |eid| OrientedEdge::new(eid, true);
+        let w_bot =
+            topo.add_wire(Wire::new(vec![fwd(e01), fwd(e12), fwd(e23), fwd(e30)], true).unwrap());
+        let w_top =
+            topo.add_wire(Wire::new(vec![fwd(e45), fwd(e56), fwd(e67), fwd(e74)], true).unwrap());
+        let w_front =
+            topo.add_wire(Wire::new(vec![fwd(e01), fwd(e15), fwd(e45), fwd(e04)], true).unwrap());
+        let w_back =
+            topo.add_wire(Wire::new(vec![fwd(e23), fwd(e37), fwd(e67), fwd(e26)], true).unwrap());
+        let w_left =
+            topo.add_wire(Wire::new(vec![fwd(e30), fwd(e04), fwd(e74), fwd(e37)], true).unwrap());
+        let w_right =
+            topo.add_wire(Wire::new(vec![fwd(e12), fwd(e26), fwd(e56), fwd(e15)], true).unwrap());
+        let f_bot = topo.add_face(Face::new(
+            w_bot,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, -1.0),
+                d: -z0,
+            },
+        ));
+        let f_top = topo.add_face(Face::new(
+            w_top,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: z1,
+            },
+        ));
+        let f_front = topo.add_face(Face::new(
+            w_front,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, -1.0, 0.0),
+                d: -y0,
+            },
+        ));
+        let f_back = topo.add_face(Face::new(
+            w_back,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 1.0, 0.0),
+                d: y1,
+            },
+        ));
+        let f_left = topo.add_face(Face::new(
+            w_left,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(-1.0, 0.0, 0.0),
+                d: -x0,
+            },
+        ));
+        let f_right = topo.add_face(Face::new(
+            w_right,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(1.0, 0.0, 0.0),
+                d: x1,
+            },
+        ));
+        let shell = topo
+            .add_shell(Shell::new(vec![f_bot, f_top, f_front, f_back, f_left, f_right]).unwrap());
+        topo.add_solid(Solid::new(shell, vec![]))
+    }
+
+    #[test]
+    fn face_stack_detects_expected_pairs() {
+        // Two unit cubes face-stacked on z=1.
+        // Same-domain (surface-level) pairs that ALSO have AABB overlap:
+        //   1× (z=1) cap pair, opposite normals
+        //   4× side-plane pairs (front/back/left/right), same normals
+        // Total = 5.
+        let mut topo = Topology::default();
+        let a = make_box(&mut topo, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]);
+        let b = make_box(&mut topo, [0.0, 0.0, 1.0], [1.0, 1.0, 2.0]);
+        let pairs = detect_coincident_faces(&topo, a, b, Tolerance::default()).unwrap();
+        let overlapping_count = pairs.iter().filter(|p| p.aabb_overlap).count();
+        assert_eq!(
+            overlapping_count, 5,
+            "should detect 5 SD pairs with AABB overlap, got {overlapping_count}",
+        );
+        let opposite_count = pairs
+            .iter()
+            .filter(|p| p.aabb_overlap && !p.same_orientation)
+            .count();
+        assert_eq!(
+            opposite_count, 1,
+            "exactly the cap pair has opposite normals"
+        );
+    }
+
+    #[test]
+    fn disjoint_boxes_no_coincident_overlap() {
+        // Boxes far apart — surfaces may be same-domain (parallel planes
+        // at the same offset) by coincidence, but AABBs do not overlap.
+        let mut topo = Topology::default();
+        let a = make_box(&mut topo, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]);
+        let b = make_box(&mut topo, [10.0, 10.0, 10.0], [11.0, 11.0, 11.0]);
+        let pairs = detect_coincident_faces(&topo, a, b, Tolerance::default()).unwrap();
+        let overlapping = pairs.iter().any(|p| p.aabb_overlap);
+        assert!(
+            !overlapping,
+            "disjoint boxes should have no overlapping coincident pairs"
+        );
+    }
+}

--- a/crates/algo/src/diagnostic.rs
+++ b/crates/algo/src/diagnostic.rs
@@ -60,21 +60,15 @@ pub fn detect_coincident_faces(
 ) -> Result<Vec<CoincidentFacePair>, crate::error::AlgoError> {
     use brepkit_topology::explorer;
 
-    let faces_a = explorer::solid_faces(topo, solid_a)
-        .map_err(|_| crate::error::AlgoError::AssemblyFailed("solid_a not found".into()))?;
-    let faces_b = explorer::solid_faces(topo, solid_b)
-        .map_err(|_| crate::error::AlgoError::AssemblyFailed("solid_b not found".into()))?;
+    let faces_a = explorer::solid_faces(topo, solid_a)?;
+    let faces_b = explorer::solid_faces(topo, solid_b)?;
 
     let mut pairs = Vec::new();
     for &fa in &faces_a {
-        let face_a = topo
-            .face(fa)
-            .map_err(|_| crate::error::AlgoError::AssemblyFailed("face_a not found".into()))?;
+        let face_a = topo.face(fa)?;
         let aabb_a = face_aabb(topo, fa)?;
         for &fb in &faces_b {
-            let face_b = topo
-                .face(fb)
-                .map_err(|_| crate::error::AlgoError::AssemblyFailed("face_b not found".into()))?;
+            let face_b = topo.face(fb)?;
             if let Some(same_orientation) =
                 surfaces_same_domain(face_a.surface(), face_b.surface(), tol)
             {
@@ -91,38 +85,59 @@ pub fn detect_coincident_faces(
     Ok(pairs)
 }
 
-/// Compute a face AABB from its boundary vertex positions.
+/// Number of interior parametric samples used per edge when computing
+/// the face AABB. Endpoints are always included; this controls how
+/// many midpoints are sampled along curved edges (arcs, NURBS, etc.)
+/// to capture curve bulge that would otherwise be missed by a chord-only
+/// AABB. Five interior samples is sufficient for circles/ellipses up to
+/// a half-turn and conservative for typical NURBS edges.
+const EDGE_INTERIOR_SAMPLES: usize = 5;
+
+/// Compute a curve-aware face AABB.
+///
+/// For each boundary edge we include the two endpoint vertices AND
+/// `EDGE_INTERIOR_SAMPLES` interior samples along the edge curve, so
+/// that bulge from arcs, full circles, and NURBS curves contributes to
+/// the bounding box. A vertex-only AABB would underestimate non-planar
+/// face extents (a full-circle edge whose endpoints coincide collapses
+/// to a single point), causing `aabb_overlap` to silently miss real
+/// overlaps for curved coincident faces.
 fn face_aabb(topo: &Topology, fid: FaceId) -> Result<Aabb3, crate::error::AlgoError> {
     use brepkit_math::vec::Point3;
-    let face = topo
-        .face(fid)
-        .map_err(|_| crate::error::AlgoError::AssemblyFailed("face not found".into()))?;
-    let outer = topo
-        .wire(face.outer_wire())
-        .map_err(|_| crate::error::AlgoError::AssemblyFailed("wire not found".into()))?;
+    let face = topo.face(fid)?;
+    let outer = topo.wire(face.outer_wire())?;
 
     let mut min = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
     let mut max = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
     let mut any = false;
 
+    let mut include = |p: Point3, any: &mut bool| {
+        min = Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
+        max = Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
+        *any = true;
+    };
+
     for oe in outer.edges() {
-        let edge = topo
-            .edge(oe.edge())
-            .map_err(|_| crate::error::AlgoError::AssemblyFailed("edge not found".into()))?;
-        for vid in [edge.start(), edge.end()] {
-            let v = topo
-                .vertex(vid)
-                .map_err(|_| crate::error::AlgoError::AssemblyFailed("vertex not found".into()))?;
-            let p = v.point();
-            min = Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
-            max = Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
-            any = true;
+        let edge = topo.edge(oe.edge())?;
+        let start = topo.vertex(edge.start())?.point();
+        let end = topo.vertex(edge.end())?.point();
+        include(start, &mut any);
+        include(end, &mut any);
+
+        let curve = edge.curve();
+        let (t0, t1) = curve.domain_with_endpoints(start, end);
+        for i in 1..=EDGE_INTERIOR_SAMPLES {
+            #[allow(clippy::cast_precision_loss)]
+            let frac = i as f64 / (EDGE_INTERIOR_SAMPLES as f64 + 1.0);
+            let t = t0 + (t1 - t0) * frac;
+            let p = curve.evaluate_with_endpoints(t, start, end);
+            include(p, &mut any);
         }
     }
     if !any {
-        // Empty wire — give a degenerate AABB at origin.
-        min = Point3::new(0.0, 0.0, 0.0);
-        max = Point3::new(0.0, 0.0, 0.0);
+        return Err(crate::error::AlgoError::AssemblyFailed(format!(
+            "face {fid:?} has no boundary vertices",
+        )));
     }
     Ok(Aabb3 { min, max })
 }
@@ -265,6 +280,47 @@ mod tests {
         assert_eq!(
             opposite_count, 1,
             "exactly the cap pair has opposite normals"
+        );
+    }
+
+    #[test]
+    fn curve_edge_face_aabb_includes_bulge() {
+        // Regression for the chord-only AABB bug: a face bounded by a
+        // single full-circle edge has start == end, so a vertex-only
+        // AABB collapses to a point. The curve-aware AABB must instead
+        // span the circle's diameter in x and y.
+        use brepkit_math::curves::Circle3D;
+        let mut topo = Topology::default();
+        // Single vertex serving as start/end of the full-circle edge.
+        let v0 = topo.add_vertex(Vertex::new(Point3::new(1.0, 0.0, 0.0), 1e-7));
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let edge = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Circle(circle)));
+        let wire = topo.add_wire(Wire::new(vec![OrientedEdge::new(edge, true)], true).unwrap());
+        let face = topo.add_face(Face::new(
+            wire,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: 0.0,
+            },
+        ));
+        let bbox = face_aabb(&topo, face).unwrap();
+        // True AABB of the unit circle in z=0: x∈[-1,1], y∈[-1,1].
+        // The interior samples (5 per edge) won't hit ±1 exactly, but
+        // they're well inside the circle interior so we just require the
+        // AABB to cover a non-degenerate portion of the disc.
+        assert!(
+            bbox.max.x() - bbox.min.x() > 1.0,
+            "circle edge AABB should span >1 in x, got [{}, {}]",
+            bbox.min.x(),
+            bbox.max.x()
+        );
+        assert!(
+            bbox.max.y() - bbox.min.y() > 1.0,
+            "circle edge AABB should span >1 in y, got [{}, {}]",
+            bbox.min.y(),
+            bbox.max.y()
         );
     }
 

--- a/crates/algo/src/diagnostic.rs
+++ b/crates/algo/src/diagnostic.rs
@@ -21,7 +21,7 @@ use crate::builder::same_domain::surfaces_same_domain;
 /// plane, or two cylinders with matching axis and radius). It does
 /// NOT guarantee that the faces overlap geometrically — see
 /// `aabb_overlap` for a coarse geometric filter.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CoincidentFacePair {
     /// Face from solid A.
     pub face_a: FaceId,
@@ -89,9 +89,18 @@ pub fn detect_coincident_faces(
 /// the face AABB. Endpoints are always included; this controls how
 /// many midpoints are sampled along curved edges (arcs, NURBS, etc.)
 /// to capture curve bulge that would otherwise be missed by a chord-only
-/// AABB. Five interior samples is sufficient for circles/ellipses up to
-/// a half-turn and conservative for typical NURBS edges.
-const EDGE_INTERIOR_SAMPLES: usize = 5;
+/// AABB.
+///
+/// **Why 11:** for a full-circle edge with domain `[0, 2π]`, 11 interior
+/// samples land at fractions `{1/12, 2/12, ..., 11/12}` — i.e. 30° steps.
+/// In the world frame, the worst-case angular offset from any cardinal
+/// extremum is half a step (15°), so each AABB axis recovers at least
+/// `cos(15°) ≈ 0.966` of the true extent — a ~3% per-axis underestimate
+/// in the worst case, vs. ~13% with 5 samples. For axis-aligned circles
+/// the cardinals are hit exactly. This is intentionally a coarse but
+/// O(1) approximation; callers needing exact bounds for large arcs
+/// should use a curve-specific extrema routine on `Circle3D` / `Arc3D`.
+const EDGE_INTERIOR_SAMPLES: usize = 11;
 
 /// Compute a curve-aware face AABB.
 ///
@@ -307,20 +316,20 @@ mod tests {
         ));
         let bbox = face_aabb(&topo, face).unwrap();
         // True AABB of the unit circle in z=0: x∈[-1,1], y∈[-1,1].
-        // The interior samples (5 per edge) won't hit ±1 exactly, but
-        // they're well inside the circle interior so we just require the
-        // AABB to cover a non-degenerate portion of the disc.
+        // With 11 interior samples at 30° steps the worst-case axis
+        // recovery is cos(15°) ≈ 0.966 — Circle3D's auto-generated
+        // local frame is not guaranteed to align with the world axes,
+        // so we assert ≥0.85 on each axis (well above 0 and well above
+        // the chord-only AABB which would collapse to a point).
+        let dx = bbox.max.x() - bbox.min.x();
+        let dy = bbox.max.y() - bbox.min.y();
         assert!(
-            bbox.max.x() - bbox.min.x() > 1.0,
-            "circle edge AABB should span >1 in x, got [{}, {}]",
-            bbox.min.x(),
-            bbox.max.x()
+            dx > 1.7,
+            "circle edge AABB x-span = {dx}, expected close to 2 (chord-only would be 0)",
         );
         assert!(
-            bbox.max.y() - bbox.min.y() > 1.0,
-            "circle edge AABB should span >1 in y, got [{}, {}]",
-            bbox.min.y(),
-            bbox.max.y()
+            dy > 1.7,
+            "circle edge AABB y-span = {dy}, expected close to 2 (chord-only would be 0)",
         );
     }
 

--- a/crates/algo/src/lib.rs
+++ b/crates/algo/src/lib.rs
@@ -18,6 +18,7 @@
 //!    (fuse/cut/intersect).
 
 pub mod bop;
+pub mod diagnostic;
 pub mod error;
 pub mod gfa;
 

--- a/crates/operations/tests/coaxial_cones.rs
+++ b/crates/operations/tests/coaxial_cones.rs
@@ -1,0 +1,120 @@
+//! Coaxial-cone scenarios for boolean robustness.
+//!
+//! Cone same-domain requires matching apex, axis (parallel or
+//! antiparallel), and half-angle — see `same_domain.rs`. The DETECTOR
+//! is verified by unit tests there; the GFA pipeline integration of
+//! cone SD pairs has known gaps tracked here.
+//!
+//! NOTE: `make_cone` produces a frustum (different bottom and top
+//! radius) — for true cones, use `top_radius=0.0`. Some tests here
+//! use frustums to exercise typical CAD workflows.
+
+#![allow(clippy::unwrap_used)]
+
+use std::f64::consts::PI;
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::measure::solid_volume;
+use brepkit_operations::primitives::make_cone;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+const DEFLECTION: f64 = 0.05;
+
+fn vol(topo: &Topology, solid: SolidId) -> f64 {
+    solid_volume(topo, solid, DEFLECTION).unwrap()
+}
+
+fn frustum_volume(r1: f64, r2: f64, h: f64) -> f64 {
+    PI * h * (r1 * r1 + r1 * r2 + r2 * r2) / 3.0
+}
+
+fn approx_eq(a: f64, b: f64, frac: f64) -> bool {
+    (a - b).abs() < a.abs().max(b.abs()).max(1.0) * frac
+}
+
+fn cone_at_z(topo: &mut Topology, z: f64, r1: f64, r2: f64, h: f64) -> SolidId {
+    let c = make_cone(topo, r1, r2, h).unwrap();
+    if z != 0.0 {
+        transform_solid(topo, c, &Mat4::translation(0.0, 0.0, z)).unwrap();
+    }
+    c
+}
+
+// ── 0. Baseline ────────────────────────────────────────────────────────
+
+#[test]
+fn baseline_disjoint_cones_intersect_empty() {
+    let mut topo = Topology::default();
+    let a = cone_at_z(&mut topo, 0.0, 1.0, 0.5, 1.0);
+    let b = cone_at_z(&mut topo, 10.0, 1.0, 0.5, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b);
+    if let Ok(sid) = r {
+        let v = vol(&topo, sid);
+        assert!(v < 1e-3, "disjoint cone intersect should be ~zero, got {v}");
+    }
+}
+
+// ── 1. Identical frustums ──────────────────────────────────────────────
+
+#[test]
+#[ignore = "Gap: identical-cone fuse — SD detector identifies the pair but GFA \
+            integration of cone same-domain is incomplete."]
+fn identical_cones_fuse_preserves_volume() {
+    let mut topo = Topology::default();
+    let a = cone_at_z(&mut topo, 0.0, 1.0, 0.5, 1.0);
+    let b = cone_at_z(&mut topo, 0.0, 1.0, 0.5, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = frustum_volume(1.0, 0.5, 1.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+// ── 2. Cap-on-cap stack (frustum + inverse) ────────────────────────────
+
+#[test]
+#[ignore = "Gap: cone cap-on-cap stack — cap planes are SD; lateral cone surfaces \
+            share apex/axis/half-angle so are also SD via apex line. GFA fails."]
+fn cone_cap_on_cap_stack_fuse() {
+    // Frustum A: r1=1 (z=0), r2=0.5 (z=1).
+    // Frustum B: r1=0.5 (z=1), r2=0.25 (z=2). Same apex/axis/half-angle.
+    let mut topo = Topology::default();
+    let a = cone_at_z(&mut topo, 0.0, 1.0, 0.5, 1.0);
+    let b = cone_at_z(&mut topo, 1.0, 0.5, 0.25, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = frustum_volume(1.0, 0.25, 2.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+// ── 3. Coaxial overlap (lateral SD on cone surface) ───────────────────
+
+#[test]
+#[ignore = "Gap: coaxial cone partial-Z overlap — lateral SD region is shared, \
+            but GFA does not produce a clean merged solid."]
+fn cone_coaxial_partial_z_overlap_fuse() {
+    let mut topo = Topology::default();
+    let a = cone_at_z(&mut topo, 0.0, 1.0, 0.5, 2.0);
+    let b = cone_at_z(&mut topo, 1.0, 0.75, 0.25, 2.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = frustum_volume(1.0, 0.25, 3.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+// ── 4. True cone (zero top radius) — apex-sharing scenarios ───────────
+
+#[test]
+#[ignore = "Gap: true-cone identical fuse — apex creates a degenerate edge that \
+            interacts poorly with SD merging."]
+fn identical_true_cones_fuse() {
+    let mut topo = Topology::default();
+    let a = cone_at_z(&mut topo, 0.0, 1.0, 0.0, 2.0);
+    let b = cone_at_z(&mut topo, 0.0, 1.0, 0.0, 2.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = frustum_volume(1.0, 0.0, 2.0); // = π·1²·2/3
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}

--- a/crates/operations/tests/coaxial_cylinders.rs
+++ b/crates/operations/tests/coaxial_cylinders.rs
@@ -1,0 +1,198 @@
+//! Coaxial-cylinder scenarios for boolean robustness.
+//!
+//! Tests the same-domain detector and GFA boolean pipeline against
+//! coaxial cylinder configurations. Cylinder same-domain requires
+//! matching axis line (origin along axis + parallel direction) and
+//! matching radius — see `algo/src/builder/same_domain.rs`.
+//!
+//! NOTE: cylinder unit tests in `same_domain.rs` show the DETECTOR works
+//! correctly. The end-to-end booleans below currently fail because the
+//! GFA pipeline integration of cylinder SD pairs has known gaps (see
+//! existing `boolean_stress.rs` ignored cylinder tests). This corpus
+//! documents the territory for future PRs to address.
+
+#![allow(clippy::unwrap_used)]
+
+use std::f64::consts::PI;
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::measure::solid_volume;
+use brepkit_operations::primitives::make_cylinder;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::validation::validate_shell_manifold;
+
+const DEFLECTION: f64 = 0.05;
+
+fn check_manifold(topo: &Topology, solid: SolidId) -> usize {
+    let s = topo.solid(solid).unwrap();
+    let sh = topo.shell(s.outer_shell()).unwrap();
+    assert!(
+        validate_shell_manifold(sh, topo).is_ok(),
+        "result should be manifold"
+    );
+    sh.faces().len()
+}
+
+fn vol(topo: &Topology, solid: SolidId) -> f64 {
+    solid_volume(topo, solid, DEFLECTION).unwrap()
+}
+
+fn approx_eq(a: f64, b: f64, frac: f64) -> bool {
+    (a - b).abs() < a.abs().max(b.abs()).max(1.0) * frac
+}
+
+fn cylinder_at_z(topo: &mut Topology, z: f64, radius: f64, height: f64) -> SolidId {
+    let c = make_cylinder(topo, radius, height).unwrap();
+    if z != 0.0 {
+        transform_solid(topo, c, &Mat4::translation(0.0, 0.0, z)).unwrap();
+    }
+    c
+}
+
+// ── 0. Baseline: non-coincident cylinder boolean (must pass) ──────────
+
+#[test]
+fn baseline_cylinder_disjoint_intersect_empty_or_zero() {
+    // Two cylinders far apart on z-axis — intersect is empty / zero.
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 1.0);
+    let b = cylinder_at_z(&mut topo, 10.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b);
+    if let Ok(sid) = r {
+        let v = vol(&topo, sid);
+        assert!(v < 1e-6, "disjoint intersect should be ~zero, got {v}");
+    }
+    // Err is also acceptable for a degenerate-empty intersect.
+}
+
+// ── 1. Identical cylinders (degenerate SD case) ───────────────────────
+
+#[test]
+#[ignore = "Gap: identical-cylinder fuse/intersect — SD detector identifies the pair \
+            but GFA pipeline integration produces wrong topology (volume off ~18%)."]
+fn identical_cylinders_fuse_preserves_volume() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 2.0);
+    let b = cylinder_at_z(&mut topo, 0.0, 1.0, 2.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let expected = PI * 1.0 * 1.0 * 2.0;
+    let got = vol(&topo, r);
+    assert!(
+        approx_eq(got, expected, 0.02),
+        "identical-cylinder fuse vol {got}, expected {expected}"
+    );
+}
+
+#[test]
+#[ignore = "Gap: identical-cylinder fuse/intersect — SD detector identifies the pair \
+            but GFA pipeline integration produces wrong topology (volume off ~15%)."]
+fn identical_cylinders_intersect_preserves_volume() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 2.0);
+    let b = cylinder_at_z(&mut topo, 0.0, 1.0, 2.0);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let expected = PI * 1.0 * 1.0 * 2.0;
+    let got = vol(&topo, r);
+    assert!(
+        approx_eq(got, expected, 0.02),
+        "identical-cylinder intersect vol {got}, expected {expected}"
+    );
+}
+
+// ── 2. Cap-on-cap stack (coplanar cap faces + lateral SD) ─────────────
+
+#[test]
+#[ignore = "Gap: cylinder cap-on-cap stack — SD pair found on cap planes but lateral \
+            cylinder surfaces are also SD across the joint, and GFA fails to merge cleanly."]
+fn cylinder_cap_on_cap_stack_fuse() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 1.0);
+    let b = cylinder_at_z(&mut topo, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let expected = PI * 1.0 * 1.0 * 2.0;
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+#[test]
+#[ignore = "Gap: 3-cylinder cap-stack chain — same root cause as 2-cylinder cap-stack."]
+fn cylinder_cap_on_cap_three_stack_fuse() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 1.0);
+    let b = cylinder_at_z(&mut topo, 1.0, 1.0, 1.0);
+    let c = cylinder_at_z(&mut topo, 2.0, 1.0, 1.0);
+    let ab = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let abc = boolean(&mut topo, BooleanOp::Fuse, ab, c).unwrap();
+    let _faces = check_manifold(&topo, abc);
+    let expected = PI * 1.0 * 1.0 * 3.0;
+    let got = vol(&topo, abc);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+// ── 3. Coaxial overlap (lateral SD case) ──────────────────────────────
+
+#[test]
+#[ignore = "Gap: coaxial cylinder partial-Z overlap — lateral SD region is shared \
+            but GFA does not produce a clean merged solid."]
+fn cylinder_coaxial_partial_z_overlap_fuse() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 2.0);
+    let b = cylinder_at_z(&mut topo, 1.0, 1.0, 2.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let expected = PI * 1.0 * 1.0 * 3.0;
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+#[test]
+#[ignore = "Gap: coaxial containment fuse — inner cylinder SD with outer along its \
+            full Z range should collapse to outer, but GFA fails."]
+fn cylinder_coaxial_full_z_containment_fuse() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 4.0);
+    let b = cylinder_at_z(&mut topo, 1.0, 1.0, 2.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let expected = PI * 1.0 * 1.0 * 4.0;
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+#[test]
+#[ignore = "Gap: coaxial containment intersect — should yield inner cylinder, \
+            but GFA fails on this SD configuration."]
+fn cylinder_coaxial_full_z_containment_intersect() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 4.0);
+    let b = cylinder_at_z(&mut topo, 1.0, 1.0, 2.0);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let expected = PI * 1.0 * 1.0 * 2.0;
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+// ── 4. Opposite-axis (rotated 180°) ───────────────────────────────────
+
+#[test]
+#[ignore = "Gap: opposite-axis cylinder fuse — SD detector reports `same_orientation=false`, \
+            but GFA pipeline does not yet honour the flag for cylinders."]
+fn cylinder_opposite_axis_fuse() {
+    let mut topo = Topology::default();
+    let a = cylinder_at_z(&mut topo, 0.0, 1.0, 2.0);
+    let b = make_cylinder(&mut topo, 1.0, 2.0).unwrap();
+    let flip = Mat4::translation(0.0, 0.0, 2.0) * Mat4::rotation_x(std::f64::consts::PI);
+    transform_solid(&mut topo, b, &flip).unwrap();
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let expected = PI * 1.0 * 1.0 * 2.0;
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}

--- a/crates/operations/tests/coaxial_torus.rs
+++ b/crates/operations/tests/coaxial_torus.rs
@@ -1,0 +1,126 @@
+//! Coaxial-torus scenarios for boolean robustness.
+//!
+//! Validates the new Torus arm of `surfaces_same_domain()` (added
+//! alongside this corpus). Torus same-domain requires matching center,
+//! major radius, minor radius, and z-axis (parallel or antiparallel).
+//! The DETECTOR is verified by unit tests in `same_domain.rs`; the
+//! GFA pipeline integration of torus SD pairs has known gaps tracked here.
+
+#![allow(clippy::unwrap_used)]
+
+use std::f64::consts::PI;
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::measure::solid_volume;
+use brepkit_operations::primitives::make_torus;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+const DEFLECTION: f64 = 0.05;
+const SEGMENTS: usize = 32;
+
+fn vol(topo: &Topology, solid: SolidId) -> f64 {
+    solid_volume(topo, solid, DEFLECTION).unwrap()
+}
+
+fn torus_volume(major: f64, minor: f64) -> f64 {
+    2.0 * PI * PI * major * minor * minor
+}
+
+fn approx_eq(a: f64, b: f64, frac: f64) -> bool {
+    (a - b).abs() < a.abs().max(b.abs()).max(1.0) * frac
+}
+
+fn torus_at(topo: &mut Topology, x: f64, y: f64, z: f64, major: f64, minor: f64) -> SolidId {
+    let t = make_torus(topo, major, minor, SEGMENTS).unwrap();
+    if x != 0.0 || y != 0.0 || z != 0.0 {
+        transform_solid(topo, t, &Mat4::translation(x, y, z)).unwrap();
+    }
+    t
+}
+
+// ── 0. Baseline: disjoint toruses ──────────────────────────────────────
+
+#[test]
+fn baseline_disjoint_toruses_intersect_empty() {
+    let mut topo = Topology::default();
+    let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
+    let b = torus_at(&mut topo, 20.0, 0.0, 0.0, 3.0, 0.5);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b);
+    if let Ok(sid) = r {
+        let v = vol(&topo, sid);
+        assert!(
+            v < 1e-3,
+            "disjoint torus intersect should be ~zero, got {v}"
+        );
+    }
+}
+
+// ── 1. Identical toruses (validates new Torus SD arm) ─────────────────
+
+#[test]
+#[ignore = "Gap: identical-torus fuse — new Torus SD arm correctly detects the \
+            pair (verified by unit test `torus_same_domain_same_direction_ignores_ref_dir`) \
+            but GFA pipeline integration of torus SD pairs is not yet implemented."]
+fn identical_toruses_fuse_preserves_volume() {
+    let mut topo = Topology::default();
+    let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
+    let b = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = torus_volume(3.0, 0.5);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}
+
+#[test]
+#[ignore = "Gap: identical-torus intersect — same root cause as fuse."]
+fn identical_toruses_intersect_preserves_volume() {
+    let mut topo = Topology::default();
+    let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
+    let b = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let expected = torus_volume(3.0, 0.5);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}
+
+// ── 2. Mismatched minor radius — must NOT be SD ───────────────────────
+
+#[test]
+fn toruses_different_minor_radius_intersect_nontrivial() {
+    // Two toruses sharing major axis but with different tube radii produce
+    // a non-trivial intersection. Exercises NON-SD path; the SD detector
+    // correctly returns None for this pair.
+    let mut topo = Topology::default();
+    let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
+    let b = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.7);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b);
+    // Either OK (positive volume) or Err (degenerate) is acceptable;
+    // the key requirement is that the SD detector did NOT mark this
+    // pair as same-domain (since minor radii differ).
+    if let Ok(sid) = r {
+        let v = vol(&topo, sid);
+        // Volume should be >0 and <= min(torus A, torus B).
+        assert!(v > 0.0);
+        assert!(v <= torus_volume(3.0, 0.5) + 1e-3);
+    }
+}
+
+// ── 3. Opposite axis (rotated 180°) ───────────────────────────────────
+
+#[test]
+#[ignore = "Gap: opposite-axis torus fuse — SD detector reports same_orientation=false \
+            (verified by unit test `torus_same_domain_opposite_direction`), but GFA \
+            does not yet honour the orientation flag for torus SD pairs."]
+fn torus_opposite_axis_fuse() {
+    let mut topo = Topology::default();
+    let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
+    let b = make_torus(&mut topo, 3.0, 0.5, SEGMENTS).unwrap();
+    transform_solid(&mut topo, b, &Mat4::rotation_x(PI)).unwrap();
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = torus_volume(3.0, 0.5);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}

--- a/crates/operations/tests/coincident_planes.rs
+++ b/crates/operations/tests/coincident_planes.rs
@@ -1,0 +1,273 @@
+//! Coincident-plane scenarios for boolean robustness.
+//!
+//! Topology-organized stress corpus targeting the same-domain detector
+//! and its integration with the GFA boolean pipeline. Complements
+//! `boolean_stress.rs` and `boolean_edge_cases.rs` with scenarios that
+//! specifically exercise plane-plane same-domain handling at the
+//! face / edge / vertex / partial-overlap / nested / sliver levels.
+
+#![allow(clippy::unwrap_used)]
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::measure::solid_volume;
+use brepkit_operations::primitives::make_box;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::validation::validate_shell_manifold;
+
+const DEFLECTION: f64 = 0.1;
+
+fn check_manifold(topo: &Topology, solid: SolidId) -> usize {
+    let s = topo.solid(solid).unwrap();
+    let sh = topo.shell(s.outer_shell()).unwrap();
+    assert!(
+        validate_shell_manifold(sh, topo).is_ok(),
+        "result should be manifold"
+    );
+    sh.faces().len()
+}
+
+fn assert_volume_close(topo: &Topology, solid: SolidId, expected: f64) {
+    let vol = solid_volume(topo, solid, DEFLECTION).unwrap();
+    let diff = (vol - expected).abs();
+    assert!(
+        diff < expected.max(1.0) * 0.01,
+        "volume {vol:.6} not within 1% of expected {expected:.6}"
+    );
+}
+
+fn box_at(topo: &mut Topology, x: f64, y: f64, z: f64, sx: f64, sy: f64, sz: f64) -> SolidId {
+    let b = make_box(topo, sx, sy, sz).unwrap();
+    transform_solid(topo, b, &Mat4::translation(x, y, z)).unwrap();
+    b
+}
+
+// ── 1. Face-on-face stack (most common SD case) ────────────────────────
+
+#[test]
+fn face_on_face_unit_stack_fuse() {
+    // [0,1]^3 stacked under [0,1]^2 × [1,2] — full face coincidence.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let faces = check_manifold(&topo, r);
+    assert_eq!(faces, 10, "face-stack fuse should drop the shared face");
+    assert_volume_close(&topo, r, 2.0);
+}
+
+#[test]
+fn face_on_face_three_box_chain_fuse() {
+    // Three boxes sharing two faces total ([0,1]∪[1,2]∪[2,3] in x).
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let c = box_at(&mut topo, 2.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let ab = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let abc = boolean(&mut topo, BooleanOp::Fuse, ab, c).unwrap();
+    let _faces = check_manifold(&topo, abc);
+    assert_volume_close(&topo, abc, 3.0);
+}
+
+#[test]
+fn face_on_face_tall_thin_stack_fuse() {
+    // 1×1×0.001 face-stacked on 1×1×1 — exercises sliver-thin top.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 0.0, 0.0, 1.0, 1.0, 1.0, 0.001);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    assert_volume_close(&topo, r, 1.001);
+}
+
+// ── 2. Partial face overlap (offset stacks) ────────────────────────────
+
+#[test]
+#[ignore = "Gap: partial face overlap (offset stack) currently produces non-manifold output. \
+            SD detector requires identical edge sets; partial overlap goes through FF intersection \
+            path which has issues here. Tracked as a same-domain robustness gap."]
+fn partial_face_overlap_quarter_offset_fuse() {
+    // B sits half-on, half-off A in x. Shared face is partial.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 0.5, 0.0, 1.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    assert_volume_close(&topo, r, 2.0);
+}
+
+#[test]
+fn partial_face_overlap_diagonal_offset_fuse() {
+    // B offset diagonally — only a quarter of the upper face is shared.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    assert_volume_close(&topo, r, 2.0);
+}
+
+// ── 3. Fully nested coplanar (small face inside larger) ────────────────
+
+#[test]
+#[ignore = "Gap: fully-nested coplanar fuse produces volume drift (~2% surplus). \
+            Tessellation-based volume reads ~17.33 instead of 17.0, suggesting either \
+            an internal-face leak in the result topology or winding inconsistency \
+            in the assembled shell."]
+fn fully_nested_coplanar_fuse() {
+    // Small box stacked on the centre of a larger one, top face of A
+    // strictly contains bottom face of B.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 4.0, 4.0, 1.0);
+    let b = box_at(&mut topo, 1.5, 1.5, 1.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    assert_volume_close(&topo, r, 16.0 + 1.0);
+}
+
+#[test]
+fn fully_nested_coplanar_cut() {
+    // Same shape but cut B from A — leaves L-shape with embossed top.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 4.0, 4.0, 1.0);
+    let b = box_at(&mut topo, 1.5, 1.5, 0.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Cut, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    assert_volume_close(&topo, r, 16.0 - 1.0);
+}
+
+// ── 4. Edge-on-edge contact (1D coincidence) ───────────────────────────
+
+#[test]
+fn edge_on_edge_offset_corner_fuse() {
+    // B touches A at the top edge, offset in z so they share a line, not a face.
+    // [0,1]^3 and [1,2]×[0,1]×[1,2] meet only along edge x=1, z=1, y∈[0,1].
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0);
+    // Edge-only contact — fuse should report a non-manifold result or
+    // a compound; we just require that it does not panic and that any
+    // returned solid has positive volume (single-component or merged).
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b);
+    if let Ok(sid) = r {
+        let v = solid_volume(&topo, sid, DEFLECTION).unwrap();
+        assert!(v > 0.0, "edge-contact fuse volume should be positive");
+        assert!(v <= 2.001, "edge-contact fuse volume should not exceed sum");
+    }
+}
+
+// ── 5. Vertex-on-vertex contact (0D coincidence) ───────────────────────
+
+#[test]
+fn vertex_on_vertex_diagonal_fuse() {
+    // Boxes meet at exactly one corner: [0,1]^3 vs [1,2]^3.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b);
+    if let Ok(sid) = r {
+        let v = solid_volume(&topo, sid, DEFLECTION).unwrap();
+        assert!(v > 0.0, "vertex-contact fuse volume should be positive");
+        assert!(
+            v <= 2.001,
+            "vertex-contact fuse volume should not exceed sum"
+        );
+    }
+}
+
+// ── 6. Sub-tolerance gap (sliver between two faces) ───────────────────
+
+#[test]
+fn sub_tolerance_gap_fuse_treated_as_coincident() {
+    // Faces separated by 0.4× linear tolerance — should round to coincident.
+    let gap = 4e-8; // < default linear tol 1e-7
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 0.0, 0.0, 1.0 + gap, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    let v = solid_volume(&topo, r, DEFLECTION).unwrap();
+    assert!(
+        (v - 2.0).abs() < 1e-3,
+        "sub-tolerance gap fuse volume {v} should be ~2.0"
+    );
+}
+
+#[test]
+fn super_tolerance_gap_fuse_disjoint() {
+    // Faces separated by 100× linear tolerance — should NOT be coincident.
+    let gap = 1e-5;
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 0.0, 0.0, 1.0 + gap, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b);
+    // Either a compound with two parts or two separate solids — we
+    // accept any non-panicking outcome here. The KEY assertion is that
+    // a coincidence-like result isn't fabricated.
+    if let Ok(sid) = r {
+        let v = solid_volume(&topo, sid, DEFLECTION).unwrap();
+        assert!(
+            v <= 2.0 + 1e-3,
+            "super-tolerance gap fuse volume {v} should not exceed sum"
+        );
+    }
+}
+
+// ── 7. Multi-axis coincidence (faces shared along several axes) ───────
+
+#[test]
+#[ignore = "Gap: L-shape fuse (multi-axis face share) produces non-manifold output. \
+            Two boxes meeting along an L-junction expose the same partial-overlap path \
+            as `partial_face_overlap_quarter_offset_fuse`."]
+fn multi_axis_face_share_l_shape_fuse() {
+    // L-shape: A=[0,2]×[0,1]^2, B=[0,1]×[1,2]×[0,1]. Share x∈[0,1], y=1.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 2.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let _faces = check_manifold(&topo, r);
+    assert_volume_close(&topo, r, 3.0);
+}
+
+// ── 8. Symmetry / commutativity of SD detection ───────────────────────
+
+#[test]
+fn face_on_face_fuse_is_commutative() {
+    // A∪B and B∪A should have the same volume and face count.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let ab = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let mut topo2 = Topology::default();
+    let a2 = box_at(&mut topo2, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b2 = box_at(&mut topo2, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let ba = boolean(&mut topo2, BooleanOp::Fuse, b2, a2).unwrap();
+    let v_ab = solid_volume(&topo, ab, DEFLECTION).unwrap();
+    let v_ba = solid_volume(&topo2, ba, DEFLECTION).unwrap();
+    assert!(
+        (v_ab - v_ba).abs() < 1e-6,
+        "fuse should be commutative: {v_ab} vs {v_ba}"
+    );
+}
+
+// ── 9. Anti-symmetric coplanar (opposite normals) ─────────────────────
+
+#[test]
+fn coplanar_opposite_normals_intersect_zero_volume() {
+    // Two boxes that touch only on a face — intersect should be the face,
+    // which has zero volume. Operation should not panic; result either
+    // returns Err (degenerate) or zero-volume solid.
+    let mut topo = Topology::default();
+    let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let b = box_at(&mut topo, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b);
+    if let Ok(sid) = r {
+        let v = solid_volume(&topo, sid, DEFLECTION).unwrap_or(0.0);
+        assert!(
+            v < 1e-3,
+            "coplanar-only intersect should have ~zero volume, got {v}"
+        );
+    }
+}

--- a/crates/operations/tests/coincident_planes.rs
+++ b/crates/operations/tests/coincident_planes.rs
@@ -99,6 +99,10 @@ fn partial_face_overlap_quarter_offset_fuse() {
 }
 
 #[test]
+#[ignore = "Gap: passes today but exercises the same partial-face-overlap GFA path \
+            as `partial_face_overlap_quarter_offset_fuse`. Ignored to avoid silent \
+            flakiness — should be unignored together with quarter_offset_fuse once \
+            the partial-overlap gap closes."]
 fn partial_face_overlap_diagonal_offset_fuse() {
     // B offset diagonally — only a quarter of the upper face is shared.
     let mut topo = Topology::default();

--- a/crates/operations/tests/coincident_proptest.rs
+++ b/crates/operations/tests/coincident_proptest.rs
@@ -1,0 +1,130 @@
+//! Property tests for coincident-face boolean robustness.
+//!
+//! Targets invariants that must hold across random rotations,
+//! translations, and sub-tolerance perturbations of coincident-face
+//! configurations. Complements the deterministic corpus in
+//! `coincident_planes.rs` etc.
+
+#![allow(clippy::unwrap_used)]
+
+use proptest::prelude::*;
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::measure::solid_volume;
+use brepkit_operations::primitives::make_box;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+const DEFLECTION: f64 = 0.05;
+
+fn vol(topo: &Topology, solid: SolidId) -> f64 {
+    solid_volume(topo, solid, DEFLECTION).unwrap()
+}
+
+fn box_at(topo: &mut Topology, x: f64, y: f64, z: f64, sx: f64, sy: f64, sz: f64) -> SolidId {
+    let b = make_box(topo, sx, sy, sz).unwrap();
+    transform_solid(topo, b, &Mat4::translation(x, y, z)).unwrap();
+    b
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(16))]
+
+    // Translation invariance: a face-on-face stack translated by an
+    // arbitrary vector should produce the same fused volume (within
+    // tessellation tolerance).
+    #[test]
+    fn prop_face_stack_translation_invariant(
+        tx in -10.0f64..10.0,
+        ty in -10.0f64..10.0,
+        tz in -10.0f64..10.0,
+    ) {
+        let mut topo = Topology::default();
+        let a = box_at(&mut topo, tx, ty, tz, 1.0, 1.0, 1.0);
+        let b = box_at(&mut topo, tx, ty, tz + 1.0, 1.0, 1.0, 1.0);
+        let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+        let v = vol(&topo, r);
+        prop_assert!(
+            (v - 2.0).abs() < 0.02,
+            "translated face-stack volume {v} should be ~2.0",
+        );
+    }
+
+    // Rotation invariance: rotating both boxes of a face-stack by the
+    // same Z rotation should preserve volume. The boolean exhibits up
+    // to ~15% volume drift at certain non-axis-aligned angles, which
+    // is a known gap (see ignored cylinder/cone/torus SD tests for the
+    // related GFA-integration weakness on non-axis-aligned shapes).
+    #[test]
+    #[ignore = "Gap: face-stack fuse exhibits up to ~15% volume drift at certain \
+                Z-rotation angles (e.g. 3.98 rad). Likely related to GFA face-splitting \
+                producing an extra internal face at off-axis rotations."]
+    fn prop_face_stack_z_rotation_invariant(angle in 0.0f64..std::f64::consts::TAU) {
+        let mut topo = Topology::default();
+        let a = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+        let b = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+        transform_solid(&mut topo, b, &Mat4::translation(0.0, 0.0, 1.0)).unwrap();
+        let rot = Mat4::rotation_z(angle);
+        transform_solid(&mut topo, a, &rot).unwrap();
+        transform_solid(&mut topo, b, &rot).unwrap();
+        let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+        let v = vol(&topo, r);
+        prop_assert!(
+            (v - 2.0).abs() < 0.02,
+            "z-rotated face-stack (angle={angle}) volume {v} should be ~2.0",
+        );
+    }
+
+    // Volume conservation under face-coincidence: V(A∪B) + V(A∩B) = V(A) + V(B).
+    // For face-touching boxes, V(A∩B) = 0 (coplanar contact), so V(A∪B) = V(A)+V(B).
+    #[test]
+    fn prop_face_stack_volume_conservation(
+        sx in 0.5f64..2.0,
+        sy in 0.5f64..2.0,
+        sz_a in 0.5f64..2.0,
+        sz_b in 0.5f64..2.0,
+    ) {
+        let mut topo = Topology::default();
+        let a = box_at(&mut topo, 0.0, 0.0, 0.0, sx, sy, sz_a);
+        let b = box_at(&mut topo, 0.0, 0.0, sz_a, sx, sy, sz_b);
+        let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+        let v = vol(&topo, r);
+        let expected = sx * sy * (sz_a + sz_b);
+        let rel_err = (v - expected).abs() / expected;
+        prop_assert!(
+            rel_err < 0.02,
+            "face-stack vol {v} expected {expected} rel_err {rel_err}",
+        );
+    }
+
+    // Commutativity under face-coincidence: V(A∪B) = V(B∪A).
+    #[test]
+    fn prop_face_stack_commutativity(offset_x in -0.5f64..0.5) {
+        let mut topo1 = Topology::default();
+        let a1 = box_at(&mut topo1, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        let b1 = box_at(&mut topo1, offset_x, 0.0, 1.0, 1.0, 1.0, 1.0);
+        let ab = boolean(&mut topo1, BooleanOp::Fuse, a1, b1);
+
+        let mut topo2 = Topology::default();
+        let a2 = box_at(&mut topo2, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        let b2 = box_at(&mut topo2, offset_x, 0.0, 1.0, 1.0, 1.0, 1.0);
+        let ba = boolean(&mut topo2, BooleanOp::Fuse, b2, a2);
+
+        match (ab, ba) {
+            (Ok(s1), Ok(s2)) => {
+                let v1 = vol(&topo1, s1);
+                let v2 = vol(&topo2, s2);
+                prop_assert!((v1 - v2).abs() < 0.02);
+            }
+            // If both error or one errors, the test is inconclusive but
+            // not a failure — commutativity is asserted only when both
+            // succeed. Mismatched success is a real failure.
+            (Ok(_), Err(_)) | (Err(_), Ok(_)) => {
+                prop_assert!(false, "commutativity violated: one direction succeeded, the other failed");
+            }
+            (Err(_), Err(_)) => {}
+        }
+    }
+}

--- a/crates/operations/tests/concentric_spheres.rs
+++ b/crates/operations/tests/concentric_spheres.rs
@@ -1,0 +1,118 @@
+//! Concentric-sphere scenarios for boolean robustness.
+//!
+//! Sphere same-domain requires matching center and radius; the SD
+//! detector returns `Some(true)` (always same-direction since spheres
+//! have no axis). Like cylinders, the DETECTOR works correctly
+//! (see `same_domain.rs::sphere_*` unit tests) but the GFA pipeline
+//! integration of sphere SD pairs has known gaps tracked here.
+
+#![allow(clippy::unwrap_used)]
+
+use std::f64::consts::PI;
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::measure::solid_volume;
+use brepkit_operations::primitives::make_sphere;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+const DEFLECTION: f64 = 0.05;
+const SEGMENTS: usize = 32;
+
+fn vol(topo: &Topology, solid: SolidId) -> f64 {
+    solid_volume(topo, solid, DEFLECTION).unwrap()
+}
+
+fn sphere_volume(r: f64) -> f64 {
+    4.0 * PI * r * r * r / 3.0
+}
+
+fn approx_eq(a: f64, b: f64, frac: f64) -> bool {
+    (a - b).abs() < a.abs().max(b.abs()).max(1.0) * frac
+}
+
+fn sphere_at(topo: &mut Topology, x: f64, y: f64, z: f64, radius: f64) -> SolidId {
+    let s = make_sphere(topo, radius, SEGMENTS).unwrap();
+    if x != 0.0 || y != 0.0 || z != 0.0 {
+        transform_solid(topo, s, &Mat4::translation(x, y, z)).unwrap();
+    }
+    s
+}
+
+// ── 0. Baseline: disjoint spheres ──────────────────────────────────────
+
+#[test]
+fn baseline_disjoint_spheres_intersect_empty() {
+    let mut topo = Topology::default();
+    let a = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let b = sphere_at(&mut topo, 5.0, 0.0, 0.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b);
+    if let Ok(sid) = r {
+        let v = vol(&topo, sid);
+        assert!(
+            v < 1e-3,
+            "disjoint sphere intersect should be ~zero, got {v}"
+        );
+    }
+}
+
+// ── 1. Identical spheres (degenerate SD) ──────────────────────────────
+
+#[test]
+#[ignore = "Gap: identical-sphere SD — detector identifies the pair but GFA produces \
+            wrong topology. Sphere is a single periodic face with poles, which adds \
+            seam/pole handling complexity on top of the SD merge."]
+fn identical_spheres_fuse_preserves_volume() {
+    let mut topo = Topology::default();
+    let a = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let b = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = sphere_volume(1.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}
+
+#[test]
+#[ignore = "Gap: identical-sphere intersect — same root cause as fuse."]
+fn identical_spheres_intersect_preserves_volume() {
+    let mut topo = Topology::default();
+    let a = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let b = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let expected = sphere_volume(1.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}
+
+// ── 2. Concentric different radii (NOT same-domain — must NOT merge) ──
+
+#[test]
+#[ignore = "Gap: concentric spheres of different radii — ball-in-ball topology, \
+            SD detector correctly returns None (different radii); fuse should yield \
+            outer sphere unchanged. GFA does not yet collapse the inner sphere correctly."]
+fn concentric_spheres_different_radii_fuse() {
+    let mut topo = Topology::default();
+    let outer = sphere_at(&mut topo, 0.0, 0.0, 0.0, 2.0);
+    let inner = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, outer, inner).unwrap();
+    let expected = sphere_volume(2.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.03));
+}
+
+// ── 3. Sub-tolerance shifted center (should be SD) ────────────────────
+
+#[test]
+#[ignore = "Gap: sub-tolerance center shift — SD detector should treat as identical \
+            via tolerance comparison; GFA produces wrong topology."]
+fn spheres_sub_tolerance_shifted_fuse() {
+    let mut topo = Topology::default();
+    let a = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let b = sphere_at(&mut topo, 4e-8, 0.0, 0.0, 1.0); // < linear tol 1e-7
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let expected = sphere_volume(1.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -17,6 +17,7 @@ default = ["io"]
 io = ["dep:brepkit-io"]
 
 [dependencies]
+brepkit-algo.workspace = true
 brepkit-check.workspace = true
 brepkit-geometry.workspace = true
 brepkit-io = {workspace = true, optional = true}

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -220,6 +220,31 @@ impl BrepKernel {
                     .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
+            "detectCoincidentFaces" => {
+                let a = get_u32(args, "solidA")?;
+                let b = get_u32(args, "solidB")?;
+                let a_id = self.resolve_solid(a).map_err(|e| e.to_string())?;
+                let b_id = self.resolve_solid(b).map_err(|e| e.to_string())?;
+                let pairs = brepkit_algo::diagnostic::detect_coincident_faces(
+                    self.topo(),
+                    a_id,
+                    b_id,
+                    brepkit_math::tolerance::Tolerance::default(),
+                )
+                .map_err(|e| e.to_string())?;
+                let arr: Vec<serde_json::Value> = pairs
+                    .iter()
+                    .map(|p| {
+                        serde_json::json!({
+                            "faceA": crate::handles::face_id_to_u32(p.face_a),
+                            "faceB": crate::handles::face_id_to_u32(p.face_b),
+                            "sameOrientation": p.same_orientation,
+                            "aabbOverlap": p.aabb_overlap,
+                        })
+                    })
+                    .collect();
+                Ok(serde_json::Value::Array(arr))
+            }
             "compoundCut" => {
                 let target = get_u32(args, "target")?;
                 let target_id = self.resolve_solid(target).map_err(|e| e.to_string())?;

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -232,18 +232,9 @@ impl BrepKernel {
                     brepkit_math::tolerance::Tolerance::default(),
                 )
                 .map_err(|e| e.to_string())?;
-                let arr: Vec<serde_json::Value> = pairs
-                    .iter()
-                    .map(|p| {
-                        serde_json::json!({
-                            "faceA": crate::handles::face_id_to_u32(p.face_a),
-                            "faceB": crate::handles::face_id_to_u32(p.face_b),
-                            "sameOrientation": p.same_orientation,
-                            "aabbOverlap": p.aabb_overlap,
-                        })
-                    })
-                    .collect();
-                Ok(serde_json::Value::Array(arr))
+                Ok(crate::bindings::booleans::coincident_face_pairs_to_json(
+                    &pairs,
+                ))
             }
             "compoundCut" => {
                 let target = get_u32(args, "target")?;

--- a/crates/wasm/src/bindings/booleans.rs
+++ b/crates/wasm/src/bindings/booleans.rs
@@ -47,6 +47,50 @@ impl BrepKernel {
         Ok(solid_id_to_u32(result))
     }
 
+    /// Detect surface-level coincident face pairs between two solids
+    /// without performing a boolean operation.
+    ///
+    /// Useful for warning users about same-domain configurations
+    /// (face stacks, coaxial cylinders, concentric spheres) before a
+    /// boolean. Returns a JSON array string of objects:
+    /// `[{"faceA": <u32>, "faceB": <u32>, "sameOrientation": <bool>, "aabbOverlap": <bool>}, ...]`.
+    ///
+    /// `sameOrientation` is `true` when the surface normals point the
+    /// same way at corresponding parametric points (e.g., two coplanar
+    /// faces with the same `+z` normal). `aabbOverlap` filters pairs
+    /// that are same-domain on the surface but geometrically disjoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either solid handle is invalid or any face /
+    /// edge / vertex lookup fails internally.
+    #[wasm_bindgen(js_name = "detectCoincidentFaces")]
+    pub fn detect_coincident_faces(&self, a: u32, b: u32) -> Result<String, JsError> {
+        let a_id = self.resolve_solid(a)?;
+        let b_id = self.resolve_solid(b)?;
+        let pairs = brepkit_algo::diagnostic::detect_coincident_faces(
+            self.topo(),
+            a_id,
+            b_id,
+            brepkit_math::tolerance::Tolerance::default(),
+        )
+        .map_err(|e| JsError::new(&format!("{e}")))?;
+
+        let parts: Vec<String> = pairs
+            .iter()
+            .map(|p| {
+                format!(
+                    "{{\"faceA\":{},\"faceB\":{},\"sameOrientation\":{},\"aabbOverlap\":{}}}",
+                    crate::handles::face_id_to_u32(p.face_a),
+                    crate::handles::face_id_to_u32(p.face_b),
+                    p.same_orientation,
+                    p.aabb_overlap,
+                )
+            })
+            .collect();
+        Ok(format!("[{}]", parts.join(",")))
+    }
+
     /// Intersect two solids, keeping only their common volume.
     ///
     /// Returns a new solid handle (`u32`).
@@ -405,6 +449,45 @@ mod tests {
             r#"[{{"op": "compoundCut", "args": {{"target": {a}, "tools": []}}}}]"#
         ));
         assert!(batch_has_ok(&r, 0));
+    }
+
+    // ── detectCoincidentFaces ────────────────────────────────────────
+
+    #[test]
+    fn detect_coincident_faces_two_disjoint_boxes_empty() {
+        let (mut k, setup) = two_boxes_batch();
+        let parsed: serde_json::Value = serde_json::from_str(&setup).unwrap();
+        let a = parsed[0]["ok"].as_u64().unwrap();
+        let b = parsed[1]["ok"].as_u64().unwrap();
+        let r = k.execute_batch(&format!(
+            r#"[{{"op": "detectCoincidentFaces", "args": {{"solidA": {a}, "solidB": {b}}}}}]"#
+        ));
+        let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+        let arr = parsed[0]["ok"].as_array().unwrap();
+        // Two boxes both at origin with axis-aligned planar faces will
+        // share several same-domain surfaces, but the smaller box's
+        // AABB is contained in the larger so all 6 face pairs overlap.
+        // The detector returns ALL same-domain pairs; callers filter
+        // by aabb_overlap. Just check the call succeeds and returns
+        // a JSON array.
+        assert!(!arr.is_empty(), "boxes at origin produce SD pairs: {r}");
+        for pair in arr {
+            assert!(pair.get("faceA").is_some());
+            assert!(pair.get("faceB").is_some());
+            assert!(pair.get("sameOrientation").is_some());
+            assert!(pair.get("aabbOverlap").is_some());
+        }
+    }
+
+    #[test]
+    fn detect_coincident_faces_invalid_handle_errors() {
+        let (mut k, setup) = two_boxes_batch();
+        let parsed: serde_json::Value = serde_json::from_str(&setup).unwrap();
+        let a = parsed[0]["ok"].as_u64().unwrap();
+        let r = k.execute_batch(&format!(
+            r#"[{{"op": "detectCoincidentFaces", "args": {{"solidA": {a}, "solidB": 9999}}}}]"#
+        ));
+        assert!(batch_has_error(&r, 0));
     }
 
     // ── mesh_boolean ─────────────────────────────────────────────────

--- a/crates/wasm/src/bindings/booleans.rs
+++ b/crates/wasm/src/bindings/booleans.rs
@@ -11,6 +11,36 @@ use crate::helpers::{build_triangle_mesh, panic_message, parse_boolean_op, trian
 use crate::kernel::BrepKernel;
 use crate::shapes::JsMesh;
 
+/// Serialise a slice of `CoincidentFacePair` values to a JSON array.
+///
+/// Shared by both the direct WASM binding (`detectCoincidentFaces`)
+/// and the batch dispatcher (`executeBatch` "detectCoincidentFaces"
+/// arm) so the JSON shape is guaranteed identical across the two
+/// paths — a field-name typo or boolean formatting drift in only one
+/// copy would otherwise be silently shipped to JS callers.
+///
+/// Visibility note: `pub(crate)` triggers `clippy::redundant_pub_crate`
+/// because `bindings` is a private module — the lint folds it to `pub`
+/// in this scope. We keep `pub(crate)` to make the cross-module-but-
+/// crate-internal sharing explicit.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn coincident_face_pairs_to_json(
+    pairs: &[brepkit_algo::diagnostic::CoincidentFacePair],
+) -> serde_json::Value {
+    let arr: Vec<serde_json::Value> = pairs
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "faceA": crate::handles::face_id_to_u32(p.face_a),
+                "faceB": crate::handles::face_id_to_u32(p.face_b),
+                "sameOrientation": p.same_orientation,
+                "aabbOverlap": p.aabb_overlap,
+            })
+        })
+        .collect();
+    serde_json::Value::Array(arr)
+}
+
 #[wasm_bindgen]
 impl BrepKernel {
     // ── Boolean operations ──────────────────────────────────────────
@@ -75,20 +105,7 @@ impl BrepKernel {
             brepkit_math::tolerance::Tolerance::default(),
         )
         .map_err(|e| JsError::new(&format!("{e}")))?;
-
-        let parts: Vec<String> = pairs
-            .iter()
-            .map(|p| {
-                format!(
-                    "{{\"faceA\":{},\"faceB\":{},\"sameOrientation\":{},\"aabbOverlap\":{}}}",
-                    crate::handles::face_id_to_u32(p.face_a),
-                    crate::handles::face_id_to_u32(p.face_b),
-                    p.same_orientation,
-                    p.aabb_overlap,
-                )
-            })
-            .collect();
-        Ok(format!("[{}]", parts.join(",")))
+        Ok(coincident_face_pairs_to_json(&pairs).to_string())
     }
 
     /// Intersect two solids, keeping only their common volume.
@@ -454,7 +471,13 @@ mod tests {
     // ── detectCoincidentFaces ────────────────────────────────────────
 
     #[test]
-    fn detect_coincident_faces_two_disjoint_boxes_empty() {
+    fn detect_coincident_faces_overlapping_boxes_returns_sd_pairs() {
+        // `two_boxes_batch()` creates two axis-aligned boxes (2×2×2 and
+        // 1×1×1) both at the origin — the smaller is fully contained in
+        // the larger. Each pair of axis-aligned faces shares a parallel
+        // plane normal, so the SD detector reports several same-domain
+        // pairs. We verify (a) the JSON shape and (b) at least one pair
+        // is reported with a valid `aabbOverlap` flag.
         let (mut k, setup) = two_boxes_batch();
         let parsed: serde_json::Value = serde_json::from_str(&setup).unwrap();
         let a = parsed[0]["ok"].as_u64().unwrap();
@@ -464,18 +487,12 @@ mod tests {
         ));
         let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
         let arr = parsed[0]["ok"].as_array().unwrap();
-        // Two boxes both at origin with axis-aligned planar faces will
-        // share several same-domain surfaces, but the smaller box's
-        // AABB is contained in the larger so all 6 face pairs overlap.
-        // The detector returns ALL same-domain pairs; callers filter
-        // by aabb_overlap. Just check the call succeeds and returns
-        // a JSON array.
-        assert!(!arr.is_empty(), "boxes at origin produce SD pairs: {r}");
+        assert!(!arr.is_empty(), "overlapping boxes produce SD pairs: {r}");
         for pair in arr {
-            assert!(pair.get("faceA").is_some());
-            assert!(pair.get("faceB").is_some());
-            assert!(pair.get("sameOrientation").is_some());
-            assert!(pair.get("aabbOverlap").is_some());
+            assert!(pair["faceA"].is_u64());
+            assert!(pair["faceB"].is_u64());
+            assert!(pair["sameOrientation"].is_boolean());
+            assert!(pair["aabbOverlap"].is_boolean());
         }
     }
 

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -79,6 +79,11 @@ impl BrepKernel {
         Rc::make_mut(&mut self.topo)
     }
 
+    /// Returns an immutable reference to the topology.
+    pub(crate) fn topo(&self) -> &Topology {
+        &self.topo
+    }
+
     /// Inner implementation for `make_tangent_arc_3d`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn make_tangent_arc_3d_impl(


### PR DESCRIPTION
## Summary

- Adds the **Torus arm** to `surfaces_same_domain()` — last analytic surface type missing from the same-domain detector. 16 unit tests in `same_domain.rs` (8 new) cover Plane/Cyl/Sphere/Cone/Torus same-direction, opposite-direction, and rejection cases.
- Lays down a **~30-case stress corpus** for coincident-face boolean robustness, organised by surface type into `coincident_planes.rs`, `coaxial_cylinders.rs`, `concentric_spheres.rs`, `coaxial_cones.rs`, `coaxial_torus.rs`, and `coincident_proptest.rs`. Each test either passes (validates working behaviour) or is `#[ignore]`'d with a `Gap: ...` reason documenting the territory for future PRs.
- Exposes `brepkit_algo::diagnostic::detect_coincident_faces()` + `CoincidentFacePair` for boolean preflight checks without running the full GFA pipeline.
- Adds the `detectCoincidentFaces` WASM binding (regular + `executeBatch` dispatch) so brepjs callers can warn users about same-domain configurations before unioning.

## Findings

The SD **detector** is correct for every analytic surface, but the GFA pipeline **integration** of non-plane SD pairs is substantially weaker than for planes:

- **Plane SD** — works for full face stacks; fails on partial-face overlap, fully-nested coplanar, L-shape multi-axis face share, and certain rotated face stacks (~15% volume drift at some Z-rotations).
- **Cylinder/Sphere/Cone/Torus SD** — nearly all SD configurations produce volume drift (15–18%) or non-manifold output. See `Gap:`-tagged ignored tests.

Each ignored test is a regression test waiting to be un-ignored as fixes land.

## Test plan

- [x] `cargo test -p brepkit-algo --lib` (88 passing, 16 same_domain tests, 2 diagnostic tests)
- [x] `cargo test -p brepkit-operations --tests` (all suites green, gaps marked as ignored)
- [x] `cargo test -p brepkit-wasm --lib` (175 passing, 2 new contract tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `./scripts/check-boundaries.sh`
- [x] `cargo build -p brepkit-wasm --target wasm32-unknown-unknown`