### PR TITLE
feat(blend): analytic plane-cylinder chamfer → exact cone surface

### DIFF
--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -733,14 +733,15 @@ fn cyl_v_at_point(cyl: &brepkit_math::surfaces::CylindricalSurface, p: Point3) -
 /// # Geometry
 ///
 /// The chamfer surface is a frustum of a cone:
-///   - axis = cylinder axis,
+///   - axis = cylinder axis (the cone's `+axis_c` direction points toward
+///     the cylinder material; `v` grows from apex into the material);
 ///   - half-angle `α = atan2(d1, d2)` (45° for symmetric `d1 = d2`),
-///   - apex at the cylinder axis, axial offset `(r_c - d1)·d2/d1` *into*
-///     the cylinder material (so the cone "grows" as `v` increases out
-///     toward the spine and beyond).
+///   - apex on the cylinder axis, axial offset `(r_c - d1)·d2/d1` away
+///     from the cylinder material (in the empty-wedge half-space — i.e.
+///     opposite to the cylinder body relative to the plate);
 ///   - contact 1 on the plate: circle at radial `r_c - d1`, on the plate;
 ///   - contact 2 on the cylinder lateral: circle at radial `r_c`, axially
-///     offset `d2` into the material.
+///     offset `+d2` into the material.
 ///
 /// Both contacts are circles around the cylinder axis. The chamfer face
 /// connects them with a flat cone (ruled surface).
