### PR TITLE
feat(operations): coaxial-torus boolean shortcut

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -333,6 +333,42 @@ pub fn boolean(
                 }
             }
         }
+
+        // Coaxial-torus merge shortcut: when both A and B classify as Torus
+        // with the same center, axis (parallel/antiparallel), and major
+        // radius, Fuse and Intersect collapse to a single torus by minor
+        // radius algebra. Same family as the concentric-sphere shortcut
+        // above; sidesteps GFA's torus same-domain handling for the
+        // common shared-major case.
+        if let (
+            Some(brepkit_algo::classifier::AnalyticClassifier::Torus {
+                center: ca_center,
+                axis: aa,
+                major_radius: maj_a,
+                minor_radius: min_a,
+            }),
+            Some(brepkit_algo::classifier::AnalyticClassifier::Torus {
+                center: cb_center,
+                axis: ab,
+                major_radius: maj_b,
+                minor_radius: min_b,
+            }),
+        ) = (ca.as_ref(), cb.as_ref())
+        {
+            let coincident = (*ca_center - *cb_center).length() < tol.linear;
+            // Allow either axis orientation — a torus with axis +z is the
+            // same surface as the same torus with axis -z (the small-circle
+            // sweep is symmetric about the central plane).
+            let coaxial = aa.dot(*ab).abs() > 1.0 - tol.angular;
+            let same_major = (maj_a - maj_b).abs() < tol.linear;
+            if coincident && coaxial && same_major {
+                if let Some(result) = coaxial_torus_shortcut(
+                    topo, op, a, b, *ca_center, *aa, *maj_a, *min_a, *min_b, tol,
+                )? {
+                    return Ok(result);
+                }
+            }
+        }
     }
 
     // ── GFA pipeline ─────────────────────────────────────────────────
@@ -867,6 +903,67 @@ fn concentric_sphere_shortcut(
         crate::transform::transform_solid(topo, sphere, &xform)?;
     }
     Ok(Some(sphere))
+}
+
+/// Compute the coaxial-torus boolean for two tori sharing center, axis,
+/// and major radius. Returns `Ok(None)` when the shortcut doesn't apply
+/// (Cut, or degenerate radii / overlap).
+///
+/// Like the concentric-sphere shortcut, the result tessellation density
+/// is inherited from the higher-quality input so a 64-segment input
+/// torus never silently downgrades.
+#[allow(clippy::too_many_arguments)]
+fn coaxial_torus_shortcut(
+    topo: &mut Topology,
+    op: BooleanOp,
+    a: SolidId,
+    b: SolidId,
+    center: Point3,
+    axis: Vec3,
+    major_radius: f64,
+    minor_a: f64,
+    minor_b: f64,
+    tol: brepkit_math::tolerance::Tolerance,
+) -> Result<Option<SolidId>, crate::OperationsError> {
+    if minor_a <= tol.linear || minor_b <= tol.linear || major_radius <= tol.linear {
+        return Ok(None);
+    }
+    let minor_result = match op {
+        BooleanOp::Fuse => minor_a.max(minor_b),
+        BooleanOp::Intersect => {
+            // Both minors are guaranteed > tol by the guard above.
+            minor_a.min(minor_b)
+        }
+        // Cut on coaxial tori with shared major produces a hollow torus
+        // (outer + inner small-circle shells) when minor_a > minor_b.
+        // `make_torus` doesn't build that topology — defer to GFA.
+        BooleanOp::Cut => return Ok(None),
+    };
+    if minor_result >= major_radius {
+        // make_torus rejects self-intersecting tori (minor >= major).
+        return Ok(None);
+    }
+
+    // Inherit segment count from the higher-quality input. `make_torus`
+    // accepts a `segments` param controlling u-direction discretization.
+    // We'd ideally extract this from each input solid's vertex count, but
+    // unlike make_sphere torus topology has internal seam vertices that
+    // make the relationship less clean. Approximate by the larger vertex
+    // count.
+    let segments_a = brepkit_topology::explorer::solid_vertices(topo, a)
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let segments_b = brepkit_topology::explorer::solid_vertices(topo, b)
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let segments = segments_a.max(segments_b).max(8);
+
+    // Build a fresh torus at the origin then transform to the shared
+    // center / axis. `make_torus` builds with axis = +z by default.
+    let torus = crate::primitives::make_torus(topo, major_radius, minor_result, segments)?;
+    let xform = xform_from_canonical_z(center, axis, tol);
+    crate::transform::transform_solid(topo, torus, &xform)?;
+    Ok(Some(torus))
 }
 
 /// Build the world-frame transform that maps a primitive built in the

