### PR TITLE
fix(heal): remove_internal_wires walks inner (cavity) shells

### DIFF
--- a/crates/heal/src/upgrade/remove_internal_wires.rs
+++ b/crates/heal/src/upgrade/remove_internal_wires.rs
@@ -1,22 +1,26 @@
 //! Remove internal (hole) wires from faces.
 
 use brepkit_topology::Topology;
-use brepkit_topology::face::FaceId;
+use brepkit_topology::explorer::solid_faces;
 use brepkit_topology::solid::SolidId;
 
 use crate::HealError;
 
 /// Remove all inner (hole) wires from faces in a solid.
 ///
-/// Returns the number of wires removed.
+/// Walks the outer shell *and* any inner (cavity) shells so that hollow
+/// solids' cavity-face inner wires are also removed — boolean cuts
+/// and `shell_op` can produce cavity faces with their own internal
+/// loops, which the prior outer-shell-only implementation silently
+/// preserved.
+///
+/// Returns the total number of wires removed.
 ///
 /// # Errors
 ///
 /// Returns [`HealError`] if entity lookups fail.
 pub fn remove_internal_wires(topo: &mut Topology, solid_id: SolidId) -> Result<usize, HealError> {
-    let solid_data = topo.solid(solid_id)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-    let face_ids: Vec<FaceId> = shell.faces().to_vec();
+    let face_ids = solid_faces(topo, solid_id)?;
 
     let mut removed = 0;
 
@@ -31,4 +35,96 @@ pub fn remove_internal_wires(topo: &mut Topology, solid_id: SolidId) -> Result<u
     }
 
     Ok(removed)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use brepkit_math::vec::{Point3, Vec3};
+    use brepkit_topology::edge::{Edge, EdgeCurve};
+    use brepkit_topology::face::{Face, FaceSurface};
+    use brepkit_topology::shell::Shell;
+    use brepkit_topology::solid::Solid;
+    use brepkit_topology::vertex::Vertex;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    fn add_face_with_n_inner_wires(
+        topo: &mut Topology,
+        anchor: Point3,
+        n_inner: usize,
+    ) -> brepkit_topology::face::FaceId {
+        let make_triangle = |topo: &mut Topology, base: Point3| -> brepkit_topology::wire::WireId {
+            let va = topo.add_vertex(Vertex::new(base, 1e-7));
+            let vb = topo.add_vertex(Vertex::new(
+                Point3::new(base.x() + 1.0, base.y(), base.z()),
+                1e-7,
+            ));
+            let vc = topo.add_vertex(Vertex::new(
+                Point3::new(base.x(), base.y() + 1.0, base.z()),
+                1e-7,
+            ));
+            let eab = topo.add_edge(Edge::new(va, vb, EdgeCurve::Line));
+            let ebc = topo.add_edge(Edge::new(vb, vc, EdgeCurve::Line));
+            let eca = topo.add_edge(Edge::new(vc, va, EdgeCurve::Line));
+            topo.add_wire(
+                Wire::new(
+                    vec![
+                        OrientedEdge::new(eab, true),
+                        OrientedEdge::new(ebc, true),
+                        OrientedEdge::new(eca, true),
+                    ],
+                    true,
+                )
+                .unwrap(),
+            )
+        };
+
+        let outer_wid = make_triangle(topo, anchor);
+        let inner_wires: Vec<_> = (0..n_inner)
+            .map(|i| {
+                make_triangle(
+                    topo,
+                    Point3::new(
+                        anchor.x() + 0.1 * (i as f64 + 1.0),
+                        anchor.y() + 0.1,
+                        anchor.z(),
+                    ),
+                )
+            })
+            .collect();
+        topo.add_face(Face::new(
+            outer_wid,
+            inner_wires,
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: 0.0,
+            },
+        ))
+    }
+
+    #[test]
+    fn remove_internal_wires_walks_inner_shells() {
+        // Outer shell: 1 face with 2 inner wires.
+        // Inner (cavity) shell: 1 face with 3 inner wires.
+        // Total expected removals: 2 + 3 = 5.
+        let mut topo = Topology::new();
+
+        let outer_face = add_face_with_n_inner_wires(&mut topo, Point3::new(0.0, 0.0, 0.0), 2);
+        let inner_face = add_face_with_n_inner_wires(&mut topo, Point3::new(0.0, 0.0, 5.0), 3);
+
+        let outer_shell = topo.add_shell(Shell::new(vec![outer_face]).unwrap());
+        let inner_shell = topo.add_shell(Shell::new(vec![inner_face]).unwrap());
+        let solid_id = topo.add_solid(Solid::new(outer_shell, vec![inner_shell]));
+
+        let removed = remove_internal_wires(&mut topo, solid_id).unwrap();
+        assert_eq!(
+            removed, 5,
+            "expected 5 inner-wire removals (2 outer + 3 inner), got {removed}"
+        );
+
+        // Both faces should now have zero inner wires.
+        assert_eq!(topo.face(outer_face).unwrap().inner_wires().len(), 0);
+        assert_eq!(topo.face(inner_face).unwrap().inner_wires().len(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

Continues the inner-shell-coverage audit (#652, #656, #658, #659). \`remove_internal_wires\` previously walked only \`outer_shell()\`, so inner wires on cavity faces survived a function whose contract is 'remove all internal wires from this solid.'

## Changes

- Replace hand-rolled outer-shell iteration with \`topology::explorer::solid_faces\`. Same fix pattern as the prior audit PRs.
- Update doc comment to mention the inner-shell coverage.
- Add a regression test that builds a solid with one outer face (2 inner wires) and one inner-shell face (3 inner wires); asserts 5 total removals (was 2 with the prior outer-shell-only path) and that both faces end with 0 inner wires.

## Test plan

- [x] \`cargo test -p brepkit-heal --lib\` (74/74 pass — adds 1 new test)
- [x] \`cargo clippy -p brepkit-heal --lib --tests -- -D warnings\` (clean)