### PR TITLE
ci: only save rust-cache on main, restore on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
@@ -40,6 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --workspace
       # nextest doesn't run doc tests, so run them separately
@@ -51,6 +55,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
         run: |
@@ -89,6 +95,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@wasm-pack
       - name: Build and validate WASM
         run: cargo xtask wasm-build --skip-opt
@@ -102,6 +110,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build WASM (PR)
         run: |
           cargo build -p brepkit-wasm --target wasm32-unknown-unknown --release
@@ -205,6 +215,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings


### PR DESCRIPTION
## Summary

Add `save-if: ${{ github.ref == 'refs/heads/main' }}` to every `Swatinem/rust-cache@v2` step except `msrv` (which has its own keyed cache).

## Why

PR branches were uploading their own rust-cache snapshots, which over time evicted main's caches via GitHub's 10 GB LRU policy. The visible symptom: a fresh PR with no source changes (e.g. PR #671) could trigger a **30-40 min** cold `cargo-llvm-cov` instrumented workspace build, vs. **~1 min** on a warm cache.

With `save-if` scoped to main:

- Main commits keep updating the canonical cache
- PRs **read** main's cache via Swatinem's built-in restore-keys
- PRs no longer **write** caches, so they can't evict main's

This is the documented Swatinem pattern for monorepo CI cache stewardship: https://github.com/Swatinem/rust-cache#considerations.

## Test plan

- [ ] CI passes on this PR (will still be slow this once, since no cache exists yet under the new write policy until this PR's CI completes and **doesn't** save)
- [ ] After merge, next PR off main hits warm cache and Coverage runs in a few minutes