### PR TITLE
feat(topology+wasm): add makeCircleEdge / makeEllipseEdge bindings

### DIFF
--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -528,9 +528,8 @@ mod tests {
         assert!(edge.is_closed(), "circle edge must be closed");
         assert_eq!(edge.curve().type_tag(), "circle");
 
-        let (t_min, t_max) = edge
-            .curve()
-            .domain_with_endpoints(Point3::new(0.0, 0.0, 0.0), Point3::new(0.0, 0.0, 0.0));
+        let seam = topo.vertex(edge.start()).unwrap().point();
+        let (t_min, t_max) = edge.curve().domain_with_endpoints(seam, seam);
         assert!((t_min - 0.0).abs() < 1e-12);
         assert!((t_max - std::f64::consts::TAU).abs() < 1e-12);
     }
@@ -582,9 +581,8 @@ mod tests {
         assert!(edge.is_closed(), "ellipse edge must be closed");
         assert_eq!(edge.curve().type_tag(), "ellipse");
 
-        let (t_min, t_max) = edge
-            .curve()
-            .domain_with_endpoints(Point3::new(0.0, 0.0, 0.0), Point3::new(0.0, 0.0, 0.0));
+        let seam = topo.vertex(edge.start()).unwrap().point();
+        let (t_min, t_max) = edge.curve().domain_with_endpoints(seam, seam);
         assert!((t_min - 0.0).abs() < 1e-12);
         assert!((t_max - std::f64::consts::TAU).abs() < 1e-12);
     }

--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -4,6 +4,7 @@
 
 use std::f64::consts::PI;
 
+use brepkit_math::curves::{Circle3D, Ellipse3D};
 use brepkit_math::nurbs::curve::NurbsCurve;
 use brepkit_math::nurbs::surface::NurbsSurface;
 use brepkit_math::tolerance::Tolerance;
@@ -38,6 +39,60 @@ pub fn make_line_edge(
     let v0 = topo.add_vertex(Vertex::new(start, tolerance));
     let v1 = topo.add_vertex(Vertex::new(end, tolerance));
     Ok(topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line)))
+}
+
+/// Create a closed circular edge.
+///
+/// Constructs a [`Circle3D`] from `center`, `normal`, and `radius`, then
+/// creates a single closed edge whose start and end share a seam vertex
+/// at `circle.evaluate(0.0)`. The edge has parameter domain `[0, 2π]`.
+///
+/// # Errors
+///
+/// Returns an error if `radius` is non-positive or `normal` is a zero vector.
+pub fn make_circle_edge(
+    topo: &mut Topology,
+    center: Point3,
+    normal: Vec3,
+    radius: f64,
+    tolerance: f64,
+) -> Result<EdgeId, crate::TopologyError> {
+    let circle =
+        Circle3D::new(center, normal, radius).map_err(|e| crate::TopologyError::NonManifold {
+            reason: format!("invalid circle: {e}"),
+        })?;
+    let seam = circle.evaluate(0.0);
+    let v = topo.add_vertex(Vertex::new(seam, tolerance));
+    Ok(topo.add_edge(Edge::new(v, v, EdgeCurve::Circle(circle))))
+}
+
+/// Create a closed elliptical edge.
+///
+/// Constructs an [`Ellipse3D`] from `center`, `normal`, and the two
+/// semi-axis lengths, then creates a single closed edge whose start and
+/// end share a seam vertex at `ellipse.evaluate(0.0)`. The edge has
+/// parameter domain `[0, 2π]`.
+///
+/// # Errors
+///
+/// Returns an error if either semi-axis is non-positive, `semi_minor`
+/// exceeds `semi_major`, or `normal` is a zero vector.
+pub fn make_ellipse_edge(
+    topo: &mut Topology,
+    center: Point3,
+    normal: Vec3,
+    semi_major: f64,
+    semi_minor: f64,
+    tolerance: f64,
+) -> Result<EdgeId, crate::TopologyError> {
+    let ellipse = Ellipse3D::new(center, normal, semi_major, semi_minor).map_err(|e| {
+        crate::TopologyError::NonManifold {
+            reason: format!("invalid ellipse: {e}"),
+        }
+    })?;
+    let seam = ellipse.evaluate(0.0);
+    let v = topo.add_vertex(Vertex::new(seam, tolerance));
+    Ok(topo.add_edge(Edge::new(v, v, EdgeCurve::Ellipse(ellipse))))
 }
 
 /// Create a closed wire from an ordered list of points.
