### PR TITLE
docs(algo): record band-builder investigation gap above split_face_with_internal_loops

### DIFF
--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -143,6 +143,67 @@ pub(super) fn split_noseam_face_direct(
     ]
 }
 
+// ---------------------------------------------------------------------------
+// Known gap: disc-loop interpretation is wrong for periodic surfaces.
+//
+// `split_face_with_internal_loops` below treats each closed section curve
+// as a planar disc (loop bounds a disc-shaped sub-face). This is correct
+// for plane faces, but on a u-periodic surface (cylinder/cone/sphere/torus
+// lateral) a single closed circle does NOT bound a disc — it splits the
+// periodic surface into bands. The disc-pair output produces invalid
+// topology (Euler=3, non-manifold) for box-cylinder cuts; see the pinning
+// tests:
+//   - `gfa_cut_box_cylinder_through_produces_valid_topology` (PR #534)
+//   - `gfa_cut_box_cylinder_grid_through_sequential_produces_valid_topology`
+//     (PR #537)
+//
+// The operations layer's mesh-boolean fallback rescues most callers, but
+// at the cost of falling out of GFA for any cylinder cut.
+//
+// The proper fix is a `split_periodic_face_at_circles` post-pass that
+// emits N+1 band sub-faces (each: bot_circle + seam + top_circle_rev +
+// seam_rev) for a u-periodic face cut by N closed section circles.
+//
+// Investigation notes (2026-04-30, ultimately reverted before merge):
+//
+//   1. **Topology piece works.** A band-builder gated on
+//      `cylinder_face_count == 1` (pre-registering closed-circle section
+//      endpoints in `pb_vertex_registry` so cross-face vertex sharing
+//      via `merge_duplicate_edges` fires) un-ignores the single-cyl pin:
+//      F=7 E=15 V=10 Euler=2 manifold.
+//
+//   2. **Geometry piece is the blocker.** The band-builder reused the
+//      existing section-circle endpoint chosen by `phase_ff` (some
+//      arbitrary u-angle, e.g. (5,4,0) rather than the seam (6,5,0)) as
+//      the band's wire endpoint. The seam-segment Line then connects
+//      two off-seam points, crossing the cylinder interior. This is
+//      topologically valid but geometrically inconsistent. Downstream
+//      ops that use face geometry (volume, intersection in subsequent
+//      compound_cut iterations, tessellation) hang or produce wrong
+//      results — `compound_cut_honeycomb` (9 cyls in a 3×3 grid) hangs
+//      indefinitely on iter 2 even with the band-builder gated off for
+//      that iter, because iter 1's corrupt geometry propagates.
+//
+//   3. **What the next attempt needs.** A pre-pass that, for each closed
+//      section circle on a u-periodic face: (a) creates a vertex at
+//      `surface.evaluate(seam_u, v_section)`, (b) re-parameterizes the
+//      section's pcurve to start at `u = seam_u`, (c) splits the existing
+//      seam Line edge at `v_section` so the band's seam-segment endpoints
+//      land on real topology vertices. Without (a)+(b)+(c) the band's
+//      seam doesn't lie on the cylinder surface and downstream ops break.
+//      `pb_vertex_registry` is the right place to wire the new vertices —
+//      `resolve_edge_vertices` already consults it.
+//
+//   4. **Multi-cylinder gating is a separate hard problem.** Even with
+//      correct seam geometry, multi-tool scenarios (compound_cut with
+//      tools sharing section planes — e.g. 4×4 grid) confuse BOP face-
+//      image classification. PR #535's body recommends gating on
+//      "BOP can reliably classify this band's interior" — easier to
+//      derive empirically than design a priori.
+//
+// See PRs #534, #535, #537 for the pinning test history.
+// ---------------------------------------------------------------------------
+
 /// Split a face when ALL section edges are interior (don't touch the boundary).
 ///
 /// Groups section edges into closed loops by chaining shared 3D endpoints.
@@ -152,6 +213,10 @@ pub(super) fn split_noseam_face_direct(
 ///
 /// The "outside" sub-face has the original boundary as outer wire with all
 /// loops as holes.
+///
+/// **Known limitation**: applies the planar disc-loop interpretation to
+/// periodic surfaces (cylinder/cone/sphere/torus laterals), which is
+/// wrong — see the module-level investigation notes above.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn split_face_with_internal_loops(
     surface: &FaceSurface,


### PR DESCRIPTION
## Summary

Adds a 50-line investigation-notes block above `split_face_with_internal_loops` documenting what was tried for the periodic-cylinder band-builder follow-up to PRs #534/#535/#537, what worked, what didn't, and what the next attempt needs.

## Why a docs PR

The pinning tests (#534, #537) record the symptoms. PR #535's commit body has the architectural sketch. But neither captures **what fails when you try to build it** — and that's what burned the most time in this session: getting band topology right (via `pb_vertex_registry` + `merge_duplicate_edges`) only to discover the seam-segment Lines cross the cylinder interior because they connect off-seam section endpoints, breaking `compound_cut_honeycomb` (>20 min hang on iter 2). The ranks-of-context-window worth of debugging that produced this is hard to reconstruct from the pinning tests alone.

The note sits above the disc-loop function — exactly where the next attempt would land — so the gap is discoverable rather than re-derivable.

## What the note covers

1. The disc-loop function's planar interpretation is wrong for u-periodic surfaces (background already in PRs #534/#537).
2. The band-builder's topology piece works (un-ignores the single-cyl pin) — pre-registering closed-circle section endpoints in `pb_vertex_registry` makes cross-face vertex sharing fire via `merge_duplicate_edges`.
3. The geometry piece is the blocker — reusing `phase_ff`'s off-seam section endpoints makes the seam Line cross the cylinder interior; downstream ops (volume, tessellation, subsequent intersections) hang or produce wrong results.
4. The proper fix needs a pre-pass that creates seam vertices, splits the seam edge at each section's `v`, and re-parameterizes section pcurves to start at `u = seam_u`.
5. Multi-cyl BOP-classification gating remains a separate hard problem (PR #535).

## What didn't ship

The band-builder code itself, since it can't be made geometrically sound without the pre-pass in (4). Topologically valid output isn't enough — downstream code uses face geometry. Better to record the gap clearly than ship a seemingly-working partial fix that breaks `compound_cut_honeycomb`.

## Test plan

- [x] \`cargo clippy -p brepkit-algo --all-targets -- -D warnings\` — clean
- [x] No code or test behavior changes — pure documentation
- [x] Pre-push hook (full \`cargo test --workspace\`) — green