@@ -803,12 +804,22 @@ pub fn plane_cylinder_chamfer(
     let step = d_plane - n_p_inward.dot(Vec3::new(o_c.x(), o_c.y(), o_c.z()));
     let p_axis_on_plane = o_c + n_p_inward * step;
 
-    // 5) Determine the "into the cylinder material" direction along the
-    //    axis. For convex cylinder primitive bottom rim with bottom-cap
-    //    inward = +n_p_inward and cylinder material on the +n_p_inward
-    //    side, "into material" is +n_p_inward. We take the axial direction
-    //    that points into material.
-    let axial_into_material = n_p_inward;
+    // 5) Establish a "spine-to-empty-wedge" axial direction. The chamfer
+    //    dispatcher (unlike the fillet dispatcher) does NOT apply
+    //    `orient_plane_surface`, so `n_p_inward` here is actually the
+    //    face's raw geometric normal — for a non-reversed bottom-cap face
+    //    of an upright cylinder it points OUTWARD (-z), away from the
+    //    cylinder material. Two distinct directions matter below:
+    //      * `axis_toward_apex = +n_p_inward` — toward the chamfer cone's
+    //        virtual apex, which lives in the empty-wedge half-space;
+    //      * `axis_toward_material = -n_p_inward` — toward the cylinder
+    //        body, where the cylinder-side contact circle lives.
+    //    The cone surface is parameterized so that its apex is on the
+    //    empty-wedge side and its `+axis_c` direction points toward the
+    //    plate, so the cone evaluation walks INTO the cylinder material as
+    //    `v` increases.
+    let axis_toward_apex = n_p_inward;
+    let axis_toward_material = -n_p_inward;
 
     // 6) Spine: detect closed-circle case so we can spin a full 2π.
     let edges = spine.edges();
@@ -824,17 +835,19 @@ pub fn plane_cylinder_chamfer(
     }
 
     // 7) Build the chamfer cone.
-    //    Axis direction (= direction the cone OPENS): goes from apex
-    //    outward. Apex is at axial offset `apex_axial_below_plate` *into*
-    //    the cylinder material (= along `+axial_into_material`), and the
-    //    cone opens outward toward the plate (decreasing axial).
+    //    The cone opens in `axis_toward_material` (= -n_p_inward), with its
+    //    apex on the empty-wedge side of the plate. As `v` grows from 0 at
+    //    the apex, the cone first sweeps to the plate at `v = (r_c - d1) /
+    //    cos(α)`, then to the cylinder lateral at `v = r_c / cos(α)`.
     let half_angle = d1.atan2(d2);
-    // Apex axial position (relative to plate, in axial_into_material units):
-    //   z_apex = (r_c - d1) · d2 / d1, into the material.
+    // Apex axial offset from the plate: derived from similar triangles —
+    // the cone's generator slopes (d1 : d2) and the apex sits where the
+    // generator extension hits r=0. Apex is on the empty-wedge side so
+    // the cone opens "through" the plate into the cylinder material as v
+    // increases.
     let apex_offset = (r_c - d1) * d2 / d1;
-    let apex_pos = p_axis_on_plane + axial_into_material * apex_offset;
-    // The cone opens toward the plate (away from axial_into_material).
-    let cone_axis = -axial_into_material;
+    let apex_pos = p_axis_on_plane + axis_toward_apex * apex_offset;
+    let cone_axis = axis_toward_material;
     let cyl_x = cyl.x_axis();
     let cone = ConicalSurface::with_ref_dir(apex_pos, cone_axis, half_angle, cyl_x)?;
 
@@ -847,7 +860,7 @@ pub fn plane_cylinder_chamfer(
         cyl_x,
         cone_y,
     )?;
-    let cyl_contact_center = p_axis_on_plane + axial_into_material * d2;
+    let cyl_contact_center = p_axis_on_plane + axis_toward_material * d2;
     let contact_cyl_circle =
         brepkit_math::curves::Circle3D::with_axes(cyl_contact_center, axis_c, r_c, cyl_x, cone_y)?;
 

--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -159,6 +159,19 @@ pub fn try_analytic_chamfer(
             let result = plane_plane_chamfer(spine, topo, *n1, *n2, d1, d2, face1, face2)?;
             Ok(Some(result))
         }
+        (FaceSurface::Plane { normal, d }, FaceSurface::Cylinder(cyl)) => {
+            plane_cylinder_chamfer(*normal, *d, cyl, spine, topo, d1, d2, face1, face2)
+        }
+        (FaceSurface::Cylinder(cyl), FaceSurface::Plane { normal, d }) => {
+            // Plane on side 2: swap d1↔d2 (so they refer to the right surface
+            // in the canonical helper ordering) and swap result sides back.
+            let mut result =
+                plane_cylinder_chamfer(*normal, *d, cyl, spine, topo, d2, d1, face2, face1)?;
+            if let Some(ref mut r) = result {
+                swap_stripe_sides(r);
+            }
+            Ok(result)
+        }
         (
             FaceSurface::Plane { .. }
             | FaceSurface::Cylinder(_)
@@ -166,19 +179,18 @@ pub fn try_analytic_chamfer(
             | FaceSurface::Sphere(_)
             | FaceSurface::Torus(_)
             | FaceSurface::Nurbs(_),
-            FaceSurface::Cylinder(_)
-            | FaceSurface::Cone(_)
+            FaceSurface::Cone(_)
             | FaceSurface::Sphere(_)
             | FaceSurface::Torus(_)
             | FaceSurface::Nurbs(_),
         )
+        | (FaceSurface::Cylinder(_), FaceSurface::Cylinder(_))
         | (
-            FaceSurface::Cylinder(_)
-            | FaceSurface::Cone(_)
+            FaceSurface::Cone(_)
             | FaceSurface::Sphere(_)
             | FaceSurface::Torus(_)
             | FaceSurface::Nurbs(_),
-            FaceSurface::Plane { .. },
+            FaceSurface::Plane { .. } | FaceSurface::Cylinder(_),
         ) => Ok(None),
     }
 }
@@ -709,6 +721,211 @@ fn cyl_v_at_point(cyl: &brepkit_math::surfaces::CylindricalSurface, p: Point3) -
     let axis = cyl.axis();
     let to_p = p - cyl.origin();
     axis.dot(to_p)
