### PR TITLE
feat(heal): wire SameParameter into per-face fix pipeline

### DIFF
--- a/crates/heal/src/fix/face.rs
+++ b/crates/heal/src/fix/face.rs
@@ -69,16 +69,20 @@ pub fn fix_face(
                     .map(brepkit_topology::wire::OrientedEdge::edge),
             );
         }
-        // Resolve any reshape-recorded edge replacements, skip removed
-        // edges, and dedupe (the same edge can appear in outer + inner
-        // wires, and `ReShape::resolve_edge` can collapse multiple
-        // replaced edges onto the same target).
+        // Resolve each edge to its canonical form (post-replacement),
+        // skip removed edges, and dedupe. Critical: we MUST call
+        // SameParameter on the canonical ID, not the original — if
+        // step 1 replaced A with B, `resolve_edge(A) = Some(B)` and
+        // we want SameParameter to operate on B. Plain `retain` would
+        // keep the original A in the vector, calling
+        // `fix_same_parameter_on_face` on a (possibly stale) ID.
         let mut seen = std::collections::HashSet::new();
-        edge_ids.retain(|&eid| match ctx.reshape.resolve_edge(eid) {
-            Some(canonical) => seen.insert(canonical),
-            None => false,
-        });
-        for eid in edge_ids {
+        let canonical_edges: Vec<brepkit_topology::edge::EdgeId> = edge_ids
+            .into_iter()
+            .filter_map(|eid| ctx.reshape.resolve_edge(eid))
+            .filter(|&canon| seen.insert(canon))
+            .collect();
+        for eid in canonical_edges {
             let r = super::edge::fix_same_parameter_on_face(topo, eid, face_id, ctx, config)?;
             result.merge(&r);
         }

--- a/crates/heal/src/fix/face.rs
+++ b/crates/heal/src/fix/face.rs
@@ -2,9 +2,11 @@
 //!
 //! The fix sequence:
 //! 1. Fix all wires in the face (delegate to `fix_wire`)
-//! 2. Fix wire orientation (outer wire CCW from surface normal)
-//! 3. Small area check (bbox diagonal < tolerance → mark for removal)
-//! 4. Duplicate face detection (stub)
+//! 2. Fix `SameParameter` for each edge on this face — rebuild PCurves
+//!    that deviate from their 3D curves by more than tolerance
+//! 3. Fix wire orientation (outer wire CCW from surface normal)
+//! 4. Small area check (bbox diagonal < tolerance → mark for removal)
+//! 5. Duplicate face detection (stub)
 
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
@@ -35,12 +37,33 @@ pub fn fix_face(
         .chain(face.inner_wires().iter().copied())
         .collect();
 
-    for wid in wire_ids {
-        let wire_result = super::wire::fix_wire_on_face(topo, wid, face_id, ctx, config)?;
+    for wid in &wire_ids {
+        let wire_result = super::wire::fix_wire_on_face(topo, *wid, face_id, ctx, config)?;
         result.merge(&wire_result);
     }
 
-    // 2. Fix wire orientation relative to the face normal.
+    // 2. SameParameter: each edge on this face must have a PCurve that
+    // matches its 3D curve within tolerance, otherwise downstream UV
+    // operations (CDT triangulation, intersection) drift.
+    if config.fix_same_parameter != FixMode::Off {
+        // Collect edges first (we'll mutate `topo` inside the loop).
+        let mut edge_ids: Vec<brepkit_topology::edge::EdgeId> = Vec::new();
+        for &wid in &wire_ids {
+            if let Ok(w) = topo.wire(wid) {
+                edge_ids.extend(
+                    w.edges()
+                        .iter()
+                        .map(brepkit_topology::wire::OrientedEdge::edge),
+                );
+            }
+        }
+        for eid in edge_ids {
+            let r = super::edge::fix_same_parameter_on_face(topo, eid, face_id, ctx, config)?;
+            result.merge(&r);
+        }
+    }
+
+    // 3. Fix wire orientation relative to the face normal.
     if config.fix_wire_orientation != FixMode::Off {
         let r = fix_wire_orientation(topo, face_id, ctx, config)?;
         result.merge(&r);
@@ -244,4 +267,94 @@ fn projected_signed_area(positions: &[Point3], normal: &Vec3) -> f64 {
     }
 
     area2 * 0.5
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::context::HealContext;
+    use crate::fix::config::{FixConfig, FixMode};
+    use brepkit_topology::test_utils::make_unit_square_face;
+
+    fn default_config() -> FixConfig {
+        // Disable everything except the SameParameter step we want to
+        // exercise so the test stays focused.
+        FixConfig {
+            fix_wire_orientation: FixMode::Off,
+            fix_small_area: FixMode::Off,
+            fix_duplicate_faces: FixMode::Off,
+            fix_same_parameter: FixMode::Auto,
+            ..FixConfig::default()
+        }
+    }
+
+    #[test]
+    fn fix_face_creates_missing_pcurves_via_same_parameter() {
+        // make_unit_square_face produces a planar face where the 4 edges
+        // have NO PCurves attached (test_utils doesn't register them).
+        // After fix_face with fix_same_parameter, every edge on the face
+        // should now have a registered PCurve.
+        let mut topo = Topology::new();
+        let face_id = make_unit_square_face(&mut topo);
+
+        // Pre-condition: no PCurves yet.
+        let edges_before: Vec<_> = {
+            let face = topo.face(face_id).unwrap();
+            let wire = topo.wire(face.outer_wire()).unwrap();
+            wire.edges()
+                .iter()
+                .map(brepkit_topology::wire::OrientedEdge::edge)
+                .collect()
+        };
+        for &eid in &edges_before {
+            assert!(
+                !topo.pcurves().contains(eid, face_id),
+                "edge {eid:?} should not have a PCurve before fix_face"
+            );
+        }
+
+        let mut ctx = HealContext::new();
+        let cfg = default_config();
+        let result = fix_face(&mut topo, face_id, &mut ctx, &cfg).unwrap();
+
+        // Post-condition: every edge has a PCurve.
+        for &eid in &edges_before {
+            assert!(
+                topo.pcurves().contains(eid, face_id),
+                "edge {eid:?} should have a PCurve after fix_face"
+            );
+        }
+        // And SameParameter ran for each edge → some actions taken.
+        assert!(result.actions_taken >= edges_before.len());
+    }
+
+    #[test]
+    fn fix_face_skips_same_parameter_when_off() {
+        // Symmetric: with fix_same_parameter = Off, no PCurves are created.
+        let mut topo = Topology::new();
+        let face_id = make_unit_square_face(&mut topo);
+        let edges: Vec<_> = {
+            let face = topo.face(face_id).unwrap();
+            let wire = topo.wire(face.outer_wire()).unwrap();
+            wire.edges()
+                .iter()
+                .map(brepkit_topology::wire::OrientedEdge::edge)
+                .collect()
+        };
+
+        let mut ctx = HealContext::new();
+        let cfg = FixConfig {
+            fix_same_parameter: FixMode::Off,
+            ..default_config()
+        };
+        let _ = fix_face(&mut topo, face_id, &mut ctx, &cfg).unwrap();
+
+        for &eid in &edges {
+            assert!(
+                !topo.pcurves().contains(eid, face_id),
+                "edge {eid:?} should still have no PCurve when fix_same_parameter=Off"
+            );
+        }
+    }
 }

--- a/crates/heal/src/fix/face.rs
+++ b/crates/heal/src/fix/face.rs
@@ -45,6 +45,14 @@ pub fn fix_face(
     // 2. SameParameter: each edge on this face must have a PCurve that
     // matches its 3D curve within tolerance, otherwise downstream UV
     // operations (CDT triangulation, intersection) drift.
+    //
+    // Note on reshape ordering: wire fixing in step 1 records edge
+    // replacements/removals in `ctx.reshape` but does NOT apply them
+    // to `topo` (that happens at end-of-pipeline via `ReShape::apply`).
+    // We deliberately skip edges already marked for removal here —
+    // their PCurves are irrelevant. Edges replaced by other edges are
+    // resolved through `reshape.resolve_edge` so we operate on the
+    // current canonical edge.
     if config.fix_same_parameter != FixMode::Off {
         // Collect edges first (we'll mutate `topo` inside the loop).
         // Propagate wire-lookup errors with `?` for consistency with
@@ -61,6 +69,15 @@ pub fn fix_face(
                     .map(brepkit_topology::wire::OrientedEdge::edge),
             );
         }
+        // Resolve any reshape-recorded edge replacements, skip removed
+        // edges, and dedupe (the same edge can appear in outer + inner
+        // wires, and `ReShape::resolve_edge` can collapse multiple
+        // replaced edges onto the same target).
+        let mut seen = std::collections::HashSet::new();
+        edge_ids.retain(|&eid| match ctx.reshape.resolve_edge(eid) {
+            Some(canonical) => seen.insert(canonical),
+            None => false,
+        });
         for eid in edge_ids {
             let r = super::edge::fix_same_parameter_on_face(topo, eid, face_id, ctx, config)?;
             result.merge(&r);
@@ -282,8 +299,11 @@ mod tests {
     use brepkit_topology::test_utils::make_unit_square_face;
 
     fn default_config() -> FixConfig {
-        // Disable everything except the SameParameter step we want to
-        // exercise so the test stays focused.
+        // Disable face-level steps that aren't being exercised
+        // (orientation, small-area, duplicate detection). Wire-level
+        // fixes still run with their `FixConfig::default()` values
+        // (Auto), since SameParameter operates AFTER wire fixing and
+        // we want the realistic flow.
         FixConfig {
             fix_wire_orientation: FixMode::Off,
             fix_small_area: FixMode::Off,

--- a/crates/heal/src/fix/face.rs
+++ b/crates/heal/src/fix/face.rs
@@ -47,15 +47,19 @@ pub fn fix_face(
     // operations (CDT triangulation, intersection) drift.
     if config.fix_same_parameter != FixMode::Off {
         // Collect edges first (we'll mutate `topo` inside the loop).
+        // Propagate wire-lookup errors with `?` for consistency with
+        // the rest of `fix_face`: at this point all `wire_ids` were
+        // already accessible in step 1, so an error here would
+        // indicate an unexpected topology mutation inside
+        // `fix_wire_on_face` and shouldn't be silently swallowed.
         let mut edge_ids: Vec<brepkit_topology::edge::EdgeId> = Vec::new();
         for &wid in &wire_ids {
-            if let Ok(w) = topo.wire(wid) {
-                edge_ids.extend(
-                    w.edges()
-                        .iter()
-                        .map(brepkit_topology::wire::OrientedEdge::edge),
-                );
-            }
+            let w = topo.wire(wid)?;
+            edge_ids.extend(
+                w.edges()
+                    .iter()
+                    .map(brepkit_topology::wire::OrientedEdge::edge),
+            );
         }
         for eid in edge_ids {
             let r = super::edge::fix_same_parameter_on_face(topo, eid, face_id, ctx, config)?;


### PR DESCRIPTION
## Summary

\`fix_same_parameter_on_face\` was implemented but never called from the heal pipeline — \`fix_face\` only delegated wire fixes, then ran orientation/small-area/duplicate checks. Edges with missing or deviated PCurves were left in their original state.

This PR wires it in: after fixing wires (step 1), \`fix_face\` now iterates every edge across the outer + inner wires and calls \`fix_same_parameter_on_face\` for each. Inserted as step 2 (between wire fixing and wire-orientation) so any PCurve repairs are available to subsequent steps that read UV-space data.

The per-edge stub \`fix_same_parameter_stub\` in \`edge.rs\` is retained for completeness — it's still called from \`fix_edge\` when no face context is available, where it can only emit an informational warning. Most heal-pipeline callers go through \`fix_face\` and now get the real impl.

## Tests

- \`fix_face_creates_missing_pcurves_via_same_parameter\`: builds a unit-square planar face (4 line edges, no PCurves), runs fix_face with \`fix_same_parameter = Auto\`, asserts every edge has a registered PCurve afterward and \`actions_taken >= edge_count\`.
- \`fix_face_skips_same_parameter_when_off\`: control test — \`fix_same_parameter = Off\` leaves the PCurve registry untouched.

## Test plan

- [x] \`cargo test -p brepkit-heal --lib\` — 47/47 pass
- [x] \`cargo clippy -p brepkit-heal --all-targets -- -D warnings\`
- [x] \`./scripts/check-boundaries.sh\` — boundaries valid
- [ ] CI: 15 checks including Greptile Review