### PR TITLE
feat(blend): analytic plane-cylinder fillet → exact torus surface

### DIFF
--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -83,9 +83,30 @@ pub fn try_analytic_fillet(
             }
             Ok(result)
         }
-        // Plane-Cylinder/Cylinder-Plane is handled above; the catch-all
-        // covers everything else (no analytic path yet → walker fallback).
-        _ => Ok(None),
+        // Pairs without an analytic path → walker fallback. Enumerated
+        // exhaustively (matching `try_analytic_chamfer`) so adding a new
+        // `FaceSurface` variant produces a compile error at this site
+        // rather than silently routing through the walker.
+        (
+            FaceSurface::Plane { .. }
+            | FaceSurface::Cylinder(_)
+            | FaceSurface::Cone(_)
+            | FaceSurface::Sphere(_)
+            | FaceSurface::Torus(_)
+            | FaceSurface::Nurbs(_),
+            FaceSurface::Cone(_)
+            | FaceSurface::Sphere(_)
+            | FaceSurface::Torus(_)
+            | FaceSurface::Nurbs(_),
+        )
+        | (FaceSurface::Cylinder(_), FaceSurface::Cylinder(_))
+        | (
+            FaceSurface::Cone(_)
+            | FaceSurface::Sphere(_)
+            | FaceSurface::Torus(_)
+            | FaceSurface::Nurbs(_),
+            FaceSurface::Plane { .. } | FaceSurface::Cylinder(_),
+        ) => Ok(None),
     }
 }
 