--- a/crates/operations/tests/coaxial_torus.rs
+++ b/crates/operations/tests/coaxial_torus.rs
@@ -117,3 +117,71 @@ fn torus_opposite_axis_fuse() {
     let got = vol(&topo, r);
     assert!(approx_eq(got, expected, 0.05));
 }
+
+// ── 4. Shared major, different minor — new coaxial-torus shortcut path ──
+
+#[test]
+fn coaxial_torus_fuse_collapses_to_larger_minor() {
+    // Two coaxial tori with shared center and major radius, differing
+    // minor radii: Fuse should collapse to the torus with the larger
+    // minor radius (since the smaller one is fully contained).
+    let mut topo = Topology::default();
+    let outer = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.7);
+    let inner = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.4);
+    let r = boolean(&mut topo, BooleanOp::Fuse, outer, inner).unwrap();
+    let expected = torus_volume(3.0, 0.7);
+    let got = vol(&topo, r);
+    assert!(
+        approx_eq(got, expected, 0.05),
+        "coaxial torus fuse should collapse to outer torus: got {got:.3}, expected {expected:.3}"
+    );
+}
+
+#[test]
+fn coaxial_torus_intersect_collapses_to_smaller_minor() {
+    let mut topo = Topology::default();
+    let outer = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.7);
+    let inner = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.4);
+    let r = boolean(&mut topo, BooleanOp::Intersect, outer, inner).unwrap();
+    let expected = torus_volume(3.0, 0.4);
+    let got = vol(&topo, r);
+    assert!(
+        approx_eq(got, expected, 0.05),
+        "coaxial torus intersect should collapse to inner torus: got {got:.3}, expected {expected:.3}"
+    );
+}
+
+#[test]
+fn coaxial_torus_at_offset_center_fuse() {
+    // Verify the shortcut handles a non-origin shared center.
+    let mut topo = Topology::default();
+    let outer = torus_at(&mut topo, 5.0, -2.0, 7.0, 3.0, 0.7);
+    let inner = torus_at(&mut topo, 5.0, -2.0, 7.0, 3.0, 0.4);
+    let r = boolean(&mut topo, BooleanOp::Fuse, outer, inner).unwrap();
+    let expected = torus_volume(3.0, 0.7);
+    let got = vol(&topo, r);
+    assert!(approx_eq(got, expected, 0.05));
+}
+
+#[test]
+fn non_coaxial_torus_fuse_does_not_use_shortcut() {
+    // When the major radii differ, the shortcut must NOT fire — the
+    // result must include the union geometry of the two distinct tori.
+    let mut topo = Topology::default();
+    let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.4);
+    let b = torus_at(&mut topo, 0.0, 0.0, 0.0, 5.0, 0.4);
+    if let Ok(sid) = boolean(&mut topo, BooleanOp::Fuse, a, b) {
+        let got = vol(&topo, sid);
+        // Two disjoint same-tube-radius tori at different majors don't
+        // overlap (5 - 0.4 > 3 + 0.4 ⇒ tubes don't touch). Union volume
+        // equals the sum.
+        let expected = torus_volume(3.0, 0.4) + torus_volume(5.0, 0.4);
+        // Loose because the boolean engine may produce some tessellation
+        // drift, and we're not exercising the shortcut here — just
+        // confirming we still get a non-collapsed result.
+        assert!(
+            got > expected * 0.8,
+            "disjoint coaxial tori union should preserve both volumes: got {got:.3}, expected ~{expected:.3}"
+        );
+    }
+}

--- a/crates/operations/tests/coaxial_torus.rs
+++ b/crates/operations/tests/coaxial_torus.rs
@@ -82,23 +82,29 @@ fn identical_toruses_intersect_preserves_volume() {
     assert!(approx_eq(got, expected, 0.05));
 }
 
-// ── 2. Mismatched minor radius — must NOT be SD ───────────────────────
+// ── 2. Mismatched major radius — must NOT be SD or shortcut ───────────
 
 #[test]
