### PR TITLE
fix(boolean): restore all-3-dims aabb_strictly_contains

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -451,58 +451,49 @@ fn assemble(
     growth_shells: Vec<Vec<FaceId>>,
     hole_shells: Vec<Vec<FaceId>>,
 ) -> Result<SolidId, AlgoError> {
-    // When there are multiple growth shells and no hole shells, combine all
-    // growth pieces into a single outer shell. A Shell is just a list of
-    // faces — it does not need to be a single connected component, and the
-    // divergence-theorem volume sum is correct as long as every face is
-    // included. This handles disjoint cut/fuse results (e.g., a cut that
-    // splits a solid into two pieces) without marking spare pieces as
-    // cavities (which would invert their volume contribution).
-    //
-    // When hole shells exist, the result genuinely has cavities (e.g., a
-    // shelled solid where the inner wall is reversed). Keep the classic
-    // "largest growth = outer, additional growths = inner shells" placement
-    // so the cavity vs sibling-piece distinction is preserved for callers.
-    let (outer_faces, extra_growth_shells) = if hole_shells.is_empty() && growth_shells.len() > 1 {
-        let combined: Vec<FaceId> = growth_shells.into_iter().flatten().collect();
-        (combined, Vec::<Vec<FaceId>>::new())
-    } else {
-        let outer_idx = growth_shells
-            .iter()
-            .enumerate()
-            .max_by_key(|(_, s)| s.len())
-            .map(|(i, _)| i)
-            .unwrap_or(0);
-        let mut outer = Vec::new();
-        let mut extras = Vec::new();
-        for (i, gs) in growth_shells.into_iter().enumerate() {
-            if i == outer_idx {
-                outer = gs;
-            } else {
-                extras.push(gs);
-            }
-        }
-        (outer, extras)
-    };
+    // Use the largest growth shell as outer
+    let outer_idx = growth_shells
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, s)| s.len())
+        .map(|(i, _)| i)
+        .unwrap_or(0);
 
-    let outer_shell = Shell::new(outer_faces)
+    let outer_shell = Shell::new(growth_shells[outer_idx].clone())
         .map_err(|e| AlgoError::AssemblyFailed(format!("outer shell: {e}")))?;
     let outer_id = topo.add_shell(outer_shell);
 
+    // All hole shells become inner shells of this solid
     let mut inner_ids = Vec::new();
     for hole in &hole_shells {
         if let Ok(inner_shell) = Shell::new(hole.clone()) {
             inner_ids.push(topo.add_shell(inner_shell));
         }
     }
-    for gs in &extra_growth_shells {
-        if let Ok(extra_shell) = Shell::new(gs.clone()) {
-            inner_ids.push(topo.add_shell(extra_shell));
+
+    // Additional growth shells (disjoint outward-oriented regions) are added
+    // as extra shells. For boolean results this typically doesn't happen (single
+    // connected result), but disjoint fuse can produce multiple growth shells.
+    // TODO: use Compound for true multi-region results.
+    for (i, gs) in growth_shells.iter().enumerate() {
+        if i != outer_idx {
+            if let Ok(extra_shell) = Shell::new(gs.clone()) {
+                inner_ids.push(topo.add_shell(extra_shell));
+            }
         }
     }
 
     let solid = Solid::new(outer_id, inner_ids);
     let solid_id = topo.add_solid(solid);
+
+    log::debug!(
+        "BuilderSolid: assembled solid {solid_id:?} with {} faces",
+        growth_shells
+            .iter()
+            .chain(hole_shells.iter())
+            .map(Vec::len)
+            .sum::<usize>()
+    );
 
     Ok(solid_id)
 }

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -451,49 +451,58 @@ fn assemble(
     growth_shells: Vec<Vec<FaceId>>,
     hole_shells: Vec<Vec<FaceId>>,
 ) -> Result<SolidId, AlgoError> {
-    // Use the largest growth shell as outer
-    let outer_idx = growth_shells
-        .iter()
-        .enumerate()
-        .max_by_key(|(_, s)| s.len())
-        .map(|(i, _)| i)
-        .unwrap_or(0);
+    // When there are multiple growth shells and no hole shells, combine all
+    // growth pieces into a single outer shell. A Shell is just a list of
+    // faces — it does not need to be a single connected component, and the
+    // divergence-theorem volume sum is correct as long as every face is
+    // included. This handles disjoint cut/fuse results (e.g., a cut that
+    // splits a solid into two pieces) without marking spare pieces as
+    // cavities (which would invert their volume contribution).
+    //
+    // When hole shells exist, the result genuinely has cavities (e.g., a
+    // shelled solid where the inner wall is reversed). Keep the classic
+    // "largest growth = outer, additional growths = inner shells" placement
+    // so the cavity vs sibling-piece distinction is preserved for callers.
+    let (outer_faces, extra_growth_shells) = if hole_shells.is_empty() && growth_shells.len() > 1 {
+        let combined: Vec<FaceId> = growth_shells.into_iter().flatten().collect();
+        (combined, Vec::<Vec<FaceId>>::new())
+    } else {
+        let outer_idx = growth_shells
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, s)| s.len())
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        let mut outer = Vec::new();
+        let mut extras = Vec::new();
+        for (i, gs) in growth_shells.into_iter().enumerate() {
+            if i == outer_idx {
+                outer = gs;
+            } else {
+                extras.push(gs);
+            }
+        }
+        (outer, extras)
+    };
 
-    let outer_shell = Shell::new(growth_shells[outer_idx].clone())
+    let outer_shell = Shell::new(outer_faces)
         .map_err(|e| AlgoError::AssemblyFailed(format!("outer shell: {e}")))?;
     let outer_id = topo.add_shell(outer_shell);
 
-    // All hole shells become inner shells of this solid
     let mut inner_ids = Vec::new();
     for hole in &hole_shells {
         if let Ok(inner_shell) = Shell::new(hole.clone()) {
             inner_ids.push(topo.add_shell(inner_shell));
         }
     }
-
-    // Additional growth shells (disjoint outward-oriented regions) are added
-    // as extra shells. For boolean results this typically doesn't happen (single
-    // connected result), but disjoint fuse can produce multiple growth shells.
-    // TODO: use Compound for true multi-region results.
-    for (i, gs) in growth_shells.iter().enumerate() {
-        if i != outer_idx {
-            if let Ok(extra_shell) = Shell::new(gs.clone()) {
-                inner_ids.push(topo.add_shell(extra_shell));
-            }
+    for gs in &extra_growth_shells {
+        if let Ok(extra_shell) = Shell::new(gs.clone()) {
+            inner_ids.push(topo.add_shell(extra_shell));
         }
     }
 
     let solid = Solid::new(outer_id, inner_ids);
     let solid_id = topo.add_solid(solid);
-
-    log::debug!(
-        "BuilderSolid: assembled solid {solid_id:?} with {} faces",
-        growth_shells
-            .iter()
-            .chain(hole_shells.iter())
-            .map(Vec::len)
-            .sum::<usize>()
-    );
 
     Ok(solid_id)
 }

--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -693,69 +693,6 @@ pub(super) fn face_components(topo: &Topology, solid: SolidId) -> Vec<Vec<FaceId
     components
 }
 
-/// Count connected components in a solid's outer shell via face adjacency.
-///
-/// Two faces are adjacent if they share an edge. Returns 1 for a topologically
-/// connected solid. Returns >1 if the boolean assembled disconnected groups.
-pub(super) fn count_face_components(topo: &Topology, solid: SolidId) -> usize {
-    let shell = match topo.solid(solid).and_then(|s| topo.shell(s.outer_shell())) {
-        Ok(sh) => sh,
-        Err(_) => return 0,
-    };
-    let face_ids = shell.faces();
-    if face_ids.is_empty() {
-        return 0;
-    }
-    let n = face_ids.len();
-
-    // Build edge→face index map
-    let mut edge_faces: HashMap<usize, Vec<usize>> = HashMap::new();
-    for (fi, &fid) in face_ids.iter().enumerate() {
-        let Ok(face) = topo.face(fid) else { continue };
-        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
-            let Ok(wire) = topo.wire(wid) else { continue };
-            for oe in wire.edges() {
-                edge_faces.entry(oe.edge().index()).or_default().push(fi);
-            }
-        }
-    }
-
-    // Build face adjacency
-    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
-    for faces_at_edge in edge_faces.values() {
-        for &fi in faces_at_edge {
-            for &fj in faces_at_edge {
-                if fi != fj {
-                    adj[fi].push(fj);
-                }
-            }
-        }
-    }
-
-    // Flood-fill to count components
-    let mut visited = vec![false; n];
-    let mut components = 0usize;
-    for start in 0..n {
-        if visited[start] {
-            continue;
-        }
-        components += 1;
-        let mut stack = vec![start];
-        while let Some(fi) = stack.pop() {
-            if visited[fi] {
-                continue;
-            }
-            visited[fi] = true;
-            for &nfi in &adj[fi] {
-                if !visited[nfi] {
-                    stack.push(nfi);
-                }
-            }
-        }
-    }
-    components
-}
-
 // ---------------------------------------------------------------------------
 // Post-assembly edge refinement
 // ---------------------------------------------------------------------------

--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -630,11 +630,73 @@ pub(super) fn validate_boolean_result(
     Ok(())
 }
 
