### PR TITLE
test(blend): rework sphere-sphere chamfer mixed test (PR #604 fixup)

### DIFF
--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -7658,15 +7658,13 @@ mod tests {
                     .expect("mixed sphere-sphere chamfer should produce a stripe");
 
             // Verify emitted contact endpoints lie on their respective
-            // spheres. Using `control_points()[0]` reads the
-            // implementation's chosen 3D point directly.
-            let c1_point = result
-                .stripe
-                .contact1
-                .control_points()
-                .first()
-                .copied()
-                .unwrap();
+            // spheres. Sample the EMITTED curve via
+            // `evaluate(t_start)` rather than reading control points —
+            // rational NURBS arcs have intermediate control points
+            // OFF the curve, and even endpoint coverage couples the
+            // test to construction details (degree, knot vector).
+            let (t1_start, _) = result.stripe.contact1.domain();
+            let c1_point = result.stripe.contact1.evaluate(t1_start);
             let dist_s1 = (c1_point - Point3::new(0.0, 0.0, 0.0)).length();
             assert!(
                 (dist_s1 - big_r1).abs() < 1e-9,
@@ -7674,13 +7672,8 @@ mod tests {
                  distance = {dist_s1}, want R1 = {big_r1}"
             );
 
-            let c2_point = result
-                .stripe
-                .contact2
-                .control_points()
-                .first()
-                .copied()
-                .unwrap();
+            let (t2_start, _) = result.stripe.contact2.domain();
+            let c2_point = result.stripe.contact2.evaluate(t2_start);
             let dist_s2 = (c2_point - Point3::new(0.0, 0.0, big_d)).length();
             assert!(
                 (dist_s2 - big_r2).abs() < 1e-9,

--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -7584,6 +7584,140 @@ mod tests {
         );
     }
 
+    /// Sphere-sphere mixed-convexity chamfer: covers BOTH (s1=+1, s2=−1)
+    /// and (s1=−1, s2=+1). Each is geometrically distinct from the
+    /// symmetric cases (and from each other), with contacts on different
+    /// cap arms.
+    ///
+    /// Verifies the chamfer via project_point on the EMITTED
+    /// `result.stripe.contact{1,2}` curves (not on test-computed
+    /// formulas, which would be tautological for the sphere-distance
+    /// check since `r² + (z − Cz)² = R²` holds algebraically for any
+    /// sign).
+    #[test]
+    fn sphere_sphere_chamfer_mixed_emits_cone() {
+        use brepkit_math::curves::Circle3D;
+        use brepkit_math::surfaces::SphericalSurface;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::Face;
+        use brepkit_topology::vertex::Vertex;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+
+        let big_r1: f64 = 2.0;
+        let big_r2: f64 = 2.5;
+        let big_d: f64 = 3.0;
+        let d: f64 = 0.4;
+        let a0 = (big_r1 * big_r1 - big_r2 * big_r2 + big_d * big_d) / (2.0 * big_d);
+        let r_p = (big_r1 * big_r1 - a0 * a0).sqrt();
+
+        // Run both mixed configurations (s1, s2) ∈ {(+,−), (−,+)} via a
+        // closure parameterized by which face to reverse. For each:
+        //   - emit the chamfer
+        //   - extract the actual 3D contact point from the impl's
+        //     `contact1`/`contact2` NURBS curves
+        //   - assert that the EMITTED contact lies on the corresponding
+        //     sphere (this DOES test the implementation, unlike
+        //     sampling the test's own formula — see Greptile feedback
+        //     on PR #604: r² + (z − Cz)² = R² holds algebraically for
+        //     any sign of `s_i`, so a formula-derived contact would
+        //     pass tautologically).
+        let run_case = |reverse_s1: bool, reverse_s2: bool| {
+            let mut topo = Topology::new();
+            let s1_surf = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), big_r1).unwrap();
+            let s2_surf = SphericalSurface::new(Point3::new(0.0, 0.0, big_d), big_r2).unwrap();
+            let spine_circle =
+                Circle3D::new(Point3::new(0.0, 0.0, a0), Vec3::new(0.0, 0.0, 1.0), r_p).unwrap();
+            let v = topo.add_vertex(Vertex::new(Point3::new(r_p, 0.0, a0), 1e-7));
+            let eid = topo.add_edge(Edge::new(v, v, EdgeCurve::Circle(spine_circle)));
+            let spine = Spine::from_single_edge(&topo, eid).unwrap();
+
+            let w1 = topo.add_wire(Wire::new(vec![OrientedEdge::new(eid, true)], true).unwrap());
+            let face1 = if reverse_s1 {
+                topo.add_face(Face::new_reversed(
+                    w1,
+                    vec![],
+                    FaceSurface::Sphere(s1_surf.clone()),
+                ))
+            } else {
+                topo.add_face(Face::new(w1, vec![], FaceSurface::Sphere(s1_surf.clone())))
+            };
+            let w2 = topo.add_wire(Wire::new(vec![OrientedEdge::new(eid, false)], true).unwrap());
+            let face2 = if reverse_s2 {
+                topo.add_face(Face::new_reversed(
+                    w2,
+                    vec![],
+                    FaceSurface::Sphere(s2_surf.clone()),
+                ))
+            } else {
+                topo.add_face(Face::new(w2, vec![], FaceSurface::Sphere(s2_surf.clone())))
+            };
+
+            let result =
+                sphere_sphere_chamfer(&s1_surf, &s2_surf, &spine, &topo, d, d, face1, face2)
+                    .unwrap()
+                    .expect("mixed sphere-sphere chamfer should produce a stripe");
+
+            // Verify emitted contact endpoints lie on their respective
+            // spheres. Using `control_points()[0]` reads the
+            // implementation's chosen 3D point directly.
+            let c1_point = result
+                .stripe
+                .contact1
+                .control_points()
+                .first()
+                .copied()
+                .unwrap();
+            let dist_s1 = (c1_point - Point3::new(0.0, 0.0, 0.0)).length();
+            assert!(
+                (dist_s1 - big_r1).abs() < 1e-9,
+                "({reverse_s1}, {reverse_s2}): emitted contact1 must lie on sphere1: \
+                 distance = {dist_s1}, want R1 = {big_r1}"
+            );
+
+            let c2_point = result
+                .stripe
+                .contact2
+                .control_points()
+                .first()
+                .copied()
+                .unwrap();
+            let dist_s2 = (c2_point - Point3::new(0.0, 0.0, big_d)).length();
+            assert!(
+                (dist_s2 - big_r2).abs() < 1e-9,
+                "({reverse_s1}, {reverse_s2}): emitted contact2 must lie on sphere2: \
+                 distance = {dist_s2}, want R2 = {big_r2}"
+            );
+
+            // Emitted surface is a Cone (the chamfer is a cone of
+            // revolution about the C1-C2 axis).
+            assert!(
+                matches!(result.stripe.surface, FaceSurface::Cone(_)),
+                "({reverse_s1}, {reverse_s2}): expected Cone, got {}",
+                result.stripe.surface.type_tag()
+            );
+
+            // Both emitted contact points lie on the chamfer cone via
+            // project_point round-trip.
+            if let FaceSurface::Cone(ref cone) = result.stripe.surface {
+                let (u_p, v_p) = ParametricSurface::project_point(cone, c1_point);
+                let on_cone_p1 = ParametricSurface::evaluate(cone, u_p, v_p);
+                assert!(
+                    (on_cone_p1 - c1_point).length() < 1e-9,
+                    "({reverse_s1}, {reverse_s2}): emitted contact1 must lie on chamfer cone"
+                );
+                let (u_q, v_q) = ParametricSurface::project_point(cone, c2_point);
+                let on_cone_p2 = ParametricSurface::evaluate(cone, u_q, v_q);
+                assert!(
+                    (on_cone_p2 - c2_point).length() < 1e-9,
+                    "({reverse_s1}, {reverse_s2}): emitted contact2 must lie on chamfer cone"
+                );
+            }
+        };
+
+        run_case(false, true); // (s1=+1, s2=-1)
+        run_case(true, false); // (s1=-1, s2=+1)
+    }
+
     /// Sphere-cylinder both-concave chamfer: spherical cavity + cylindrical
     /// hole-tool. Both `s_sph = s_cyl = −1` flip the meridian arms relative
     /// to convex.
@@ -9930,117 +10064,6 @@ mod tests {
         assert!(
             (on_torus_cyl - want_cyl).length() < 1e-9,
             "cyl contact on torus: {on_torus_cyl:?} vs {want_cyl:?}"
-        );
-    }
-
-    /// Sphere-sphere mixed-convexity chamfer: sphere1 face NOT reversed
-    /// (convex), sphere2 face REVERSED (concave). The implementation
-    /// already supported `s_i = ±1` per face but only symmetric (both
-    /// convex / both concave) cases had tests.
-    ///
-    /// For R1=2, R2=2.5, D=3, sphere1 NOT reversed, sphere2 REVERSED, d=0.4:
-    ///   - sphere1 contact uses convex arm (toward apex of upper cap)
-    ///   - sphere2 contact uses concave arm (toward south pole)
-    ///   - resulting chamfer cone is geometrically distinct from both
-    ///     symmetric cases — a fresh code path that wasn't exercised
-    ///     before.
-    #[test]
-    fn sphere_sphere_chamfer_mixed_emits_cone() {
-        use brepkit_math::curves::Circle3D;
-        use brepkit_math::surfaces::SphericalSurface;
-        use brepkit_topology::edge::{Edge, EdgeCurve};
-        use brepkit_topology::face::Face;
-        use brepkit_topology::vertex::Vertex;
-        use brepkit_topology::wire::{OrientedEdge, Wire};
-
-        let mut topo = Topology::new();
-        let big_r1: f64 = 2.0;
-        let big_r2: f64 = 2.5;
-        let big_d: f64 = 3.0;
-        let d: f64 = 0.4;
-
-        let a0 = (big_r1 * big_r1 - big_r2 * big_r2 + big_d * big_d) / (2.0 * big_d);
-        let r_p_sq = big_r1 * big_r1 - a0 * a0;
-        let r_p = r_p_sq.sqrt();
-
-        let s1 = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), big_r1).unwrap();
-        let s2 = SphericalSurface::new(Point3::new(0.0, 0.0, big_d), big_r2).unwrap();
-        let spine_circle =
-            Circle3D::new(Point3::new(0.0, 0.0, a0), Vec3::new(0.0, 0.0, 1.0), r_p).unwrap();
-        let v = topo.add_vertex(Vertex::new(Point3::new(r_p, 0.0, a0), 1e-7));
-        let eid = topo.add_edge(Edge::new(v, v, EdgeCurve::Circle(spine_circle)));
-        let spine = Spine::from_single_edge(&topo, eid).unwrap();
-
-        // sphere1 NOT reversed; sphere2 REVERSED.
-        let w1 = topo.add_wire(Wire::new(vec![OrientedEdge::new(eid, true)], true).unwrap());
-        let face1 = topo.add_face(Face::new(w1, vec![], FaceSurface::Sphere(s1.clone())));
-        let w2 = topo.add_wire(Wire::new(vec![OrientedEdge::new(eid, false)], true).unwrap());
-        let face2 = topo.add_face(Face::new_reversed(
-            w2,
-            vec![],
-            FaceSurface::Sphere(s2.clone()),
-        ));
-
-        let result = sphere_sphere_chamfer(&s1, &s2, &spine, &topo, d, d, face1, face2)
-            .unwrap()
-            .expect("mixed sphere-sphere chamfer should produce a stripe");
-
-        let chamfer_cone = match result.stripe.surface {
-            FaceSurface::Cone(c) => c,
-            other => panic!("expected Cone, got {}", other.type_tag()),
-        };
-
-        // Predicted contacts (s1=+1, s2=-1).
-        let s1_signed = 1.0_f64;
-        let s2_signed = -1.0_f64;
-        let delta1 = d / big_r1;
-        let delta2 = d / big_r2;
-        let (sin1, cos1) = delta1.sin_cos();
-        let (sin2, cos2) = delta2.sin_cos();
-        let p1_r = r_p * cos1 + s1_signed * a0 * sin1;
-        let p1_z = a0 * cos1 - s1_signed * r_p * sin1;
-        let p2_r = r_p * cos2 + s2_signed * (big_d - a0) * sin2;
-        let p2_z = big_d - (big_d - a0) * cos2 + s2_signed * r_p * sin2;
-
-        // Sphere1 on convex arm: contact1 below spine (z < a0).
-        assert!(
-            p1_z < a0,
-            "sphere1 (convex) contact should be below spine: got {p1_z} vs a0={a0}"
-        );
-        // Sphere2 on concave arm: contact2 also below spine (toward
-        // sphere1's side instead of away).
-        assert!(
-            p2_z < a0,
-            "sphere2 (concave) contact should be below spine: got {p2_z} vs a0={a0}"
-        );
-
-        // Verify chamfer cone surface contains both contacts AND each
-        // contact lies on its respective sphere.
-        let want_p1 = Point3::new(p1_r, 0.0, p1_z);
-        let want_p2 = Point3::new(p2_r, 0.0, p2_z);
-        let (u_p, v_p) = ParametricSurface::project_point(&chamfer_cone, want_p1);
-        let on_cone_p1 = ParametricSurface::evaluate(&chamfer_cone, u_p, v_p);
-        let (u_q, v_q) = ParametricSurface::project_point(&chamfer_cone, want_p2);
-        let on_cone_p2 = ParametricSurface::evaluate(&chamfer_cone, u_q, v_q);
-        assert!(
-            (on_cone_p1 - want_p1).length() < 1e-9,
-            "sphere1 contact must lie on chamfer cone: {on_cone_p1:?} vs {want_p1:?}"
-        );
-        assert!(
-            (on_cone_p2 - want_p2).length() < 1e-9,
-            "sphere2 contact must lie on chamfer cone: {on_cone_p2:?} vs {want_p2:?}"
-        );
-
-        // Both contacts on respective spheres.
-        let dist_s1 = (want_p1 - Point3::new(0.0, 0.0, 0.0)).length();
-        let dist_s2 = (want_p2 - Point3::new(0.0, 0.0, big_d)).length();
-        assert!(
-            (dist_s1 - big_r1).abs() < 1e-9,
-            "sphere1 contact must lie on sphere1: {dist_s1} vs R1={big_r1}"
-        );
-        assert!(
-            (dist_s2 - big_r2).abs() < 1e-9,
-            "sphere2 contact must lie on sphere2: {dist_s2} vs R2={big_r2}"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #604 — the fixup commit addressing review feedback was prepared locally but never reached origin before #604 was merged. Apply the rework here.

## Greptile + Copilot review feedback addressed

1. **Tautological sphere-distance assertions** (Greptile P2): the previous test computed \`want_p1 = (p1_r, 0, p1_z)\` from its own formula, then asserted \`|want_p1 − C1| = R1\`. By construction \`p1_r² + (p1_z − C1.z)² = R1²\` algebraically for any sign of \`s_i\`, so the sphere-distance check only validated the test's arithmetic — not the implementation. Rewritten to read the EMITTED contact endpoint from \`result.stripe.contact1.control_points()[0]\` (the impl's own NURBS curve) and check THAT lies on sphere1.

2. **Missing complementary mixed case** (Greptile P2): the previous test only covered \`(s1=+1, s2=−1)\`. Refactored into a parameterized closure exercising BOTH \`(s1=+1, s2=−1)\` AND \`(s1=−1, s2=+1)\` — distinct geometric configurations on different code paths.

3. **Test placement** (Copilot): the new test was at the end of the file, far from the convex and both-concave siblings. Moved adjacent so all sphere-sphere chamfer coverage stays grouped.

Net: -111 lines (delete old far-away test) + 134 lines (rework adjacent). All 88 unit tests still pass.

## Test plan

- [x] cargo test -p brepkit-blend (88 unit pass)
- [x] cargo clippy -p brepkit-blend --all-targets -- -D warnings (clean)
- [x] cargo fmt --all