-fn toruses_different_minor_radius_intersect_nontrivial() {
-    // Two toruses sharing major axis but with different tube radii produce
-    // a non-trivial intersection. Exercises NON-SD path; the SD detector
-    // correctly returns None for this pair.
+fn toruses_different_major_radius_intersect_nontrivial() {
+    // Two toruses sharing center and axis but with different MAJOR radii
+    // (minor radii also differ here). Exercises the GFA non-SD path; the
+    // coaxial-torus shortcut bails because `same_major` is false, and the
+    // SD detector correctly returns None since the toroidal surfaces
+    // differ. Originally this test used matching majors with mismatched
+    // minors, but #556 added a coaxial-torus Fuse/Intersect shortcut that
+    // would silently route those exact inputs through the fast path,
+    // hiding the GFA coverage gap. Switched to mismatched majors so the
+    // test continues to validate the GFA pipeline.
     let mut topo = Topology::default();
     let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.5);
-    let b = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.7);
+    let b = torus_at(&mut topo, 0.0, 0.0, 0.0, 4.0, 0.7);
     let r = boolean(&mut topo, BooleanOp::Intersect, a, b);
     // Either OK (positive volume) or Err (degenerate) is acceptable;
-    // the key requirement is that the SD detector did NOT mark this
-    // pair as same-domain (since minor radii differ).
+    // the key requirement is that neither the SD detector nor the
+    // coaxial-torus shortcut hijacked this pair.
     if let Ok(sid) = r {
         let v = vol(&topo, sid);
-        // Volume should be >0 and <= min(torus A, torus B).
+        // Volume should be >0 and <= the smaller-tube torus volume.
         assert!(v > 0.0);
         assert!(v <= torus_volume(3.0, 0.5) + 1e-3);
     }
@@ -164,9 +170,11 @@ fn coaxial_torus_at_offset_center_fuse() {
 }
 
 #[test]
-fn non_coaxial_torus_fuse_does_not_use_shortcut() {
-    // When the major radii differ, the shortcut must NOT fire — the
-    // result must include the union geometry of the two distinct tori.
+fn different_major_torus_fuse_does_not_use_shortcut() {
+    // The two tori share center and axis (so they ARE coaxial) but have
+    // different *major* radii. The shortcut must NOT fire — its
+    // `same_major` guard rejects this pair — so the result must include
+    // the union geometry of two distinct tori.
     let mut topo = Topology::default();
     let a = torus_at(&mut topo, 0.0, 0.0, 0.0, 3.0, 0.4);
     let b = torus_at(&mut topo, 0.0, 0.0, 0.0, 5.0, 0.4);


### PR DESCRIPTION
## Summary

Closes the boolean-shortcut family for axis-aligned analytic primitives: coaxial cylinders (#541), coaxial cones (#541), box pairs (#541), concentric spheres (#549), and now **coaxial tori**. When both A and B classify as Torus with shared center, axis (parallel or antiparallel), and major radius, Fuse and Intersect collapse to a single torus via minor-radius algebra.

| Op | Result |
|----|--------|
| **Fuse** | minor = \`max(min_a, min_b)\` |
| **Intersect** | minor = \`min(min_a, min_b)\` |
| **Cut** | falls through to GFA (hollow torus needs outer + inner shells) |

## Detection details

- **Center**: \`|c_a − c_b| < tol.linear\`
- **Axis**: \`|axis_a · axis_b| > 1 − tol.angular\` — accepts both parallel and antiparallel axes since a torus is symmetric about its central plane (rotating its axis 180° gives the same surface).
- **Major radius**: \`|maj_a − maj_b| < tol.linear\`
- **Minor sanity**: result minor must satisfy \`make_torus\`'s \`minor < major\` self-intersection check.

## Test plan

4 new tests on top of the existing 5 in \`coaxial_torus.rs\`:
- \`coaxial_torus_fuse_collapses_to_larger_minor\`
- \`coaxial_torus_intersect_collapses_to_smaller_minor\`
- \`coaxial_torus_at_offset_center_fuse\` — non-origin shared center
- \`non_coaxial_torus_fuse_does_not_use_shortcut\` — guardrail confirming different-major pairs still route through GFA

\`cargo test --workspace\` — 0 failures. \`cargo clippy --all-targets -- -D warnings\` — clean. Layer boundaries unchanged.

## Follow-ups (out of scope)

- Cut on coaxial tori (hollow-torus topology builder).
- Coaxial-torus with mismatched majors but compatible cross-section (more complex SD case).