### PR TITLE
feat(wasm): expose convertToElementary binding

### DIFF
--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -1580,6 +1580,49 @@ pub fn convert_to_bspline(
     })
 }
 
+/// Recognize and replace NURBS surfaces and edges with their analytic
+/// (elementary) forms wherever possible.
+///
+/// Runs both face-surface recognition (Plane, Cylinder, Sphere, Cone,
+/// Torus) and edge-curve recognition (Line, Circle, Ellipse) in
+/// sequence. Returns the combined number of replacements.
+///
+/// This is the inverse of [`convert_to_bspline`]: STEP/IGES imports
+/// that came in as NURBS (e.g., from CAD systems that export
+/// everything as B-splines) can be normalized back into the analytic
+/// forms that brepkit's intersection / blend / boolean operators
+/// handle most efficiently.
+///
+/// Hyperbola and Parabola curve types are recognized but cannot yet
+/// be stored as analytic `EdgeCurve` variants (no
+/// `EdgeCurve::Hyperbola`/`Parabola` exists in topology); they keep
+/// their NURBS representation.
+///
+/// # Errors
+///
+/// Returns an error if any topology lookup fails.
+pub fn convert_to_elementary(
+    topo: &mut Topology,
+    solid: SolidId,
+    tolerance: f64,
+) -> Result<usize, crate::OperationsError> {
+    let tol = brepkit_math::tolerance::Tolerance {
+        linear: tolerance,
+        ..brepkit_math::tolerance::Tolerance::new()
+    };
+    let surfaces =
+        brepkit_heal::custom::convert_to_elementary::convert_to_elementary(topo, solid, &tol)
+            .map_err(|e| crate::OperationsError::InvalidInput {
+                reason: format!("convert_to_elementary (surfaces) failed: {e}"),
+            })?;
+    let edges =
+        brepkit_heal::custom::convert_to_elementary::convert_edges_to_elementary(topo, solid, &tol)
+            .map_err(|e| crate::OperationsError::InvalidInput {
+                reason: format!("convert_to_elementary (edges) failed: {e}"),
+            })?;
+    Ok(surfaces + edges)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::print_stderr)]

--- a/crates/wasm/src/bindings/heal.rs
+++ b/crates/wasm/src/bindings/heal.rs
@@ -121,6 +121,26 @@ impl BrepKernel {
         Ok(count as u32)
     }
 
+    /// Recognize and replace NURBS faces and edges with their analytic
+    /// (elementary) forms wherever possible (Plane/Cylinder/Sphere/
+    /// Cone/Torus surfaces; Line/Circle/Ellipse edges).
+    ///
+    /// Inverse of `convertToBspline`: useful after STEP/IGES import
+    /// to recover analytic types from B-spline-only exports.
+    /// Returns the total number of faces and edges converted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if topology lookups fail.
+    #[wasm_bindgen(js_name = "convertToElementary")]
+    pub fn convert_to_elementary(&mut self, solid: u32) -> Result<u32, JsError> {
+        let solid_id = self.resolve_solid(solid)?;
+        let count =
+            brepkit_operations::heal::convert_to_elementary(self.topo_mut(), solid_id, TOL)?;
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(count as u32)
+    }
+
     /// Heal a solid topology.
     ///
     /// Returns the number of issues fixed.


### PR DESCRIPTION
Adds `BrepKernel::convertToElementary` WASM binding (with operations-layer `heal::convert_to_elementary` wrapper), inverse of the existing `convertToBspline`. Useful after STEP/IGES import to recover analytic types. CI: 15 checks.