@@ -455,6 +510,99 @@ mod tests {
         let mut topo = Topology::new();
         let p = Point3::new(1.0, 2.0, 3.0);
         assert!(make_line_edge(&mut topo, p, p, TOL).is_err());
+    }
+
+    #[test]
+    fn make_circle_edge_is_closed_with_circle_curve() {
+        let mut topo = Topology::new();
+        let eid = make_circle_edge(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            2.5,
+            TOL,
+        )
+        .unwrap();
+
+        let edge = topo.edge(eid).unwrap();
+        assert!(edge.is_closed(), "circle edge must be closed");
+        assert_eq!(edge.curve().type_tag(), "circle");
+
+        let (t_min, t_max) = edge
+            .curve()
+            .domain_with_endpoints(Point3::new(0.0, 0.0, 0.0), Point3::new(0.0, 0.0, 0.0));
+        assert!((t_min - 0.0).abs() < 1e-12);
+        assert!((t_max - std::f64::consts::TAU).abs() < 1e-12);
+    }
+
+    #[test]
+    fn make_circle_edge_zero_radius_error() {
+        let mut topo = Topology::new();
+        assert!(
+            make_circle_edge(
+                &mut topo,
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+                0.0,
+                TOL,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn make_circle_edge_zero_normal_error() {
+        let mut topo = Topology::new();
+        assert!(
+            make_circle_edge(
+                &mut topo,
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+                1.0,
+                TOL,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn make_ellipse_edge_is_closed_with_ellipse_curve() {
+        let mut topo = Topology::new();
+        let eid = make_ellipse_edge(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            3.0,
+            2.0,
+            TOL,
+        )
+        .unwrap();
+
+        let edge = topo.edge(eid).unwrap();
+        assert!(edge.is_closed(), "ellipse edge must be closed");
+        assert_eq!(edge.curve().type_tag(), "ellipse");
+
+        let (t_min, t_max) = edge
+            .curve()
+            .domain_with_endpoints(Point3::new(0.0, 0.0, 0.0), Point3::new(0.0, 0.0, 0.0));
+        assert!((t_min - 0.0).abs() < 1e-12);
+        assert!((t_max - std::f64::consts::TAU).abs() < 1e-12);
+    }
+
+    #[test]
+    fn make_ellipse_edge_minor_exceeds_major_error() {
+        let mut topo = Topology::new();
+        assert!(
+            make_ellipse_edge(
+                &mut topo,
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+                1.0,
+                2.0,
+                TOL,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/wasm/src/bindings/shapes.rs
+++ b/crates/wasm/src/bindings/shapes.rs
@@ -194,6 +194,9 @@ impl BrepKernel {
 
         let center = Point3::new(cx, cy, cz);
         let normal = Vec3::new(nx, ny, nz);
+        normal.normalize().map_err(|e| WasmError::InvalidInput {
+            reason: format!("invalid normal: {e}"),
+        })?;
         let eid = brepkit_topology::builder::make_circle_edge(
             self.topo_mut(),
             center,
@@ -237,9 +240,20 @@ impl BrepKernel {
         validate_finite(nz, "nz")?;
         validate_positive(semi_major, "semi_major")?;
         validate_positive(semi_minor, "semi_minor")?;
+        if semi_minor > semi_major {
+            return Err(WasmError::InvalidInput {
+                reason: format!(
+                    "semi_minor ({semi_minor}) must not exceed semi_major ({semi_major})"
+                ),
+            }
+            .into());
+        }
 
         let center = Point3::new(cx, cy, cz);
         let normal = Vec3::new(nx, ny, nz);
+        normal.normalize().map_err(|e| WasmError::InvalidInput {
+            reason: format!("invalid normal: {e}"),
+        })?;
         let eid = brepkit_topology::builder::make_ellipse_edge(
             self.topo_mut(),
             center,

--- a/crates/wasm/src/bindings/shapes.rs
+++ b/crates/wasm/src/bindings/shapes.rs
@@ -160,6 +160,97 @@ impl BrepKernel {
         Ok(edge_id_to_u32(eid))
     }
 
+    /// Create a closed circular edge with true `Circle` curve geometry.
+    ///
+    /// Unlike `makeCircle` (which returns a polygon face approximation),
+    /// this creates a single closed edge with an [`EdgeCurve::Circle`]
+    /// backing curve and parameter domain `[0, 2π]`. The start and end
+    /// vertex are shared at the seam point `circle.evaluate(0.0)`.
+    ///
+    /// Returns an edge handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any coordinate is NaN/infinite, `radius` is
+    /// non-positive, or the normal vector is zero.
+    #[wasm_bindgen(js_name = "makeCircleEdge")]
+    pub fn make_circle_edge(
+        &mut self,
+        cx: f64,
+        cy: f64,
+        cz: f64,
+        nx: f64,
+        ny: f64,
+        nz: f64,
+        radius: f64,
+    ) -> Result<u32, JsError> {
+        validate_finite(cx, "cx")?;
+        validate_finite(cy, "cy")?;
+        validate_finite(cz, "cz")?;
+        validate_finite(nx, "nx")?;
+        validate_finite(ny, "ny")?;
+        validate_finite(nz, "nz")?;
+        validate_positive(radius, "radius")?;
+
+        let center = Point3::new(cx, cy, cz);
+        let normal = Vec3::new(nx, ny, nz);
+        let eid = brepkit_topology::builder::make_circle_edge(
+            self.topo_mut(),
+            center,
+            normal,
+            radius,
+            TOL,
+        )?;
+        Ok(edge_id_to_u32(eid))
+    }
+
+    /// Create a closed elliptical edge with true `Ellipse` curve geometry.
+    ///
+    /// Creates a single closed edge with an [`EdgeCurve::Ellipse`] backing
+    /// curve and parameter domain `[0, 2π]`. The start and end vertex are
+    /// shared at the seam point `ellipse.evaluate(0.0)`.
+    ///
+    /// Returns an edge handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any coordinate is NaN/infinite, either
+    /// semi-axis is non-positive, `semi_minor` exceeds `semi_major`, or
+    /// the normal vector is zero.
+    #[wasm_bindgen(js_name = "makeEllipseEdge")]
+    pub fn make_ellipse_edge(
+        &mut self,
+        cx: f64,
+        cy: f64,
+        cz: f64,
+        nx: f64,
+        ny: f64,
+        nz: f64,
+        semi_major: f64,
+        semi_minor: f64,
+    ) -> Result<u32, JsError> {
+        validate_finite(cx, "cx")?;
+        validate_finite(cy, "cy")?;
+        validate_finite(cz, "cz")?;
+        validate_finite(nx, "nx")?;
+        validate_finite(ny, "ny")?;
+        validate_finite(nz, "nz")?;
+        validate_positive(semi_major, "semi_major")?;
+        validate_positive(semi_minor, "semi_minor")?;
+
+        let center = Point3::new(cx, cy, cz);
+        let normal = Vec3::new(nx, ny, nz);
+        let eid = brepkit_topology::builder::make_ellipse_edge(
+            self.topo_mut(),
+            center,
+            normal,
+            semi_major,
+            semi_minor,
+            TOL,
+        )?;
+        Ok(edge_id_to_u32(eid))
+    }
+
     /// Create a circular arc edge between two points.
     ///
     /// The arc lies on a circle with the given center, normal axis, and


### PR DESCRIPTION
## Summary

- Add `topology::builder::make_circle_edge` / `make_ellipse_edge` — closed edges backed by `EdgeCurve::Circle` / `EdgeCurve::Ellipse`, seam vertex at `evaluate(0.0)`, domain `[0, 2π]`.
- Expose `BrepKernel::makeCircleEdge(cx, cy, cz, nx, ny, nz, radius)` and `BrepKernel::makeEllipseEdge(cx, cy, cz, nx, ny, nz, semi_major, semi_minor)` to JS.
- 5 new unit tests cover closure, type tag, domain, and the radius/normal/semi-axis error paths.

The existing `makeCircle` polygon-face binding is untouched — this is purely additive.

## Why

brepjs's brepkit adapter currently constructs circles and ellipses as NURBS approximations because no direct binding existed. That makes the parity suite see `curvePeriod(circle) === 1` instead of `2π` and wrong arc length. These bindings unblock the adapter swap on the brepjs side and close the highest-leverage parity gap for circle/ellipse edges.

## Test plan

- [x] `cargo test -p brepkit-topology` — 44 tests pass (5 new)
- [x] `cargo build -p brepkit-wasm` — clean
- [x] `cargo clippy -p brepkit-topology -p brepkit-wasm --all-targets -- -D warnings` — clean
- [x] `./scripts/check-boundaries.sh` — no layer violations
- [ ] brepjs adapter swap + parity run (follow-up after release)