+/// Split a solid's outer shell into connected face groups.
+///
+/// Two faces are adjacent if they share an edge. Returns each connected
+/// group as a Vec<FaceId> — a single-component solid produces one group,
+/// a multi-region solid (disjoint pieces in one shell) produces N groups.
+pub(super) fn face_components(topo: &Topology, solid: SolidId) -> Vec<Vec<FaceId>> {
+    let shell = match topo.solid(solid).and_then(|s| topo.shell(s.outer_shell())) {
+        Ok(sh) => sh,
+        Err(_) => return Vec::new(),
+    };
+    let face_ids: Vec<FaceId> = shell.faces().to_vec();
+    if face_ids.is_empty() {
+        return Vec::new();
+    }
+    let n = face_ids.len();
+
+    let mut edge_faces: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (fi, &fid) in face_ids.iter().enumerate() {
+        let Ok(face) = topo.face(fid) else { continue };
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            let Ok(wire) = topo.wire(wid) else { continue };
+            for oe in wire.edges() {
+                edge_faces.entry(oe.edge().index()).or_default().push(fi);
+            }
+        }
+    }
+
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for faces_at_edge in edge_faces.values() {
+        for &fi in faces_at_edge {
+            for &fj in faces_at_edge {
+                if fi != fj {
+                    adj[fi].push(fj);
+                }
+            }
+        }
+    }
+
+    let mut visited = vec![false; n];
+    let mut components: Vec<Vec<FaceId>> = Vec::new();
+    for start in 0..n {
+        if visited[start] {
+            continue;
+        }
+        let mut comp_faces = Vec::new();
+        let mut stack = vec![start];
+        while let Some(fi) = stack.pop() {
+            if visited[fi] {
+                continue;
+            }
+            visited[fi] = true;
+            comp_faces.push(face_ids[fi]);
+            for &nfi in &adj[fi] {
+                if !visited[nfi] {
+                    stack.push(nfi);
+                }
+            }
+        }
+        components.push(comp_faces);
+    }
+    components
+}
+
 /// Count connected components in a solid's outer shell via face adjacency.
 ///
 /// Two faces are adjacent if they share an edge. Returns 1 for a topologically
 /// connected solid. Returns >1 if the boolean assembled disconnected groups.
-#[allow(dead_code)]
 pub(super) fn count_face_components(topo: &Topology, solid: SolidId) -> usize {
     let shell = match topo.solid(solid).and_then(|s| topo.shell(s.outer_shell())) {
         Ok(sh) => sh,

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -4,7 +4,7 @@
 //! with mesh boolean (co-refinement) as a fallback when GFA fails or produces
 //! invalid results.
 
-mod assembly;
+pub mod assembly;
 mod classify;
 mod types;
 use assembly::validate_boolean_result;
@@ -92,8 +92,11 @@ pub fn boolean(
                     && i_max.z() <= o_max.z() + margin
             };
         // AABB-strictly-contains (strict): outer must also be ≥10% larger in
-        // ≥2 dims. Used as the no-classifier fallback to avoid false-positive
-        // containment when AABBs overlap but neither solid contains the other.
+        // ALL 3 dims. Used as the no-classifier fallback to detect true
+        // nested containment (e.g., a ring fully inside a shell's cavity)
+        // without false-positives on sparse multi-shell solids (e.g., a
+        // fuse of disjoint boxes whose AABB technically encloses another
+        // solid's AABB while mostly being empty space).
         let aabb_strictly_contains =
             |inner: &Option<(Point3, Point3)>, outer: &Option<(Point3, Point3)>| -> bool {
                 if !aabb_encloses(inner, outer) {
@@ -108,9 +111,7 @@ pub fn boolean(
                     (o_max.z() - o_min.z(), i_max.z() - i_min.z()),
                 ];
                 dims.iter()
-                    .filter(|(outer_d, inner_d)| *outer_d > *inner_d * 1.1)
-                    .count()
-                    >= 2
+                    .all(|(outer_d, inner_d)| *outer_d > *inner_d * 1.1)
             };
 
         // Bidirectional vertex check via the analytic classifier — the
@@ -137,11 +138,12 @@ pub fn boolean(
             .unwrap_or(false);
 
         // Containment shortcut: A contains B when all B vertices are
-        // inside-or-on A AND A's AABB encloses B's. The vertex check
-        // handles cases where AABB centers coincide (e.g., concentric
-        // cylinders of same radius, different heights) where the prior
-        // center-based check failed. Falls back to AABB-only when the
-        // containing solid's classifier is unavailable.
+        // inside-or-on A AND A's AABB encloses B's. Falls back to a
+        // strict AABB-only check when the containing solid has no
+        // classifier — the strict check requires ≥10% larger in ALL
+        // three dims so that sparse multi-shell solids (e.g., a fuse
+        // of two disjoint boxes) don't false-positive as "contains
+        // another solid".
         let b_in_a = (all_b_verts_in_a && aabb_encloses(&aabb_b, &aabb_a))
             || (ca.is_none() && aabb_strictly_contains(&aabb_b, &aabb_a));
         let a_in_b = (all_a_verts_in_b && aabb_encloses(&aabb_a, &aabb_b))
@@ -421,17 +423,59 @@ pub fn boolean(
                     );
                     return Ok(result);
                 }
+                // Multi-region manifold result (e.g., a cut that splits a
+                // solid into N disjoint pieces). N independently closed
+                // manifolds have combined Euler = 2*N. Falling back to mesh
+                // boolean here would collapse the disjoint pieces down to a
+                // single region's volume (the symptom we were seeing in
+                // `cut with simplify` returning vol 166 instead of 1000).
+                //
+                // Gate strictly on closed-manifold (every edge shared by
+                // exactly 2 faces) AND on the face-adjacency component
+                // count matching Euler/2, so a partially-assembled GFA
+                // failure (boundary edges, dangling faces, non-shared
+                // edges) still falls through to mesh-boolean.
+                let components = crate::boolean::assembly::count_face_components(topo, result);
+                #[allow(clippy::cast_possible_wrap)]
+                let expected_euler = (components as i64) * 2;
+                if components >= 2
+                    && euler == expected_euler
+                    && is_closed_manifold(topo, result).unwrap_or(false)
+                    && validate_boolean_result(topo, result).is_ok()
+                {
+                    log::info!(
+                        "GFA multi-region succeeded in {:.1}ms ({result_faces} faces, {components} pieces)",
+                        timer_elapsed_ms(gfa_start)
+                    );
+                    return Ok(result);
+                }
             }
             log::warn!(
-                "GFA result failed validation in {:.1}ms (faces={result_faces}), falling back to mesh boolean",
+                "GFA result failed validation in {:.1}ms (faces={result_faces}), falling back",
                 timer_elapsed_ms(gfa_start)
             );
         }
         Err(e) => {
             log::warn!(
-                "GFA boolean failed in {:.1}ms ({e}), falling back to mesh boolean",
+                "GFA boolean failed in {:.1}ms ({e}), falling back",
                 timer_elapsed_ms(gfa_start)
             );
+        }
+    }
+
+    // ── Multi-region input fallback (Cut only) ───────────────────────
+    // When the input solid carries multiple disjoint pieces (a previous
+    // cut split a solid into N parts), GFA's pavefiller can't process
+    // them together — feeding the whole thing in loses regions. Splitting
+    // into per-component cuts and recombining preserves the missing
+    // pieces. Cut distributes over disjoint union; Fuse/Intersect have
+    // more complex interaction semantics so we leave those to mesh.
+    if op == BooleanOp::Cut {
+        let comp_count = crate::boolean::assembly::count_face_components(topo, a);
+        if comp_count >= 2 {
+            if let Ok(result) = cut_multi_region_input(topo, a, b, comp_count) {
+                return Ok(result);
+            }
         }
     }
 
@@ -556,8 +600,15 @@ pub fn boolean_with_evolution(
     let centroid_dist_sq_max = 100.0;
 
     for &(out_idx, out_normal, out_centroid) in &output_faces {
+        // Collect every input face whose normal+centroid is "close enough"
+        // to the output face. When fuse simplifies two coincident-plane
+        // inputs into one output (e.g. fuse of touching boxes via the
+        // box-pair shortcut: the top faces of A and B both collapse onto
+        // the result's top face), picking only the single best-scoring
+        // input drops the other input's metadata. Recording every
+        // qualifying input under the same output preserves both origins.
         let mut best_score = f64::NEG_INFINITY;
-        let mut best_input: Option<usize> = None;
+        let mut matches: Vec<(usize, f64)> = Vec::new();
 
         for &(in_idx, in_normal, in_centroid) in &input_faces {
             let dot = out_normal.dot(in_normal);
@@ -574,19 +625,28 @@ pub fn boolean_with_evolution(
                 continue;
             }
 
-            // Score: higher normal alignment + closer centroid = better.
             let score = dot - dist_sq / centroid_dist_sq_max;
             if score > best_score {
                 best_score = score;
-                best_input = Some(in_idx);
             }
+            matches.push((in_idx, score));
         }
 
-        if let Some(in_idx) = best_input {
-            evo.add_modified(in_idx, out_idx);
-            matched_inputs.insert(in_idx);
-        } else {
+        if matches.is_empty() {
             unmatched_outputs.push((out_idx, out_normal, out_centroid));
+            continue;
+        }
+
+        // Accept any match within a small tolerance of the best score —
+        // ties (or near-ties) usually indicate two input faces that
+        // legitimately contributed to the same output (e.g., the two
+        // halves of a face that merged across a same-domain boundary).
+        let score_tol = 0.05;
+        for &(in_idx, score) in &matches {
+            if score >= best_score - score_tol {
+                evo.add_modified(in_idx, out_idx);
+                matched_inputs.insert(in_idx);
+            }
         }
     }
 
@@ -701,7 +761,16 @@ fn box_pair_shortcut(
                 ),
             )
         }
-        BooleanOp::Cut => return Ok(None),
+        BooleanOp::Cut => {
+            // Cut shortcut: when B spans A in 2 of 3 dims (≥ A's extent
+            // on both sides) and overlaps in the third, the result is
+            // up-to-2 axis-aligned boxes (the leftover slabs on either
+            // side of B in the cutting dim). This avoids routing through
+            // GFA's same-domain handling which currently mishandles the
+            // 4-coincident-face case (target's lateral walls + tool's
+            // matching walls).
+            return box_pair_cut_shortcut(topo, a_min, a_max, b_min, b_max, eps);
+        }
     };
     let dx = max.x() - min.x();
     let dy = max.y() - min.y();
@@ -715,6 +784,116 @@ fn box_pair_shortcut(
         crate::transform::transform_solid(topo, bx, &xform)?;
     }
     Ok(Some(bx))
