### PR TITLE
feat(topology+wasm): add makeCircleEdgeWithRef / makeEllipseEdgeWithRef bindings

### DIFF
--- a/crates/math/src/curves.rs
+++ b/crates/math/src/curves.rs
@@ -121,6 +121,40 @@ impl Circle3D {
         })
     }
 
+    /// Create a new circle with a caller-supplied reference x-direction.
+    ///
+    /// `ref_dir` is projected onto the plane perpendicular to `normal` to
+    /// produce `u_axis`. Circles are radially symmetric so the choice of
+    /// `u_axis` has no geometric effect — but it does fix the seam vertex
+    /// at `evaluate(0.0)`, which downstream code (closed-edge construction,
+    /// PCurve computation) can depend on.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `radius` is non-positive or `normal` is zero.
+    pub fn new_with_ref(
+        center: Point3,
+        normal: Vec3,
+        radius: f64,
+        ref_dir: Vec3,
+    ) -> Result<Self, MathError> {
+        if radius <= 0.0 {
+            return Err(MathError::ParameterOutOfRange {
+                value: radius,
+                min: 0.0,
+                max: f64::INFINITY,
+            });
+        }
+        let f = Frame3::from_normal_and_ref(center, normal, ref_dir)?;
+        Ok(Self {
+            center,
+            normal: f.z,
+            radius,
+            u_axis: f.x,
+            v_axis: f.y,
+        })
+    }
+
     /// Evaluate the circle at angle `t` (radians).
     #[must_use]
     pub fn evaluate(&self, t: f64) -> Point3 {
@@ -256,6 +290,49 @@ impl Ellipse3D {
             });
         }
         let f = Frame3::from_normal(center, normal)?;