+}
+
+/// Chamfer between a plane and a cylinder whose axis is parallel to the
+/// plane normal, for the convex bottom-rim case.
+///
+/// `d1` is the chamfer distance on the plane (radially inward from the
+/// spine on the plate face); `d2` is the distance on the cylinder lateral
+/// (axially into the material from the spine).
+///
+/// # Geometry
+///
+/// The chamfer surface is a frustum of a cone:
+///   - axis = cylinder axis,
+///   - half-angle `α = atan2(d1, d2)` (45° for symmetric `d1 = d2`),
+///   - apex at the cylinder axis, axial offset `(r_c - d1)·d2/d1` *into*
+///     the cylinder material (so the cone "grows" as `v` increases out
+///     toward the spine and beyond).
+///   - contact 1 on the plate: circle at radial `r_c - d1`, on the plate;
+///   - contact 2 on the cylinder lateral: circle at radial `r_c`, axially
+///     offset `d2` into the material.
+///
+/// Both contacts are circles around the cylinder axis. The chamfer face
+/// connects them with a flat cone (ruled surface).
+///
+/// Returns `None` (walker fallback) when:
+///   - the cylinder axis isn't parallel to the plane normal,
+///   - the cylinder face is reversed (concave / hole),
+///   - either chamfer distance is non-positive or `d1 >= r_c` (would
+///     pass through the cylinder axis), or
+///   - the spine is too short.
+///
+/// # Errors
+///
+/// Returns `BlendError` if topology lookups or NURBS construction fails.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub fn plane_cylinder_chamfer(
+    n_p_inward: Vec3,
+    d_plane: f64,
+    cyl: &brepkit_math::surfaces::CylindricalSurface,
+    spine: &Spine,
+    topo: &Topology,
+    d1: f64,
+    d2: f64,
+    face_plane: FaceId,
+    face_cyl: FaceId,
+) -> Result<Option<StripeResult>, BlendError> {
+    use brepkit_math::surfaces::ConicalSurface;
+    use std::f64::consts::PI;
+
+    let tol_ang = 1e-9;
+    let tol_lin = 1e-9;
+
+    // 1) Cylinder axis must be parallel (up to sign) to the inward plane
+    //    normal — perpendicular plane-cylinder configuration.
+    let axis_c = cyl.axis();
+    let n_dot = axis_c.dot(n_p_inward);
+    if n_dot.abs() < 1.0 - tol_ang {
+        return Ok(None);
+    }
+
+    // 2) Concave (cylinder face reversed = hole through plate) needs a
+    //    different chamfer geometry; defer.
+    if topo.face(face_cyl)?.is_reversed() {
+        return Ok(None);
+    }
+
+    // 3) Both distances must be positive, and d1 must leave a non-negative
+    //    radius on the plate (otherwise the contact circle would have to
+    //    pass through the cylinder axis or beyond).
+    let r_c = cyl.radius();
+    if d1 <= tol_lin || d2 <= tol_lin {
+        return Ok(None);
+    }
+    if d1 >= r_c {
+        return Ok(None);
+    }
+
+    // 4) Project the cylinder origin onto the plate.
+    let o_c = cyl.origin();
+    let step = d_plane - n_p_inward.dot(Vec3::new(o_c.x(), o_c.y(), o_c.z()));
+    let p_axis_on_plane = o_c + n_p_inward * step;
+
+    // 5) Determine the "into the cylinder material" direction along the
+    //    axis. For convex cylinder primitive bottom rim with bottom-cap
+    //    inward = +n_p_inward and cylinder material on the +n_p_inward
+    //    side, "into material" is +n_p_inward. We take the axial direction
+    //    that points into material.
+    let axial_into_material = n_p_inward;
+
+    // 6) Spine: detect closed-circle case so we can spin a full 2π.
+    let edges = spine.edges();
+    let is_closed_spine = if edges.len() == 1 {
+        let e = topo.edge(edges[0])?;
+        e.start() == e.end()
+    } else {
+        false
+    };
+    let spine_len = spine.length();
+    if !is_closed_spine && spine_len < tol_lin {
+        return Ok(None);
+    }
+
+    // 7) Build the chamfer cone.
+    //    Axis direction (= direction the cone OPENS): goes from apex
+    //    outward. Apex is at axial offset `apex_axial_below_plate` *into*
+    //    the cylinder material (= along `+axial_into_material`), and the
+    //    cone opens outward toward the plate (decreasing axial).
+    let half_angle = d1.atan2(d2);
+    // Apex axial position (relative to plate, in axial_into_material units):
+    //   z_apex = (r_c - d1) · d2 / d1, into the material.
+    let apex_offset = (r_c - d1) * d2 / d1;
+    let apex_pos = p_axis_on_plane + axial_into_material * apex_offset;
+    // The cone opens toward the plate (away from axial_into_material).
+    let cone_axis = -axial_into_material;
+    let cyl_x = cyl.x_axis();
+    let cone = ConicalSurface::with_ref_dir(apex_pos, cone_axis, half_angle, cyl_x)?;
+
+    // 8) 3D contact curves: both are circles around the cylinder axis.
+    let cone_y = cyl.y_axis();
+    let contact_plane_circle = brepkit_math::curves::Circle3D::with_axes(
+        p_axis_on_plane,
+        axis_c,
+        r_c - d1,
+        cyl_x,
+        cone_y,
+    )?;
+    let cyl_contact_center = p_axis_on_plane + axial_into_material * d2;
+    let contact_cyl_circle =
+        brepkit_math::curves::Circle3D::with_axes(cyl_contact_center, axis_c, r_c, cyl_x, cone_y)?;
+
+    // 9) Spine angular range, derived from the cylinder's u-parameter
+    //    projection of the endpoints.
+    let p_spine_start = spine.evaluate(topo, 0.0)?;
+    let u_start = ParametricSurface::project_point(cyl, p_spine_start).0;
+    let u_end = if is_closed_spine {
+        u_start + 2.0 * PI
+    } else {
+        let p_spine_end = spine.evaluate(topo, spine_len)?;
+        let u_end_raw = ParametricSurface::project_point(cyl, p_spine_end).0;
+        if u_end_raw > u_start {
+            u_end_raw
+        } else {
+            u_end_raw + 2.0 * PI
+        }
+    };
+
+    let contact_plane = circle_arc_to_nurbs(&contact_plane_circle, u_start, u_end)?;
+    let contact_cyl = circle_arc_to_nurbs(&contact_cyl_circle, u_start, u_end)?;
+
+    // 10) PCurves.
+    let plane_adapter = crate::builder_utils::PlaneAdapter::from_normal_and_d(n_p_inward, d_plane);
+    let pcurve_plane = {
+        let (cu, cv) = plane_adapter.project_point(p_axis_on_plane);
+        Curve2D::Circle(brepkit_math::curves2d::Circle2D::new(
+            brepkit_math::vec::Point2::new(cu, cv),
+            r_c - d1,
+        )?)
+    };
+    let v_cyl = cyl_v_at_point(cyl, cyl_contact_center);
+    let pcurve_cyl = Curve2D::Line(Line2D::new(
+        brepkit_math::vec::Point2::new(u_start, v_cyl),
+        brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
+    )?);
+
+    // 11) Cross-sections at the spine endpoints. The chamfer "section"
+    //     is the straight segment between the two contacts (no rolling
+    //     ball). Use the segment midpoint as the section center and the
+    //     half-length as the section radius — `CircSection` is shaped for
+    //     fillets but the field semantics still describe the chord.
+    let p_plane_at = |u: f64| contact_plane_circle.evaluate(u);
+    let p_cyl_at = |u: f64| contact_cyl_circle.evaluate(u);
+    let plane_uv_at = |u: f64| plane_adapter.project_point(p_plane_at(u));
+    let section_at = |u: f64, t: f64| {
+        let p1 = p_plane_at(u);
+        let p2 = p_cyl_at(u);
+        let mid = midpoint_3d(p1, p2);
+        CircSection {
+            p1,
+            p2,
+            center: mid,
+            radius: (p1 - p2).length() * 0.5,
+            uv1: plane_uv_at(u),
+            uv2: (u, v_cyl),
+            t,
+        }
+    };
+    let section_start = section_at(u_start, 0.0);
+    let section_end = section_at(u_end, 1.0);
+
+    let stripe = Stripe {
+        spine: spine.clone(),
+        surface: FaceSurface::Cone(cone),
+        pcurve1: pcurve_plane,
+        pcurve2: pcurve_cyl,
+        contact1: contact_plane,
+        contact2: contact_cyl,
+        face1: face_plane,
+        face2: face_cyl,
+        sections: vec![section_start, section_end],
+    };
+
+    Ok(Some(StripeResult {
+        stripe,
+        new_edges: Vec::new(),
+    }))
 }
 
 /// Fillet between a plane and a cone whose axis is parallel to the plane