+}
+
+/// Cut shortcut for two axis-aligned boxes: returns the leftover
+/// portion(s) when B slices through A in one dimension while spanning
+/// A in the other two dimensions. The result is 0, 1, or 2 axis-aligned
+/// boxes packaged into a single multi-region Solid.
+///
+/// Returns `Ok(None)` when the shortcut doesn't fit — e.g., B doesn't
+/// span A in any 2 dims, B touches only a corner, etc. The general path
+/// (GFA) handles those cases.
+fn box_pair_cut_shortcut(
+    topo: &mut Topology,
+    a_min: Point3,
+    a_max: Point3,
+    b_min: Point3,
+    b_max: Point3,
+    eps: f64,
+) -> Result<Option<SolidId>, crate::OperationsError> {
+    // B must span A in 2 of 3 dims (B_min ≤ A_min - eps AND B_max ≥ A_max + eps,
+    // i.e., B's extent covers A's extent in that dim).
+    let x_spans = b_min.x() <= a_min.x() + eps && b_max.x() >= a_max.x() - eps;
+    let y_spans = b_min.y() <= a_min.y() + eps && b_max.y() >= a_max.y() - eps;
+    let z_spans = b_min.z() <= a_min.z() + eps && b_max.z() >= a_max.z() - eps;
+    let spans_count = u8::from(x_spans) + u8::from(y_spans) + u8::from(z_spans);
+    if spans_count != 2 {
+        return Ok(None);
+    }
+    // In the non-spanning dim, B must actually intersect A.
+    let (a_lo, a_hi, b_lo, b_hi) = if !x_spans {
+        (a_min.x(), a_max.x(), b_min.x(), b_max.x())
+    } else if !y_spans {
+        (a_min.y(), a_max.y(), b_min.y(), b_max.y())
+    } else {
+        (a_min.z(), a_max.z(), b_min.z(), b_max.z())
+    };
+    if b_hi <= a_lo + eps || b_lo >= a_hi - eps {
+        return Ok(None);
+    }
+
+    // Build the leftover slabs. There are 0, 1, or 2 pieces depending on
+    // whether B extends past A on each side in the cutting dim.
+    let cuts: Vec<(f64, f64)> = {
+        let mut pieces = Vec::with_capacity(2);
+        if b_lo > a_lo + eps {
+            pieces.push((a_lo, b_lo)); // slab before B
+        }
+        if b_hi < a_hi - eps {
+            pieces.push((b_hi, a_hi)); // slab after B
+        }
+        pieces
+    };
+    if cuts.is_empty() {
+        // B fully covers A in the cutting dim → cut leaves nothing.
+        // Let the general path handle this (it errors).
+        return Ok(None);
+    }
+
+    let piece_solids: Vec<SolidId> = cuts
+        .iter()
+        .map(|&(lo, hi)| -> Result<SolidId, crate::OperationsError> {
+            let (dx, dy, dz, tx, ty, tz) = if !x_spans {
+                (
+                    hi - lo,
+                    a_max.y() - a_min.y(),
+                    a_max.z() - a_min.z(),
+                    lo,
+                    a_min.y(),
+                    a_min.z(),
+                )
+            } else if !y_spans {
+                (
+                    a_max.x() - a_min.x(),
+                    hi - lo,
+                    a_max.z() - a_min.z(),
+                    a_min.x(),
+                    lo,
+                    a_min.z(),
+                )
+            } else {
+                (
+                    a_max.x() - a_min.x(),
+                    a_max.y() - a_min.y(),
+                    hi - lo,
+                    a_min.x(),
+                    a_min.y(),
+                    lo,
+                )
+            };
+            let bx = crate::primitives::make_box(topo, dx, dy, dz)?;
+            if tx.abs() > eps || ty.abs() > eps || tz.abs() > eps {
+                let xform = brepkit_math::mat::Mat4::translation(tx, ty, tz);
+                crate::transform::transform_solid(topo, bx, &xform)?;
+            }
+            Ok(bx)
+        })
+        .collect::<Result<_, _>>()?;
+
+    if piece_solids.len() == 1 {
+        return Ok(Some(piece_solids[0]));
+    }
+
+    // Combine pieces into a single multi-region solid.
+    let mut all_faces: Vec<brepkit_topology::face::FaceId> = Vec::new();
+    for &p in &piece_solids {
+        let p_data = topo.solid(p)?;
+        for &fid in topo.shell(p_data.outer_shell())?.faces() {
+            all_faces.push(fid);
+        }
+    }
+    Ok(Some(make_solid_from_face_subset(topo, &all_faces)?))
 }
 
 /// Compute the coaxial-cylinder boolean for two cylinders sharing axis,
@@ -1125,6 +1304,158 @@ fn mesh_result_to_face_specs(result: &crate::mesh_boolean::MeshBooleanResult) ->
 
 /// Merge duplicate vertices in a solid's shell by position.
 ///
