### PR TITLE
test(blend): cover both mixed-convexity cyl-cyl parallel-axis chamfer cases

### DIFF
--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -9776,6 +9776,137 @@ mod tests {
         );
     }
 
+    /// Cylinder-cylinder mixed-convexity chamfer: covers BOTH (s1=+1,
+    /// s2=−1) and (s1=−1, s2=+1) at the +y spine.
+    ///
+    /// In mixed configs the per-cyl angular displacement signs combine
+    /// asymmetrically:
+    ///   Δθ_1 = y_sign · s1 · d/r1
+    ///   Δθ_2 = −y_sign · s2 · d/r2
+    /// The product `s1 · s2` differs from the symmetric cases, giving
+    /// a chord between contacts with a different slope and hence a
+    /// distinct chamfer plane.
+    ///
+    /// Verifies emitted contact endpoints via `evaluate(t_start)` and
+    /// asserts each lies on its cylinder surface AND on the chamfer
+    /// plane (residual against `n · p − d` < tol).
+    #[test]
+    fn cylinder_cylinder_chamfer_mixed_emits_plane() {
+        use brepkit_math::surfaces::CylindricalSurface;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::Face;
+        use brepkit_topology::vertex::Vertex;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+
+        let r1: f64 = 2.0;
+        let r2: f64 = 2.5;
+        let big_d: f64 = 3.0;
+        let d: f64 = 0.4;
+        let x_spine = (r1 * r1 - r2 * r2 + big_d * big_d) / (2.0 * big_d);
+        let y_spine = (r1 * r1 - x_spine * x_spine).sqrt();
+
+        let run_case = |reverse_s1: bool, reverse_s2: bool| {
+            let mut topo = Topology::new();
+            let cyl1 =
+                CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), r1)
+                    .unwrap();
+            let cyl2 =
+                CylindricalSurface::new(Point3::new(big_d, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), r2)
+                    .unwrap();
+            let z_lo = 0.0_f64;
+            let z_hi = 4.0_f64;
+            let p_start = Point3::new(x_spine, y_spine, z_lo);
+            let p_end = Point3::new(x_spine, y_spine, z_hi);
+            let v_start = topo.add_vertex(Vertex::new(p_start, 1e-7));
+            let v_end = topo.add_vertex(Vertex::new(p_end, 1e-7));
+            let line = brepkit_math::nurbs::curve::NurbsCurve::new(
+                1,
+                vec![0.0, 0.0, 1.0, 1.0],
+                vec![p_start, p_end],
+                vec![1.0, 1.0],
+            )
+            .unwrap();
+            let eid = topo.add_edge(Edge::new(v_start, v_end, EdgeCurve::NurbsCurve(line)));
+            let spine = Spine::from_single_edge(&topo, eid).unwrap();
+
+            let w1 = topo.add_wire(Wire::new(vec![OrientedEdge::new(eid, true)], false).unwrap());
+            let face1 = if reverse_s1 {
+                topo.add_face(Face::new_reversed(
+                    w1,
+                    vec![],
+                    FaceSurface::Cylinder(cyl1.clone()),
+                ))
+            } else {
+                topo.add_face(Face::new(w1, vec![], FaceSurface::Cylinder(cyl1.clone())))
+            };
+            let w2 = topo.add_wire(Wire::new(vec![OrientedEdge::new(eid, false)], false).unwrap());
+            let face2 = if reverse_s2 {
+                topo.add_face(Face::new_reversed(
+                    w2,
+                    vec![],
+                    FaceSurface::Cylinder(cyl2.clone()),
+                ))
+            } else {
+                topo.add_face(Face::new(w2, vec![], FaceSurface::Cylinder(cyl2.clone())))
+            };
+
+            let result = cylinder_cylinder_chamfer(&cyl1, &cyl2, &spine, &topo, d, d, face1, face2)
+                .unwrap()
+                .expect("mixed cyl-cyl chamfer should produce a stripe");
+
+            let (chamfer_normal, chamfer_d) = match result.stripe.surface {
+                FaceSurface::Plane { normal, d } => (normal, d),
+                ref other => panic!(
+                    "({reverse_s1}, {reverse_s2}): expected Plane, got {}",
+                    other.type_tag()
+                ),
+            };
+
+            // Read EMITTED contact endpoints.
+            let (t1_start, _) = result.stripe.contact1.domain();
+            let c1_point = result.stripe.contact1.evaluate(t1_start);
+            let (t2_start, _) = result.stripe.contact2.domain();
+            let c2_point = result.stripe.contact2.evaluate(t2_start);
+
+            // Each lies on its cylinder surface.
+            let dist_c1_axis = (c1_point.x().powi(2) + c1_point.y().powi(2)).sqrt();
+            let dist_c2_axis = ((c2_point.x() - big_d).powi(2) + c2_point.y().powi(2)).sqrt();
+            assert!(
+                (dist_c1_axis - r1).abs() < 1e-9,
+                "({reverse_s1}, {reverse_s2}): c1 must lie on cyl1: \
+                 distance = {dist_c1_axis}, want r1 = {r1}"
+            );
+            assert!(
+                (dist_c2_axis - r2).abs() < 1e-9,
+                "({reverse_s1}, {reverse_s2}): c2 must lie on cyl2: \
+                 distance = {dist_c2_axis}, want r2 = {r2}"
+            );
+
+            // Both contacts on the chamfer plane.
+            let on_plane_1 =
+                chamfer_normal.dot(Vec3::new(c1_point.x(), c1_point.y(), c1_point.z())) - chamfer_d;
+            let on_plane_2 =
+                chamfer_normal.dot(Vec3::new(c2_point.x(), c2_point.y(), c2_point.z())) - chamfer_d;
+            assert!(
+                on_plane_1.abs() < 1e-9,
+                "({reverse_s1}, {reverse_s2}): c1 on chamfer plane: residual {on_plane_1}"
+            );
+            assert!(
+                on_plane_2.abs() < 1e-9,
+                "({reverse_s1}, {reverse_s2}): c2 on chamfer plane: residual {on_plane_2}"
+            );
+
+            // Plane normal perpendicular to z (cyl axes).
+            assert!(
+                chamfer_normal.z().abs() < 1e-12,
+                "({reverse_s1}, {reverse_s2}): plane normal should be perpendicular to z, got {chamfer_normal:?}"
+            );
+        };
+
+        run_case(false, true); // (s1=+1, s2=-1)
+        run_case(true, false); // (s1=-1, s2=+1)
+    }
+
     /// Cone-cone coaxial convex chamfer: two cones sharing an axis with
     /// different half-angles. Chamfer surface is an axisymmetric cone
     /// connecting both cone-generator contact circles.