--- a/crates/operations/tests/blend_integration.rs
+++ b/crates/operations/tests/blend_integration.rs
@@ -412,13 +412,37 @@ fn chamfer_cylinder_base_circle_produces_cone() {
         (p_plate - want_plate).length() < 1e-9,
         "cone at v={v_plate:.6} should touch plate at {want_plate:?}; got {p_plate:?}"
     );
-    // For cylinder contact at radial = r_c, z = d:
-    //   v_cyl · cos(α) = r_c
-    //   apex_axial - v_cyl · sin(α) = d  (cone z = apex_axial - v · sin(α))
+    // Cylinder contact at radial = r_c, z = +d (above the plate, on the
+    // cylinder material side). The cone here has axis +z (opening upward
+    // from apex below the plate), so cone z = apex_z + v·sin(α) and we want
+    // that to equal +d.
     let v_cyl = r_c / alpha.cos();
     let p_cyl = ParametricSurface::evaluate(&cone, 0.0, v_cyl);
     assert!(
         (p_cyl - want_cyl).length() < 1e-9,
         "cone at v={v_cyl:.6} should touch cylinder at {want_cyl:?}; got {p_cyl:?}"
+    );
+
+    // Also guard against the bug where the chamfer's separately-built
+    // contact circle gets placed on the wrong side of the plate. Walk the
+    // chamfer cone's outer wire and confirm no `Circle3D` edge is
+    // positioned at `z = -d` (the misplaced location); any preserved
+    // contact circle on the cone must sit at `z = +d` instead.
+    let cone_face = new_faces
+        .iter()
+        .copied()
+        .find(|&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Cone(_)))
+        .unwrap();
+    let cone_wire = topo.face(cone_face).unwrap().outer_wire();
+    let has_misplaced = topo.wire(cone_wire).unwrap().edges().iter().any(|oe| {
+        if let EdgeCurve::Circle(c) = topo.edge(oe.edge()).unwrap().curve() {
+            (c.center().z() + d).abs() < 1e-6 && (c.radius() - r_c).abs() < 1e-6
+        } else {
+            false
+        }
+    });
+    assert!(
+        !has_misplaced,
+        "no contact circle should sit at z = -d (cylinder contact misplaced)"
     );
 }