+/// Cut a multi-region input solid: split the components, cut each
+/// against `b` independently, then combine the per-component results
+/// back into a single multi-region solid.
+///
+/// This works around the GFA pavefiller's assumption of a single
+/// connected input — feeding a 2-piece "solid" into GFA loses one piece
+/// at a time as the cut proceeds (Category B `multiple cuts creating
+/// three pieces` and gear bore are both downstream of this).
+fn cut_multi_region_input(
+    topo: &mut Topology,
+    a: SolidId,
+    b: SolidId,
+    comp_count: usize,
+) -> Result<SolidId, crate::OperationsError> {
+    let components = crate::boolean::assembly::face_components(topo, a);
+    debug_assert_eq!(components.len(), comp_count);
+
+    let mut per_component_results: Vec<SolidId> = Vec::with_capacity(components.len());
+    for comp_faces in components {
+        // Copy the component's faces into a fresh single-component solid
+        // so the boolean engine sees a connected manifold.
+        let comp_solid_raw = make_solid_from_face_subset(topo, &comp_faces)?;
+        // Deep-copy the component into a fresh solid so its faces/edges/
+        // vertices have fresh IDs disjoint from the original multi-region
+        // input — GFA's pavefiller can stumble on shared vertex IDs across
+        // what it considers a single "solid A".
+        let comp_solid = crate::copy::copy_solid(topo, comp_solid_raw)?;
+        match boolean(topo, BooleanOp::Cut, comp_solid, b) {
+            Ok(r) => per_component_results.push(r),
+            Err(crate::OperationsError::InvalidInput { .. }) => {
+                per_component_results.push(comp_solid);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Combine all per-component results into a single multi-region solid.
+    // Collect every face from every result into one outer shell. The
+    // results are pairwise disjoint by construction (each came from a
+    // disjoint input component cut by the same tool), so a single shell
+    // containing all their faces is a valid manifold representation.
+    let mut all_faces: Vec<brepkit_topology::face::FaceId> = Vec::new();
+    for &r in &per_component_results {
+        let r_data = topo.solid(r)?;
+        for &fid in topo.shell(r_data.outer_shell())?.faces() {
+            all_faces.push(fid);
+        }
+    }
+    make_solid_from_face_subset(topo, &all_faces)
+}
+
+/// Build a new solid whose outer shell consists exactly of the given
+/// faces. Faces are referenced as-is (no copying) — the caller is
+/// expected to pass faces that already form a closed manifold.
+///
+/// `reversed=true` faces are NORMALIZED on the way in: a fresh face is
+/// created with the surface normal negated, the wires reversed, and
+/// `reversed=false`. Boolean operations downstream are sensitive to the
+/// `reversed` flag (cut1's output carries reversed faces that GFA can't
+/// re-process cleanly even via deep-copy), so handing GFA an
+/// orientation-normalized solid recovers the fresh-primitive code path.
+fn make_solid_from_face_subset(
+    topo: &mut Topology,
+    faces: &[brepkit_topology::face::FaceId],
+) -> Result<SolidId, crate::OperationsError> {
+    use brepkit_topology::face::{Face, FaceSurface};
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    let mut normalized: Vec<brepkit_topology::face::FaceId> = Vec::with_capacity(faces.len());
+    for &fid in faces {
+        let face = topo.face(fid)?;
+        if !face.is_reversed() {
+            normalized.push(fid);
+            continue;
+        }
+        let flipped_surface = match face.surface() {
+            FaceSurface::Plane { normal, d } => FaceSurface::Plane {
+                normal: -*normal,
+                d: -*d,
+            },
+            // Non-planar reversed faces (cylinder/cone/etc.) cannot have
+            // their surface negated trivially. Leave as-is — those cases
+            // hit cylinder/sphere-specific code paths in GFA that don't
+            // suffer from the same reversed-flag sensitivity.
+            other => {
+                normalized.push(fid);
+                let _ = other;
+                continue;
+            }
+        };
+        let outer_wid = face.outer_wire();
+        let inner_wids: Vec<_> = face.inner_wires().to_vec();
+        let outer_wire = topo.wire(outer_wid)?;
+        let outer_reversed: Vec<OrientedEdge> = outer_wire
+            .edges()
+            .iter()
+            .rev()
+            .map(|oe| OrientedEdge::new(oe.edge(), !oe.is_forward()))
+            .collect();
+        let new_outer_wire =
+            Wire::new(outer_reversed, true).map_err(crate::OperationsError::Topology)?;
+        let new_outer_wid = topo.add_wire(new_outer_wire);
+        let mut new_inner_wids = Vec::with_capacity(inner_wids.len());
+        for iw in &inner_wids {
+            let w = topo.wire(*iw)?;
+            let rev: Vec<OrientedEdge> = w
+                .edges()
+                .iter()
+                .rev()
+                .map(|oe| OrientedEdge::new(oe.edge(), !oe.is_forward()))
+                .collect();
+            let new_w = Wire::new(rev, true).map_err(crate::OperationsError::Topology)?;
+            new_inner_wids.push(topo.add_wire(new_w));
+        }
+        let new_face = Face::new(new_outer_wid, new_inner_wids, flipped_surface);
+        normalized.push(topo.add_face(new_face));
+    }
+
+    let shell = brepkit_topology::shell::Shell::new(normalized)
+        .map_err(crate::OperationsError::Topology)?;
+    let shell_id = topo.add_shell(shell);
+    let solid = brepkit_topology::solid::Solid::new(shell_id, Vec::new());
+    Ok(topo.add_solid(solid))
+}
+
+/// Check whether a solid's outer shell is a closed manifold: every edge
+/// is shared by exactly 2 faces. Returns `false` for open shells
+/// (boundary edges with count == 1) and non-manifold shells (count > 2).
+///
+/// Stricter than [`brepkit_topology::validation::validate_shell_manifold`],
+/// which only rejects edges shared by *more* than two faces.
+fn is_closed_manifold(topo: &Topology, solid: SolidId) -> Result<bool, crate::OperationsError> {
+    use std::collections::HashMap;
+
+    let s = topo.solid(solid)?;
+    let shell = topo.shell(s.outer_shell())?;
+    let mut counts: HashMap<usize, usize> = HashMap::new();
+    for &fid in shell.faces() {
+        let face = topo.face(fid)?;
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            let wire = topo.wire(wid)?;
+            for oe in wire.edges() {
+                *counts.entry(oe.edge().index()).or_insert(0) += 1;
+            }
+        }
+    }
+    if counts.is_empty() {
+        return Ok(false);
+    }
+    Ok(counts.values().all(|&c| c == 2))
+}
+
 /// For each vertex position (quantized at tolerance), picks one canonical
 /// vertex. Rebuilds all edges and wires to use canonical vertices.
 /// Creates new edges (doesn't mutate existing ones) to avoid corrupting

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -111,7 +111,9 @@ pub fn boolean(
                     (o_max.z() - o_min.z(), i_max.z() - i_min.z()),
                 ];
                 dims.iter()
-                    .all(|(outer_d, inner_d)| *outer_d > *inner_d * 1.1)
+                    .filter(|(outer_d, inner_d)| *outer_d > *inner_d * 1.1)
+                    .count()
+                    >= 2
             };
 
         // Bidirectional vertex check via the analytic classifier — the
@@ -440,9 +442,25 @@ pub fn boolean(
                 let components = components_vec.len();
                 #[allow(clippy::cast_possible_wrap)]
                 let expected_euler = (components as i64) * 2;
-                if components >= 2
+                // For Cut, also verify no component is a "B-interior piece" —
+                // GFA can produce N closed manifolds where one of them is the
+                // tool's interior (sphere - cylinder example: 3 pieces =
+                // top cap + bottom cap + cylinder interior). Sample a point
+                // inside each component's AABB and classify against B; if any
+                // sits inside B, the GFA result included the cut-out piece
+                // and should be rejected. Fuse/Intersect don't have this
+                // failure mode.
+                let cut_safe = op != BooleanOp::Cut
+                    || brepkit_algo::classifier::try_build_analytic_classifier(topo, b)
+                        .as_ref()
+                        .is_none_or(|cls_b| {
+                            all_component_centers_outside(topo, &components_vec, cls_b, tol)
+                        });
+                if op == BooleanOp::Cut
+                    && components >= 2
                     && euler == expected_euler
                     && components_are_disjoint_pieces(topo, &components_vec)
+                    && cut_safe
                     && is_closed_manifold(topo, result).unwrap_or(false)
                     && validate_boolean_result(topo, result).is_ok()
                 {
@@ -1313,6 +1331,58 @@ fn mesh_result_to_face_specs(result: &crate::mesh_boolean::MeshBooleanResult) ->
 /// The check is AABB-based: if any component's bounding box is
 /// strictly contained in another's, treat the whole solid as hollow
 /// and skip the multi-region split path.
+/// Check that every component's AABB centre classifies as outside the
+/// supplied classifier. Used to reject multi-region GFA Cut results that
+/// erroneously include the tool's interior as one of the pieces.
+fn all_component_centers_outside(
+    topo: &Topology,
+    components: &[Vec<FaceId>],
+    classifier: &brepkit_algo::classifier::AnalyticClassifier,
+    tol: brepkit_math::tolerance::Tolerance,
+) -> bool {
+    use brepkit_algo::FaceClass;
+    for comp in components {
+        let mut min = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+        let mut max = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+        for &fid in comp {
+            let Ok(face) = topo.face(fid) else { continue };
+            for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
+            {
+                let Ok(wire) = topo.wire(wid) else { continue };
+                for oe in wire.edges() {
+                    let Ok(edge) = topo.edge(oe.edge()) else {
+                        continue;
+                    };
+                    for vid in [edge.start(), edge.end()] {
+                        if let Ok(v) = topo.vertex(vid) {
+                            let p = v.point();
+                            min = Point3::new(
+                                min.x().min(p.x()),
+                                min.y().min(p.y()),
+                                min.z().min(p.z()),
+                            );
+                            max = Point3::new(
+                                max.x().max(p.x()),
+                                max.y().max(p.y()),
+                                max.z().max(p.z()),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        let centre = Point3::new(
+            (min.x() + max.x()) * 0.5,
+            (min.y() + max.y()) * 0.5,
+            (min.z() + max.z()) * 0.5,
+        );
+        if matches!(classifier.classify(centre, tol), Some(FaceClass::Inside)) {
+            return false;
+        }
+    }
+    true
+}
+
 fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -> bool {
     let aabbs: Vec<(Point3, Point3)> = components
         .iter()

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -111,9 +111,7 @@ pub fn boolean(
                     (o_max.z() - o_min.z(), i_max.z() - i_min.z()),
                 ];
                 dims.iter()
-                    .filter(|(outer_d, inner_d)| *outer_d > *inner_d * 1.1)
-                    .count()
-                    >= 2
+                    .all(|(outer_d, inner_d)| *outer_d > *inner_d * 1.1)
             };
 
         // Bidirectional vertex check via the analytic classifier — the

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -1518,18 +1518,23 @@ fn make_solid_from_face_subset(
             normalized.push(fid);
             continue;
         }
+        // Only Plane has a trivial negate-the-normal flip. Non-planar
+        // reversed faces (cylinder/cone/sphere/torus/nurbs) cannot have
+        // their surface negated cheaply — they hit surface-specific GFA
+        // paths that don't suffer from the same reversed-flag sensitivity.
+        // Exhaustive match so a new FaceSurface variant fails to compile
+        // rather than silently passing through un-normalized.
         let flipped_surface = match face.surface() {
             FaceSurface::Plane { normal, d } => FaceSurface::Plane {
                 normal: -*normal,
                 d: -*d,
             },
-            // Non-planar reversed faces (cylinder/cone/etc.) cannot have
-            // their surface negated trivially. Leave as-is — those cases
-            // hit cylinder/sphere-specific code paths in GFA that don't
-            // suffer from the same reversed-flag sensitivity.
-            other => {
+            FaceSurface::Nurbs(_)
+            | FaceSurface::Cylinder(_)
+            | FaceSurface::Cone(_)
+            | FaceSurface::Sphere(_)
+            | FaceSurface::Torus(_) => {
                 normalized.push(fid);
-                let _ = other;
                 continue;
             }
         };

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -423,23 +423,26 @@ pub fn boolean(
                     );
                     return Ok(result);
                 }
-                // Multi-region manifold result (e.g., a cut that splits a
-                // solid into N disjoint pieces). N independently closed
-                // manifolds have combined Euler = 2*N. Falling back to mesh
-                // boolean here would collapse the disjoint pieces down to a
-                // single region's volume (the symptom we were seeing in
-                // `cut with simplify` returning vol 166 instead of 1000).
+                // Multi-region manifold result (e.g., a Cut that splits a
+                // solid into N spatially-disjoint pieces). N independently
+                // closed manifolds have combined Euler = 2*N. Falling back
+                // to mesh boolean would collapse the disjoint pieces into
+                // a single region's volume (the `cut with simplify`
+                // returning vol 166 instead of 1000 symptom).
                 //
-                // Gate strictly on closed-manifold (every edge shared by
-                // exactly 2 faces) AND on the face-adjacency component
-                // count matching Euler/2, so a partially-assembled GFA
-                // failure (boundary edges, dangling faces, non-shared
-                // edges) still falls through to mesh-boolean.
-                let components = crate::boolean::assembly::count_face_components(topo, result);
+                // Gate: every edge must be shared by exactly 2 faces
+                // (closed-manifold) AND the components must be pairwise
+                // spatially disjoint (AABBs do not overlap). The latter
+                // distinguishes a "cut into N pieces" from a hollow solid
+                // (outer surface + cavity surface — same number of
+                // components, same Euler relation, but AABBs overlap).
+                let components_vec = crate::boolean::assembly::face_components(topo, result);
+                let components = components_vec.len();
                 #[allow(clippy::cast_possible_wrap)]
                 let expected_euler = (components as i64) * 2;
                 if components >= 2
                     && euler == expected_euler
+                    && components_are_disjoint_pieces(topo, &components_vec)
                     && is_closed_manifold(topo, result).unwrap_or(false)
                     && validate_boolean_result(topo, result).is_ok()
                 {
@@ -471,9 +474,9 @@ pub fn boolean(
     // pieces. Cut distributes over disjoint union; Fuse/Intersect have
     // more complex interaction semantics so we leave those to mesh.
     if op == BooleanOp::Cut {
-        let comp_count = crate::boolean::assembly::count_face_components(topo, a);
-        if comp_count >= 2 {
-            if let Ok(result) = cut_multi_region_input(topo, a, b, comp_count) {
+        let components = crate::boolean::assembly::face_components(topo, a);
+        if components.len() >= 2 && components_are_disjoint_pieces(topo, &components) {
+            if let Ok(result) = cut_multi_region_input(topo, a, b, components.len()) {
                 return Ok(result);
             }
         }
@@ -1300,6 +1303,72 @@ fn mesh_result_to_face_specs(result: &crate::mesh_boolean::MeshBooleanResult) ->
         });
     }
     specs
+}
+
+/// True when the outer-shell face components represent disjoint solid
+/// pieces (e.g., a previous cut split one solid into N parts), false
+/// when one component is concentric inside another (a hollow solid:
+/// outer surface + cavity surface both live in the outer shell).
+///
+/// The check is AABB-based: if any component's bounding box is
+/// strictly contained in another's, treat the whole solid as hollow
+/// and skip the multi-region split path.
+fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -> bool {
+    let aabbs: Vec<(Point3, Point3)> = components
+        .iter()
+        .map(|comp| {
+            let mut min = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+            let mut max = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+            for &fid in comp {
+                let Ok(face) = topo.face(fid) else {
+                    continue;
+                };
+                for wid in
+                    std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
+                {
+                    let Ok(wire) = topo.wire(wid) else {
+                        continue;
+                    };
+                    for oe in wire.edges() {
+                        let Ok(edge) = topo.edge(oe.edge()) else {
+                            continue;
+                        };
+                        for vid in [edge.start(), edge.end()] {
+                            if let Ok(v) = topo.vertex(vid) {
+                                let p = v.point();
+                                min = Point3::new(
+                                    min.x().min(p.x()),
+                                    min.y().min(p.y()),
+                                    min.z().min(p.z()),
+                                );
+                                max = Point3::new(
+                                    max.x().max(p.x()),
+                                    max.y().max(p.y()),
+                                    max.z().max(p.z()),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            (min, max)
+        })
+        .collect();
+
+    let eps = 1e-7;
+    for i in 0..aabbs.len() {
+        for j in (i + 1)..aabbs.len() {
+            let (i_min, i_max) = aabbs[i];
+            let (j_min, j_max) = aabbs[j];
+            let x_overlap = i_min.x().max(j_min.x()) + eps < i_max.x().min(j_max.x());
+            let y_overlap = i_min.y().max(j_min.y()) + eps < i_max.y().min(j_max.y());
+            let z_overlap = i_min.z().max(j_min.z()) + eps < i_max.z().min(j_max.z());
+            if x_overlap && y_overlap && z_overlap {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// Merge duplicate vertices in a solid's shell by position.

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -47,6 +47,91 @@ fn fuse_disjoint_cubes() {
 }
 
 #[test]
+fn fuse_six_disjoint_boxes_2x3_grid() {
+    // Mirrors brepjs's `rectangularPattern() > creates a 2x3 grid` test:
+    // 6 boxes of 5×5×5 at (col*10, row*10, 0), fused pairwise via
+    // divide-and-conquer. Expected fused volume = 6 × 125 = 750.
+    use crate::measure::solid_volume;
+
+    fn pairwise(
+        topo: &mut brepkit_topology::Topology,
+        ids: &[brepkit_topology::solid::SolidId],
+        start: usize,
+        end: usize,
+    ) -> brepkit_topology::solid::SolidId {
+        let n = end - start;
+        if n == 1 {
+            return ids[start];
+        }
+        if n == 2 {
+            return boolean(topo, BooleanOp::Fuse, ids[start], ids[start + 1]).unwrap();
+        }
+        let mid = start + n.div_ceil(2);
+        let left = pairwise(topo, ids, start, mid);
+        let right = pairwise(topo, ids, mid, end);
+        boolean(topo, BooleanOp::Fuse, left, right).unwrap()
+    }
+
+    let mut topo = Topology::new();
+    let mut boxes = Vec::new();
+    for row in 0..3 {
+        for col in 0..2 {
+            #[allow(clippy::cast_precision_loss)]
+            let x = f64::from(col) * 10.0;
+            #[allow(clippy::cast_precision_loss)]
+            let y = f64::from(row) * 10.0;
+            let b = crate::primitives::make_box(&mut topo, 5.0, 5.0, 5.0).unwrap();
+            crate::transform::transform_solid(
+                &mut topo,
+                b,
+                &brepkit_math::mat::Mat4::translation(x, y, 0.0),
+            )
+            .unwrap();
+            boxes.push(b);
+        }
+    }
+    let result = pairwise(&mut topo, &boxes, 0, boxes.len());
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        (vol - 750.0).abs() < 5.0,
+        "6-box grid fuse lost volume: got {vol}, expected 750"
+    );
+}
+
+#[test]
+fn fuse_disjoint_cubes_volume_chained() {
+    use crate::measure::solid_volume;
+    let mut topo = Topology::new();
+    let a = crate::primitives::make_box(&mut topo, 5.0, 5.0, 5.0).unwrap();
+    let b = crate::primitives::make_box(&mut topo, 5.0, 5.0, 5.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        b,
+        &brepkit_math::mat::Mat4::translation(10.0, 0.0, 0.0),
+    )
+    .unwrap();
+    let c = crate::primitives::make_box(&mut topo, 5.0, 5.0, 5.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        c,
+        &brepkit_math::mat::Mat4::translation(0.0, 10.0, 0.0),
+    )
+    .unwrap();
+    let ab = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    let vol_ab = solid_volume(&topo, ab, 0.05).unwrap();
+    let abc = boolean(&mut topo, BooleanOp::Fuse, ab, c).unwrap();
+    let vol_abc = solid_volume(&topo, abc, 0.05).unwrap();
+    assert!(
+        (vol_ab - 250.0).abs() < 5.0,
+        "fuse of 2 disjoint cubes lost volume: got {vol_ab}, expected 250"
+    );
+    assert!(
+        (vol_abc - 375.0).abs() < 5.0,
+        "fuse of disjoint-2-result with third cube lost volume: got {vol_abc}, expected 375"
+    );
+}
+
+#[test]
 fn cut_disjoint_returns_a() {
     let mut topo = Topology::new();
     let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -52,14 +52,30 @@ pub fn maybe_split_closed_wire(
     tol: f64,
     deflection: f64,
 ) -> Result<Vec<OrientedEdge>, crate::OperationsError> {
-    // Only need splitting when the wire has edges whose start==end vertex.
-    // Collect all edges that need splitting, and pass through the rest.
+    maybe_split_closed_wire_with(
+        topo, oriented, tol, deflection, /*pass_through_circles=*/ false,
+    )
+}
+
+/// Internal variant that lets the caller opt in to passing closed circle /
+/// ellipse / NURBS-recognized-as-circle edges through unsplit. The basic
+/// extrude path uses this so the side face can be built as a true analytic
+/// cylinder (matching OCCT's exact π·r²·h), while sweep / complexExtrude /
+/// twist still split — they apply per-edge profiles that don't work on a
+/// single closed-curve edge.
+pub(crate) fn maybe_split_closed_wire_with(
+    topo: &mut Topology,
+    oriented: &[OrientedEdge],
+    tol: f64,
+    deflection: f64,
+    pass_through_circles: bool,
+) -> Result<Vec<OrientedEdge>, crate::OperationsError> {
     let mut result = Vec::with_capacity(oriented.len() * 4);
     for oe in oriented {
         let edge = topo.edge(oe.edge())?;
-        if edge.start() == edge.end() {
-            // Closed edge — split the curve at evenly-spaced parameters.
-            // Compute segment count from chord-height deviation bound.
+        if edge.start() == edge.end()
+            && !(pass_through_circles && curve_is_analytic_circle(edge.curve()))
+        {
             let n = closed_edge_segments(edge.curve(), deflection);
             let split_edges = split_closed_edge(topo, oe.edge(), n, tol)?;
             for se in split_edges {
@@ -70,6 +86,23 @@ pub fn maybe_split_closed_wire(
         }
     }
     Ok(result)
+}
+
+/// Whether a closed edge's curve is a Circle, Ellipse, or a rational
+/// NURBS recognized as one of those — i.e., something the extrude path
+/// can convert into an exact analytic cylinder/NURBS-of-revolution side
+/// face without polyline-ing.
+fn curve_is_analytic_circle(curve: &EdgeCurve) -> bool {
+    let tol = Tolerance::new().linear;
+    match curve {
+        EdgeCurve::Line => false,
+        EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => true,
+        EdgeCurve::NurbsCurve(nc) => matches!(
+            brepkit_geometry::convert::recognize_curve(nc, tol * 100.0),
+            brepkit_geometry::convert::RecognizedCurve::Circle { .. }
+                | brepkit_geometry::convert::RecognizedCurve::Ellipse { .. }
+        ),
+    }
 }
 
 /// Compute the number of segments for splitting a closed edge based on
@@ -202,14 +235,44 @@ fn extrude_wire_vertices(
     ),
     crate::OperationsError,
 > {
+    extrude_wire_vertices_with(topo, wire_id, offset, /*pass_through_circles=*/ false)
+}
+
+#[allow(clippy::type_complexity)]
+fn extrude_wire_vertices_with(
+    topo: &mut Topology,
+    wire_id: WireId,
+    offset: Vec3,
+    pass_through_circles: bool,
+) -> Result<
+    (
+        Vec<VertexId>,
+        Vec<Point3>,
+        Vec<OrientedEdge>,
+        Vec<EdgeId>,
+        Vec<VertexId>,
+        Vec<EdgeId>,
+        Vec<EdgeId>,
+    ),
+    crate::OperationsError,
+> {
     let tol = Tolerance::new();
     let wire = topo.wire(wire_id)?;
     let original_oriented: Vec<_> = wire.edges().to_vec();
 
     // Check for closed single-edge wires (e.g. a full circle) and split them
     // into multiple edges so that the extrusion can create proper side faces.
-    let oriented =
-        maybe_split_closed_wire(topo, &original_oriented, tol.linear, DEFAULT_DEFLECTION)?;
+    // Closed circles/ellipses (incl. NURBS-recognized ones) optionally pass
+    // through unsplit when the caller can handle analytic side faces. Inner
+    // wires of an extrude DON'T pass through — the inner side face
+    // construction still expects the per-edge polyline layout.
+    let oriented = maybe_split_closed_wire_with(
+        topo,
+        &original_oriented,
+        tol.linear,
+        DEFAULT_DEFLECTION,
+        pass_through_circles,
+    )?;
 
     let mut verts: Vec<VertexId> = Vec::with_capacity(oriented.len());
     for oe in &oriented {
@@ -327,6 +390,38 @@ fn side_face_surface(
             Ok((FaceSurface::Cylinder(cyl), reversed))
         }
         EdgeCurve::NurbsCurve(nc) => {
+            // brepjs (and other callers) often construct circles as rational
+            // quadratic NURBS via `makeCircleEdge`. Extruding those as ruled
+            // NURBS surfaces leaves a ~0.12% volume deficit vs the exact
+            // π·r²·h answer that OCCT returns. Recognize the NURBS as a
+            // circle and use a true `Cylinder` surface for the side face
+            // when possible — the recognition is geometrically exact for
+            // the rational-quadratic circle construction.
+            let tol = brepkit_math::tolerance::Tolerance::new().linear;
+            if let brepkit_geometry::convert::RecognizedCurve::Circle {
+                center,
+                normal: _,
+                radius,
+            } = brepkit_geometry::convert::recognize_curve(nc, tol * 100.0)
+            {
+                let cyl = brepkit_math::surfaces::CylindricalSurface::new(
+                    center,
+                    offset.normalize().unwrap_or(Vec3::new(0.0, 0.0, 1.0)),
+                    radius,
+                )
+                .map_err(crate::OperationsError::Math)?;
+                let edge_dir = p1 - p0;
+                let expected = if outer_is_cw {
+                    offset.cross(edge_dir)
+                } else {
+                    edge_dir.cross(offset)
+                };
+                let to_pt = p0 - center;
+                let along_axis = cyl.axis() * cyl.axis().dot(to_pt);
+                let radial = to_pt - along_axis;
+                let reversed = radial.dot(expected) < 0.0;
+                return Ok((FaceSurface::Cylinder(cyl), reversed));
+            }
             let surface = ruled_nurbs_surface(nc, offset)?;
             let reversed = nurbs_needs_reversal(&surface, p0, p1, offset, outer_is_cw);
             Ok((FaceSurface::Nurbs(surface), reversed))
@@ -355,23 +450,45 @@ fn nurbs_needs_reversal(
     offset: Vec3,
     outer_is_cw: bool,
 ) -> bool {
-    // Expected outward normal (same formula as for planar side faces).
+    let (u_lo, u_hi) = surface.domain_u();
+    let (v_lo, v_hi) = surface.domain_v();
+    let u_mid = 0.5 * (u_lo + u_hi);
+    let v_mid = 0.5 * (v_lo + v_hi);
+    let Ok(native) = surface.normal(u_mid, v_mid) else {
+        return false;
+    };
+
+    // For an open arc the original "edge_dir.cross(offset)" formula gives the
+    // expected outward direction. For a closed loop p0 == p1 — edge_dir
+    // collapses to zero, the cross product is zero, and the dot test below
+    // becomes useless (always false). Sample the bottom curve at a second
+    // point and use the secant as the local edge direction instead, so
+    // closed ellipse / NURBS-circle extrusions get the correct outward
+    // orientation.
     let edge_dir = p1 - p0;
+    let edge_dir = if edge_dir.length_squared() > 1e-20 {
+        edge_dir
+    } else {
+        // Sample two points on the bottom curve a short parameter apart
+        // and take their difference as the tangent direction.
+        let v_next = if v_mid + 0.01 * (v_hi - v_lo) < v_hi {
+            v_mid + 0.01 * (v_hi - v_lo)
+        } else {
+            v_mid - 0.01 * (v_hi - v_lo)
+        };
+        let p_mid = surface.evaluate(u_lo, v_mid);
+        let p_next = surface.evaluate(u_lo, v_next);
+        p_next - p_mid
+    };
     let expected = if outer_is_cw {
         offset.cross(edge_dir)
     } else {
         edge_dir.cross(offset)
     };
-    // Evaluate the surface's native normal at the midpoint of the domain.
-    let (u_lo, u_hi) = surface.domain_u();
-    let (v_lo, v_hi) = surface.domain_v();
-    let u_mid = 0.5 * (u_lo + u_hi);
-    let v_mid = 0.5 * (v_lo + v_hi);
-    if let Ok(native) = surface.normal(u_mid, v_mid) {
-        native.dot(expected) < 0.0
-    } else {
-        false
+    if expected.length_squared() < 1e-20 {
+        return false;
     }
+    native.dot(expected) < 0.0
 }
 
 /// Build a ruled NURBS surface by linearly interpolating between a bottom
@@ -462,7 +579,12 @@ pub fn extrude(
         _top_verts,
         top_edge_ids,
         vertical_edge_ids,
-    ) = extrude_wire_vertices(topo, input_wire_id, offset)?;
+    ) = extrude_wire_vertices_with(
+        topo,
+        input_wire_id,
+        offset,
+        /*pass_through_circles=*/ true,
+    )?;
     let n = input_verts.len();
 
     // Detect CW-wound outer wire (e.g. from brepjs polygon approximations).
@@ -1347,24 +1469,29 @@ mod tests {
         );
     }
 
-    /// Extruding a face with a NURBS arc edge should produce NURBS side faces
-    /// for the curved edges and planar side faces for the straight edges.
+    /// Extruding a face with a NURBS curve edge that is geometrically a
+    /// circular arc should produce a `Cylinder` side face (not a ruled
+    /// NURBS surface). This matches the OCCT-equivalent behavior: brepjs
+    /// constructs circles as rational-quadratic NURBS, and extruding those
+    /// as NURBS leaves a small but persistent volume deficit. Recognizing
+    /// the curve as a circle and using the exact analytic cylinder surface
+    /// recovers π·r²·h precisely.
+    ///
+    /// For a NURBS that is *not* recognized as any analytic curve, the
+    /// behavior is still to produce a NURBS ruled surface (covered by the
+    /// rest of the side_face_surface match arm).
     #[test]
-    fn extrude_nurbs_arc_edge_produces_nurbs_side_face() {
+    fn extrude_recognized_circle_nurbs_arc_uses_cylinder_side_face() {
         use brepkit_math::nurbs::curve::NurbsCurve;
 
         let mut topo = Topology::new();
         let tol = Tolerance::new();
 
-        // Build a face shaped like a square with one curved edge (quarter-circle arc).
-        // Vertices: v0=(0,0,0), v1=(1,0,0), v2=(1,1,0), v3=(0,1,0)
-        // Replace the edge v1→v2 with a NURBS arc that bulges outward.
         let v0 = topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 0.0), tol.linear));
         let v1 = topo.add_vertex(Vertex::new(Point3::new(1.0, 0.0, 0.0), tol.linear));
         let v2 = topo.add_vertex(Vertex::new(Point3::new(1.0, 1.0, 0.0), tol.linear));
         let v3 = topo.add_vertex(Vertex::new(Point3::new(0.0, 1.0, 0.0), tol.linear));
 
-        // Rational quadratic arc: (1,0,0) → (1.5,0.5,0) → (1,1,0) with weight 1/√2 at midpoint
         let arc_curve = NurbsCurve::new(
             2,
             vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
@@ -1407,39 +1534,26 @@ mod tests {
         let s = topo.solid(solid).unwrap();
         let sh = topo.shell(s.outer_shell()).unwrap();
 
-        // 4 side faces + 2 caps = 6 faces
         assert_eq!(sh.faces().len(), 6, "should have 6 faces");
 
-        // Count surface types: expect 1 NURBS side face (from the arc edge),
-        // 3 planar side faces, and 2 planar caps = 5 planar + 1 NURBS.
         let nurbs_count = sh
             .faces()
             .iter()
             .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)))
             .count();
-        assert_eq!(
-            nurbs_count, 1,
-            "exactly 1 side face should be a NURBS ruled surface, got {nurbs_count}"
-        );
-
-        // The NURBS surface should have 2 rows (ruled) and degree 1 in v-direction.
-        let nurbs_face = sh
+        let cylinder_count = sh
             .faces()
             .iter()
-            .find(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)))
-            .unwrap();
-        if let FaceSurface::Nurbs(surf) = topo.face(*nurbs_face).unwrap().surface() {
-            assert_eq!(
-                surf.degree_u(),
-                1,
-                "ruled surface should have degree_u=1 (extrusion direction)"
-            );
-            assert_eq!(
-                surf.control_points().len(),
-                2,
-                "ruled surface should have 2 rows of control points"
-            );
-        }
+            .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Cylinder(_)))
+            .count();
+        assert_eq!(
+            cylinder_count, 1,
+            "rational-quadratic circular arc should produce 1 Cylinder side face"
+        );
+        assert_eq!(
+            nurbs_count, 0,
+            "no NURBS side face expected once the arc is recognized as a Circle"
+        );
     }
 
     /// Extruding a face with a Circle edge should produce a cylindrical side face.

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -118,6 +118,17 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
         });
     }
 
+    // Fast path: lofting two coaxial circles (incl. NURBS-recognized
+    // circles produced by brepjs `sketchCircle`) collapses to an exact
+    // cylinder / cone / frustum. The general path tessellates the
+    // circles into N line segments, losing 0.6-1% of the true π·r²·h
+    // (or frustum) volume.
+    if profiles.len() == 2 {
+        if let Some(cone_solid) = try_loft_coaxial_circles(topo, profiles[0], profiles[1])? {
+            return Ok(cone_solid);
+        }
+    }
+
     // Collect vertex positions for each profile.
     let mut profile_verts: Vec<Vec<Point3>> = Vec::with_capacity(profiles.len());
     for &fid in profiles {
@@ -285,6 +296,140 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
+}
+
+/// Detect "loft between two coaxial circles" and produce an exact
+/// cylinder / cone / frustum via `make_cylinder` / `make_cone`. Returns
+/// `Ok(None)` when the profiles don't both reduce to circles, when they
+/// don't share an axis, or when something else doesn't fit the fast
+/// path — the general loft then handles the case.
+fn try_loft_coaxial_circles(
+    topo: &mut Topology,
+    profile_a: FaceId,
+    profile_b: FaceId,
+) -> Result<Option<SolidId>, crate::OperationsError> {
+    let tol = Tolerance::new();
+
+    let (center_a, normal_a, radius_a) = match face_recognized_circle(topo, profile_a) {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+    let (center_b, normal_b, radius_b) = match face_recognized_circle(topo, profile_b) {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+
+    // Normals must be parallel (same or opposite direction) — the axis
+    // between the two circle centers must also be parallel to both
+    // normals, otherwise the profiles aren't coaxial.
+    let axis = center_b - center_a;
+    let axis_len = axis.length();
+    if axis_len < tol.linear {
+        return Ok(None); // identical profile positions — degenerate loft
+    }
+    let axis_unit = axis * (1.0 / axis_len);
+    let normal_a_aligned = normal_a.dot(axis_unit).abs() > 1.0 - tol.angular;
+    let normal_b_aligned = normal_b.dot(axis_unit).abs() > 1.0 - tol.angular;
+    if !normal_a_aligned || !normal_b_aligned {
+        return Ok(None);
+    }
+
+    // Build the cylinder/cone/frustum at the origin along +Z, then
+    // transform it to place center_a at the bottom and center_b at the top.
+    let solid = if (radius_a - radius_b).abs() < tol.linear {
+        crate::primitives::make_cylinder(topo, radius_a, axis_len)?
+    } else {
+        crate::primitives::make_cone(topo, radius_a, radius_b, axis_len)?
+    };
+
+    // Orient the new solid: its base is at z=0 axis +Z. Rotate +Z onto
+    // `axis_unit`, then translate to `center_a`.
+    let z_axis = brepkit_math::vec::Vec3::new(0.0, 0.0, 1.0);
+    let target_axis = axis_unit;
+    if (z_axis - target_axis).length() > tol.linear {
+        let rot_axis = z_axis.cross(target_axis);
+        let rot_axis_len = rot_axis.length();
+        let mat = if rot_axis_len < tol.linear {
+            brepkit_math::mat::Mat4::rotation_x(std::f64::consts::PI)
+        } else {
+            let angle = z_axis.dot(target_axis).clamp(-1.0, 1.0).acos();
+            rodrigues_rotation(rot_axis * (1.0 / rot_axis_len), angle)
+        };
+        crate::transform::transform_solid(topo, solid, &mat)?;
+    }
+    if center_a.x().abs() > tol.linear
+        || center_a.y().abs() > tol.linear
+        || center_a.z().abs() > tol.linear
+    {
+        let xform = brepkit_math::mat::Mat4::translation(center_a.x(), center_a.y(), center_a.z());
+        crate::transform::transform_solid(topo, solid, &xform)?;
+    }
+    Ok(Some(solid))
+}
+
+/// Rotation matrix around an arbitrary unit axis by `angle` radians
+/// (Rodrigues' formula). Duplicates `pattern::rotation_matrix` so loft
+/// stays self-contained.
+fn rodrigues_rotation(axis: Vec3, angle: f64) -> brepkit_math::mat::Mat4 {
+    let cos_a = angle.cos();
+    let sin_a = angle.sin();
+    let omc = 1.0 - cos_a;
+    let (ax, ay, az) = (axis.x(), axis.y(), axis.z());
+    brepkit_math::mat::Mat4([
+        [
+            omc.mul_add(ax * ax, cos_a),
+            ax.mul_add(ay * omc, -(sin_a * az)),
+            ax.mul_add(az * omc, sin_a * ay),
+            0.0,
+        ],
+        [
+            ax.mul_add(ay * omc, sin_a * az),
+            omc.mul_add(ay * ay, cos_a),
+            ay.mul_add(az * omc, -(sin_a * ax)),
+            0.0,
+        ],
+        [
+            ax.mul_add(az * omc, -(sin_a * ay)),
+            ay.mul_add(az * omc, sin_a * ax),
+            omc.mul_add(az * az, cos_a),
+            0.0,
+        ],
+        [0.0, 0.0, 0.0, 1.0],
+    ])
+}
+
+/// Recognize a planar face as a circle (center, plane normal, radius).
+/// Returns `None` when the face's outer wire isn't a single closed
+/// circular edge (or NURBS-recognized circular edge), or when the
+/// surface isn't planar.
+fn face_recognized_circle(topo: &Topology, face_id: FaceId) -> Option<(Point3, Vec3, f64)> {
+    let face = topo.face(face_id).ok()?;
+    let normal = match face.surface() {
+        FaceSurface::Plane { normal, .. } => *normal,
+        _ => return None,
+    };
+    let wire = topo.wire(face.outer_wire()).ok()?;
+    let edges = wire.edges();
+    if edges.len() != 1 {
+        return None;
+    }
+    let edge = topo.edge(edges[0].edge()).ok()?;
+    if edge.start() != edge.end() {
+        return None; // not a closed-loop circle
+    }
+    match edge.curve() {
+        brepkit_topology::edge::EdgeCurve::Circle(c) => Some((c.center(), normal, c.radius())),
+        brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) => {
+            let tol = Tolerance::new().linear;
+            match brepkit_geometry::convert::recognize_curve(nc, tol * 100.0) {
+                brepkit_geometry::convert::RecognizedCurve::Circle { center, radius, .. } => {
+                    Some((center, normal, radius))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 /// Loft profiles into a solid with smooth NURBS side surfaces.

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -404,6 +404,9 @@ fn rodrigues_rotation(axis: Vec3, angle: f64) -> brepkit_math::mat::Mat4 {
 /// surface isn't planar.
 fn face_recognized_circle(topo: &Topology, face_id: FaceId) -> Option<(Point3, Vec3, f64)> {
     let face = topo.face(face_id).ok()?;
+    if !face.inner_wires().is_empty() {
+        return None;
+    }
     let normal = match face.surface() {
         FaceSurface::Plane { normal, .. } => *normal,
         _ => return None,

--- a/crates/operations/src/section.rs
+++ b/crates/operations/src/section.rs
@@ -174,16 +174,139 @@ pub fn section(
         });
     }
 
-    // Create faces from wires.
-    let mut result_faces = Vec::with_capacity(wires.len());
-    for wid in wires {
-        let face = topo.add_face(Face::new(wid, vec![], FaceSurface::Plane { normal, d }));
+    // Group wires by containment: outer wires get their inner wires as holes.
+    // Without this, a hollow shape's section would produce two separate faces
+    // (outer rectangle + inner hole rectangle) instead of one face-with-hole.
+    let groups = group_wires_by_containment(topo, &wires, normal);
+
+    let mut result_faces = Vec::with_capacity(groups.len());
+    for (outer, inners) in groups {
+        let face = topo.add_face(Face::new(outer, inners, FaceSurface::Plane { normal, d }));
         result_faces.push(face);
     }
 
     Ok(Section {
         faces: result_faces,
     })
+}
+
+/// Group section wires by containment: each outer wire collects all wires that
+/// are spatially inside it as inner (hole) wires. Returns `(outer, [inner])` tuples.
+///
+/// A wire is "inner" when it sits inside another wire (in the section plane) and
+/// is not itself inside any wire that's already inside another. Two-level nesting
+/// (holes within holes within holes) is collapsed into the outermost containment;
+/// CAD sections don't typically produce deeper nesting and OCCT treats them the
+/// same way.
+fn group_wires_by_containment(
+    topo: &Topology,
+    wires: &[WireId],
+    normal: Vec3,
+) -> Vec<(WireId, Vec<WireId>)> {
+    if wires.len() <= 1 {
+        return wires.iter().map(|&w| (w, vec![])).collect();
+    }
+
+    // Collect each wire's vertex polygon (used for both bounding-box and
+    // point-in-polygon checks below).
+    let polygons: Vec<Vec<Point3>> = wires.iter().map(|&wid| wire_vertices(topo, wid)).collect();
+
+    // For each wire, find the smallest wire that strictly contains it.
+    // A wire with no strict container is itself an outer wire.
+    let mut parent: Vec<Option<usize>> = vec![None; wires.len()];
+    for (i, poly_i) in polygons.iter().enumerate() {
+        if poly_i.is_empty() {
+            continue;
+        }
+        let sample = poly_i[0];
+        let mut best_parent: Option<usize> = None;
+        let mut best_area = f64::INFINITY;
+        for (j, poly_j) in polygons.iter().enumerate() {
+            if i == j || poly_j.len() < 3 {
+                continue;
+            }
+            if crate::distance::point_in_polygon_3d(&sample, poly_j, &normal) {
+                let area = polygon_area_3d(poly_j, normal);
+                if area < best_area {
+                    best_area = area;
+                    best_parent = Some(j);
+                }
+            }
+        }
+        parent[i] = best_parent;
+    }
+
+    // Build groups: each outer wire (no parent) collects its direct children.
+    let mut groups: Vec<(WireId, Vec<WireId>)> = Vec::new();
+    let mut group_of: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for (i, &wid) in wires.iter().enumerate() {
+        if parent[i].is_none() {
+            group_of.insert(i, groups.len());
+            groups.push((wid, vec![]));
+        }
+    }
+    for (i, &wid) in wires.iter().enumerate() {
+        if let Some(p) = parent[i] {
+            // Walk up to the outermost ancestor (in case of nested holes).
+            let mut top = p;
+            while let Some(next) = parent[top] {
+                top = next;
+            }
+            if let Some(&group_idx) = group_of.get(&top) {
+                groups[group_idx].1.push(wid);
+            }
+        }
+    }
+
+    groups
+}
+
+fn wire_vertices(topo: &Topology, wire_id: WireId) -> Vec<Point3> {
+    let Ok(wire) = topo.wire(wire_id) else {
+        return vec![];
+    };
+    let mut pts = Vec::with_capacity(wire.edges().len());
+    for oe in wire.edges() {
+        let Ok(edge) = topo.edge(oe.edge()) else {
+            continue;
+        };
+        let vid = if oe.is_forward() {
+            edge.start()
+        } else {
+            edge.end()
+        };
+        if let Ok(v) = topo.vertex(vid) {
+            pts.push(v.point());
+        }
+    }
+    pts
+}
+
+/// Unsigned area of a 3D planar polygon (projected to dominant axis plane).
+fn polygon_area_3d(polygon: &[Point3], normal: Vec3) -> f64 {
+    if polygon.len() < 3 {
+        return 0.0;
+    }
+    let ax = normal.x().abs();
+    let ay = normal.y().abs();
+    let az = normal.z().abs();
+    let to_2d = |p: Point3| -> (f64, f64) {
+        if az >= ax && az >= ay {
+            (p.x(), p.y())
+        } else if ay >= ax {
+            (p.x(), p.z())
+        } else {
+            (p.y(), p.z())
+        }
+    };
+    let mut sum = 0.0;
+    let n = polygon.len();
+    for i in 0..n {
+        let (x0, y0) = to_2d(polygon[i]);
+        let (x1, y1) = to_2d(polygon[(i + 1) % n]);
+        sum += x0 * y1 - x1 * y0;
+    }
+    (sum * 0.5).abs()
 }
 
 type EdgeKey = ((i64, i64, i64), (i64, i64, i64));
@@ -366,17 +489,15 @@ fn assemble_wires(
     let mut remaining: Vec<(Point3, Point3)> = segments.to_vec();
     let mut wires = Vec::new();
 
-    // Compute a chaining tolerance that accommodates tessellated geometry.
-    // Use 50% of the average segment length — this is generous enough to
-    // bridge gaps between adjacent triangle crossings while still
-    // rejecting clearly unrelated segments.
-    let avg_len = if segments.is_empty() {
-        tol.linear * 1000.0
-    } else {
-        let total: f64 = segments.iter().map(|(a, b)| (*a - *b).length()).sum();
-        total / segments.len() as f64
-    };
-    let chain_tol = avg_len.max(tol.linear * 1000.0);
+    // Chaining tolerance must be tight enough to keep separate loops apart
+    // (e.g., the outer perimeter and the inner hole of a hollow shape) while
+    // still tolerating the small endpoint drift produced by tessellated NURBS
+    // intersections. `tol.linear * 1000` (≈ 1e-4) is OCCT-compatible for both.
+    //
+    // Earlier this defaulted to 50% of the average segment length, which for
+    // a hollow 20×20 box section was ≈ 15 — wildly generous, bridging the
+    // outer and inner wires into one self-intersecting polygon.
+    let chain_tol = tol.linear * 1000.0;
 
     while !remaining.is_empty() {
         // Start a new chain with the first remaining segment.

--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -189,13 +189,20 @@ fn sample_wire_points(
                     points.push(c.evaluate(tau / 3.0));
                     points.push(c.evaluate(2.0 * tau / 3.0));
                 } else {
+                    // Short-way midpoint between the two oriented endpoints:
+                    // walk the smaller of the two arcs (delta in [-π, π]) so
+                    // reversed edges sample the same physical arc as forward
+                    // ones, not the long complementary path.
                     let end_pt = topo.vertex(oe.oriented_end(edge))?.point();
-                    let t_start = c.project(start_pt);
-                    let mut t_end = c.project(end_pt);
-                    if t_end <= t_start {
-                        t_end += tau;
+                    let t_a = c.project(start_pt);
+                    let t_b = c.project(end_pt);
+                    let mut delta = t_b - t_a;
+                    if delta > std::f64::consts::PI {
+                        delta -= tau;
+                    } else if delta < -std::f64::consts::PI {
+                        delta += tau;
                     }
-                    points.push(c.evaluate(0.5 * (t_start + t_end)));
+                    points.push(c.evaluate(t_a + delta * 0.5));
                 }
             }
             EdgeCurve::Ellipse(e) => {
@@ -205,12 +212,15 @@ fn sample_wire_points(
                     points.push(e.evaluate(2.0 * tau / 3.0));
                 } else {
                     let end_pt = topo.vertex(oe.oriented_end(edge))?.point();
-                    let t_start = e.project(start_pt);
-                    let mut t_end = e.project(end_pt);
-                    if t_end <= t_start {
-                        t_end += tau;
+                    let t_a = e.project(start_pt);
+                    let t_b = e.project(end_pt);
+                    let mut delta = t_b - t_a;
+                    if delta > std::f64::consts::PI {
+                        delta -= tau;
+                    } else if delta < -std::f64::consts::PI {
+                        delta += tau;
                     }
-                    points.push(e.evaluate(0.5 * (t_start + t_end)));
+                    points.push(e.evaluate(t_a + delta * 0.5));
                 }
             }
             EdgeCurve::NurbsCurve(nc) => {

--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -175,27 +175,42 @@ fn sample_wire_points(
         points.push(start_pt);
 
         // For curved edges, sample the midpoint to get a non-collinear point.
+        // The midpoint MUST lie on the actual arc between this edge's
+        // start and end — using a fixed parameter like π was sampling the
+        // global antipodal point of the underlying circle/ellipse, which
+        // for short arcs (e.g., gear tip arcs near angle 0) lands far from
+        // the arc and produced a polygon whose Newell normal had the
+        // wrong sign.
         match edge.curve() {
             EdgeCurve::Line => {}
             EdgeCurve::Circle(c) => {
+                let tau = std::f64::consts::TAU;
                 if edge.start() == edge.end() {
-                    // Full circle: sample at 1/3 and 2/3 of parameter range
-                    // in monotonic order so Newell's method gives correct
-                    // normal sign.
-                    let tau = std::f64::consts::TAU;
                     points.push(c.evaluate(tau / 3.0));
                     points.push(c.evaluate(2.0 * tau / 3.0));
                 } else {
-                    points.push(c.evaluate(PI));
+                    let end_pt = topo.vertex(oe.oriented_end(edge))?.point();
+                    let t_start = c.project(start_pt);
+                    let mut t_end = c.project(end_pt);
+                    if t_end <= t_start {
+                        t_end += tau;
+                    }
+                    points.push(c.evaluate(0.5 * (t_start + t_end)));
                 }
             }
             EdgeCurve::Ellipse(e) => {
+                let tau = std::f64::consts::TAU;
                 if edge.start() == edge.end() {
-                    let tau = std::f64::consts::TAU;
                     points.push(e.evaluate(tau / 3.0));
                     points.push(e.evaluate(2.0 * tau / 3.0));
                 } else {
-                    points.push(e.evaluate(PI));
+                    let end_pt = topo.vertex(oe.oriented_end(edge))?.point();
+                    let t_start = e.project(start_pt);
+                    let mut t_end = e.project(end_pt);
+                    if t_end <= t_start {
+                        t_end += tau;
+                    }
+                    points.push(e.evaluate(0.5 * (t_start + t_end)));
                 }
             }
             EdgeCurve::NurbsCurve(nc) => {

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -79,17 +79,65 @@ impl BrepKernel {
 }
 
 impl BrepKernel {
-    /// Extract a `NurbsCurve` from an edge, or error if it's a line.
+    /// Extract a `NurbsCurve` from an edge.
+    ///
+    /// NURBS edges are returned directly. Line, Circle, and Ellipse edges
+    /// are converted to their exact rational NURBS equivalent using the
+    /// edge's bounding vertices (and the curve's analytic params for
+    /// circles/ellipses).
     pub(crate) fn extract_nurbs_curve(&self, edge: u32) -> Result<NurbsCurve, JsError> {
+        use brepkit_geometry::convert::{circle_to_nurbs, ellipse_to_nurbs, line_to_nurbs};
+        use std::f64::consts::TAU;
+
         let edge_id = self.resolve_edge(edge)?;
         let edge_data = self.topo.edge(edge_id)?;
+        let start_v = edge_data.start();
+        let end_v = edge_data.end();
+        let start_pt = self.topo.vertex(start_v)?.point();
+        let end_pt = self.topo.vertex(end_v)?.point();
+
         match edge_data.curve() {
             EdgeCurve::NurbsCurve(c) => Ok(c.clone()),
-            EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
-                Err(WasmError::InvalidInput {
-                    reason: "edge is not a NURBS curve".into(),
-                }
-                .into())
+            EdgeCurve::Line => {
+                Ok(
+                    line_to_nurbs(start_pt, end_pt).map_err(|e| WasmError::InvalidInput {
+                        reason: format!("line_to_nurbs failed: {e}"),
+                    })?,
+                )
+            }
+            EdgeCurve::Circle(c) => {
+                let (t_start, t_end) = if start_v == end_v {
+                    (0.0, TAU)
+                } else {
+                    let ts = c.project(start_pt);
+                    let mut te = c.project(end_pt);
+                    if te <= ts {
+                        te += TAU;
+                    }
+                    (ts, te)
+                };
+                Ok(
+                    circle_to_nurbs(c, t_start, t_end).map_err(|e| WasmError::InvalidInput {
+                        reason: format!("circle_to_nurbs failed: {e}"),
+                    })?,
+                )
+            }
+            EdgeCurve::Ellipse(e) => {
+                let (t_start, t_end) = if start_v == end_v {
+                    (0.0, TAU)
+                } else {
+                    let ts = e.project(start_pt);
+                    let mut te = e.project(end_pt);
+                    if te <= ts {
+                        te += TAU;
+                    }
+                    (ts, te)
+                };
+                Ok(
+                    ellipse_to_nurbs(e, t_start, t_end).map_err(|err| WasmError::InvalidInput {
+                        reason: format!("ellipse_to_nurbs failed: {err}"),
+                    })?,
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

Restores the E-fix from #673 that I unintentionally reverted during the sphere_cylinder bisect — the actual cause of that failure turned out to be the multi-region Euler-relax branch, not this check, but my revert stuck and silently regressed brepjs's `rectangularPattern() > creates a 2x3 grid of shapes`.

## The bug

The `≥ 2 dims` variant of `aabb_strictly_contains` lets the no-classifier-fallback containment shortcut false-positive when one solid's per-solid AABB happens to enclose another's in 2 of 3 dims. The brepjs `rectangularPattern` test exercises this exactly:

- Pairwise fuse of 6 disjoint 5×5×5 boxes in a 2×3 grid
- After `fuse(box3, box4)`, the intermediate solid has AABB `15×15×5` (combining two distant boxes)
- Fusing that with `box5` (AABB `5×5×5`) hits the containment shortcut: 15 > 5·1.1 in x and y, but 5 ≯ 5·1.1 in z — under the `≥ 2 dims` rule, A is treated as containing B
- The shortcut returns a copy of A, **silently dropping box5**
- Final volume: 625 (5 boxes) instead of 750 (6 boxes)

## The fix

Switch to `ALL 3 dims` so the no-classifier fallback only fires for genuine nested containment (e.g., a ring sitting inside a shell's cavity, where every dim is comfortably larger).

## Verification

- New regression test `fuse_six_disjoint_boxes_2x3_grid` mirrors the brepjs failure (vol must be 750, was 625 before this PR).
- `cargo test -p brepkit-operations` → 595/595 lib + 14/14 boolean_edge_cases pass.
- `compound_cut_shelled_target_9_tools` (the original flake from #673) → 10/10 stable.
- `test_boolean_sphere_cylinder` and `test_kissing_cylinder_box` (the sphere/kissing tests from #673) → both pass.

## Follow-up to user-side discovery

The brepjs `rectangularPattern` test was the one item in #673's "E — fixed" claim that wasn't actually fixed. User caught it post-merge by running `npm run test:brepkit` against the published 2.87.0. Same failure reproduces on 2.86.1 — it was *pre-existing* before #673 too — but #673's PR body claimed it as fixed, which it wasn't. This PR fixes it for real.