### PR TITLE
test(wasm): un-ignore gridfinity_lip_fillet_fuse_volume + diagnose remaining gaps

### DIFF
--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -577,7 +577,6 @@ fn compound_cut_bbox_accurate() {
 ///
 /// Solids: 0=box, 1=filleted, 2=lip_box, 3=fused
 #[test]
-#[ignore = "fuse volume 8140 vs expected ~16000 — boolean coplanar face classification (#270)"]
 fn gridfinity_lip_fillet_fuse_volume() {
     let mut k = BrepKernel::new();
 


### PR DESCRIPTION
## Summary

PR #531 (Torus same-domain + corpus) inadvertently fixed one of the seven `#[ignore]`d gridfinity reproducer tests. Un-ignoring `gridfinity_lip_fillet_fuse_volume` (gridfinity-layout-tool issue #270) and documenting the diagnosis for the remaining six so the next PR has a clear entry point.

**Now passing**: `gridfinity_lip_fillet_fuse_volume` — original failure was "fuse volume 8140 vs ~16000, boolean coplanar face classification". Tightened same-domain handling in #531 closed this case.

**Still ignored** (6 of original 7):

| Test | Failure mode |
|------|-------------------|
| `sequential_booleans_volume_accuracy` (#260) | 7.2% volume error after 3 sequential cylinder cuts (971.3 vs 905.8) |
| `gridfinity_d1_lip_ring_loft_cut` | volume 7412 mm³ vs expected 100-5000 |
| `gridfinity_d1a1c_octagon_cut` | Euler = -19 (expected 2) |
| `gridfinity_d1b_lip_ring_no_coplanar` | Euler = -1, 7 validation issues |
| `gridfinity_d4_full_1x1_bin` | Adjusted Euler = -16 (expected 2) |
| `gridfinity_d5_box_with_filleted_lip` | Euler = -19 before fillet |

## Diagnosis (for follow-up)

Investigated the simplest reproducer (`sequential_booleans_volume_accuracy` — 3 cylinder cuts on a box). Root cause:

1. **GFA produces correct face count (7) but invalid topology** for a single box-cylinder cut:
   - 16 edges shared by 3 faces (non-manifold)
   - 97 boundary edges (shell not closed)
   - Validation fails → pipeline falls back to mesh boolean
2. **Mesh boolean fallback polygonalizes the cylinder** into 227 faces.
3. **Sequential cuts compound** the over-split topology — each cut starts from a 200+ face polygonalised solid, classification fails on the now-fragmented coplanar pieces, producing catastrophic volume errors (cut #2 removes 12× the expected volume).

The data:
```
single cyl-box cut:  volume 971 vs 968.6 ✓ (mesh fallback path, polygonalized)
2 sequential cuts:   volume 622 vs 937   ✗ (compounded over-split failure)
3 sequential cuts:   volume 593 vs 905   ✗
compound_cut(box, 3): volume 593         ✗ (same root cause as sequential)
```

GFA's 7-face count is the right shape — the bug is in the assembly/wire-reconstruction step where rank-A and rank-B face images aren't sharing edges correctly. Fixing this should let the GFA result pass validation and avoid the mesh fallback entirely, which would unblock most of the remaining gridfinity tests.

**Specific files to examine for the follow-up PR**: `crates/algo/src/builder/{assemble,builder_solid,fill_images_faces}.rs` — `merge_duplicate_edges` is already invoked but doesn't recover from the duplication produced by analytic surface intersections.

## Test plan

- [x] `cargo test -p brepkit-wasm --lib bindings::gridfinity_tests` (19 pass, 6 ignored — was 18/7)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] No regressions in any other test suite