### PR TITLE
fix(io): mesh writers (OBJ/PLY/glTF) walk inner (cavity) shells

### DIFF
--- a/crates/io/src/gltf/writer.rs
+++ b/crates/io/src/gltf/writer.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 
 use brepkit_operations::tessellate;
 use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
 use brepkit_topology::solid::SolidId;
 
 /// Write one or more solids to glTF binary (.glb) format.
@@ -31,10 +32,11 @@ pub fn write_glb(
     let mut vertex_offset: u32 = 0;
 
     for &solid_id in solids {
-        let solid = topo.solid(solid_id)?;
-        let shell = topo.shell(solid.outer_shell())?;
+        // Walk outer + inner (cavity) shells so hollow solids'
+        // cavity surfaces are present in the GLB output.
+        let face_ids = solid_faces(topo, solid_id)?;
 
-        for &face_id in shell.faces() {
+        for &face_id in &face_ids {
             let mesh = tessellate::tessellate(topo, face_id, deflection)?;
             let offset = vertex_offset;
 

--- a/crates/io/src/obj/writer.rs
+++ b/crates/io/src/obj/writer.rs
@@ -4,6 +4,7 @@ use std::fmt::Write;
 
 use brepkit_operations::tessellate::{self, TriangleMesh};
 use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
 use brepkit_topology::solid::SolidId;
 
 /// Write one or more solids to OBJ format as a UTF-8 string.
@@ -22,10 +23,13 @@ pub fn write_obj(
     let mut merged = TriangleMesh::default();
 
     for &solid_id in solids {
-        let solid = topo.solid(solid_id)?;
-        let shell = topo.shell(solid.outer_shell())?;
+        // Walk outer + inner (cavity) shells. A hollow solid's
+        // cavity surface is part of the geometry the user expects
+        // to round-trip through OBJ; outer-shell-only would emit a
+        // mesh with the void unrepresented.
+        let face_ids = solid_faces(topo, solid_id)?;
 
-        for &face_id in shell.faces() {
+        for &face_id in &face_ids {
             let mesh = tessellate::tessellate(topo, face_id, deflection)?;
             let offset = merged.positions.len();
 

--- a/crates/io/src/ply/writer.rs
+++ b/crates/io/src/ply/writer.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 
 use brepkit_operations::tessellate;
 use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
 use brepkit_topology::solid::SolidId;
 
 /// PLY output format.
@@ -33,10 +34,11 @@ pub fn write_ply(
     let mut vertex_offset: u32 = 0;
 
     for &solid_id in solids {
-        let solid = topo.solid(solid_id)?;
-        let shell = topo.shell(solid.outer_shell())?;
+        // Walk outer + inner (cavity) shells so hollow solids'
+        // cavity surfaces are present in the PLY output.
+        let face_ids = solid_faces(topo, solid_id)?;
 
-        for &face_id in shell.faces() {
+        for &face_id in &face_ids {
             let mesh = tessellate::tessellate(topo, face_id, deflection)?;
 
             #[allow(clippy::cast_possible_truncation)]


### PR DESCRIPTION
## Summary

Continues the inner-shell-coverage audit (now extended into the io layer). The OBJ, PLY, and glTF writers each iterated only the outer shell, so a hollow solid's cavity surfaces never made it into the exported mesh. A user exporting a shelled-out part to OBJ would lose the inner wall geometry entirely; reimporting the OBJ would round-trip to a *closed* (un-shelled) solid — a real fidelity bug, not theoretical.

## Changes

Replace each writer's hand-rolled \`topo.shell(solid.outer_shell())\` iteration with \`topology::explorer::solid_faces\`, which transparently flattens outer + inner shell faces. Same canonical pattern as the heal-layer audit fixes (#652, #656, #658, #659, #661, #663) — see CLAUDE.md 'Walking faces in a solid' (added in #664) for the rule.

Files touched:

- \`crates/io/src/obj/writer.rs\`
- \`crates/io/src/ply/writer.rs\`
- \`crates/io/src/gltf/writer.rs\`

## Why no new test

The io tests are mostly format-validity checks (parse round-trip, header structure) rather than geometric coverage. Writing a hollow-solid round-trip test that asserts cavity faces appear in the output is a larger undertaking that warrants a dedicated PR. The existing 131 io tests pass.

## Test plan

- [x] \`cargo test -p brepkit-io --lib\` (131/131 pass)
- [x] \`cargo clippy -p brepkit-io --lib --tests -- -D warnings\` (clean)