### PR TITLE
fix(boolean): deterministic face order in face_components

### DIFF
--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -668,6 +668,16 @@ pub(super) fn face_components(topo: &Topology, solid: SolidId) -> Vec<Vec<FaceId
         }
     }
 
+    // Sort + dedup adjacency so DFS visits neighbors in a stable order,
+    // independent of HashMap iteration order in `edge_faces`. Without this,
+    // `cut_multi_region_input` builds per-component subsolids with
+    // shuffled face order, which percolates through the boolean pipeline
+    // and makes `compound_cut_*` tests flaky.
+    for neighbors in &mut adj {
+        neighbors.sort_unstable();
+        neighbors.dedup();
+    }
+
     let mut visited = vec![false; n];
     let mut components: Vec<Vec<FaceId>> = Vec::new();
     for start in 0..n {

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -157,12 +157,25 @@ pub fn boolean(
         if aabbs_match && all_b_verts_in_a && all_a_verts_in_b {
             return match op {
                 BooleanOp::Fuse | BooleanOp::Intersect => Ok(crate::copy::copy_solid(topo, a)?),
-                BooleanOp::Cut => Err(crate::OperationsError::InvalidInput {
-                    reason: "Cut of identical solids produces empty result".into(),
+                BooleanOp::Cut => Err(crate::OperationsError::EmptyResult {
+                    reason: "Cut of identical solids".into(),
                 }),
             };
         }
-        // For Cut with containment, defer to GFA (produces shelled solid).
+        // Containment shortcuts:
+        // - Fuse/Intersect with either containment direction: copy the
+        //   appropriate solid.
+        // - Cut with A ⊆ B: result is empty (A is fully removed). Return
+        //   EmptyResult explicitly — without this short-circuit, GFA falls
+        //   back to producing a degenerate vol=0 solid that callers
+        //   mistake for a real result, breaking volume invariants like
+        //   `vol((A-B) ∪ (A∩B)) = vol(A)`.
+        // - Cut with B ⊂ A: defer to GFA (produces hollow solid).
+        if op == BooleanOp::Cut && a_in_b && !b_in_a {
+            return Err(crate::OperationsError::EmptyResult {
+                reason: "Cut with target fully contained in tool".into(),
+            });
+        }
         if (b_in_a || a_in_b) && op != BooleanOp::Cut {
             return match (op, b_in_a, a_in_b) {
                 (BooleanOp::Fuse, true, _) => Ok(crate::copy::copy_solid(topo, a)?),
@@ -1276,8 +1289,8 @@ fn mesh_boolean_fallback(
     let mb_result = crate::mesh_boolean::mesh_boolean(&mesh_a, &mesh_b, op, tol.linear)?;
     let face_specs = mesh_result_to_face_specs(&mb_result);
     if face_specs.is_empty() {
-        return Err(crate::OperationsError::InvalidInput {
-            reason: "mesh boolean produced empty result".into(),
+        return Err(crate::OperationsError::EmptyResult {
+            reason: "mesh boolean produced no output faces".into(),
         });
     }
     let result = assemble_solid_mixed(topo, &face_specs, tol)?;
@@ -1470,7 +1483,10 @@ fn cut_multi_region_input(
         let comp_solid = crate::copy::copy_solid(topo, comp_solid_raw)?;
         match boolean(topo, BooleanOp::Cut, comp_solid, b) {
             Ok(r) => per_component_results.push(r),
-            Err(crate::OperationsError::InvalidInput { .. }) => {
+            Err(
+                crate::OperationsError::EmptyResult { .. }
+                | crate::OperationsError::InvalidInput { .. },
+            ) => {
                 per_component_results.push(comp_solid);
             }
             Err(e) => return Err(e),

--- a/crates/operations/src/lib.rs
+++ b/crates/operations/src/lib.rs
@@ -109,6 +109,21 @@ pub enum OperationsError {
     #[error("non-manifold result")]
     NonManifoldResult,
 
+    /// The operation produced an empty result (no geometry).
+    ///
+    /// Boolean operations return this when the algebraic outcome is the
+    /// empty set: `Cut(A, B)` when `A ⊆ B`, or any operation on
+    /// pre-collapsed inputs. Distinguishable from [`InvalidInput`] so
+    /// callers can apply empty-operand identity rules without
+    /// string-matching the error message.
+    ///
+    /// [`InvalidInput`]: Self::InvalidInput
+    #[error("empty result: {reason}")]
+    EmptyResult {
+        /// Description of the empty-result scenario.
+        reason: String,
+    },
+
     /// A referenced topology entity was not found.
     #[error(transparent)]
     Topology(#[from] brepkit_topology::TopologyError),

--- a/crates/operations/src/mesh_boolean.rs
+++ b/crates/operations/src/mesh_boolean.rs
@@ -66,8 +66,8 @@ pub fn mesh_boolean(
     let mesh = assemble_result(&split_a, &split_b, &classify_a, &classify_b, op);
 
     if mesh.positions.is_empty() {
-        return Err(OperationsError::InvalidInput {
-            reason: "mesh boolean produced empty result".into(),
+        return Err(OperationsError::EmptyResult {
+            reason: "mesh boolean produced no output vertices".into(),
         });
     }
 

--- a/crates/operations/tests/boolean_invariants.rs
+++ b/crates/operations/tests/boolean_invariants.rs
@@ -3,7 +3,7 @@
 //! Verifies conservation laws, commutativity, and algebraic identities
 //! that must hold for any correct boolean implementation.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use brepkit_math::mat::Mat4;
 use brepkit_operations::OperationsError;
@@ -401,7 +401,8 @@ fn identical_solids_cut_errors_or_empty() {
 fn safe_vol(topo: &Topology, result: Result<SolidId, OperationsError>) -> f64 {
     match result {
         Ok(s) => solid_volume(topo, s, DEFLECTION).unwrap_or(0.0),
-        Err(_) => 0.0,
+        Err(OperationsError::EmptyResult { .. }) => 0.0,
+        Err(e) => panic!("unexpected boolean error (only EmptyResult should map to 0): {e:?}"),
     }
 }
 
@@ -532,7 +533,9 @@ fn intersect_contained_solid_returns_contained() {
 #[test]
 fn cut_then_fuse_back_containment() {
     // Full invariant: vol((A-B) ∪ (A∩B)) ≈ vol(A), with A ⊂ B.
-    // (A-B) is empty (A is fully cut away). (A∩B) ≈ A.
+    // (A-B) is empty (A is fully cut away), so applying the empty-operand
+    // identity `empty ∪ X = X` leaves (A∩B), which the containment
+    // shortcut returns as ≈ A.
     let mut topo = Topology::new();
     let a = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
     let b = make_box(&mut topo, 0.95, 0.95, 0.95).unwrap();
@@ -545,25 +548,16 @@ fn cut_then_fuse_back_containment() {
         matches!(diff_result, Err(OperationsError::EmptyResult { .. })),
         "Cut(A ⊂ B, B) should return EmptyResult, got {diff_result:?}"
     );
-    let diff_opt: Option<SolidId> = diff_result.ok();
 
     let inter = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
     let vol_inter = vol(&topo, inter);
 
-    let vol_fused = match diff_opt {
-        Some(diff) => {
-            let fused = boolean(&mut topo, BooleanOp::Fuse, diff, inter).unwrap();
-            vol(&topo, fused)
-        }
-        None => vol_inter,
-    };
-
-    let rel_error = (vol_fused - vol_a).abs() / vol_a;
+    // With (A-B) empty, the invariant reduces to vol_inter ≈ vol_a.
+    let rel_error = (vol_inter - vol_a).abs() / vol_a;
     assert!(
         rel_error < 1e-5,
-        "(A-B) ∪ (A∩B) should reconstruct A (A ⊂ B): got vol_fused={vol_fused:.10}, \
-         vol_a={vol_a:.10}, vol_inter={vol_inter:.10}, diff_was_empty={} (rel error {:.4}%)",
-        diff_opt.is_none(),
+        "empty ∪ (A∩B) should reconstruct A (A ⊂ B): vol_inter={vol_inter:.10}, \
+         vol_a={vol_a:.10} (rel error {:.4}%)",
         rel_error * 100.0
     );
 }

--- a/crates/operations/tests/boolean_invariants.rs
+++ b/crates/operations/tests/boolean_invariants.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use brepkit_math::mat::Mat4;
+use brepkit_operations::OperationsError;
 use brepkit_operations::boolean::{BooleanOp, boolean};
 use brepkit_operations::copy::copy_solid;
 use brepkit_operations::measure::solid_volume;
@@ -385,6 +386,186 @@ fn identical_solids_cut_errors_or_empty() {
             );
         }
     }
+}
+
+// -- Near-coincident-face robustness (brepjs parity) ---------------------
+//
+// Both scenarios put face coincidence within the default `Tolerance::new()
+// .linear = 1e-7` band. They mirror brepjs parity tests that exposed the
+// classifier failing to handle near-coincident face geometry consistently.
+//
+// These tests use the same empty-result contract as `cut_box_by_large_sphere_containment`
+// in `boolean/tests.rs`: a boolean returning `Err` is treated as an empty result
+// (volume 0) so the invariant can be evaluated set-theoretically.
+
+fn safe_vol(topo: &Topology, result: Result<SolidId, OperationsError>) -> f64 {
+    match result {
+        Ok(s) => solid_volume(topo, s, DEFLECTION).unwrap_or(0.0),
+        Err(_) => 0.0,
+    }
+}
+
+#[test]
+fn cut_then_fuse_back_recovers_volume_near_coincident() {
+    // INVARIANT: vol((A - B) ∪ (A ∩ B)) === vol(A)
+    //
+    // A = 0.5000001³ box at origin; B = 0.5³ box at origin.
+    // B is nearly contained in A — the +x/+y/+z faces are 1e-7 apart, exactly
+    // the default linear tolerance. Empty-result contract: `(A - B)` may
+    // legitimately return `Err` (the difference is sub-tolerance and treated
+    // as empty); when that happens, `(empty) ∪ (A ∩ B) = (A ∩ B)`.
+    let mut topo = Topology::new();
+    let a = make_box(&mut topo, 0.500_000_1, 0.500_000_1, 0.500_000_1).unwrap();
+    let b = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let vol_a = vol(&topo, a);
+
+    let a_cut = make_box(&mut topo, 0.500_000_1, 0.500_000_1, 0.500_000_1).unwrap();
+    let b_cut = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let diff_opt: Option<SolidId> = boolean(&mut topo, BooleanOp::Cut, a_cut, b_cut).ok();
+    let vol_diff = diff_opt.map(|s| vol(&topo, s)).unwrap_or(0.0);
+
+    let inter = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let vol_inter = vol(&topo, inter);
+
+    // Build the (A-B) ∪ (A∩B) — when diff is empty, just use inter.
+    let vol_fused = match diff_opt {
+        Some(diff) => {
+            let fused = boolean(&mut topo, BooleanOp::Fuse, diff, inter).unwrap();
+            vol(&topo, fused)
+        }
+        None => vol_inter,
+    };
+
+    let rel_error = (vol_fused - vol_a).abs() / vol_a;
+    assert!(
+        rel_error < 1e-4,
+        "(A-B) ∪ (A∩B) should reconstruct A: got vol_fused={vol_fused:.10}, vol_a={vol_a:.10} \
+         (rel error {:.4}%). vol(A-B)={vol_diff:.3e}, vol(A∩B)={vol_inter:.10}",
+        rel_error * 100.0
+    );
+}
+
+#[test]
+fn inclusion_exclusion_near_coincident_faces() {
+    // INVARIANT: vol(A ∪ B) + vol(A ∩ B) === vol(A) + vol(B)
+    //
+    // A = 0.5³ box at origin. B = 0.5³ box shifted by (0, 0.5 - 1e-7, 0).
+    // A's +y face (y=0.5) and B's -y face (y=0.4999999) are 1e-7 apart,
+    // exactly the default linear tolerance. Either operation may legitimately
+    // return an empty-result error; account for that with the safe_vol helper.
+    let mut topo = Topology::new();
+    let a = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let b = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let offset = 0.5_f64 - 1e-7;
+    transform_solid(&mut topo, b, &Mat4::translation(0.0, offset, 0.0)).unwrap();
+    let vol_a = vol(&topo, a);
+    let vol_b = vol(&topo, b);
+
+    let a2 = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let b2 = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    transform_solid(&mut topo, b2, &Mat4::translation(0.0, offset, 0.0)).unwrap();
+    let fused_result = boolean(&mut topo, BooleanOp::Fuse, a2, b2);
+    let vol_fused = safe_vol(&topo, fused_result);
+
+    let a3 = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let b3 = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    transform_solid(&mut topo, b3, &Mat4::translation(0.0, offset, 0.0)).unwrap();
+    let inter_result = boolean(&mut topo, BooleanOp::Intersect, a3, b3);
+    let vol_inter = safe_vol(&topo, inter_result);
+
+    let lhs = vol_a + vol_b;
+    let rhs = vol_fused + vol_inter;
+    let rel_error = (lhs - rhs).abs() / lhs;
+    assert!(
+        rel_error < 1e-4,
+        "inclusion-exclusion: V(A)+V(B)={lhs:.10}, V(A∪B)+V(A∩B)={rhs:.10} \
+         (vol_fused={vol_fused:.10}, vol_inter={vol_inter:.3e}, rel error {:.4}%)",
+        rel_error * 100.0
+    );
+}
+
+// -- Containment robustness (brepjs parity) ------------------------------
+//
+// A ⊂ B sharing the origin corner. Mathematically:
+//   intersect(A, B) = A         (vol 0.125)
+//   cut(A, B)       = ∅         (Err per empty-result contract)
+//   fuse(∅, A)      = A         (vol 0.125)
+//
+// brepjs counterexample for cut-then-fuse-back: `[0.5, 0.9531210881257514,
+// 1.7801e-308]` decodes to A=unitCube(0.5,0.5,0.5), B=unitCube(0.95,0.95,0.95)
+// offset by (1.78e-308, 0, 0) ≈ origin. Failure mode on brepjs: vol_fused=0,
+// meaning intersect(A,B) didn't return A.
+
+#[test]
+fn cut_contained_solid_returns_empty_result() {
+    // A ⊂ B → Cut(A, B) is empty per the empty-result contract.
+    // Without the explicit containment-Cut shortcut, GFA fabricates a
+    // degenerate vol=0 solid that callers mistake for a real result.
+    let mut topo = Topology::new();
+    let a = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let b = make_box(&mut topo, 0.95, 0.95, 0.95).unwrap();
+    let result = boolean(&mut topo, BooleanOp::Cut, a, b);
+    assert!(
+        matches!(result, Err(OperationsError::EmptyResult { .. })),
+        "Cut(A ⊂ B, B) should return EmptyResult, got {result:?}"
+    );
+}
+
+#[test]
+fn intersect_contained_solid_returns_contained() {
+    // A ⊂ B with shared origin corner. intersect(A, B) must return ≈ A.
+    let mut topo = Topology::new();
+    let a = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let b = make_box(&mut topo, 0.95, 0.95, 0.95).unwrap();
+    let inter = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let v = vol(&topo, inter);
+    let expected = 0.125_f64;
+    let rel_error = (v - expected).abs() / expected;
+    assert!(
+        rel_error < 1e-5,
+        "intersect(A ⊂ B) should return A: got vol={v:.10}, expected {expected:.10} \
+         (rel error {:.4}%)",
+        rel_error * 100.0
+    );
+}
+
+#[test]
+fn cut_then_fuse_back_containment() {
+    // Full invariant: vol((A-B) ∪ (A∩B)) ≈ vol(A), with A ⊂ B.
+    // (A-B) is empty (A is fully cut away). (A∩B) ≈ A.
+    let mut topo = Topology::new();
+    let a = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let b = make_box(&mut topo, 0.95, 0.95, 0.95).unwrap();
+    let vol_a = vol(&topo, a);
+
+    let a_cut = make_box(&mut topo, 0.5, 0.5, 0.5).unwrap();
+    let b_cut = make_box(&mut topo, 0.95, 0.95, 0.95).unwrap();
+    let diff_result = boolean(&mut topo, BooleanOp::Cut, a_cut, b_cut);
+    assert!(
+        matches!(diff_result, Err(OperationsError::EmptyResult { .. })),
+        "Cut(A ⊂ B, B) should return EmptyResult, got {diff_result:?}"
+    );
+    let diff_opt: Option<SolidId> = diff_result.ok();
+
+    let inter = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let vol_inter = vol(&topo, inter);
+
+    let vol_fused = match diff_opt {
+        Some(diff) => {
+            let fused = boolean(&mut topo, BooleanOp::Fuse, diff, inter).unwrap();
+            vol(&topo, fused)
+        }
+        None => vol_inter,
+    };
+
+    let rel_error = (vol_fused - vol_a).abs() / vol_a;
+    assert!(
+        rel_error < 1e-5,
+        "(A-B) ∪ (A∩B) should reconstruct A (A ⊂ B): got vol_fused={vol_fused:.10}, \
+         vol_a={vol_a:.10}, vol_inter={vol_inter:.10}, diff_was_empty={} (rel error {:.4}%)",
+        diff_opt.is_none(),
+        rel_error * 100.0
+    );
 }
 
 // -- Cut cylinder from box ------------------------------------------------


### PR DESCRIPTION
## Summary

`face_components` built its adjacency list by iterating `edge_faces` (a `HashMap`), so the DFS visited neighbors in random hash order. Per-component face vectors came out in different orders run-to-run, which percolated through `cut_multi_region_input → make_solid_from_face_subset → boolean(Cut, …)` and produced two stable-but-different volume answers for the same compound-cut input.

## Why now

`compound_cut_shelled_target_9_tools` has been latently flaky (~5% locally over 20 trials). With #681's containment-Cut shortcut landed, more multi-region inputs reach `cut_multi_region_input`, so the flake became visible — it failed twice in a row on the release-please 2.88.1 branch (PR #682), blocking the release.

## Fix

Sort and dedup each adjacency list before DFS. Components and their face orders are now a deterministic function of input topology.

```rust
for neighbors in &mut adj {
    neighbors.sort_unstable();
    neighbors.dedup();
}
```

## Test plan

- [x] 30/30 passes locally for `compound_cut_shelled_target_9_tools` (was 19/20 before).
- [x] `cargo test -p brepkit-operations` — fully green, no regressions.
- [ ] Watch CI for #682 to clear once this merges and release-please rebases.