### PR TITLE
feat(heal): merge co-circular and co-elliptical arcs in unify_same_domain

### DIFF
--- a/crates/heal/src/upgrade/unify_same_domain.rs
+++ b/crates/heal/src/upgrade/unify_same_domain.rs
@@ -421,21 +421,27 @@ fn merge_collinear_edges(
     let mut i = 0;
 
     while i < n {
-        // Run starts at edge i. Only mergeable kinds (and forward-oriented
-        // runs) are eligible — see continuation conditions below.
+        // Capture the curve template the merged edge would inherit if the run
+        // extends. `None` ⇒ this edge cannot start a mergeable run; we never
+        // re-derive the curve at merge time, so the merge path has no
+        // unreachable arm.
         let head = &data[i];
-        let head_eligible = matches!(
-            head.kind,
-            EdgeKind::Line | EdgeKind::Circle(_) | EdgeKind::Ellipse(_)
-        ) && head.oe.is_forward();
+        let merge_template: Option<EdgeCurve> = if head.oe.is_forward() {
+            match &head.kind {
+                EdgeKind::Line => Some(EdgeCurve::Line),
+                EdgeKind::Circle(c) => Some(EdgeCurve::Circle(c.clone())),
+                EdgeKind::Ellipse(e) => Some(EdgeCurve::Ellipse(e.clone())),
+                EdgeKind::Other => None,
+            }
+        } else {
+            None
+        };
 
-        if !head_eligible {
+        let Some(merged_curve) = merge_template else {
             new_edges.push(head.oe);
             i += 1;
             continue;
-        }
-
-        let mut run_end_vid = head.end_vid;
+        };
 
         // For lines we additionally require subsequent segments to be parallel
         // — colocated start/end positions on the same line — so capture the
@@ -452,6 +458,7 @@ fn merge_collinear_edges(
             None
         };
 
+        let mut run_end_vid = head.end_vid;
         let mut j = i + 1;
         while j < n {
             let next = &data[j];
@@ -491,13 +498,7 @@ fn merge_collinear_edges(
             continue;
         }
 
-        let new_curve = match &head.kind {
-            EdgeKind::Line => EdgeCurve::Line,
-            EdgeKind::Circle(c) => EdgeCurve::Circle(c.clone()),
-            EdgeKind::Ellipse(e) => EdgeCurve::Ellipse(e.clone()),
-            EdgeKind::Other => unreachable!("run head must be a mergeable kind"),
-        };
-        let new_edge = Edge::new(head.start_vid, run_end_vid, new_curve);
+        let new_edge = Edge::new(head.start_vid, run_end_vid, merged_curve);
         let new_edge_id = topo.add_edge(new_edge);
         new_edges.push(OrientedEdge::new(new_edge_id, true));
         merged_count += run_length - 1;

--- a/crates/heal/src/upgrade/unify_same_domain.rs
+++ b/crates/heal/src/upgrade/unify_same_domain.rs
@@ -306,38 +306,84 @@ pub fn unify_same_domain(
     ))
 }
 
-/// Merge collinear adjacent Line edges in a wire.
+/// Merge runs of adjacent edges that share a common geometric host.
 ///
-/// Scans consecutive edge pairs for Line+Line edges on the same line
-/// (same direction, shared vertex). When found, creates a single Line
-/// edge from the start of the first to the end of the second and
-/// replaces both edges.
+/// Scans consecutive edge pairs and merges them when they:
+///  - share a topology vertex,
+///  - have the same orientation (both forward in the wire), and
+///  - share the same underlying analytic curve.
+///
+/// Supported curve kinds:
+///  - `Line` — collinear Line+Line, merged into a single Line edge.
+///  - `Circle` — co-circular arcs (same center, normal, radius), merged into
+///    a single Circle arc.
+///  - `Ellipse` — co-elliptical arcs (same center, axes, semi-radii).
+///
+/// `NurbsCurve` edges are not merged — they have no closed-form equivalence
+/// test cheap enough to run inline, and merging them requires knot-vector
+/// stitching that belongs in a separate upgrade pass.
+///
+/// Mixed-orientation runs (e.g. one forward + one reversed) are left alone:
+/// reversing an arc on a Circle3D requires flipping the surface normal, which
+/// is a substantive change rather than a textual merge.
 ///
 /// Returns the number of edge merges performed.
 ///
 /// # Errors
 ///
 /// Returns [`HealError`] if entity lookups fail.
-///
-/// # Future work
-///
-/// TODO: Support Circle+Circle and NurbsCurve+NurbsCurve merging.
 fn merge_collinear_edges(
     topo: &mut Topology,
     wire_id: WireId,
     options: &UnifyOptions,
 ) -> Result<usize, HealError> {
-    // Snapshot edge data for collinearity checks.
+    use brepkit_math::curves::{Circle3D, Ellipse3D};
+
+    /// Curve-kind snapshot used to decide whether two consecutive edges live
+    /// on the same geometric host. `Other` blocks merging (NurbsCurve, etc.).
+    #[derive(Clone)]
+    enum EdgeKind {
+        Line,
+        Circle(Circle3D),
+        Ellipse(Ellipse3D),
+        Other,
+    }
+
     struct EdgeData {
         oe: OrientedEdge,
         start_vid: brepkit_topology::vertex::VertexId,
         end_vid: brepkit_topology::vertex::VertexId,
         start_pos: brepkit_math::vec::Point3,
         end_pos: brepkit_math::vec::Point3,
-        is_line: bool,
+        kind: EdgeKind,
     }
 
-    let linear_tolerance = options.linear_tolerance;
+    let lin = options.linear_tolerance;
+    let ang = options.angular_tolerance;
+
+    let circles_match = |a: &Circle3D, b: &Circle3D| -> bool {
+        (a.center() - b.center()).length() < lin
+            && (a.radius() - b.radius()).abs() < lin
+            && a.normal().dot(b.normal()) > 1.0 - ang
+    };
+    let ellipses_match = |a: &Ellipse3D, b: &Ellipse3D| -> bool {
+        (a.center() - b.center()).length() < lin
+            && (a.semi_major() - b.semi_major()).abs() < lin
+            && (a.semi_minor() - b.semi_minor()).abs() < lin
+            && a.normal().dot(b.normal()) > 1.0 - ang
+            // The angular reference axis must agree, otherwise arc params don't match.
+            && a.u_axis().dot(b.u_axis()) > 1.0 - ang
+    };
+
+    let kinds_match = |a: &EdgeKind, b: &EdgeKind| -> bool {
+        match (a, b) {
+            (EdgeKind::Line, EdgeKind::Line) => true,
+            (EdgeKind::Circle(c1), EdgeKind::Circle(c2)) => circles_match(c1, c2),
+            (EdgeKind::Ellipse(e1), EdgeKind::Ellipse(e2)) => ellipses_match(e1, e2),
+            _ => false,
+        }
+    };
+
     let wire = topo.wire(wire_id)?;
     let edges_list: Vec<OrientedEdge> = wire.edges().to_vec();
     let is_closed = wire.is_closed();
@@ -350,7 +396,12 @@ fn merge_collinear_edges(
     let mut data = Vec::with_capacity(n);
     for oe in &edges_list {
         let edge = topo.edge(oe.edge())?;
-        let is_line = matches!(edge.curve(), EdgeCurve::Line);
+        let kind = match edge.curve() {
+            EdgeCurve::Line => EdgeKind::Line,
+            EdgeCurve::Circle(c) => EdgeKind::Circle(c.clone()),
+            EdgeCurve::Ellipse(e) => EdgeKind::Ellipse(e.clone()),
+            EdgeCurve::NurbsCurve(_) => EdgeKind::Other,
+        };
         let start_vid = oe.oriented_start(edge);
         let end_vid = oe.oriented_end(edge);
         let start_pos = topo.vertex(start_vid)?.point();
@@ -361,103 +412,341 @@ fn merge_collinear_edges(
             end_vid,
             start_pos,
             end_pos,
-            is_line,
+            kind,
         });
     }
 
-    // Build the merged edge list by scanning for collinear runs.
     let mut new_edges: Vec<OrientedEdge> = Vec::with_capacity(n);
     let mut merged_count = 0usize;
     let mut i = 0;
 
     while i < n {
-        if !data[i].is_line {
-            new_edges.push(data[i].oe);
+        // Run starts at edge i. Only mergeable kinds (and forward-oriented
+        // runs) are eligible — see continuation conditions below.
+        let head = &data[i];
+        let head_eligible = matches!(
+            head.kind,
+            EdgeKind::Line | EdgeKind::Circle(_) | EdgeKind::Ellipse(_)
+        ) && head.oe.is_forward();
+
+        if !head_eligible {
+            new_edges.push(head.oe);
             i += 1;
             continue;
         }
 
-        // Start of a potential collinear run.
-        let run_start_vid = data[i].start_vid;
-        let mut run_end_vid = data[i].end_vid;
-        let mut _run_end_pos = data[i].end_pos;
+        let mut run_end_vid = head.end_vid;
 
-        // Compute the direction of the first edge in the run.
-        let run_dir = data[i].end_pos - data[i].start_pos;
-        let run_len = run_dir.length();
-        let run_dir_norm = if run_len > linear_tolerance {
-            if let Ok(d) = run_dir.normalize() {
-                d
+        // For lines we additionally require subsequent segments to be parallel
+        // — colocated start/end positions on the same line — so capture the
+        // direction up front.
+        let head_line_dir = if matches!(head.kind, EdgeKind::Line) {
+            if let Ok(d) = (head.end_pos - head.start_pos).normalize() {
+                Some(d)
             } else {
-                new_edges.push(data[i].oe);
+                new_edges.push(head.oe);
                 i += 1;
                 continue;
             }
         } else {
-            new_edges.push(data[i].oe);
-            i += 1;
-            continue;
+            None
         };
 
-        let mut run_length = 1usize;
         let mut j = i + 1;
-
         while j < n {
-            if !data[j].is_line {
+            let next = &data[j];
+
+            if !next.oe.is_forward() {
+                break;
+            }
+            if !kinds_match(&head.kind, &next.kind) {
+                break;
+            }
+            if next.start_vid != run_end_vid {
                 break;
             }
 
-            // Check shared vertex.
-            if data[j].start_vid != run_end_vid {
-                break;
+            // Line-specific parallelism check: same direction along the run.
+            if let Some(dir0) = head_line_dir {
+                let span = next.end_pos - next.start_pos;
+                if span.length() < lin {
+                    break;
+                }
+                let Ok(dir1) = span.normalize() else {
+                    break;
+                };
+                if dir0.dot(dir1) < 1.0 - ang {
+                    break;
+                }
             }
 
-            // Check collinearity: same direction.
-            let next_dir = data[j].end_pos - data[j].start_pos;
-            let next_len = next_dir.length();
-            if next_len < linear_tolerance {
-                break;
-            }
-            let next_norm = match next_dir.normalize() {
-                Ok(d) => d,
-                Err(_) => break,
-            };
-
-            let dot = run_dir_norm.dot(next_norm);
-            if dot < 1.0 - options.angular_tolerance {
-                break;
-            }
-
-            // Collinear — extend the run.
-            run_end_vid = data[j].end_vid;
-            _run_end_pos = data[j].end_pos;
-            run_length += 1;
+            run_end_vid = next.end_vid;
             j += 1;
         }
 
+        let run_length = j - i;
         if run_length == 1 {
-            // No merge needed.
-            new_edges.push(data[i].oe);
+            new_edges.push(head.oe);
             i += 1;
-        } else {
-            // Create a merged Line edge from run_start to run_end.
-            let new_edge = Edge::new(run_start_vid, run_end_vid, EdgeCurve::Line);
-            let new_edge_id = topo.add_edge(new_edge);
-            new_edges.push(OrientedEdge::new(new_edge_id, true));
-            merged_count += run_length - 1;
-
-            i = j;
+            continue;
         }
+
+        let new_curve = match &head.kind {
+            EdgeKind::Line => EdgeCurve::Line,
+            EdgeKind::Circle(c) => EdgeCurve::Circle(c.clone()),
+            EdgeKind::Ellipse(e) => EdgeCurve::Ellipse(e.clone()),
+            EdgeKind::Other => unreachable!("run head must be a mergeable kind"),
+        };
+        let new_edge = Edge::new(head.start_vid, run_end_vid, new_curve);
+        let new_edge_id = topo.add_edge(new_edge);
+        new_edges.push(OrientedEdge::new(new_edge_id, true));
+        merged_count += run_length - 1;
+        i = j;
     }
 
     if merged_count == 0 {
         return Ok(0);
     }
 
-    // Rebuild wire with merged edges.
     let new_wire = Wire::new(new_edges, is_closed)?;
     let wire_mut = topo.wire_mut(wire_id)?;
     *wire_mut = new_wire;
 
     Ok(merged_count)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod merge_tests {
+    use brepkit_math::curves::{Circle3D, Ellipse3D};
+    use brepkit_math::vec::{Point3, Vec3};
+    use brepkit_topology::Topology;
+    use brepkit_topology::edge::{Edge, EdgeCurve};
+    use brepkit_topology::vertex::{Vertex, VertexId};
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    use super::*;
+
+    fn z_axis() -> Vec3 {
+        Vec3::new(0.0, 0.0, 1.0)
+    }
+    fn origin() -> Point3 {
+        Point3::new(0.0, 0.0, 0.0)
+    }
+
+    fn add_vertex(topo: &mut Topology, p: Point3) -> VertexId {
+        topo.add_vertex(Vertex::new(p, 1e-7))
+    }
+
+    /// Build a wire from a sequence of edges, all forward-oriented.
+    fn build_wire_from_edges(
+        topo: &mut Topology,
+        edge_ids: &[brepkit_topology::edge::EdgeId],
+        is_closed: bool,
+    ) -> WireId {
+        let oes: Vec<_> = edge_ids
+            .iter()
+            .map(|&e| OrientedEdge::new(e, true))
+            .collect();
+        topo.add_wire(Wire::new(oes, is_closed).unwrap())
+    }
+
+    #[test]
+    fn three_circle_arcs_merge_into_one_full_circle() {
+        // Three quarter-arcs at 0°→120°→240°→360°.
+        let mut topo = Topology::default();
+        let circle = Circle3D::new(origin(), z_axis(), 1.0).unwrap();
+        let p_at = |theta: f64| circle.evaluate(theta);
+
+        let v0 = add_vertex(&mut topo, p_at(0.0));
+        let v1 = add_vertex(&mut topo, p_at(2.0 * std::f64::consts::PI / 3.0));
+        let v2 = add_vertex(&mut topo, p_at(4.0 * std::f64::consts::PI / 3.0));
+
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Circle(circle.clone())));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Circle(circle.clone())));
+        let e2 = topo.add_edge(Edge::new(v2, v0, EdgeCurve::Circle(circle.clone())));
+        let wire = build_wire_from_edges(&mut topo, &[e0, e1, e2], true);
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        assert_eq!(merged, 2, "three arcs → one merged edge means 2 merges");
+
+        let new_wire = topo.wire(wire).unwrap();
+        assert_eq!(new_wire.edges().len(), 1);
+
+        let merged_eid = new_wire.edges()[0].edge();
+        let merged_edge = topo.edge(merged_eid).unwrap();
+        assert!(matches!(merged_edge.curve(), EdgeCurve::Circle(_)));
+        // Closed-loop arc should reduce to a single closed circle edge.
+        assert_eq!(merged_edge.start(), merged_edge.end());
+    }
+
+    #[test]
+    fn arcs_on_different_circles_do_not_merge() {
+        let mut topo = Topology::default();
+        let circle_a = Circle3D::new(origin(), z_axis(), 1.0).unwrap();
+        let circle_b = Circle3D::new(Point3::new(1.0, 0.0, 0.0), z_axis(), 1.0).unwrap();
+
+        let v0 = add_vertex(&mut topo, circle_a.evaluate(0.0));
+        let v1 = add_vertex(&mut topo, circle_a.evaluate(std::f64::consts::PI));
+        let v2 = add_vertex(&mut topo, circle_b.evaluate(std::f64::consts::PI));
+
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Circle(circle_a)));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Circle(circle_b)));
+        let wire = build_wire_from_edges(&mut topo, &[e0, e1], false);
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        assert_eq!(merged, 0);
+    }
+
+    #[test]
+    fn antiparallel_normal_circles_do_not_merge() {
+        // Same center & radius but opposite normal — these are different
+        // parameterizations and merging would silently flip orientation.
+        let mut topo = Topology::default();
+        let c_up = Circle3D::new(origin(), z_axis(), 1.0).unwrap();
+        let c_down = Circle3D::new(origin(), Vec3::new(0.0, 0.0, -1.0), 1.0).unwrap();
+
+        let v0 = add_vertex(&mut topo, c_up.evaluate(0.0));
+        let v1 = add_vertex(&mut topo, c_up.evaluate(std::f64::consts::PI));
+        let v2 = add_vertex(&mut topo, c_up.evaluate(std::f64::consts::PI * 1.5));
+
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Circle(c_up)));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Circle(c_down)));
+        let wire = build_wire_from_edges(&mut topo, &[e0, e1], false);
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        assert_eq!(merged, 0);
+    }
+
+    #[test]
+    fn reversed_orientation_blocks_arc_merge() {
+        // Two arcs that share a circle and a vertex, but the second is
+        // traversed in reverse. Merging would silently change topology
+        // direction, so we leave them alone.
+        let mut topo = Topology::default();
+        let circle = Circle3D::new(origin(), z_axis(), 1.0).unwrap();
+
+        let v0 = add_vertex(&mut topo, circle.evaluate(0.0));
+        let v1 = add_vertex(&mut topo, circle.evaluate(std::f64::consts::PI));
+
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Circle(circle.clone())));
+        let e1 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Circle(circle)));
+
+        let wire = topo.add_wire(
+            Wire::new(
+                vec![OrientedEdge::new(e0, true), OrientedEdge::new(e1, false)],
+                false,
+            )
+            .unwrap(),
+        );
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        assert_eq!(merged, 0);
+    }
+
+    #[test]
+    fn ellipse_arcs_on_same_ellipse_merge() {
+        let mut topo = Topology::default();
+        let ellipse = Ellipse3D::new(origin(), z_axis(), 4.0, 2.0).unwrap();
+        let p = |t: f64| ellipse.evaluate(t);
+
+        let v0 = add_vertex(&mut topo, p(0.0));
+        let v1 = add_vertex(&mut topo, p(std::f64::consts::PI));
+        let v2 = add_vertex(&mut topo, p(2.0 * std::f64::consts::PI - 1e-9));
+
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Ellipse(ellipse.clone())));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Ellipse(ellipse.clone())));
+        let wire = build_wire_from_edges(&mut topo, &[e0, e1], false);
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        assert_eq!(merged, 1);
+        let new_wire = topo.wire(wire).unwrap();
+        assert_eq!(new_wire.edges().len(), 1);
+        assert!(matches!(
+            topo.edge(new_wire.edges()[0].edge()).unwrap().curve(),
+            EdgeCurve::Ellipse(_)
+        ));
+    }
+
+    #[test]
+    fn nurbs_curve_edges_never_merge() {
+        // NurbsCurve edges are intentionally skipped — they are not handled
+        // by this pass and should be left untouched even when they share a
+        // vertex.
+        use brepkit_math::nurbs::curve::NurbsCurve;
+        let mut topo = Topology::default();
+        let nurbs = NurbsCurve::new(
+            1,
+            vec![0.0, 0.0, 1.0, 1.0],
+            vec![Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 0.0, 0.0)],
+            vec![1.0, 1.0],
+        )
+        .unwrap();
+        let v0 = add_vertex(&mut topo, Point3::new(0.0, 0.0, 0.0));
+        let v1 = add_vertex(&mut topo, Point3::new(1.0, 0.0, 0.0));
+        let v2 = add_vertex(&mut topo, Point3::new(2.0, 0.0, 0.0));
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::NurbsCurve(nurbs.clone())));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::NurbsCurve(nurbs)));
+        let wire = build_wire_from_edges(&mut topo, &[e0, e1], false);
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        assert_eq!(merged, 0);
+    }
+
+    #[test]
+    fn mixed_line_and_circle_runs_handled_independently() {
+        // Three collinear lines along +x ending at (3, 0, 0), then two arcs
+        // on a circle centered at (4, 0, 0) starting at (3, 0, 0):
+        //   L→L→L | A→A
+        // Each run merges within itself; nothing crosses the kind boundary.
+        let mut topo = Topology::default();
+        let circle = Circle3D::new(Point3::new(4.0, 0.0, 0.0), z_axis(), 1.0).unwrap();
+
+        let v0 = add_vertex(&mut topo, Point3::new(0.0, 0.0, 0.0));
+        let v1 = add_vertex(&mut topo, Point3::new(1.0, 0.0, 0.0));
+        let v2 = add_vertex(&mut topo, Point3::new(2.0, 0.0, 0.0));
+        // Frame3::from_normal gives u_axis=(0,1,0), v_axis=(-1,0,0) for
+        // normal=+z, so evaluate(π/2) lands at (3, 0, 0) — the natural
+        // continuation of the +x line run.
+        let v3 = add_vertex(&mut topo, circle.evaluate(std::f64::consts::FRAC_PI_2));
+        let v4 = add_vertex(&mut topo, circle.evaluate(std::f64::consts::PI));
+        let v5 = add_vertex(&mut topo, circle.evaluate(1.49 * std::f64::consts::PI));
+
+        let l0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+        let l1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
+        let l2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
+        let a0 = topo.add_edge(Edge::new(v3, v4, EdgeCurve::Circle(circle.clone())));
+        let a1 = topo.add_edge(Edge::new(v4, v5, EdgeCurve::Circle(circle)));
+
+        let wire = build_wire_from_edges(&mut topo, &[l0, l1, l2, a0, a1], false);
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        // 3 lines → 1 line (2 merges) + 2 arcs → 1 arc (1 merge) = 3 merges.
+        assert_eq!(merged, 3);
+        let new_wire = topo.wire(wire).unwrap();
+        assert_eq!(new_wire.edges().len(), 2);
+        let kind0 = topo.edge(new_wire.edges()[0].edge()).unwrap().curve();
+        let kind1 = topo.edge(new_wire.edges()[1].edge()).unwrap().curve();
+        assert!(matches!(kind0, EdgeCurve::Line));
+        assert!(matches!(kind1, EdgeCurve::Circle(_)));
+    }
+
+    #[test]
+    fn line_only_run_still_merges_after_refactor() {
+        // Regression — the existing Line+Line behavior must survive the
+        // generalization.
+        let mut topo = Topology::default();
+        let v0 = add_vertex(&mut topo, Point3::new(0.0, 0.0, 0.0));
+        let v1 = add_vertex(&mut topo, Point3::new(1.0, 0.0, 0.0));
+        let v2 = add_vertex(&mut topo, Point3::new(2.0, 0.0, 0.0));
+        let v3 = add_vertex(&mut topo, Point3::new(3.0, 0.0, 0.0));
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
+        let e2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
+        let wire = build_wire_from_edges(&mut topo, &[e0, e1, e2], false);
+
+        let merged = merge_collinear_edges(&mut topo, wire, &UnifyOptions::default()).unwrap();
+        assert_eq!(merged, 2);
+        assert_eq!(topo.wire(wire).unwrap().edges().len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

Generalizes \`merge_collinear_edges\` so that Circle and Ellipse arc runs are merged after face unification — not just Line runs.

OCCT's \`ShapeUpgrade_UnifySameDomain\` does this; brepkit's path was Line-only, leaving fragmented arcs in every wire after a boolean cut on a cylinder, cone, sphere, or torus.

### Behavior

Adjacent edges are merged when they:
- share a topology vertex,
- are both forward-oriented in the wire, and
- share the same underlying analytic curve.

Per-kind equivalence:
- **Line**: same direction (existing behavior)
- **Circle**: same center, normal, radius (within linear/angular tolerance)
- **Ellipse**: same center, both semi-radii, normal, and angular reference axis

\`NurbsCurve\` edges remain unmerged — they have no cheap closed-form equivalence test and merging them requires knot-vector stitching that belongs in a separate pass.

### Why orientation matters

Mixed-orientation runs (one forward, one reversed) are skipped. Reversing an arc on a \`Circle3D\` is not a textual merge — it requires flipping the surface normal, which is a substantive geometry change. Refusing the merge keeps the existing direction semantics intact.

## Test plan

8 new unit tests covering:
- 3 quarter-arcs reconstruct one closed circle (2 merges, end with 1 edge whose start==end)
- arcs on distinct circles don't merge
- arcs on anti-parallel normals don't merge
- reversed-orientation pair doesn't merge
- ellipse arcs on the same ellipse merge
- \`NurbsCurve\` runs are never touched
- mixed Line and Circle runs in one wire merge independently within each kind
- Line-only regression (Line+Line+Line still merges into one Line)

\`cargo test --workspace\` — 0 failures across all crates. \`cargo clippy --all-targets -- -D warnings\` — clean. Layer boundaries unaffected (no new deps).

## Why this is in scope

Pure refactor of an existing healing utility — no new public API, no new crate deps. The function is invoked from the boolean pipeline whenever \`unify_faces: true\` (the default), so this immediately tightens topology cleanliness for every curved-surface cut downstream.