### PR TITLE
feat(operations): concentric-sphere boolean shortcut

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -327,7 +327,7 @@ pub fn boolean(
             let coincident = (*ca_center - *cb_center).length() < tol.linear;
             if coincident {
                 if let Some(result) =
-                    concentric_sphere_shortcut(topo, op, *ca_center, *ra, *rb, tol)?
+                    concentric_sphere_shortcut(topo, op, a, b, *ca_center, *ra, *rb, tol)?
                 {
                     return Ok(result);
                 }
@@ -806,7 +806,6 @@ fn coaxial_cone_shortcut(
     Ok(Some(cone))
 }
 
-/// Build the world-frame transform that maps a primitive built in the
 /// Compute the concentric-sphere boolean for two spheres sharing a
 /// center. Returns `Ok(None)` when the shortcut doesn't apply (Cut, or
 /// degenerate radii).
@@ -814,9 +813,18 @@ fn coaxial_cone_shortcut(
 /// Sphere-sphere is simpler than the cylinder/cone analogues because
 /// there's no axial range — the result radius is just `max(r_a, r_b)`
 /// for Fuse and `min(r_a, r_b)` for Intersect.
+///
+/// The new sphere's tessellation density (segment count) is inherited from
+/// whichever input has a higher equatorial vertex count, so a
+/// 64-segment input never silently downgrades to a coarse default. This
+/// relies on `make_sphere` allocating exactly `segments` equatorial
+/// vertices and no pole vertices — see `crates/operations/src/primitives.rs`.
+#[allow(clippy::too_many_arguments)]
 fn concentric_sphere_shortcut(
     topo: &mut Topology,
     op: BooleanOp,
+    a: SolidId,
+    b: SolidId,
     center: Point3,
     r_a: f64,
     r_b: f64,
@@ -828,14 +836,9 @@ fn concentric_sphere_shortcut(
     let r_result = match op {
         BooleanOp::Fuse => r_a.max(r_b),
         BooleanOp::Intersect => {
-            let r = r_a.min(r_b);
-            // Strict overlap: spheres must intersect in a region of positive
-            // volume for the intersect to be non-degenerate. For concentric
-            // spheres, that's just `r > tol`.
-            if r <= tol.linear {
-                return Ok(None);
-            }
-            r
+            // Both r_a and r_b are guaranteed > tol.linear by the guard above,
+            // so `min(r_a, r_b)` is always positive here.
+            r_a.min(r_b)
         }
         // Cut(A, B) on concentric spheres yields a hollow ball when r_a > r_b;
         // empty when r_a ≤ r_b. The hollow-ball case needs an outer + inner
@@ -843,10 +846,19 @@ fn concentric_sphere_shortcut(
         BooleanOp::Cut => return Ok(None),
     };
 
-    // Match the segment count used by the existing concentric_spheres test
-    // corpus (32 segments) — gives ~5% volume accuracy on a unit sphere,
-    // which is what those tests expect.
-    let sphere = crate::primitives::make_sphere(topo, r_result, 32)?;
+    // Inherit segment count from whichever input was tessellated more finely.
+    // `make_sphere(r, n)` allocates exactly `n` equatorial vertices; because
+    // sphere primitives are fully describe by (center, radius), all vertices
+    // belong to that ring. Floor at 4 to satisfy `make_sphere`'s lower bound.
+    let segments_a = brepkit_topology::explorer::solid_vertices(topo, a)
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let segments_b = brepkit_topology::explorer::solid_vertices(topo, b)
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let segments = segments_a.max(segments_b).max(4);
+
+    let sphere = crate::primitives::make_sphere(topo, r_result, segments)?;
     if center.x().abs() > tol.linear
         || center.y().abs() > tol.linear
         || center.z().abs() > tol.linear
@@ -857,6 +869,7 @@ fn concentric_sphere_shortcut(
     Ok(Some(sphere))
 }
 
+/// Build the world-frame transform that maps a primitive built in the
 /// canonical Z-up local frame (origin at world origin, axis = +Z) to a
 /// world frame at `world_origin` with up-axis `axis` (assumed
 /// unit-length). Uses Rodrigues' rotation formula for the general case.

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -302,6 +302,37 @@ pub fn boolean(
                 return Ok(result);
             }
         }
+
+        // Concentric-sphere merge shortcut: when both A and B classify as
+        // Sphere with coincident centers, Fuse and Intersect collapse to a
+        // single sphere by radius algebra. Bypasses GFA's coplanar-pole
+        // handling (which currently routes spheres through the same SD
+        // pipeline that flakes on coaxial cylinders pre-#541).
+        //
+        // Cut intentionally falls through to GFA: subtracting an inner
+        // sphere from an outer one yields a hollow ball, whose topology
+        // (outer shell + inner shell) requires builder support beyond the
+        // single-sphere primitive used here.
+        if let (
+            Some(brepkit_algo::classifier::AnalyticClassifier::Sphere {
+                center: ca_center,
+                radius: ra,
+            }),
+            Some(brepkit_algo::classifier::AnalyticClassifier::Sphere {
+                center: cb_center,
+                radius: rb,
+            }),
+        ) = (ca.as_ref(), cb.as_ref())
+        {
+            let coincident = (*ca_center - *cb_center).length() < tol.linear;
+            if coincident {
+                if let Some(result) =
+                    concentric_sphere_shortcut(topo, op, *ca_center, *ra, *rb, tol)?
+                {
+                    return Ok(result);
+                }
+            }
+        }
     }
 
     // ── GFA pipeline ─────────────────────────────────────────────────
@@ -776,6 +807,56 @@ fn coaxial_cone_shortcut(
 }
 
 /// Build the world-frame transform that maps a primitive built in the
+/// Compute the concentric-sphere boolean for two spheres sharing a
+/// center. Returns `Ok(None)` when the shortcut doesn't apply (Cut, or
+/// degenerate radii).
+///
+/// Sphere-sphere is simpler than the cylinder/cone analogues because
+/// there's no axial range — the result radius is just `max(r_a, r_b)`
+/// for Fuse and `min(r_a, r_b)` for Intersect.
+fn concentric_sphere_shortcut(
+    topo: &mut Topology,
+    op: BooleanOp,
+    center: Point3,
+    r_a: f64,
+    r_b: f64,
+    tol: brepkit_math::tolerance::Tolerance,
+) -> Result<Option<SolidId>, crate::OperationsError> {
+    if r_a <= tol.linear || r_b <= tol.linear {
+        return Ok(None);
+    }
+    let r_result = match op {
+        BooleanOp::Fuse => r_a.max(r_b),
+        BooleanOp::Intersect => {
+            let r = r_a.min(r_b);
+            // Strict overlap: spheres must intersect in a region of positive
+            // volume for the intersect to be non-degenerate. For concentric
+            // spheres, that's just `r > tol`.
+            if r <= tol.linear {
+                return Ok(None);
+            }
+            r
+        }
+        // Cut(A, B) on concentric spheres yields a hollow ball when r_a > r_b;
+        // empty when r_a ≤ r_b. The hollow-ball case needs an outer + inner
+        // shell, which `make_sphere` doesn't produce — defer to GFA.
+        BooleanOp::Cut => return Ok(None),
+    };
+
+    // Match the segment count used by the existing concentric_spheres test
+    // corpus (32 segments) — gives ~5% volume accuracy on a unit sphere,
+    // which is what those tests expect.
+    let sphere = crate::primitives::make_sphere(topo, r_result, 32)?;
+    if center.x().abs() > tol.linear
+        || center.y().abs() > tol.linear
+        || center.z().abs() > tol.linear
+    {
+        let xform = brepkit_math::mat::Mat4::translation(center.x(), center.y(), center.z());
+        crate::transform::transform_solid(topo, sphere, &xform)?;
+    }
+    Ok(Some(sphere))
+}
+
 /// canonical Z-up local frame (origin at world origin, axis = +Z) to a
 /// world frame at `world_origin` with up-axis `axis` (assumed
 /// unit-length). Uses Rodrigues' rotation formula for the general case.

--- a/crates/operations/tests/concentric_spheres.rs
+++ b/crates/operations/tests/concentric_spheres.rs
@@ -95,6 +95,54 @@ fn concentric_spheres_different_radii_fuse() {
     assert!(approx_eq(got, expected, 0.03));
 }
 
+#[test]
+fn concentric_spheres_different_radii_intersect_collapses_to_inner() {
+    let mut topo = Topology::default();
+    let outer = sphere_at(&mut topo, 0.0, 0.0, 0.0, 3.0);
+    let inner = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.5);
+    let r = boolean(&mut topo, BooleanOp::Intersect, outer, inner).unwrap();
+    // Intersection of concentric spheres == smaller sphere.
+    let expected = sphere_volume(1.5);
+    let got = vol(&topo, r);
+    assert!(
+        approx_eq(got, expected, 0.05),
+        "concentric intersect should collapse to inner sphere: got {got:.3}, expected {expected:.3}"
+    );
+}
+
+#[test]
+fn concentric_spheres_at_offset_center_fuse() {
+    // Verify the shortcut handles a non-origin shared center: both spheres
+    // translated to (5, -2, 7) before the boolean.
+    let mut topo = Topology::default();
+    let outer = sphere_at(&mut topo, 5.0, -2.0, 7.0, 2.0);
+    let inner = sphere_at(&mut topo, 5.0, -2.0, 7.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, outer, inner).unwrap();
+    let expected = sphere_volume(2.0);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}
+
+#[test]
+fn non_concentric_spheres_fuse_does_not_use_shortcut() {
+    // When centers don't coincide, the shortcut must NOT fire — the result
+    // must include the union geometry (lens-shaped intersection lobe).
+    // Two unit spheres offset by 1 along x: the union has volume
+    //   2·V_sphere(1) - V_lens
+    // where V_lens is the small intersection. Roughly: 2·(4π/3) - small ≈ 8.38 - 0.1 ≈ 8.28.
+    let mut topo = Topology::default();
+    let a = sphere_at(&mut topo, 0.0, 0.0, 0.0, 1.0);
+    let b = sphere_at(&mut topo, 1.0, 0.0, 0.0, 1.0);
+    let r = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let got = vol(&topo, r);
+    let single = sphere_volume(1.0); // ≈ 4.189
+    // The union should be more than one sphere but less than two.
+    assert!(
+        got > single * 1.2 && got < single * 2.0,
+        "non-concentric union should be between 1.2× and 2× a single sphere: got {got:.3}"
+    );
+}
+
 // ── 3. Sub-tolerance shifted center (should be SD) ────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a Fuse/Intersect shortcut for **concentric spheres** to the boolean dispatcher, mirroring the existing \`coaxial_cylinder_shortcut\`, \`coaxial_cone_shortcut\`, and \`box_pair_shortcut\` patterns landed in PR #541.

## Behavior

When both A and B classify as \`AnalyticClassifier::Sphere\` and their centers coincide within linear tolerance:

| Op | Result |
|----|--------|
| **Fuse** | radius = \`max(r_a, r_b)\` |
| **Intersect** | radius = \`min(r_a, r_b)\` (rejected if degenerate) |
| **Cut** | falls through to GFA (a hollow ball needs outer + inner shells, beyond what \`make_sphere\` produces) |

The shortcut returns a fresh primitive at the shared center, so chained ops see canonical 32-face sphere topology rather than residual GFA splits.

## Why this matters

Sphere-sphere booleans currently go through the same SD-detection pipeline as cylinder/cone, which has documented coplanar / coincident-pole gaps. The shortcut sidesteps those entirely for the most common concentric case.

## Test plan

8 concentric-sphere tests pass (5 existing + 3 new):

- \`concentric_spheres_different_radii_intersect_collapses_to_inner\` — verifies the new Intersect path reduces to the inner sphere.
- \`concentric_spheres_at_offset_center_fuse\` — non-origin shared center; confirms the translation step works.
- \`non_concentric_spheres_fuse_does_not_use_shortcut\` — guardrail that verifies off-center pairs still route through GFA and produce the lens-shaped union (volume between 1.2× and 2.0× a single sphere).

\`cargo test --workspace\` — 0 failures. \`cargo clippy --all-targets -- -D warnings\` — clean. Layer boundaries unchanged.

## Follow-ups (out of scope)

- Cut on concentric spheres: implement directly as a hollow-ball builder (outer shell at \`r_outer\`, inner shell at \`r_inner\`, both spherical) when \`r_outer > r_inner\`. Currently delegates to GFA, which may not handle this cleanly either.
- Coaxial-torus shortcut: same axis + same major radius collapses to a single torus by minor-radius algebra. Same family as this PR.