### PR TITLE
docs(operations): document convert_to_elementary partial-mutation behavior

### DIFF
--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -1598,9 +1598,26 @@ pub fn convert_to_bspline(
 /// `EdgeCurve::Hyperbola`/`Parabola` exists in topology); they keep
 /// their NURBS representation.
 ///
+/// # Atomicity
+///
+/// Recognition runs in two passes (surfaces, then edges). Each pass
+/// snapshots its inputs before mutating, and individual mutations
+/// can't fail on valid topology — the only failure path is the
+/// initial topology lookup at the start of each pass. A pass that
+/// gets past its snapshot will run to completion.
+///
+/// As a result, an error from the *edge* pass means the surface
+/// pass already committed its mutations: the topology is in a
+/// partially converted state (analytic surfaces, NURBS edges).
+/// In practice the edge-pass failure mode requires malformed
+/// topology — a cleanly-loaded solid won't hit it. Callers that
+/// need transactional semantics should checkpoint the topology
+/// first and restore on error.
+///
 /// # Errors
 ///
-/// Returns an error if any topology lookup fails.
+/// Returns an error if any topology lookup fails. See the
+/// "Atomicity" section above for partial-mutation semantics.
 pub fn convert_to_elementary(
     topo: &mut Topology,
     solid: SolidId,


### PR DESCRIPTION
## Summary

Greptile flagged on #648 that `convert_to_elementary` is non-atomic: surface and edge recognition run as separate passes, and an error from the edge pass leaves the surface pass's mutations committed.

After tracing the failure paths, both passes can only fail at their initial topology lookup (snapshot phase) — once they get past the snapshot, the per-entity mutation loop can't error because we hold the entities exclusively under `&mut Topology`. So the actual failure mode is "snapshot fails on already-malformed topology," which is rare in practice.

This PR doesn't restructure for atomicity — it documents the partial-mutation semantics honestly so callers know what to rely on.

## Changes

Add an 'Atomicity' section to the docstring:

1. Each pass is internally consistent (snapshot-then-apply within a pass).
2. Across passes, an edge-pass error leaves the solid with analytic surfaces but NURBS edges — partially converted but well-formed.
3. Callers needing transactional semantics should checkpoint via the existing checkpoint API and restore on error.

## Why not a full atomic refactor

A 'plan all mutations, then apply' architecture is feasible — the heal-layer functions could be split into snapshot/plan and apply phases — but it's a substantial restructuring of `heal::custom::convert_to_elementary` and not justified given the failure-mode rarity. The honest documentation lets us close the Greptile concern without adding complexity that won't pay off.

## Test plan

- [x] `cargo build -p brepkit-operations` — clean
- [x] `cargo doc -p brepkit-operations --no-deps` — clean (no rustdoc warnings)