### PR DESCRIPTION
## Summary

Adds `cylinder_cylinder_chamfer_mixed_emits_plane`, a parameterized
closure-based test that exercises both `(s1=+1, s2=-1)` and
`(s1=-1, s2=+1)` mixed-convexity configurations of the parallel-axis
cylinder-cylinder analytic chamfer fast path.

The `cylinder_cylinder_chamfer` implementation already handles all four
`signed_offset_i = ±1` combinations (per-face reverse flag determines
whether the offset adds or subtracts from the cyl radius). Prior to
this PR, only the symmetric cases (convex-convex and both-concave) had
direct tests; this fills the last gap in the analytic blend mixed-
config coverage matrix.

## Geometric note

In mixed configs, the per-cyl angular displacement signs combine
asymmetrically:

```
Δθ_1 = y_sign · s1 · d/r1
Δθ_2 = -y_sign · s2 · d/r2
```

The product `s1 · s2` differs from symmetric cases (`+1` vs `-1`),
giving the chord between contacts a different slope and hence a
distinct chamfer plane orientation. The test verifies the implementa-
tion produces the right plane in both mixed configs.

## Test plan

- [x] `cargo test -p brepkit-blend --lib analytic::tests::cylinder_cylinder_chamfer` — 3/3 pass (90 total in crate)
- [x] `cargo fmt --all`
- [x] `cargo clippy -p brepkit-blend --all-targets -- -D warnings`
- [ ] CI: 15 checks including Greptile Review

## Coverage status

This is the closing PR for mixed-config coverage:

| Pair                | Convex | Both-concave | Mixed |
|---------------------|--------|--------------|-------|
| Plane × Cyl         | ✓      | ✓            | ✓     |
| Plane × Cone        | ✓      | ✓            | ✓     |
| Plane × Sphere      | ✓      | ✓            | ✓     |
| Sphere × Sphere     | ✓      | ✓            | ✓     |
| Sphere × Cyl/Cone   | ✓      | ✓            | ✓     |
| Cyl-Cyl parallel    | ✓      | ✓            | ✓ (PRs #607 fillet, this PR chamfer) |
| Cone-Cone coaxial   | ✓      | ✓            | ✓ (PRs #594 fillet, #606 chamfer)    |