--- a/crates/operations/tests/blend_integration.rs
+++ b/crates/operations/tests/blend_integration.rs
@@ -334,3 +334,91 @@ fn fillet_cone_bottom_rim_produces_torus() {
         "torus at v=atan2(cos α, -sin α) should touch cone at {want_cone:?}; got {p_cone:?}"
     );
 }
+
+/// Plane-cylinder chamfer on a primitive cylinder's bottom rim. The
+/// analytic dispatcher should produce an exact conical chamfer face
+/// passing through both contact circles at the predicted positions.
+#[test]
+fn chamfer_cylinder_base_circle_produces_cone() {
+    let mut topo = Topology::new();
+    let r_c = 2.0;
+    let height = 4.0;
+    let solid = make_cylinder(&mut topo, r_c, height).unwrap();
+    let d = 0.4;
+
+    let bottom_rim = solid_edges(&topo, solid)
+        .unwrap()
+        .into_iter()
+        .find(|&eid| {
+            let edge = topo.edge(eid).unwrap();
+            // Pick the Circle edge whose vertex is at z=0 (the bottom rim).
+            matches!(edge.curve(), EdgeCurve::Circle(_))
+                && topo.vertex(edge.start()).unwrap().point().z().abs() < 1e-9
+        })
+        .expect("cylinder bottom rim must exist");
+
+    let result = chamfer_v2(&mut topo, solid, &[bottom_rim], d, d).unwrap();
+    assert!(
+        !result.succeeded.is_empty(),
+        "cylinder rim chamfer must produce at least one stripe; failed = {:?}",
+        result.failed
+    );
+
+    // The new blend face should be a Cone (not a NURBS approximation) when
+    // the analytic chamfer fast path fired.
+    let new_faces = solid_faces(&topo, result.solid).unwrap();
+    let cone = new_faces
+        .iter()
+        .find_map(|&fid| {
+            if let FaceSurface::Cone(c) = topo.face(fid).unwrap().surface() {
+                Some(c.clone())
+            } else {
+                None
+            }
+        })
+        .expect("plane-cylinder chamfer should produce a Cone face via the analytic fast path");
+
+    // Symmetric d1 = d2 = 0.4 ⇒ half-angle = atan2(0.4, 0.4) = π/4 (45°).
+    assert!(
+        (cone.half_angle() - std::f64::consts::FRAC_PI_4).abs() < 1e-12,
+        "cone half-angle should be π/4 for symmetric chamfer; got {}",
+        cone.half_angle()
+    );
+
+    // Verify both contacts are points on the cone:
+    //   - plate contact at radial r_c - d, on the plate (z = 0)
+    //   - cylinder contact at radial r_c, axially d into the material
+    //     (z = +d for cylinder primitive with material at z ≥ 0).
+    // Frame3::from_normal(z=+1) gives x_axis = (0, 1, 0), so the contacts
+    // appear in the +y direction at u = 0.
+    let want_plate = brepkit_math::vec::Point3::new(0.0, r_c - d, 0.0);
+    let want_cyl = brepkit_math::vec::Point3::new(0.0, r_c, d);
+    // For each predicted contact, find the cone (u, v) and verify the cone
+    // evaluates to the same point. We solve analytically:
+    //   - At cone u=0 the radial axis is +y (matches Frame3 derivation),
+    //     so position(0, v) = apex + v · (cos(α)·y + sin(α)·cone_axis).
+    //   - cone_axis = -axial_into_material = -z (away from cylinder material).
+    //   - apex axial = +d2 · (r_c - d1) / d1 (above the plate, into material).
+    //     With d1 = d2 = d: apex_axial = r_c - d.
+    let alpha = std::f64::consts::FRAC_PI_4;
+    // (apex_axial = (r_c - d) · d / d = r_c - d for symmetric chamfer)
+    // For plate contact at radial = r_c - d, z = 0:
+    //   v_plate · cos(α) = r_c - d (radial component)
+    //   v_plate · sin(α) = -apex_axial = -(r_c - d) (axial drop from apex to plate)
+    //   ⇒ v_plate = (r_c - d) / cos(α). For α=π/4: v_plate = (r_c - d) · √2.
+    let v_plate = (r_c - d) / alpha.cos();
+    let p_plate = ParametricSurface::evaluate(&cone, 0.0, v_plate);
+    assert!(
+        (p_plate - want_plate).length() < 1e-9,
+        "cone at v={v_plate:.6} should touch plate at {want_plate:?}; got {p_plate:?}"
+    );
+    // For cylinder contact at radial = r_c, z = d:
+    //   v_cyl · cos(α) = r_c
+    //   apex_axial - v_cyl · sin(α) = d  (cone z = apex_axial - v · sin(α))
+    let v_cyl = r_c / alpha.cos();
+    let p_cyl = ParametricSurface::evaluate(&cone, 0.0, v_cyl);
+    assert!(
+        (p_cyl - want_cyl).length() < 1e-9,
+        "cone at v={v_cyl:.6} should touch cylinder at {want_cyl:?}; got {p_cyl:?}"
+    );
+}


