### PR TITLE
fix(heal): fix_split_common_vertex walks inner (cavity) shells

### DIFF
--- a/crates/heal/src/fix/split_vertex.rs
+++ b/crates/heal/src/fix/split_vertex.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use brepkit_topology::Topology;
 use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::solid_faces;
 use brepkit_topology::solid::SolidId;
 use brepkit_topology::vertex::{Vertex, VertexId};
 
@@ -40,10 +41,11 @@ pub fn fix_split_common_vertex(
     ctx: &mut HealContext,
     _config: &FixConfig,
 ) -> Result<FixResult, HealError> {
-    let solid_data = topo.solid(solid_id)?;
-    let shell_id = solid_data.outer_shell();
-    let shell = topo.shell(shell_id)?;
-    let face_ids: Vec<_> = shell.faces().to_vec();
+    // Walk outer + inner (cavity) shells. Over-connection counting
+    // is solid-scoped: a vertex can be over-connected via a mix of
+    // outer-shell and inner-shell edges, and outer-shell-only would
+    // miss those cases.
+    let face_ids = solid_faces(topo, solid_id)?;
 
     // Count edges per vertex and collect edge-face associations.
     let mut vertex_edge_count: HashMap<usize, (VertexId, usize)> = HashMap::new();
@@ -128,10 +130,9 @@ fn split_vertex(
     ctx: &mut HealContext,
 ) -> Result<usize, HealError> {
     // ── Step 1: Find all edges connected to this vertex ──────────
-    let solid_data = topo.solid(solid_id)?;
-    let shell_id = solid_data.outer_shell();
-    let shell = topo.shell(shell_id)?;
-    let face_ids: Vec<_> = shell.faces().to_vec();
+    // Walk outer + inner (cavity) shells (see top-level comment in
+    // `fix_split_common_vertex`).
+    let face_ids = solid_faces(topo, solid_id)?;
 
     // Build: edge_id -> set of face_ids that reference it
     // Also: collect edges that touch our vertex


### PR DESCRIPTION
## Summary

Continues the inner-shell-coverage audit (#652, #656, #658, #659, #661). \`fix_split_common_vertex\` had two outer-shell-only walks (the top-level over-connection counter and the inner \`split_vertex\` helper); both missed cavity-shell edges, so over-connected vertices straddling the outer + cavity boundary were under-counted and judged not-over-connected.

## Changes

- Replace both outer-shell iterations with \`topology::explorer::solid_faces\`. Same fix pattern as the prior audit PRs.
- Add explanatory comments at each call site noting that over-connection counting is solid-scoped (a vertex can be over-connected via a mix of outer-shell and inner-shell edges).

## Why no new test

The function is complex — it splits topology based on edge-face adjacency components. A focused inner-shell test would require constructing a contrived over-connected vertex straddling two shells, which is indirect and brittle. The existing 75 heal tests cover the splitting logic; the inner-shell extension is structurally identical to the outer-shell path already exercised.

## Test plan

- [x] \`cargo test -p brepkit-heal --lib\` (75/75 pass)
- [x] \`cargo clippy -p brepkit-heal --lib --tests -- -D warnings\` (clean)