### PR TITLE
docs(blend): refresh analytic.rs header to reflect current coverage matrix

### DIFF
--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -2,12 +2,36 @@
 #![allow(dead_code)]
 //! Analytic fast paths for common surface pairs.
 //!
-//! Closed-form fillet and chamfer solutions for plane-plane and plane-cylinder
-//! surface pairs. These bypass the walking engine entirely, producing exact
-//! geometry that is 10-100x faster than Newton-Raphson marching.
+//! Closed-form fillet and chamfer solutions for surface pairs that admit
+//! axisymmetric or planar blend geometry. These bypass the walking engine
+//! entirely, producing exact geometry 10–100× faster than Newton-Raphson
+//! marching.
 //!
-//! About 80% of real-world fillets are between plane-plane or plane-cylinder
-//! pairs, making these fast paths high-impact optimizations.
+//! # Coverage matrix
+//!
+//! Each pair below has fast paths for both fillet and chamfer (unless
+//! noted), handling all four convex/concave combinations via per-face
+//! `signed_offset_i ∈ {+1, −1}`:
+//!
+//! | Pair                           | Blend surface           | Notes                       |
+//! |--------------------------------|-------------------------|-----------------------------|
+//! | Plane × Plane                  | Cylinder (fillet) / Plane (chamfer) | dihedral edge       |
+//! | Plane × {Cylinder, Cone, Sphere} | Torus (fillet) / Cone (chamfer)   | axis ⟂ plate       |
+//! | Sphere × {Sphere, Cylinder, Cone} | Torus (fillet) / Cone (chamfer)   | sphere on shared axis |
+//! | Cylinder × Cylinder (parallel axes) | Cylinder (fillet) / Plane (chamfer) | spine = parallel lines |
+//! | Cone × Cone (coaxial)          | Torus (fillet) / Cone (chamfer) | shared axis, β1 ≠ β2     |
+//!
+//! # Fallthrough configurations
+//!
+//! Pairs whose intersection isn't a circle, line, or pair of either
+//! return `Ok(None)` so the walker takes over:
+//!   - Cyl × Cyl with non-parallel axes (perpendicular tee, oblique)
+//!   - Cone × Cone with non-coaxial axes
+//!   - Cyl × Cone in any orientation
+//!   - Anything involving Torus or NURBS surfaces
+//!
+//! Roughly 80% of real-world fillets fit one of the analytic pairs, so
+//! these fast paths are high-impact optimizations.
 
 use brepkit_math::curves2d::{Curve2D, Line2D};
 use brepkit_math::nurbs::curve::NurbsCurve;

--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -13,22 +13,26 @@
 //! noted), handling all four convex/concave combinations via per-face
 //! `signed_offset_i ∈ {+1, −1}`:
 //!
-//! | Pair                           | Blend surface           | Notes                       |
-//! |--------------------------------|-------------------------|-----------------------------|
-//! | Plane × Plane                  | Cylinder (fillet) / Plane (chamfer) | dihedral edge       |
-//! | Plane × {Cylinder, Cone, Sphere} | Torus (fillet) / Cone (chamfer)   | axis ⟂ plate       |
-//! | Sphere × {Sphere, Cylinder, Cone} | Torus (fillet) / Cone (chamfer)   | sphere on shared axis |
-//! | Cylinder × Cylinder (parallel axes) | Cylinder (fillet) / Plane (chamfer) | spine = parallel lines |
-//! | Cone × Cone (coaxial)          | Torus (fillet) / Cone (chamfer) | shared axis, β1 ≠ β2     |
+//! | Pair                           | Blend surface           | Axis-alignment requirement      |
+//! |--------------------------------|-------------------------|---------------------------------|
+//! | Plane × Plane                  | Cylinder (fillet) / Plane (chamfer) | none — dihedral edge       |
+//! | Plane × {Cylinder, Cone, Sphere} | Torus (fillet) / Cone (chamfer) | other surface's axis ⟂ plate     |
+//! | Sphere × {Cylinder, Cone}      | Torus (fillet) / Cone (chamfer) | sphere centre on cyl/cone axis line |
+//! | Sphere × Sphere                | Torus (fillet) / Cone (chamfer) | none — axis is line C1→C2 by construction |
+//! | Cylinder × Cylinder (parallel axes) | Cylinder (fillet) / Plane (chamfer) | parallel cyl axes, intersecting   |
+//! | Cone × Cone (coaxial)          | Torus (fillet) / Cone (chamfer) | shared axis line, β1 ≠ β2         |
 //!
 //! # Fallthrough configurations
 //!
-//! Pairs whose intersection isn't a circle, line, or pair of either
-//! return `Ok(None)` so the walker takes over:
-//!   - Cyl × Cyl with non-parallel axes (perpendicular tee, oblique)
-//!   - Cone × Cone with non-coaxial axes
-//!   - Cyl × Cone in any orientation
-//!   - Anything involving Torus or NURBS surfaces
+//! Each helper returns `Ok(None)` when its preconditions don't hold,
+//! so the walker takes over. Common reasons to fall through:
+//!   - Required axis alignment fails (e.g. sphere centre off the
+//!     cylinder axis, cone axes not coincident, cyl axes not parallel)
+//!   - Pair has no closed-form blend at all (Cyl × Cone in any
+//!     orientation, perpendicular cyl × cyl, non-coaxial cone × cone)
+//!   - Helper-specific guards (degenerate spine, spindle torus,
+//!     `r ≥ R_s` for concave-sphere, etc. — see each helper's docs)
+//!   - Surface variant not yet wired analytically (Torus, NURBS)
 //!
 //! Roughly 80% of real-world fillets fit one of the analytic pairs, so
 //! these fast paths are high-impact optimizations.


### PR DESCRIPTION
## Summary

The module-level docstring on \`crates/blend/src/analytic.rs\` claimed analytic fast paths exist "for plane-plane and plane-cylinder surface pairs" — accurate at the start of this analytic-blend expansion but stale after ~30 PRs adding plane-cone, plane-sphere, sphere-sphere, sphere-cyl, sphere-cone, cyl-cyl parallel-axis, and cone-cone coaxial pairs.

Replace with:

- Coverage matrix table listing every analytic pair, the emitted blend surface (Torus / Cylinder / Cone / Plane), and the convex/concave handling status.
- Explicit **fallthrough section** listing configs that legitimately need the walker (perpendicular cyl-cyl, non-coaxial cone-cone, cyl-cone, torus, NURBS).
- Updated "80% of real-world fillets" framing — still applies to the expanded coverage.

No code change.

## Test plan

- [x] cargo clippy -p brepkit-blend --all-targets -- -D warnings (clean)