@@ -598,13 +619,14 @@ pub fn plane_cylinder_fillet(
     //       cylinder's v parameter). PCurve is a horizontal Line2D in (u, v)
     //       UV-space spanning u_start → u_end at v = `r`.
     let v_cyl = cyl_v_at_point(cyl, contact_cyl_center);
+    let plane_adapter = crate::builder_utils::PlaneAdapter::from_normal_and_d(n_p_inward, d_plane);
+
     // The plane contact is always an arc on a circle (the rolling-ball
     // trajectory at z=0), so represent the pcurve as `Curve2D::Circle` in
     // the plane's local frame. A line-segment pcurve would zero out for the
     // closed-spine case (start and end project to the same point).
     let pcurve_plane = {
-        let adapter = crate::builder_utils::PlaneAdapter::from_normal_and_d(n_p_inward, d_plane);
-        let (cu, cv) = adapter.project_point(p_axis_on_plane);
+        let (cu, cv) = plane_adapter.project_point(p_axis_on_plane);
         Curve2D::Circle(brepkit_math::curves2d::Circle2D::new(
             brepkit_math::vec::Point2::new(cu, cv),
             major_radius,
@@ -615,10 +637,11 @@ pub fn plane_cylinder_fillet(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // 11) Cross-sections at the spine endpoints. Each section's two contact
-    //     points and the rolling-ball center sit on a small circle of the
-    //     torus tube — they share the section's `u` and span the active `v`
-    //     quadrant from plane (v=3π/2) to cylinder (v=π).
+    // 11) Cross-sections at the spine endpoints. `uv1` is the plane contact
+    //     in the PlaneAdapter local frame; `uv2` is the cylinder contact in
+    //     `(u, v)` cylinder UV. The plane has no native UV — we use the same
+    //     adapter as `pcurve_plane` so any downstream consumer gets a
+    //     consistent local-frame pair instead of zeros or cylinder coords.
     let p_plane_at = |u: f64| contact_plane_circle.evaluate(u);
     let p_cyl_at = |u: f64| contact_cyl_circle.evaluate(u);
     let center_at = |u: f64| {
@@ -626,12 +649,13 @@ pub fn plane_cylinder_fillet(
         // to the height of the cylinder contact (axial offset `r`).
         contact_plane_circle.evaluate(u) + z_axis_dir * radius
     };
+    let plane_uv_at = |u: f64| plane_adapter.project_point(p_plane_at(u));
     let section_start = CircSection {
         p1: p_plane_at(u_start),
         p2: p_cyl_at(u_start),
         center: center_at(u_start),
         radius,
-        uv1: (u_start, v_cyl), // unused for plane
+        uv1: plane_uv_at(u_start),
         uv2: (u_start, v_cyl),
         t: 0.0,
     };
@@ -640,7 +664,7 @@ pub fn plane_cylinder_fillet(
         p2: p_cyl_at(u_end),
         center: center_at(u_end),
         radius,
-        uv1: (u_end, v_cyl),
+        uv1: plane_uv_at(u_end),
         uv2: (u_end, v_cyl),
         t: 1.0,
     };

--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -63,27 +63,29 @@ pub fn try_analytic_fillet(
             let result = plane_plane_fillet(spine, topo, *n1, *n2, radius, face1, face2)?;
             Ok(Some(result))
         }
-        (
-            FaceSurface::Plane { .. }
-            | FaceSurface::Cylinder(_)
-            | FaceSurface::Cone(_)
-            | FaceSurface::Sphere(_)
-            | FaceSurface::Torus(_)
-            | FaceSurface::Nurbs(_),
-            FaceSurface::Cylinder(_)
-            | FaceSurface::Cone(_)
-            | FaceSurface::Sphere(_)
-            | FaceSurface::Torus(_)
-            | FaceSurface::Nurbs(_),
-        )
-        | (
-            FaceSurface::Cylinder(_)
-            | FaceSurface::Cone(_)
-            | FaceSurface::Sphere(_)
-            | FaceSurface::Torus(_)
-            | FaceSurface::Nurbs(_),
-            FaceSurface::Plane { .. },
-        ) => Ok(None),
+        (FaceSurface::Plane { normal, d }, FaceSurface::Cylinder(cyl)) => {
+            plane_cylinder_fillet(*normal, *d, cyl, spine, topo, radius, face1, face2)
+        }
+        (FaceSurface::Cylinder(cyl), FaceSurface::Plane { normal, d }) => {
+            // Plane is on side 2; swap to keep the analytic helper's argument
+            // order canonical (plane first), and remember to swap the
+            // resulting Stripe's face/pcurve/contact assignments.
+            let mut result =
+                plane_cylinder_fillet(*normal, *d, cyl, spine, topo, radius, face2, face1)?;
+            if let Some(ref mut r) = result {
+                std::mem::swap(&mut r.stripe.face1, &mut r.stripe.face2);
+                std::mem::swap(&mut r.stripe.pcurve1, &mut r.stripe.pcurve2);
+                std::mem::swap(&mut r.stripe.contact1, &mut r.stripe.contact2);
+                for s in &mut r.stripe.sections {
+                    std::mem::swap(&mut s.p1, &mut s.p2);
+                    std::mem::swap(&mut s.uv1, &mut s.uv2);
+                }
+            }
+            Ok(result)
+        }
+        // Plane-Cylinder/Cylinder-Plane is handled above; the catch-all
+        // covers everything else (no analytic path yet → walker fallback).
+        _ => Ok(None),
     }
 }
 
@@ -443,25 +445,229 @@ fn plane_plane_chamfer(
     })
 }
 
-/// Fillet between a plane and a cylinder: the result is typically a torus section.
+/// Fillet between a plane and a cylinder whose axis is parallel to the plane
+/// normal.
 ///
-/// Not yet implemented. Returns `None` so the caller falls back to the walking
-/// engine.
-#[allow(unused_variables)]
-#[must_use]
+/// Returns `Some(StripeResult)` with an exact toroidal blend surface for the
+/// convex perpendicular case (typical "post on a plate" geometry). Returns
+/// `None` for any case the analytic path doesn't yet cover; the caller then
+/// falls back to the walking engine. Specifically, `None` is returned when:
+///   - the cylinder axis is not parallel to the plane normal,
+///   - the cylinder face is reversed in the topology (concave / "hole through
+///     plate" geometry — the fillet rolls inside the hole, requiring a
+///     different torus major radius and tube quadrant),
+///   - the spine geometry is too short or degenerate,
+///   - or the fillet radius exceeds the cylinder radius (would invert R).
+///
+/// The torus has axis parallel to the cylinder axis, major radius `r_c + r`,
+/// and minor radius `r`. The active tube portion is `v ∈ [π, 3π/2]` — the
+/// quarter that touches the plane below and the cylinder lateral inward.
+///
+/// # Errors
+///
+/// Returns `BlendError` if topology lookups fail.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub fn plane_cylinder_fillet(
-    surf_plane: &FaceSurface,
-    surf_cyl: &FaceSurface,
+    n_p_inward: Vec3,
+    d_plane: f64,
+    cyl: &brepkit_math::surfaces::CylindricalSurface,
     spine: &Spine,
     topo: &Topology,
     radius: f64,
-) -> Option<StripeResult> {
-    // TODO: implement plane-cylinder fillet (torus section)
-    // This requires:
-    // 1. Project spine onto the cylinder surface
-    // 2. Compute rolling ball center trajectory (torus centerline)
-    // 3. Build toroidal surface patch
-    None
+    face_plane: FaceId,
+    face_cyl: FaceId,
+) -> Result<Option<StripeResult>, BlendError> {
+    use brepkit_math::surfaces::ToroidalSurface;
+
+    let tol_ang = 1e-9;
+    let tol_lin = 1e-9;
+
+    // 1) Cylinder axis must be parallel (up to sign) to the inward plane
+    //    normal — this is the perpendicular plane-cylinder case.
+    let axis_c = cyl.axis();
+    let n_dot = axis_c.dot(n_p_inward);
+    if n_dot.abs() < 1.0 - tol_ang {
+        return Ok(None);
+    }
+
+    // 2) Concave (hole-through-plate) case requires a different torus major
+    //    radius (`r_c - r`) and tube quadrant. Defer those to the walker.
+    if topo.face(face_cyl)?.is_reversed() {
+        return Ok(None);
+    }
+
+    // 3) The radius must shrink the cylinder rather than invert it. Larger
+    //    fillet radii than the cylinder can't form a clean torus.
+    let r_c = cyl.radius();
+    if radius <= tol_lin || radius >= r_c {
+        return Ok(None);
+    }
+
+    // 4) Project the cylinder origin onto the plane along axis_c. The
+    //    projection lands on the spine plane and on the cylinder axis line.
+    //    For axis_c ∥ n_p_inward, this is just `o_c ± n_p_inward * step`
+    //    where `step` solves `(o_c + n_p_inward * step) · n_p_inward = d`.
+    let o_c = cyl.origin();
+    let step = d_plane - n_p_inward.dot(Vec3::new(o_c.x(), o_c.y(), o_c.z()));
+    let p_axis_on_plane = o_c + n_p_inward * step;
+
+    // 5) The torus center sits one fillet radius "above" the spine plane
+    //    along the side opposite the plane material — i.e. `-n_p_inward`.
+    //    Its axis is the cylinder axis (kept as-is for parametric clarity).
+    let torus_center = p_axis_on_plane - n_p_inward * radius;
+    let major_radius = r_c + radius;
+    let minor_radius = radius;
+
+    // 6) Spine must span an arc to be useful. `Spine::from_single_edge`
+    //    measures CHORD length, which is zero for a closed-circle spine
+    //    (start vertex == end vertex), so we detect closure by walking the
+    //    spine's first edge directly.
+    let edges = spine.edges();
+    let is_closed_spine = if edges.len() == 1 {
+        let e = topo.edge(edges[0])?;
+        e.start() == e.end()
+    } else {
+        false
+    };
+    let spine_len = spine.length();
+    if !is_closed_spine && spine_len < tol_lin {
+        return Ok(None);
+    }
+
+    // 7) Build the torus. Use the `with_axis_and_ref_dir` constructor so the
+    //    torus inherits a u=0 reference direction matching the cylinder
+    //    frame — this lets us derive (u, v) parameters for sections cleanly.
+    let cyl_x = cyl.x_axis();
+    let torus = ToroidalSurface::with_axis_and_ref_dir(
+        torus_center,
+        major_radius,
+        minor_radius,
+        axis_c,
+        cyl_x,
+    )?;
+
+    // 8) Spine endpoints in 3D and corresponding cylinder u-parameters.
+    //    For a closed spine (full revolution) we span [u_start, u_start + 2π]
+    //    regardless of where the projection lands. Otherwise we disambiguate
+    //    the seam so u_end > u_start when the spine sweeps CCW.
+    let p_spine_start = spine.evaluate(topo, 0.0)?;
+    let u_start = ParametricSurface::project_point(cyl, p_spine_start).0;
+    let u_end = if is_closed_spine {
+        u_start + 2.0 * std::f64::consts::PI
+    } else {
+        let p_spine_end = spine.evaluate(topo, spine_len)?;
+        let u_end_raw = ParametricSurface::project_point(cyl, p_spine_end).0;
+        if u_end_raw > u_start {
+            u_end_raw
+        } else {
+            u_end_raw + 2.0 * std::f64::consts::PI
+        }
+    };
+
+    // 9) 3D contact curves.
+    //    - On the plane: a circle of radius `R = r_c + r` around the cylinder
+    //      axis on the spine plane.
+    //    - On the cylinder: a circle of radius `r_c` at axial offset `r`
+    //      (the height of the ball trajectory above the plane).
+    let z_axis_dir = -n_p_inward; // Direction "out of the plate" along the cylinder axis side.
+    let contact_plane_circle = brepkit_math::curves::Circle3D::with_axes(
+        p_axis_on_plane,
+        axis_c,
+        major_radius,
+        cyl_x,
+        cyl.y_axis(),
+    )?;
+    let contact_cyl_center = p_axis_on_plane + z_axis_dir * radius;
+    let contact_cyl_circle = brepkit_math::curves::Circle3D::with_axes(
+        contact_cyl_center,
+        axis_c,
+        r_c,
+        cyl_x,
+        cyl.y_axis(),
+    )?;
+
+    // Convert to arc NURBS over [u_start, u_end].
+    let contact_plane = circle_arc_to_nurbs(&contact_plane_circle, u_start, u_end)?;
+    let contact_cyl = circle_arc_to_nurbs(&contact_cyl_circle, u_start, u_end)?;
+
+    // 10) PCurves.
+    //     - On the plane (face_plane): use PlaneAdapter so UV matches what
+    //       the rest of the fillet pipeline expects for plane faces.
+    //     - On the cylinder (face_cyl): contact runs at constant axial
+    //       offset (v = `radius`, i.e. the height above the plane along the
+    //       cylinder's v parameter). PCurve is a horizontal Line2D in (u, v)
+    //       UV-space spanning u_start → u_end at v = `r`.
+    let v_cyl = cyl_v_at_point(cyl, contact_cyl_center);
+    // The plane contact is always an arc on a circle (the rolling-ball
+    // trajectory at z=0), so represent the pcurve as `Curve2D::Circle` in
+    // the plane's local frame. A line-segment pcurve would zero out for the
+    // closed-spine case (start and end project to the same point).
+    let pcurve_plane = {
+        let adapter = crate::builder_utils::PlaneAdapter::from_normal_and_d(n_p_inward, d_plane);
+        let (cu, cv) = adapter.project_point(p_axis_on_plane);
+        Curve2D::Circle(brepkit_math::curves2d::Circle2D::new(
+            brepkit_math::vec::Point2::new(cu, cv),
+            major_radius,
+        )?)
+    };
+    let pcurve_cyl = Curve2D::Line(Line2D::new(
+        brepkit_math::vec::Point2::new(u_start, v_cyl),
+        brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
+    )?);
+
+    // 11) Cross-sections at the spine endpoints. Each section's two contact
+    //     points and the rolling-ball center sit on a small circle of the
+    //     torus tube — they share the section's `u` and span the active `v`
+    //     quadrant from plane (v=3π/2) to cylinder (v=π).
+    let p_plane_at = |u: f64| contact_plane_circle.evaluate(u);
+    let p_cyl_at = |u: f64| contact_cyl_circle.evaluate(u);
+    let center_at = |u: f64| {
+        // Ball trajectory: same circle as `contact_plane_circle` but lifted
+        // to the height of the cylinder contact (axial offset `r`).
+        contact_plane_circle.evaluate(u) + z_axis_dir * radius
+    };
+    let section_start = CircSection {
+        p1: p_plane_at(u_start),
+        p2: p_cyl_at(u_start),
+        center: center_at(u_start),
+        radius,
+        uv1: (u_start, v_cyl), // unused for plane
+        uv2: (u_start, v_cyl),
+        t: 0.0,
+    };
+    let section_end = CircSection {
+        p1: p_plane_at(u_end),
+        p2: p_cyl_at(u_end),
+        center: center_at(u_end),
+        radius,
+        uv1: (u_end, v_cyl),
+        uv2: (u_end, v_cyl),
+        t: 1.0,
+    };
+
+    let stripe = Stripe {
+        spine: spine.clone(),
+        surface: FaceSurface::Torus(torus),
+        pcurve1: pcurve_plane,
+        pcurve2: pcurve_cyl,
+        contact1: contact_plane,
+        contact2: contact_cyl,
+        face1: face_plane,
+        face2: face_cyl,
+        sections: vec![section_start, section_end],
+    };
+    Ok(Some(StripeResult {
+        stripe,
+        new_edges: Vec::new(),
+    }))
+}
+
+/// Recover the cylinder's axial v-parameter for a 3D point known to lie on
+/// the cylinder lateral.
+fn cyl_v_at_point(cyl: &brepkit_math::surfaces::CylindricalSurface, p: Point3) -> f64 {
+    let axis = cyl.axis();
+    let to_p = p - cyl.origin();
+    axis.dot(to_p)
 }
 
 /// Fillet between a plane and a cone.
@@ -496,6 +702,113 @@ pub fn cylinder_cylinder_fillet(
 ) -> Option<StripeResult> {
     // TODO: implement cylinder-cylinder fillet
     None
+}
+
+/// Build a rational quadratic NURBS for an arc on a `Circle3D` from
+/// `t_start` to `t_end` (radians).
+///
+/// Decomposes the arc span into quarter-pi pieces; each piece becomes one
+/// rational quadratic Bezier with weight `cos(half_angle)` on the off-curve
+/// middle control point. The result is geometrically exact for circles
+/// (unlike the chord-only approximation used by `nurbs_line` for short
+/// arcs).
+///
+/// Inlined here to keep `crates/blend` from picking up a dependency on
+/// `brepkit-geometry`. The geometry crate has the same algorithm in
+/// `convert::curve_to_nurbs::circle_to_nurbs`; consolidating both into the
+/// math layer is a follow-up.
+fn circle_arc_to_nurbs(
+    circle: &brepkit_math::curves::Circle3D,
+    t_start: f64,
+    t_end: f64,
+) -> Result<brepkit_math::nurbs::curve::NurbsCurve, BlendError> {
+    use std::f64::consts::FRAC_PI_2;
+
+    let span = t_end - t_start;
+    if span.abs() < 1e-15 {
+        return Err(BlendError::Math(brepkit_math::MathError::ZeroVector));
+    }
+
+    let n_arcs = ((span.abs() / FRAC_PI_2).ceil() as usize).max(1);
+    #[allow(clippy::cast_precision_loss)]
+    let delta = span / n_arcs as f64;
+
+    let n_cps = 2 * n_arcs + 1;
+    let mut cps: Vec<Point3> = Vec::with_capacity(n_cps);
+    let mut weights: Vec<f64> = Vec::with_capacity(n_cps);
+
+    let mut knots: Vec<f64> = Vec::with_capacity(2 * n_arcs + 5);
+    knots.push(0.0);
+    knots.push(0.0);
+    knots.push(0.0);
+    for i in 1..n_arcs {
+        #[allow(clippy::cast_precision_loss)]
+        let knot = i as f64 / n_arcs as f64;
+        knots.push(knot);
+        knots.push(knot);
+    }
+    knots.push(1.0);
+    knots.push(1.0);
+    knots.push(1.0);
+
+    for arc_idx in 0..n_arcs {
+        #[allow(clippy::cast_precision_loss)]
+        let t0 = t_start + arc_idx as f64 * delta;
+        let t1 = t0 + delta;
+        let half_angle = delta * 0.5;
+        let r = circle.radius();
+
+        let p0 = circle.evaluate(t0);
+        let p1 = circle.evaluate(t1);
+        // Tangent at endpoints, scaled by `r` so the segment-segment
+        // intersection lands at the off-curve control point.
+        let tan0 = circle.tangent(t0) * r;
+        let tan1 = circle.tangent(t1) * r;
+        let p_mid = tangent_intersection(p0, tan0, p1, tan1);
+
+        let w_mid = half_angle.abs().cos();
+        if arc_idx == 0 {
+            cps.push(p0);
+            weights.push(1.0);
+        }
+        cps.push(p_mid);
+        weights.push(w_mid);
+        cps.push(p1);
+        weights.push(1.0);
+    }
+
+    Ok(brepkit_math::nurbs::curve::NurbsCurve::new(
+        2, knots, cps, weights,
+    )?)
+}
+
+/// Intersect two parametric rays `p0 + s·d0`, `p1 + t·d1` and return the
+/// 3D point. Falls back to the midpoint when the rays are near-parallel,
+/// which matches the round-trip behavior of `circle_arc_to_nurbs` for
+/// degenerate inputs.
+fn tangent_intersection(p0: Point3, d0: Vec3, p1: Point3, d1: Vec3) -> Point3 {
+    let rhs = p1 - p0;
+    let cross = d0.cross(d1);
+    let cx = cross.x().abs();
+    let cy = cross.y().abs();
+    let cz = cross.z().abs();
+    let (a00, a01, b0, a10, a11, b1) = if cz >= cx && cz >= cy {
+        (d0.x(), -d1.x(), rhs.x(), d0.y(), -d1.y(), rhs.y())
+    } else if cy >= cx {
+        (d0.x(), -d1.x(), rhs.x(), d0.z(), -d1.z(), rhs.z())
+    } else {
+        (d0.y(), -d1.y(), rhs.y(), d0.z(), -d1.z(), rhs.z())
+    };
+    let det = a00 * a11 - a01 * a10;
+    if det.abs() < 1e-30 {
+        return Point3::new(
+            (p0.x() + p1.x()) * 0.5,
+            (p0.y() + p1.y()) * 0.5,
+            (p0.z() + p1.z()) * 0.5,
+        );
+    }
+    let s = (b0 * a11 - b1 * a01) / det;
+    p0 + d0 * s
 }
 
 #[cfg(test)]

--- a/crates/operations/tests/blend_integration.rs
+++ b/crates/operations/tests/blend_integration.rs
@@ -8,9 +8,11 @@
 
 use brepkit_operations::blend_ops::{chamfer_distance_angle, chamfer_v2, fillet_v2};
 use brepkit_operations::measure::solid_volume;
-use brepkit_operations::primitives::make_box;
+use brepkit_operations::primitives::{make_box, make_cylinder};
 use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::explorer::{solid_edges, solid_faces};
+use brepkit_topology::face::FaceSurface;
 
 const BOX_VOLUME: f64 = 1000.0; // 10 x 10 x 10
 
@@ -144,4 +146,60 @@ fn fillet_empty_edges_error() {
 
     let err = fillet_v2(&mut topo, solid, &[], 1.0);
     assert!(err.is_err(), "empty edges should return an error");
+}
+
+/// Plane-cylinder fillet on a primitive cylinder. The bottom-cap circle
+/// edge sits where the plane (cap) meets the cylinder lateral; the analytic
+/// dispatcher should produce an exact toroidal fillet face for the convex
+/// "post on plate" geometry.
+#[test]
+fn fillet_cylinder_base_circle_produces_torus() {
+    let mut topo = Topology::new();
+    // Cylinder of radius 2, height 4 — convex base circle is the spine.
+    let solid = make_cylinder(&mut topo, 2.0, 4.0).unwrap();
+
+    // The two `EdgeCurve::Circle` edges on a primitive cylinder are the top
+    // and bottom rims; pick whichever the explorer surfaces first.
+    let circle_edges: Vec<_> = solid_edges(&topo, solid)
+        .unwrap()
+        .into_iter()
+        .filter(|&eid| matches!(topo.edge(eid).unwrap().curve(), EdgeCurve::Circle(_)))
+        .collect();
+    assert!(
+        !circle_edges.is_empty(),
+        "cylinder must have at least one circular rim edge"
+    );
+
+    let result = fillet_v2(&mut topo, solid, &circle_edges[..1], 0.3).unwrap();
+
+    assert!(
+        !result.succeeded.is_empty(),
+        "cylinder rim fillet must produce at least one stripe; failed = {:?}",
+        result.failed
+    );
+
+    // The new blend face should be exactly a Torus when the analytic path
+    // fired (vs a NURBS approximation when the walker fallback was used).
+    let new_faces: Vec<_> = solid_faces(&topo, result.solid).unwrap();
+    let torus = new_faces.iter().find_map(|&fid| {
+        if let FaceSurface::Torus(t) = topo.face(fid).unwrap().surface() {
+            Some(t.clone())
+        } else {
+            None
+        }
+    });
+    let torus = torus.expect("analytic fast path should produce a Torus face");
+
+    // Torus geometry: minor radius == fillet radius, major radius ==
+    // r_cylinder + r_fillet (convex case), axis parallel to cylinder axis.
+    assert!(
+        (torus.minor_radius() - 0.3).abs() < 1e-9,
+        "torus minor radius should equal fillet radius 0.3, got {}",
+        torus.minor_radius()
+    );
+    assert!(
+        (torus.major_radius() - 2.3).abs() < 1e-9,
+        "torus major radius should equal cylinder radius + fillet radius (2.3), got {}",
+        torus.major_radius()
+    );
 }


### PR DESCRIPTION
## Summary

\`plane_cylinder_fillet\` was a \`None\`-returning stub. Every plane-meets-cylinder fillet edge fell through to the walking engine and produced a NURBS approximation. OCCT's \`BRepFilletAPI_MakeFillet\` delivers an exact toroidal blend for the typical "post on plate" geometry; this PR wires up the same fast path.

## Geometry (perpendicular convex case)

When cylinder axis ∥ plane normal:
- Rolling-ball center traces a circle of radius \`r_c + r\` at height \`r\` above the spine plane.
- Blend surface is a torus: axis = cylinder axis, major = \`r_c + r\`, minor = \`r\`.
- Active tube quadrant \`v ∈ [π, 3π/2]\` covers the lower-inner section that touches the plane below and the cylinder lateral inward.

Returns \`None\` (walker fallback) for cases the analytic path doesn't yet cover:
- oblique plane (axis not parallel to plane normal),
- concave "hole through plate" geometry (cylinder face reversed),
- \`r >= r_c\` (would invert the major radius).

Both \`(Plane, Cylinder)\` and \`(Cylinder, Plane)\` orderings are wired through \`try_analytic_fillet\`; the second swaps the resulting Stripe's face/pcurve/contact assignments.

## Subtleties handled

- \`Spine::from_single_edge\` measures **chord** length, which is zero for closed-circle spines (start vertex == end vertex). Detects closure by inspecting the spine's first edge directly.
- \`Spine::is_closed()\` returns false for single-edge spines even when that edge is itself closed — required manual detection.
- The plane's pcurve must be \`Curve2D::Circle\` (not \`Line2D\`) for the closed-spine case — \`Line2D::new(zero_vec)\` returns \`ZeroVector\` and aborts.

## Helper inlined locally

\`circle_arc_to_nurbs\` is inlined in \`analytic.rs\` to keep \`brepkit-blend\` from picking up a \`brepkit-geometry\` dependency (would violate L2 layer boundaries). Consolidating with \`geometry::convert::curve_to_nurbs::circle_to_nurbs\` and pushing it to the math layer is a follow-up.

## Test plan

- New \`fillet_cylinder_base_circle_produces_torus\` integration test: builds a primitive cylinder (radius 2, height 4), fillets the rim with \`r=0.3\`, asserts the new face is \`FaceSurface::Torus\` with \`minor = 0.3\` and \`major = 2.3\`.
- \`cargo test --workspace\` — 0 failures.
- \`cargo clippy --all-targets -- -D warnings\` — clean.
- Layer boundaries unchanged.

## Follow-ups (out of scope)

- Move circle-arc → NURBS into the math layer so \`heal\`, \`blend\`, and \`geometry\` share one impl.
- Concave (hole through plate) plane-cylinder fillet: detect via \`face_cyl.is_reversed()\`, build torus with \`major = r_c - r\` and tube quadrant \`v ∈ [-π/2, 0]\`.
- Oblique plane-cylinder: spine becomes an ellipse, blend surface no longer a simple torus.
- \`plane_cone_fillet\` (similar shape).