### PR TITLE
feat(wasm): register convertToElementary in batch dispatch

### DIFF
--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -679,6 +679,18 @@ impl BrepKernel {
                     "converted": count,
                 }))
             }
+            "convertToElementary" => {
+                let s = get_u32(args, "solid")?;
+                let tol = get_f64(args, "tolerance").unwrap_or(crate::helpers::TOL);
+                let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;
+                let count =
+                    brepkit_operations::heal::convert_to_elementary(self.topo_mut(), solid_id, tol)
+                        .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!({
+                    "solid": solid_id_to_u32(solid_id),
+                    "converted": count,
+                }))
+            }
             "healSolid" => {
                 let s = get_u32(args, "solid")?;
                 let tol = get_f64(args, "tolerance").unwrap_or(1e-7);

--- a/crates/wasm/src/bindings/heal.rs
+++ b/crates/wasm/src/bindings/heal.rs
@@ -304,4 +304,45 @@ mod tests {
         assert!(first > 0);
         assert_eq!(second, 0, "second pass should convert nothing");
     }
+
+    #[test]
+    fn convert_to_elementary_via_batch_round_trip() {
+        // Round-trip a cylinder through the batch dispatch: NURBS-ify
+        // it, then recognize back. The convertToElementary entry was
+        // missing from `dispatch_op` before this PR, so prior to the
+        // fix this test would have hit the catch-all "unknown
+        // operation" arm.
+        let mut k = BrepKernel::new();
+        let r = k.execute_batch(
+            r#"[
+                {"op": "makeCylinder", "args": {"radius": 1, "height": 2}},
+                {"op": "convertToBspline", "args": {"solid": 0}},
+                {"op": "convertToElementary", "args": {"solid": 0}}
+            ]"#,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+        // convertToElementary must reach the dispatch arm — not the
+        // catch-all — so the result is `ok`, not `error`.
+        let ok = parsed[2]["ok"]
+            .as_object()
+            .expect("convertToElementary should be dispatched, got error");
+        assert!(ok.get("solid").is_some(), "missing 'solid' field");
+        let converted = ok["converted"].as_u64().expect("expected 'converted' u64");
+        assert!(
+            converted > 0,
+            "expected >=1 recognition (the cylinder lateral face at minimum), got {converted}"
+        );
+    }
+
+    #[test]
+    fn convert_to_elementary_via_batch_invalid_handle_errors() {
+        let mut k = BrepKernel::new();
+        let r = k.execute_batch(r#"[{"op": "convertToElementary", "args": {"solid": 999}}]"#);
+        let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+        assert!(
+            parsed[0]["error"].is_string(),
+            "expected error for invalid handle, got: {}",
+            parsed[0]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The `convertToElementary` binding (added in #648) was reachable via direct method calls but missing from `dispatch_op` in `bindings/batch.rs`, so any call through `executeBatch` hit the catch-all 'unknown operation' arm. Greptile flagged this on the original review.

## Changes

- Add the `convertToElementary` arm to `dispatch_op`, modeled on `convertToBspline`. Returns `{ \"solid\": ..., \"converted\": ... }`.
- Optional `tolerance` argument (defaults to `helpers::TOL` = 1e-7). Callers now have the flexibility to relax recognition for noisy STEP imports without needing a separate API. The non-batch binding still hardcodes `TOL`.
- Two contract tests:
  - `convert_to_elementary_via_batch_round_trip`: cylinder → convertToBspline → convertToElementary, asserts `ok` (not `error`) and ≥1 recognition. Without this dispatch entry the third op would return `error: unknown operation`.
  - `convert_to_elementary_via_batch_invalid_handle_errors`: handle 999 → expected error path through `resolve_solid`.

## Why this matters

`executeBatch` is the dispatch surface used by the brepjs adapter for batched WASM calls. A binding that's reachable on the Rust struct but not on the batch table is invisible to most JS callers — exactly the asymmetry that prompted the original Greptile flag.

## Test plan

- [x] `cargo test -p brepkit-wasm --lib bindings::heal::tests` (5/5 pass)
- [x] `cargo clippy -p brepkit-wasm --lib --tests -- -D warnings` (clean)
- [x] `cargo build -p brepkit-wasm --target wasm32-unknown-unknown` (clean)