+        Ok(Self {
+            center,
+            normal: f.z,
+            semi_major,
+            semi_minor,
+            u_axis: f.x,
+            v_axis: f.y,
+        })
+    }
+
+    /// Create a new ellipse with a caller-supplied reference major-axis direction.
+    ///
+    /// `ref_dir` is projected onto the plane perpendicular to `normal` to
+    /// produce `u_axis` (which carries the `semi_major` extent). If
+    /// `ref_dir` is parallel to `normal`, falls back to an arbitrary
+    /// perpendicular choice per [`Frame3::from_normal_and_ref`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either semi-axis is non-positive, `semi_minor`
+    /// exceeds `semi_major`, or `normal` is zero.
+    pub fn new_with_ref(
+        center: Point3,
+        normal: Vec3,
+        semi_major: f64,
+        semi_minor: f64,
+        ref_dir: Vec3,
+    ) -> Result<Self, MathError> {
+        if semi_major <= 0.0 || semi_minor <= 0.0 {
+            return Err(MathError::ParameterOutOfRange {
+                value: semi_major.min(semi_minor),
+                min: 0.0,
+                max: f64::INFINITY,
+            });
+        }
+        if semi_minor > semi_major {
+            return Err(MathError::ParameterOutOfRange {
+                value: semi_minor,
+                min: 0.0,
+                max: semi_major,
+            });
+        }
+        let f = Frame3::from_normal_and_ref(center, normal, ref_dir)?;
         Ok(Self {
             center,
             normal: f.z,

--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -49,6 +49,13 @@ pub fn make_line_edge(
 /// of the seam vertex at `circle.evaluate(0.0)`. The edge has parameter
 /// domain `[0, 2π]`.
 ///
+/// If `ref_dir` is zero or (nearly) parallel to `normal`, the underlying
+/// [`Frame3::from_normal_and_ref`] falls back to an arbitrary perpendicular
+/// axis — the seam orientation is *not* pinned in that case. The WASM
+/// boundary rejects zero `ref_dir` outright; callers of the topology
+/// layer should pass a non-zero, non-parallel direction to actually pin
+/// the seam.
+///
 /// # Errors
 ///
 /// Returns an error if `radius` is non-positive or `normal` is a zero vector.
@@ -102,6 +109,13 @@ pub fn make_circle_edge(
 /// `ref_dir` is projected onto the plane perpendicular to `normal` to fix
 /// the orientation of the ellipse's major axis (`u_axis`, carrying the
 /// `semi_major` extent). The edge has parameter domain `[0, 2π]`.
+///
+/// If `ref_dir` is zero or (nearly) parallel to `normal`, the underlying
+/// [`Frame3::from_normal_and_ref`] falls back to an arbitrary perpendicular
+/// axis — the major-axis orientation is *not* pinned in that case. The
+/// WASM boundary rejects zero `ref_dir` outright; callers of the topology
+/// layer should pass a non-zero, non-parallel direction to actually pin
+/// the major axis.
 ///
 /// # Errors
 ///

--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -5,6 +5,7 @@
 use std::f64::consts::PI;
 
 use brepkit_math::curves::{Circle3D, Ellipse3D};
+use brepkit_math::frame::Frame3;
 use brepkit_math::nurbs::curve::NurbsCurve;
 use brepkit_math::nurbs::surface::NurbsSurface;
 use brepkit_math::tolerance::Tolerance;
@@ -41,11 +42,42 @@ pub fn make_line_edge(
     Ok(topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line)))
 }
 
+/// Create a closed circular edge with a caller-supplied reference x-direction.
+///
+/// `ref_dir` is projected onto the plane perpendicular to `normal` to fix
+/// the orientation of the circle's `u_axis` — and therefore the position
+/// of the seam vertex at `circle.evaluate(0.0)`. The edge has parameter
+/// domain `[0, 2π]`.
+///
+/// # Errors
+///
+/// Returns an error if `radius` is non-positive or `normal` is a zero vector.
+pub fn make_circle_edge_with_ref(
+    topo: &mut Topology,
+    center: Point3,
+    normal: Vec3,
+    radius: f64,
+    ref_dir: Vec3,
+    tolerance: f64,
+) -> Result<EdgeId, crate::TopologyError> {
+    let circle = Circle3D::new_with_ref(center, normal, radius, ref_dir).map_err(|e| {
+        crate::TopologyError::NonManifold {
+            reason: format!("invalid circle: {e}"),
+        }
+    })?;
+    let seam = circle.evaluate(0.0);
+    let v = topo.add_vertex(Vertex::new(seam, tolerance));
+    Ok(topo.add_edge(Edge::new(v, v, EdgeCurve::Circle(circle))))
+}
+
 /// Create a closed circular edge.
 ///
 /// Constructs a [`Circle3D`] from `center`, `normal`, and `radius`, then
 /// creates a single closed edge whose start and end share a seam vertex
 /// at `circle.evaluate(0.0)`. The edge has parameter domain `[0, 2π]`.
+///
+/// Delegates to [`make_circle_edge_with_ref`] using the default frame's
+/// x-axis ([`Frame3::from_normal`]) as the reference direction.
 ///
 /// # Errors
 ///
@@ -57,13 +89,40 @@ pub fn make_circle_edge(
     radius: f64,
     tolerance: f64,
 ) -> Result<EdgeId, crate::TopologyError> {
-    let circle =
-        Circle3D::new(center, normal, radius).map_err(|e| crate::TopologyError::NonManifold {
-            reason: format!("invalid circle: {e}"),
+    let ref_dir = Frame3::from_normal(center, normal)
+        .map_err(|e| crate::TopologyError::NonManifold {
+            reason: format!("invalid circle frame: {e}"),
+        })?
+        .x;
+    make_circle_edge_with_ref(topo, center, normal, radius, ref_dir, tolerance)
+}
+
+/// Create a closed elliptical edge with a caller-supplied reference major-axis.
+///
+/// `ref_dir` is projected onto the plane perpendicular to `normal` to fix
+/// the orientation of the ellipse's major axis (`u_axis`, carrying the
+/// `semi_major` extent). The edge has parameter domain `[0, 2π]`.
+///
+/// # Errors
+///
+/// Returns an error if either semi-axis is non-positive, `semi_minor`
+/// exceeds `semi_major`, or `normal` is a zero vector.
+pub fn make_ellipse_edge_with_ref(
+    topo: &mut Topology,
+    center: Point3,
+    normal: Vec3,
+    semi_major: f64,
+    semi_minor: f64,
+    ref_dir: Vec3,
+    tolerance: f64,
+) -> Result<EdgeId, crate::TopologyError> {
+    let ellipse = Ellipse3D::new_with_ref(center, normal, semi_major, semi_minor, ref_dir)
+        .map_err(|e| crate::TopologyError::NonManifold {
+            reason: format!("invalid ellipse: {e}"),
         })?;
-    let seam = circle.evaluate(0.0);
+    let seam = ellipse.evaluate(0.0);
     let v = topo.add_vertex(Vertex::new(seam, tolerance));
-    Ok(topo.add_edge(Edge::new(v, v, EdgeCurve::Circle(circle))))
+    Ok(topo.add_edge(Edge::new(v, v, EdgeCurve::Ellipse(ellipse))))
 }
 
 /// Create a closed elliptical edge.
@@ -72,6 +131,9 @@ pub fn make_circle_edge(
 /// semi-axis lengths, then creates a single closed edge whose start and
 /// end share a seam vertex at `ellipse.evaluate(0.0)`. The edge has
 /// parameter domain `[0, 2π]`.
+///
+/// Delegates to [`make_ellipse_edge_with_ref`] using the default frame's
+/// x-axis ([`Frame3::from_normal`]) as the reference direction.
 ///
 /// # Errors
 ///
@@ -85,14 +147,14 @@ pub fn make_ellipse_edge(
     semi_minor: f64,
     tolerance: f64,
 ) -> Result<EdgeId, crate::TopologyError> {
-    let ellipse = Ellipse3D::new(center, normal, semi_major, semi_minor).map_err(|e| {
-        crate::TopologyError::NonManifold {
-            reason: format!("invalid ellipse: {e}"),
-        }
-    })?;
-    let seam = ellipse.evaluate(0.0);
-    let v = topo.add_vertex(Vertex::new(seam, tolerance));
-    Ok(topo.add_edge(Edge::new(v, v, EdgeCurve::Ellipse(ellipse))))
+    let ref_dir = Frame3::from_normal(center, normal)
+        .map_err(|e| crate::TopologyError::NonManifold {
+            reason: format!("invalid ellipse frame: {e}"),
+        })?
+        .x;
+    make_ellipse_edge_with_ref(
+        topo, center, normal, semi_major, semi_minor, ref_dir, tolerance,
+    )
 }
 
 /// Create a closed wire from an ordered list of points.
@@ -600,6 +662,117 @@ mod tests {
                 TOL,
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn make_circle_edge_with_ref_seam_at_supplied_x() {
+        // ref_dir=[1,0,0] with normal=[0,0,1]: u_axis should align with +x,
+        // putting the seam vertex (circle.evaluate(0.0) = center + r·u_axis)
+        // at (r, 0, 0). The default frame produces u_axis=[0,1,0] so the
+        // seam lands at (0, r, 0) — verifies the ref_dir takes effect.
+        let mut topo = Topology::new();
+        let eid = make_circle_edge_with_ref(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            3.0,
+            Vec3::new(1.0, 0.0, 0.0),
+            TOL,
+        )
+        .unwrap();
+
+        let edge = topo.edge(eid).unwrap();
+        let seam = topo.vertex(edge.start()).unwrap().point();
+        assert!(
+            (seam.x() - 3.0).abs() < 1e-12,
+            "seam.x should be 3.0, got {}",
+            seam.x()
+        );
+        assert!(
+            seam.y().abs() < 1e-12,
+            "seam.y should be 0, got {}",
+            seam.y()
+        );
+        assert!(
+            seam.z().abs() < 1e-12,
+            "seam.z should be 0, got {}",
+            seam.z()
+        );
+
+        // Sanity: default-frame variant puts the seam at +y instead.
+        let mut topo2 = Topology::new();
+        let eid2 = make_circle_edge(
+            &mut topo2,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            3.0,
+            TOL,
+        )
+        .unwrap();
+        let seam2 = topo2
+            .vertex(topo2.edge(eid2).unwrap().start())
+            .unwrap()
+            .point();
+        assert!(
+            (seam2.y() - 3.0).abs() < 1e-12,
+            "default-frame seam.y should be 3.0, got {}",
+            seam2.y()
+        );
+    }
+
+    #[test]
+    fn make_ellipse_edge_with_ref_major_axis_along_supplied_dir() {
+        // ref_dir=[1,0,0] with normal=[0,0,1]: u_axis aligns with +x, so
+        // the seam vertex (ellipse.evaluate(0.0) = center + semi_major·u_axis)
+        // lands at (semi_major, 0, 0). This is what brepjs's `sketchEllipse`
+        // assumes; the default frame puts the major axis along +y, which
+        // breaks the volume of `sketchEllipse(5,2).extrude(10)` because
+        // the adapter falls back to a NURBS approximation.
+        let mut topo = Topology::new();
+        let eid = make_ellipse_edge_with_ref(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            5.0,
+            2.0,
+            Vec3::new(1.0, 0.0, 0.0),
+            TOL,
+        )
+        .unwrap();
+
+        let edge = topo.edge(eid).unwrap();
+        let seam = topo.vertex(edge.start()).unwrap().point();
+        assert!(
+            (seam.x() - 5.0).abs() < 1e-12,
+            "seam.x should be semi_major (5.0), got {}",
+            seam.x()
+        );
+        assert!(
+            seam.y().abs() < 1e-12,
+            "seam.y should be 0, got {}",
+            seam.y()
+        );
+
+        // Sanity: default-frame variant puts the major-axis seam along +y.
+        let mut topo2 = Topology::new();
+        let eid2 = make_ellipse_edge(
+            &mut topo2,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            5.0,
+            2.0,
+            TOL,
+        )
+        .unwrap();
+        let seam2 = topo2
+            .vertex(topo2.edge(eid2).unwrap().start())
+            .unwrap()
+            .point();
+        assert!(
+            (seam2.y() - 5.0).abs() < 1e-12,
+            "default-frame seam.y should be 5.0, got {}",
+            seam2.y()
         );
     }
 

--- a/crates/wasm/src/bindings/shapes.rs
+++ b/crates/wasm/src/bindings/shapes.rs
@@ -265,6 +265,132 @@ impl BrepKernel {
         Ok(edge_id_to_u32(eid))
     }
 
+    /// Create a closed circular edge with a caller-supplied reference x-direction.
+    ///
+    /// Like [`makeCircleEdge`](Self::make_circle_edge), but `ref_dir = (rx, ry, rz)`
+    /// is projected onto the plane perpendicular to the normal to fix the
+    /// circle's `u_axis` — which controls the seam vertex position at
+    /// `circle.evaluate(0.0)`. Use when downstream code (PCurve computation,
+    /// extrusion frame) depends on a specific seam placement.
+    ///
+    /// Returns an edge handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any coordinate is NaN/infinite, `radius` is
+    /// non-positive, or the normal vector is zero.
+    #[wasm_bindgen(js_name = "makeCircleEdgeWithRef")]
+    pub fn make_circle_edge_with_ref(
+        &mut self,
+        cx: f64,
+        cy: f64,
+        cz: f64,
+        nx: f64,
+        ny: f64,
+        nz: f64,
+        radius: f64,
+        rx: f64,
+        ry: f64,
+        rz: f64,
+    ) -> Result<u32, JsError> {
+        validate_finite(cx, "cx")?;
+        validate_finite(cy, "cy")?;
+        validate_finite(cz, "cz")?;
+        validate_finite(nx, "nx")?;
+        validate_finite(ny, "ny")?;
+        validate_finite(nz, "nz")?;
+        validate_finite(rx, "rx")?;
+        validate_finite(ry, "ry")?;
+        validate_finite(rz, "rz")?;
+        validate_positive(radius, "radius")?;
+
+        let center = Point3::new(cx, cy, cz);
+        let normal = Vec3::new(nx, ny, nz);
+        normal.normalize().map_err(|e| WasmError::InvalidInput {
+            reason: format!("invalid normal: {e}"),
+        })?;
+        let ref_dir = Vec3::new(rx, ry, rz);
+        let eid = brepkit_topology::builder::make_circle_edge_with_ref(
+            self.topo_mut(),
+            center,
+            normal,
+            radius,
+            ref_dir,
+            TOL,
+        )?;
+        Ok(edge_id_to_u32(eid))
+    }
+
+    /// Create a closed elliptical edge with a caller-supplied reference major-axis.
+    ///
+    /// Like [`makeEllipseEdge`](Self::make_ellipse_edge), but `ref_dir = (rx, ry, rz)`
+    /// is projected onto the plane perpendicular to the normal to fix the
+    /// ellipse's major-axis direction (`u_axis`, carrying `semi_major`).
+    /// Use this when the caller has an intended major-axis orientation —
+    /// otherwise the default-frame variant chooses an arbitrary
+    /// perpendicular, which can cause adapters to fall back to NURBS
+    /// approximations to preserve their requested orientation.
+    ///
+    /// Returns an edge handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any coordinate is NaN/infinite, either
+    /// semi-axis is non-positive, `semi_minor` exceeds `semi_major`, or
+    /// the normal vector is zero.
+    #[wasm_bindgen(js_name = "makeEllipseEdgeWithRef")]
+    pub fn make_ellipse_edge_with_ref(
+        &mut self,
+        cx: f64,
+        cy: f64,
+        cz: f64,
+        nx: f64,
+        ny: f64,
+        nz: f64,
+        semi_major: f64,
+        semi_minor: f64,
+        rx: f64,
+        ry: f64,
+        rz: f64,
+    ) -> Result<u32, JsError> {
+        validate_finite(cx, "cx")?;
+        validate_finite(cy, "cy")?;
+        validate_finite(cz, "cz")?;
+        validate_finite(nx, "nx")?;
+        validate_finite(ny, "ny")?;
+        validate_finite(nz, "nz")?;
+        validate_finite(rx, "rx")?;
+        validate_finite(ry, "ry")?;
+        validate_finite(rz, "rz")?;
+        validate_positive(semi_major, "semi_major")?;
+        validate_positive(semi_minor, "semi_minor")?;
+        if semi_minor > semi_major {
+            return Err(WasmError::InvalidInput {
+                reason: format!(
+                    "semi_minor ({semi_minor}) must not exceed semi_major ({semi_major})"
+                ),
+            }
+            .into());
+        }
+
+        let center = Point3::new(cx, cy, cz);
+        let normal = Vec3::new(nx, ny, nz);
+        normal.normalize().map_err(|e| WasmError::InvalidInput {
+            reason: format!("invalid normal: {e}"),
+        })?;
+        let ref_dir = Vec3::new(rx, ry, rz);
+        let eid = brepkit_topology::builder::make_ellipse_edge_with_ref(
+            self.topo_mut(),
+            center,
+            normal,
+            semi_major,
+            semi_minor,
+            ref_dir,
+            TOL,
+        )?;
+        Ok(edge_id_to_u32(eid))
+    }
+
     /// Create a circular arc edge between two points.
     ///
     /// The arc lies on a circle with the given center, normal axis, and

--- a/crates/wasm/src/bindings/shapes.rs
+++ b/crates/wasm/src/bindings/shapes.rs
@@ -273,12 +273,17 @@ impl BrepKernel {
     /// `circle.evaluate(0.0)`. Use when downstream code (PCurve computation,
     /// extrusion frame) depends on a specific seam placement.
     ///
+    /// `ref_dir` must be non-zero (rejected at this boundary) and ideally
+    /// not parallel to the normal — `Frame3::from_normal_and_ref` falls
+    /// back to an arbitrary perpendicular when the projection of `ref_dir`
+    /// onto the plane is degenerate, defeating the purpose of this call.
+    ///
     /// Returns an edge handle (`u32`).
     ///
     /// # Errors
     ///
     /// Returns an error if any coordinate is NaN/infinite, `radius` is
-    /// non-positive, or the normal vector is zero.
+    /// non-positive, or the normal vector or `ref_dir` is zero.
     #[wasm_bindgen(js_name = "makeCircleEdgeWithRef")]
     pub fn make_circle_edge_with_ref(
         &mut self,
@@ -310,6 +315,9 @@ impl BrepKernel {
             reason: format!("invalid normal: {e}"),
         })?;
         let ref_dir = Vec3::new(rx, ry, rz);
+        ref_dir.normalize().map_err(|e| WasmError::InvalidInput {
+            reason: format!("invalid ref_dir: {e}"),
+        })?;
         let eid = brepkit_topology::builder::make_circle_edge_with_ref(
             self.topo_mut(),
             center,
@@ -331,13 +339,18 @@ impl BrepKernel {
     /// perpendicular, which can cause adapters to fall back to NURBS
     /// approximations to preserve their requested orientation.
     ///
+    /// `ref_dir` must be non-zero (rejected at this boundary) and ideally
+    /// not parallel to the normal — `Frame3::from_normal_and_ref` falls
+    /// back to an arbitrary perpendicular when the projection of `ref_dir`
+    /// onto the plane is degenerate, defeating the purpose of this call.
+    ///
     /// Returns an edge handle (`u32`).
     ///
     /// # Errors
     ///
     /// Returns an error if any coordinate is NaN/infinite, either
     /// semi-axis is non-positive, `semi_minor` exceeds `semi_major`, or
-    /// the normal vector is zero.
+    /// the normal vector or `ref_dir` is zero.
     #[wasm_bindgen(js_name = "makeEllipseEdgeWithRef")]
     pub fn make_ellipse_edge_with_ref(
         &mut self,
@@ -379,6 +392,9 @@ impl BrepKernel {
             reason: format!("invalid normal: {e}"),
         })?;
         let ref_dir = Vec3::new(rx, ry, rz);
+        ref_dir.normalize().map_err(|e| WasmError::InvalidInput {
+            reason: format!("invalid ref_dir: {e}"),
+        })?;
         let eid = brepkit_topology::builder::make_ellipse_edge_with_ref(
             self.topo_mut(),
             center,


### PR DESCRIPTION
## Summary

Mirror of #679's edge builders, extended with caller-supplied reference x-direction so the seam vertex / major-axis orientation can be pinned. The default-frame variants now delegate to the new `_with_ref` versions using `Frame3::from_normal(...)?.x`, so behavior is unchanged for existing callers.

- `Circle3D::new_with_ref(center, normal, radius, ref_dir)` and
- `Ellipse3D::new_with_ref(center, normal, major, minor, ref_dir)` use the existing `Frame3::from_normal_and_ref` helper (project-and-orthogonalize).
- `topology::builder::make_circle_edge_with_ref` / `make_ellipse_edge_with_ref` take `ref_dir: Vec3`; the existing 4-arg builders delegate.
- `BrepKernel::makeCircleEdgeWithRef(cx,cy,cz,nx,ny,nz,radius,rx,ry,rz)` and `makeEllipseEdgeWithRef(..., semi_major, semi_minor, rx, ry, rz)` — same validation pattern as the existing bindings plus `validate_finite` on the ref-dir coords.

## Why

Closes the last brepjs parity failure: `sketchEllipse(5, 2).extrude(10)` volume = 313.43 vs expected π·5·2·10 ≈ 314.16. brepjs's adapter currently falls back to a NURBS arc approximation (~0.2% volume error) when the caller supplies an explicit `xDir`, because the prior native `makeEllipseEdge` binding accepted only `(center, normal, semi_major, semi_minor)` and derived `u_axis` via `Frame3::from_normal`. For `normal=[0,0,1]` that returns `x=[0,1,0]` — 90° off from the canned sketch's `xDir=[1,0,0]`, so the adapter can't safely use it. With the new binding the adapter can honor the caller's xDir directly.

## Test plan

- [x] `cargo test -p brepkit-topology` — 46 lib tests pass (15 builder + 2 new for `*_with_ref`).
- [x] `cargo test -p brepkit-math` — passes.
- [x] `cargo build -p brepkit-wasm` — clean.
- [x] `cargo clippy -p brepkit-topology -p brepkit-math -p brepkit-wasm --all-targets -- -D warnings` — clean.
- [x] `./scripts/check-boundaries.sh` — clean.
- [ ] brepjs adapter swap to use `makeEllipseEdgeWithRef` when xDir is supplied (follow-up after a new brepkit-wasm release ships).

Purely additive — the existing `makeCircleEdge` / `makeEllipseEdge` bindings are untouched. Same shape as #679; should be a small Greptile pass.