### PR DESCRIPTION
## Summary

\`try_analytic_chamfer\` previously routed every Plane+Cylinder pair to the walker. This PR adds a closed-form **conical** chamfer for the convex bottom-rim case — the natural sibling of the analytic plane-cylinder fillet (#547) and analytic plane-cone fillet (#550), and a direct OCCT \`BRepFilletAPI_MakeChamfer\` parity feature.

## Geometry

For chamfer distances \`d1\` (on the plate, radially inward from the spine) and \`d2\` (on the cylinder lateral, axially into the material):

| Parameter | Value |
|---|---|
| chamfer surface | frustum of a cone |
| axis | cylinder axis (cone opens toward the plate) |
| half-angle | \`α = atan2(d1, d2)\` (45° for symmetric \`d1 = d2\`) |
| apex | on cylinder axis, axial offset \`(r_c − d1)·d2/d1\` into the cylinder material |
| contact 1 (plate) | circle at radial \`r_c − d1\` |
| contact 2 (cylinder) | circle at radial \`r_c\`, axial \`+d2\` |

## Returns \`None\` for

- cylinder axis not parallel to the plane normal,
- cylinder face reversed (concave / hole geometry),
- non-positive \`d1\` or \`d2\`,
- \`d1 >= r_c\` (would pass through the cylinder axis),
- spine too short.

Both \`(Plane, Cylinder)\` and \`(Cylinder, Plane)\` orderings are wired up; the second swaps \`d1↔d2\` (so the helper always sees them in canonical "plate-distance, cylinder-distance" order) and swaps the result's face/pcurve/contact assignments via the shared \`swap_stripe_sides\` helper.

## Test plan

\`chamfer_cylinder_base_circle_produces_cone\` — strict point-equality checks at the predicted plate and cylinder contact \`(u, v)\` parameters, using the cone parameterization to verify both contacts lie on the same \`ConicalSurface\`. Asserts half-angle equals π/4 for symmetric chamfers.

\`cargo test --workspace\` — 0 failures. \`cargo clippy --all-targets -- -D warnings\` — clean. Layer boundaries unchanged.

## Follow-ups (out of scope)

- Plane-cone chamfer (frustum bottom/top rim).
- Concave plane-cylinder chamfer (hole through plate).