### PR TITLE
fix(algo): preserve pave_block_id through disc-loop path; refine pinning test diagnosis

### DIFF
--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -192,7 +192,13 @@ pub(super) fn split_face_with_internal_loops(
             end_3d: section.end,
             forward: true,
             source_edge_idx: None,
-            pave_block_id: None,
+            // Preserve the section's pave_block_id so cross-face edge
+            // sharing (box face inner wire ↔ cylinder face outer wire)
+            // works through `resolve_edge_vertices`'s PaveBlock path.
+            // Previously dropped to None, which forced position-fallback
+            // lookup that created duplicate vertices on the cylinder
+            // side of cylinder-cut booleans.
+            pave_block_id: section.pave_block_id,
         });
     }
 

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -1279,15 +1279,11 @@ fn solid_topology_summary(
             interpretation to closed section circles, which is correct only \
             for plane faces. On a cylinder lateral, a single closed circle \
             doesn't bound a disc — two parallel circles split the cylinder \
-            into 3 bands. The disc path produces 1-edge wires that leave \
-            the cylinder lateral disconnected (edges=14 not 15, Euler=3 not 2), \
-            which then fails operations-layer validation and triggers a \
-            mesh-boolean fallback that polygonalises the cylinder into ~227 \
-            faces. Fix requires a dedicated `split_periodic_face_into_bands` \
-            that knows how to construct band sub-faces (bottom circle + seam \
-            + top circle reversed + seam reversed) for each [v_a, v_b] segment \
-            between cuts. Tracked: gridfinity-layout-tool #260 / #270 path. \
-            See PR #533 body for full diagnosis + this test for the contract."]
+            into 3 bands. Fixing this requires a `split_periodic_face_into_bands` \
+            that constructs band sub-faces (bottom circle + seam + top circle \
+            reversed + seam reversed) AND avoids regressing compound_cut grids \
+            (where multiple cylinders share section planes). Tracked: \
+            gridfinity-layout-tool #260 / #270."]
 fn gfa_cut_box_cylinder_through_produces_valid_topology() {
     // Box [0,10]^3 with a cylinder r=1 at (5,5) piercing fully through
     // (z=-2 to z=12). The result should be a closed manifold solid:


### PR DESCRIPTION
## Summary

Two narrow changes from the gridfinity-parity investigation:

1. **`split_face_with_internal_loops`** no longer drops the section edge's `pave_block_id` to `None` when emitting `OrientedPCurveEdge`s. Preserving it lets `resolve_edge_vertices`' PaveBlock-identity path fire on disc sub-faces, modestly improving cross-face vertex sharing for shared section curves (box face inner wire ↔ cylinder face wire).
2. **Refines the diagnostic comment** on the previously-added `gfa_cut_box_cylinder_through_produces_valid_topology` pinning test (PR #534) to reflect findings from this session's deeper attempt.

## Investigation summary

Wrote a `merge_periodic_discs_into_bands` post-pass that converts the disc-loop output into proper band sub-faces (`bot_circle + seam + top_circle_rev + seam_rev`) on u-periodic surfaces. Combined with a closed-section vertex pre-pass, **it makes the pinning test pass** for single box-cylinder cuts.

But it **cascades a regression** in `compound_cut_matches_sequential_4x4_grid`: when multiple cylinders share section planes (e.g., a 4×4 grid of cylinders all cutting through a slab), the band's BOP classification picks up wrong interior points across cylinders, and the result loses material reduction. Reverted that work; the disc-path `pave_block_id` fix is the only behavior change retained.

## What the next session needs

The proper fix is a `merge_periodic_discs_into_bands` that:
- Constructs band sub-faces (4-edge wire) for cylinder/cone/sphere/torus cuts  
- Pre-registers section circle vertices in `pb_vertex_registry` so the seam-bridge edge resolves to the existing topology vertex (this part was working)
- **Doesn't fire** when the BOP classification can't reliably distinguish band interiors across multiple grid cylinders — perhaps gated on `arena.curves.iter().filter(|c| c.is_circle).count()` or detecting overlap between sections

Detailed code for the band-merger is preserved in this PR's commit history (rebase-extractable from earlier commits on the local branch) for the next session.

## Test plan

- [x] `cargo test --workspace` — all suites green (no regressions)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Pinning test stays `#[ignore]`'d but with refined diagnostic