### PR TITLE
fix(algo): close compound boolean variance + lay foundation for box-sphere intersect

### DIFF
--- a/crates/algo/src/ds/face_info.rs
+++ b/crates/algo/src/ds/face_info.rs
@@ -1,6 +1,6 @@
 //! Per-face state accumulated during PaveFiller.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use brepkit_topology::vertex::VertexId;
 
@@ -10,18 +10,25 @@ use super::pave::PaveBlockId;
 ///
 /// Populated incrementally by PaveFiller phases (VE, EF, FF).
 /// Consumed by the Builder to split faces.
+///
+/// `BTreeSet` (not `HashSet`) so iteration is deterministic by ID — downstream
+/// face splitting in `fill_images_faces` iterates `pave_blocks_in` to build
+/// `SectionSource` lists, and HashSet's random iteration order produces
+/// different split topologies across runs, which cascades into 100–500×
+/// per-iter variance in compound boolean benchmarks. See PR #689 for the
+/// other two sites that drove the same nondeterminism.
 #[derive(Debug, Clone, Default)]
 pub struct FaceInfo {
     /// Pave blocks lying ON the face boundary (original boundary edges, split).
-    pub pave_blocks_on: HashSet<PaveBlockId>,
+    pub pave_blocks_on: BTreeSet<PaveBlockId>,
     /// Pave blocks lying IN the face interior (from other faces' edges crossing).
-    pub pave_blocks_in: HashSet<PaveBlockId>,
+    pub pave_blocks_in: BTreeSet<PaveBlockId>,
     /// Section pave blocks from face-face intersection curves.
-    pub pave_blocks_sc: HashSet<PaveBlockId>,
+    pub pave_blocks_sc: BTreeSet<PaveBlockId>,
     /// Vertices on the face boundary.
-    pub vertices_on: HashSet<VertexId>,
+    pub vertices_on: BTreeSet<VertexId>,
     /// Vertices in the face interior.
-    pub vertices_in: HashSet<VertexId>,
+    pub vertices_in: BTreeSet<VertexId>,
     /// Vertices from section curves.
-    pub vertices_sc: HashSet<VertexId>,
+    pub vertices_sc: BTreeSet<VertexId>,
 }

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -138,6 +138,38 @@ pub fn perform(
             };
 
             for raw in raw_curves {
+                // Closed Circle3D sections — produced by plane-sphere
+                // intersections — get split at face-boundary crossings so
+                // downstream face splitters see open arcs they can match
+                // up. Without this, the closed curve is dropped by
+                // `split_noseam_face_direct` and the spherical sub-face is
+                // lost entirely.
+                //
+                // Note: the split here is structurally correct (the FF
+                // arcs now have proper endpoints on the analytic face's
+                // boundary), but `split_noseam_face_direct` still can't
+                // form a single closed cap loop when 2+ arcs cross on a
+                // sphere hemisphere (e.g. the great circles from x=0 and
+                // y=0 planes meeting at the pole). The hemisphere falls
+                // back to "unsplit" → the spherical sub-face is missing
+                // from the GFA output → the boolean pipeline retries with
+                // mesh boolean. Closing that gap requires generalising
+                // the face splitter for multi-arc sphere hemispheres —
+                // see `crates/algo/src/builder/face_splitter/mod.rs:138`
+                // dispatch and `special_cases.rs::split_noseam_face_direct`.
+                if let EdgeCurve::Circle(circle) = &raw.curve {
+                    let is_closed = (raw.p_start - raw.p_end).length() < tol.linear;
+                    if is_closed {
+                        let crossings = closed_circle_boundary_crossings(topo, fa, fb, circle, tol);
+                        if crossings.len() >= 2 {
+                            emit_split_circle_arcs(
+                                topo, arena, fa, fb, &raw, circle, &crossings, tol,
+                            );
+                            continue;
+                        }
+                    }
+                }
+
                 // Create topology vertices at the curve endpoints.
                 // For closed curves (Circle/Ellipse), start and end are the same
                 // 3D point — reuse one vertex for correct seam topology.
@@ -644,6 +676,258 @@ fn find_nearby_face_vertex(
         }
     }
     None
+}
+
+/// Find where a closed `Circle3D` section crosses the outer-wire
+/// boundary of the analytic-surface face in the pair (the non-plane
+/// face, which holds the boundary the curve actually exits at).
+///
+/// Returns crossings as `(t_on_circle, point_3d)` sorted by `t`, with
+/// duplicates removed. Only `Line`-curve boundary edges are considered.
+///
+/// Rationale: for plane-sphere intersections, the closed curve lies on
+/// both the plane face and the sphere hemisphere, but the *meaningful*
+/// boundary crossings are on the sphere hemisphere's equator polygon
+/// — those are the points where the section enters/leaves the
+/// hemisphere region. Using those crossings as split points gives
+/// half-arcs that cleanly bound a spherical cap sub-face. The plane
+/// face's boundary crossings can introduce points interior to the
+/// sphere hemisphere, producing arcs that don't form closed loops on
+/// the hemisphere.
+fn closed_circle_boundary_crossings(
+    topo: &Topology,
+    face_a: FaceId,
+    face_b: FaceId,
+    circle: &brepkit_math::curves::Circle3D,
+    tol: Tolerance,
+) -> Vec<(f64, Point3)> {
+    let mut hits: Vec<(f64, Point3)> = Vec::new();
+
+    // Pick the non-plane face for boundary crossings. If both are planes
+    // or both are non-plane, fall back to using both (existing behavior).
+    let analytic_face = |fid: FaceId| -> Option<FaceId> {
+        let face = topo.face(fid).ok()?;
+        if matches!(face.surface(), FaceSurface::Plane { .. }) {
+            None
+        } else {
+            Some(fid)
+        }
+    };
+    let analytic_a = analytic_face(face_a);
+    let analytic_b = analytic_face(face_b);
+    let faces_to_check: Vec<FaceId> = match (analytic_a, analytic_b) {
+        (None, Some(b)) => vec![b],
+        (Some(a), None) => vec![a],
+        _ => vec![face_a, face_b],
+    };
+
+    for &fid in &faces_to_check {
+        let Ok(face) = topo.face(fid) else {
+            continue;
+        };
+        let Ok(wire) = topo.wire(face.outer_wire()) else {
+            continue;
+        };
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            // Only line boundary edges are supported for now (covers all
+            // current sphere-hemisphere + box-face boundaries).
+            if !matches!(edge.curve(), EdgeCurve::Line) {
+                continue;
+            }
+            let Ok(sv) = topo.vertex(edge.start()) else {
+                continue;
+            };
+            let Ok(ev) = topo.vertex(edge.end()) else {
+                continue;
+            };
+            for (p, t) in circle.intersect_segment(sv.point(), ev.point(), tol.linear) {
+                // Dedup against existing hits by 3D distance.
+                let dup = hits
+                    .iter()
+                    .any(|(_, q)| (*q - p).length() < tol.linear * 10.0);
+                if !dup {
+                    hits.push((t, p));
+                }
+            }
+        }
+    }
+
+    hits.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    log::trace!(
+        "closed_circle_boundary_crossings: face_a={face_a:?} face_b={face_b:?} hits={}",
+        hits.len()
+    );
+
+    // If we found more than 4 crossings, the circle is almost certainly
+    // coincident with one of the face boundaries (e.g. the equator polygon
+    // approximating a great circle on a sphere). In that case the curve
+    // is the boundary itself, not an interior section — fall back to the
+    // existing closed-curve handling instead of splitting.
+    if hits.len() > 4 {
+        log::debug!(
+            "closed_circle_boundary_crossings: {} hits — assuming coincident with boundary, \
+             skipping split",
+            hits.len()
+        );
+        return Vec::new();
+    }
+
+    hits
+}
+
+/// Emit N arc edges + `IntersectionCurveDS` entries for a closed-circle
+/// section split at `crossings` (≥ 2 entries, sorted by circle parameter
+/// `t`).
+///
+/// Each arc becomes its own `IntersectionCurveDS` so that the downstream
+/// `build_section_edges` path sees N separate (open) section sources
+/// instead of one closed curve. `build_section_edges` reconstructs each
+/// section's start/end from the curve's `t_range`, so the per-arc t-range
+/// here is what carries the split through.
+///
+/// Arcs whose midpoints fall outside the AABB of either face are dropped
+/// — those portions of the original closed curve are not geometrically
+/// "on" the face pair, so emitting them as sections would confuse the
+/// face splitter.
+#[allow(clippy::too_many_arguments)]
+fn emit_split_circle_arcs(
+    topo: &mut Topology,
+    arena: &mut GfaArena,
+    face_a: FaceId,
+    face_b: FaceId,
+    raw: &RawCurve,
+    circle: &brepkit_math::curves::Circle3D,
+    crossings: &[(f64, Point3)],
+    tol: Tolerance,
+) {
+    // Compute AABBs for each face. For analytic faces the outer wire
+    // alone doesn't enclose the face region (e.g. a sphere hemisphere has
+    // its outer wire on the equator plane while the surface extends to
+    // the pole) — so we union the wire AABB with the surface's AABB to
+    // get a usable bounding region.
+    let face_aabb = |fid: FaceId| -> Option<Aabb3> {
+        let face = topo.face(fid).ok()?;
+        let wire = topo.wire(face.outer_wire()).ok()?;
+        let mut min = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+        let mut max = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+        let mut any = false;
+        for oe in wire.edges() {
+            if let Ok(edge) = topo.edge(oe.edge()) {
+                for vid in [edge.start(), edge.end()] {
+                    if let Ok(v) = topo.vertex(vid) {
+                        let p = v.point();
+                        min =
+                            Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
+                        max =
+                            Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
+                        any = true;
+                    }
+                }
+            }
+        }
+        if !any {
+            return None;
+        }
+        // For analytic surfaces with finite extent, union the wire AABB
+        // with the surface AABB. This expands a "degenerate-in-Z hemisphere
+        // wire" (z=0 only) up to the actual hemisphere extent.
+        if let FaceSurface::Sphere(sphere) = face.surface() {
+            let r = sphere.radius();
+            let c = sphere.center();
+            min = Point3::new(
+                min.x().min(c.x() - r),
+                min.y().min(c.y() - r),
+                min.z().min(c.z() - r),
+            );
+            max = Point3::new(
+                max.x().max(c.x() + r),
+                max.y().max(c.y() + r),
+                max.z().max(c.z() + r),
+            );
+        }
+        Some(Aabb3 { min, max }.expanded(tol.linear * 10.0))
+    };
+    let bbox_a = face_aabb(face_a);
+    let bbox_b = face_aabb(face_b);
+    let in_both = |p: Point3| -> bool {
+        let a_ok = bbox_a.as_ref().is_none_or(|b| b.contains_point(p));
+        let b_ok = bbox_b.as_ref().is_none_or(|b| b.contains_point(p));
+        a_ok && b_ok
+    };
+
+    // Create / snap vertices at each crossing point.
+    let mut crossing_vids: Vec<brepkit_topology::vertex::VertexId> =
+        Vec::with_capacity(crossings.len());
+    for (_, p) in crossings {
+        let vid = super::helpers::find_nearby_pave_vertex(topo, arena, *p, tol)
+            .or_else(|| find_nearby_face_vertex(topo, face_a, *p, tol))
+            .or_else(|| find_nearby_face_vertex(topo, face_b, *p, tol))
+            .unwrap_or_else(|| topo.add_vertex(Vertex::new(*p, tol.linear)));
+        crossing_vids.push(vid);
+    }
+
+    let n = crossings.len();
+    let mut emitted = 0_usize;
+    for i in 0..n {
+        let (t0, _p0) = crossings[i];
+        // Wrap to next crossing; for the last arc that means going back to
+        // the first crossing through the seam (t0 → t1 + 2π).
+        let next_i = (i + 1) % n;
+        let (mut t1, _p1) = crossings[next_i];
+        if t1 <= t0 {
+            t1 += std::f64::consts::TAU;
+        }
+
+        // Sample the arc midpoint and drop the arc if it isn't on both faces.
+        let t_mid = (t0 + t1) * 0.5;
+        let mid_3d = circle.evaluate(t_mid);
+        if !in_both(mid_3d) {
+            log::debug!(
+                "FF: drop closed-circle arc {i}/{n} (midpoint {mid_3d:?} outside face pair)"
+            );
+            continue;
+        }
+
+        let start_vid = crossing_vids[i];
+        let end_vid = crossing_vids[next_i];
+
+        let edge = Edge::new(start_vid, end_vid, EdgeCurve::Circle(circle.clone()));
+        let edge_id = topo.add_edge(edge);
+
+        let start_pave = Pave::new(start_vid, t0);
+        let end_pave = Pave::new(end_vid, t1);
+        let pb = PaveBlock::new(edge_id, start_pave, end_pave);
+        let pb_id = arena.pave_blocks.alloc(pb);
+
+        let curve_index = arena.curves.len();
+        arena.curves.push(IntersectionCurveDS {
+            curve: EdgeCurve::Circle(circle.clone()),
+            face_a,
+            face_b,
+            // The full-circle bbox is a safe over-approximation for any arc.
+            bbox: raw.bbox,
+            pave_blocks: vec![pb_id],
+            t_range: (t0, t1),
+        });
+
+        arena.interference.ff.push(Interference::FF {
+            f1: face_a,
+            f2: face_b,
+            curve_index,
+        });
+        emitted += 1;
+
+        log::debug!(
+            "FF: split closed circle arc {i}/{n}: faces {face_a:?}/{face_b:?} \
+             t=[{t0:.4},{t1:.4}] edge={edge_id:?} pb={pb_id:?}"
+        );
+    }
+
+    log::debug!("FF: emitted {emitted}/{n} arcs after AABB filter for {face_a:?}/{face_b:?}");
 }
 
 /// Compute AABB for a NURBS curve.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -755,7 +755,7 @@ fn closed_circle_boundary_crossings(
         }
     }
 
-    hits.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    hits.sort_by(|a, b| a.0.total_cmp(&b.0));
 
     log::trace!(
         "closed_circle_boundary_crossings: face_a={face_a:?} face_b={face_b:?} hits={}",
@@ -859,19 +859,29 @@ fn emit_split_circle_arcs(
         a_ok && b_ok
     };
 
-    // Create / snap vertices at each crossing point.
-    let mut crossing_vids: Vec<brepkit_topology::vertex::VertexId> =
-        Vec::with_capacity(crossings.len());
-    for (_, p) in crossings {
-        let vid = super::helpers::find_nearby_pave_vertex(topo, arena, *p, tol)
-            .or_else(|| find_nearby_face_vertex(topo, face_a, *p, tol))
-            .or_else(|| find_nearby_face_vertex(topo, face_b, *p, tol))
-            .unwrap_or_else(|| topo.add_vertex(Vertex::new(*p, tol.linear)));
-        crossing_vids.push(vid);
-    }
-
+    // Pass 1: determine which arcs survive the AABB filter, *before*
+    // allocating any topology vertices. Otherwise dropping an arc could
+    // leave its crossing vertices orphaned in the topology (no edges
+    // reference them) — visible to any downstream pass that iterates all
+    // vertices. We also split each surviving arc into sub-arcs of span
+    // ≤ π so the resulting `EdgeCurve::Circle` is unambiguous: several
+    // downstream consumers (tessellation's `shorter_arc_range` in
+    // `tessellate/mod.rs`, wire sampling in `topology/builder.rs`)
+    // interpret an open circle edge as the *shorter* arc between its
+    // endpoints, so a span > π would be flipped to the complementary
+    // arc and break face splitting/classification.
+    //
+    // Each survivor records the inserted crossing points along with
+    // their (t, 3D) values; pass 2 then materialises just those
+    // vertices (in order) and builds the edges.
+    //
+    // Each point is `(t, 3D point, original-crossing-index-or-None)`.
+    // Endpoints carry `Some(crossing_index)` so we can dedup with
+    // adjacent arcs sharing the same crossing vertex; midpoints
+    // (inserted to keep span ≤ π) carry `None` and always get a fresh
+    // vertex allocation.
     let n = crossings.len();
-    let mut emitted = 0_usize;
+    let mut survivors: Vec<Vec<(f64, Point3, Option<usize>)>> = Vec::new();
     for i in 0..n {
         let (t0, _p0) = crossings[i];
         // Wrap to next crossing; for the last arc that means going back to
@@ -882,7 +892,6 @@ fn emit_split_circle_arcs(
             t1 += std::f64::consts::TAU;
         }
 
-        // Sample the arc midpoint and drop the arc if it isn't on both faces.
         let t_mid = (t0 + t1) * 0.5;
         let mid_3d = circle.evaluate(t_mid);
         if !in_both(mid_3d) {
@@ -892,39 +901,87 @@ fn emit_split_circle_arcs(
             continue;
         }
 
-        let start_vid = crossing_vids[i];
-        let end_vid = crossing_vids[next_i];
+        // Split spans > π into 2+ sub-arcs by inserting midpoint vertices
+        // at evenly spaced t-values. Each sub-arc then has span ≤ π so
+        // downstream "shorter arc" interpretation matches the intended arc.
+        let arc_span = t1 - t0;
+        let n_sub = (arc_span / std::f64::consts::PI).ceil().max(1.0) as usize;
+        let step = arc_span / n_sub as f64;
+        let mut points: Vec<(f64, Point3, Option<usize>)> = Vec::with_capacity(n_sub + 1);
+        points.push((t0, crossings[i].1, Some(i)));
+        for k in 1..n_sub {
+            let tk = t0 + step * k as f64;
+            points.push((tk, circle.evaluate(tk), None));
+        }
+        points.push((t1, crossings[next_i].1, Some(next_i)));
 
-        let edge = Edge::new(start_vid, end_vid, EdgeCurve::Circle(circle.clone()));
-        let edge_id = topo.add_edge(edge);
+        survivors.push(points);
+    }
 
-        let start_pave = Pave::new(start_vid, t0);
-        let end_pave = Pave::new(end_vid, t1);
-        let pb = PaveBlock::new(edge_id, start_pave, end_pave);
-        let pb_id = arena.pave_blocks.alloc(pb);
+    // Pass 2: allocate vertices only for crossings/midpoints used by
+    // surviving arcs, then materialise edges + pave blocks.
+    let mut crossing_vids: Vec<Option<brepkit_topology::vertex::VertexId>> = vec![None; n];
+    let resolve_crossing =
+        |topo: &mut Topology, arena: &GfaArena, p: Point3| -> brepkit_topology::vertex::VertexId {
+            super::helpers::find_nearby_pave_vertex(topo, arena, p, tol)
+                .or_else(|| find_nearby_face_vertex(topo, face_a, p, tol))
+                .or_else(|| find_nearby_face_vertex(topo, face_b, p, tol))
+                .unwrap_or_else(|| topo.add_vertex(Vertex::new(p, tol.linear)))
+        };
 
-        let curve_index = arena.curves.len();
-        arena.curves.push(IntersectionCurveDS {
-            curve: EdgeCurve::Circle(circle.clone()),
-            face_a,
-            face_b,
-            // The full-circle bbox is a safe over-approximation for any arc.
-            bbox: raw.bbox,
-            pave_blocks: vec![pb_id],
-            t_range: (t0, t1),
-        });
+    let mut emitted = 0_usize;
+    let num_survivors = survivors.len();
+    for (a_idx, arc_points) in survivors.into_iter().enumerate() {
+        // Walk consecutive (t, point) pairs to emit one edge per sub-arc.
+        for w in arc_points.windows(2) {
+            let (t_s, p_s, idx_s) = w[0];
+            let (t_e, p_e, idx_e) = w[1];
 
-        arena.interference.ff.push(Interference::FF {
-            f1: face_a,
-            f2: face_b,
-            curve_index,
-        });
-        emitted += 1;
+            let start_vid = match idx_s {
+                Some(ci) => {
+                    *crossing_vids[ci].get_or_insert_with(|| resolve_crossing(topo, arena, p_s))
+                }
+                None => topo.add_vertex(Vertex::new(p_s, tol.linear)),
+            };
+            let end_vid = match idx_e {
+                Some(ci) => {
+                    *crossing_vids[ci].get_or_insert_with(|| resolve_crossing(topo, arena, p_e))
+                }
+                None => topo.add_vertex(Vertex::new(p_e, tol.linear)),
+            };
 
-        log::debug!(
-            "FF: split closed circle arc {i}/{n}: faces {face_a:?}/{face_b:?} \
-             t=[{t0:.4},{t1:.4}] edge={edge_id:?} pb={pb_id:?}"
-        );
+            let edge = Edge::new(start_vid, end_vid, EdgeCurve::Circle(circle.clone()));
+            let edge_id = topo.add_edge(edge);
+
+            let start_pave = Pave::new(start_vid, t_s);
+            let end_pave = Pave::new(end_vid, t_e);
+            let pb = PaveBlock::new(edge_id, start_pave, end_pave);
+            let pb_id = arena.pave_blocks.alloc(pb);
+
+            let curve_index = arena.curves.len();
+            arena.curves.push(IntersectionCurveDS {
+                curve: EdgeCurve::Circle(circle.clone()),
+                face_a,
+                face_b,
+                // The full-circle bbox is a safe over-approximation for any arc.
+                bbox: raw.bbox,
+                pave_blocks: vec![pb_id],
+                t_range: (t_s, t_e),
+            });
+
+            arena.interference.ff.push(Interference::FF {
+                f1: face_a,
+                f2: face_b,
+                curve_index,
+            });
+            emitted += 1;
+
+            log::debug!(
+                "FF: split closed circle arc {a_idx}/{num_survivors}: \
+                 faces {face_a:?}/{face_b:?} t=[{t_s:.4},{t_e:.4}] \
+                 edge={edge_id:?} pb={pb_id:?}"
+            );
+        }
     }
 
     log::debug!("FF: emitted {emitted}/{n} arcs after AABB filter for {face_a:?}/{face_b:?}");

--- a/crates/math/src/curves.rs
+++ b/crates/math/src/curves.rs
@@ -319,7 +319,12 @@ impl Circle3D {
             let b = p0_u * du + p0_v * dv;
             let c = p0_u * p0_u + p0_v * p0_v - self.radius * self.radius;
             let disc = b * b - a * c;
-            if a < tol * tol || disc < -tol {
+            // `disc` has units of length^4 (it's b² - a·c, both products of
+            // squared coordinates). Compare against a scale-aware threshold
+            // `(tol² · a)` rather than raw `tol` (which is length).
+            // Negative discriminants smaller than this in magnitude are
+            // floating-point noise on a tangent intersection — clamp to 0.
+            if a < tol * tol || disc < -tol * tol * a {
                 return out;
             }
             let disc = disc.max(0.0);

--- a/crates/math/src/curves.rs
+++ b/crates/math/src/curves.rs
@@ -243,6 +243,126 @@ impl Circle3D {
             v_axis,
         })
     }
+
+    /// Intersect the circle with a 3D line segment.
+    ///
+    /// Returns up to 2 intersection points along with their angle parameter
+    /// `t` on the circle. Points returned are restricted to the segment
+    /// `[seg_start, seg_end]` (with `tol` slack on the endpoints).
+    ///
+    /// Cases:
+    /// - Segment crosses the circle's plane at one point: at most 1
+    ///   intersection (when that crossing is on the circle, within `tol`).
+    /// - Segment lies in the circle's plane: up to 2 intersections.
+    /// - Segment is parallel to the plane but offset: 0 intersections.
+    ///
+    /// `tol` is the absolute linear tolerance for "on the plane" and
+    /// "on the circle" tests, and for clamping the segment parameter.
+    #[must_use]
+    pub fn intersect_segment(
+        &self,
+        seg_start: Point3,
+        seg_end: Point3,
+        tol: f64,
+    ) -> Vec<(Point3, f64)> {
+        let mut out = Vec::new();
+        let d = seg_end - seg_start;
+        let seg_len_sq = d.length_squared();
+        if seg_len_sq < tol * tol {
+            return out;
+        }
+
+        // Signed distance of each endpoint to the circle's plane.
+        let h0 = (seg_start - self.center).dot(self.normal);
+        let h1 = (seg_end - self.center).dot(self.normal);
+
+        let on_plane = |p: Point3| -> bool {
+            let v = p - self.center;
+            let in_plane = v.dot(self.normal).abs() < tol;
+            let r = v.length();
+            in_plane && (r - self.radius).abs() < tol
+        };
+
+        // Helper: append `t_seg` (segment parameter) → intersection point with
+        // `tol` slack on the endpoints; drop duplicates within `tol`.
+        let mut push_if_unique = |p: Point3| {
+            let v = p - self.center;
+            // angle in [0, 2π)
+            let mut t = v.dot(self.v_axis).atan2(v.dot(self.u_axis));
+            if t < 0.0 {
+                t += std::f64::consts::TAU;
+            }
+            if out
+                .iter()
+                .any(|(q, _): &(Point3, f64)| (*q - p).length() < tol)
+            {
+                return;
+            }
+            out.push((p, t));
+        };
+
+        if h0.abs() < tol && h1.abs() < tol {
+            // Segment lies in the circle's plane: solve 2D line-circle.
+            // Project everything into UV coordinates centered at the circle.
+            let p0_u = (seg_start - self.center).dot(self.u_axis);
+            let p0_v = (seg_start - self.center).dot(self.v_axis);
+            let p1_u = (seg_end - self.center).dot(self.u_axis);
+            let p1_v = (seg_end - self.center).dot(self.v_axis);
+            let du = p1_u - p0_u;
+            let dv = p1_v - p0_v;
+            // |P0 + s*(P1-P0)|² = r²
+            // a*s² + 2*b*s + c = 0 where
+            //   a = du² + dv²
+            //   b = p0_u*du + p0_v*dv
+            //   c = p0_u² + p0_v² - r²
+            let a = du * du + dv * dv;
+            let b = p0_u * du + p0_v * dv;
+            let c = p0_u * p0_u + p0_v * p0_v - self.radius * self.radius;
+            let disc = b * b - a * c;
+            if a < tol * tol || disc < -tol {
+                return out;
+            }
+            let disc = disc.max(0.0);
+            let sqrt_disc = disc.sqrt();
+            let s_slack = tol / seg_len_sq.sqrt();
+            for s in [(-b - sqrt_disc) / a, (-b + sqrt_disc) / a] {
+                if s >= -s_slack && s <= 1.0 + s_slack {
+                    let s = s.clamp(0.0, 1.0);
+                    let p = Point3::new(
+                        seg_start.x() + s * d.x(),
+                        seg_start.y() + s * d.y(),
+                        seg_start.z() + s * d.z(),
+                    );
+                    push_if_unique(p);
+                }
+            }
+        } else if h0 * h1 <= tol * tol {
+            // Segment crosses the circle's plane (or touches it). Solve
+            // for the unique s where signed-distance = 0:
+            //   h0 + s*(h1 - h0) = 0  →  s = h0 / (h0 - h1)
+            let denom = h0 - h1;
+            if denom.abs() < tol {
+                return out;
+            }
+            let s = h0 / denom;
+            let s_slack = tol / seg_len_sq.sqrt();
+            if s < -s_slack || s > 1.0 + s_slack {
+                return out;
+            }
+            let s = s.clamp(0.0, 1.0);
+            let p = Point3::new(
+                seg_start.x() + s * d.x(),
+                seg_start.y() + s * d.y(),
+                seg_start.z() + s * d.z(),
+            );
+            if on_plane(p) {
+                push_if_unique(p);
+            }
+        }
+        // else: segment is on one side of the plane → no crossings.
+
+        out
+    }
 }
 
 // ── Ellipse3D ──────────────────────────────────────────────────────
@@ -763,6 +883,65 @@ mod tests {
     #[test]
     fn circle_zero_radius_error() {
         assert!(Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 0.0).is_err());
+    }
+
+    #[test]
+    fn circle_intersect_segment_in_plane_two_points() {
+        // Unit circle in xy plane, segment from (-2,0,0) to (2,0,0) — crosses at ±1 along x.
+        let c = Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let hits = c.intersect_segment(
+            Point3::new(-2.0, 0.0, 0.0),
+            Point3::new(2.0, 0.0, 0.0),
+            1e-9,
+        );
+        assert_eq!(hits.len(), 2);
+        // u_axis defaults to +x for a +z normal; so points are at t = 0 and π.
+        let xs: Vec<f64> = hits.iter().map(|(p, _)| p.x()).collect();
+        assert!(xs.iter().any(|x| (x - 1.0).abs() < 1e-9));
+        assert!(xs.iter().any(|x| (x + 1.0).abs() < 1e-9));
+    }
+
+    #[test]
+    fn circle_intersect_segment_crosses_plane() {
+        // Great circle in x=0 plane (sphere-equator type): radius 8, normal +x.
+        // Segment from (1, 8, 0) to (-1, 8, 0): crosses x=0 at (0, 8, 0), which is on the circle.
+        let c = Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0), 8.0).unwrap();
+        let hits = c.intersect_segment(
+            Point3::new(1.0, 8.0, 0.0),
+            Point3::new(-1.0, 8.0, 0.0),
+            1e-7,
+        );
+        assert_eq!(hits.len(), 1);
+        let (p, _t) = hits[0];
+        assert!((p.x()).abs() < 1e-7);
+        assert!((p.y() - 8.0).abs() < 1e-7);
+        assert!((p.z()).abs() < 1e-7);
+    }
+
+    #[test]
+    fn circle_intersect_segment_polygon_vertex_on_circle() {
+        // The box-sphere case: equator polygon edge from a vertex AT (0,8,0)
+        // (which lies on a great circle from the x=0 plane) outward.
+        let c = Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0), 8.0).unwrap();
+        // Polygon vertex 4 at (0, 8, 0), polygon vertex 5 at (-3.06..., 7.39..., 0).
+        let v4 = Point3::new(0.0, 8.0, 0.0);
+        let v5 = Point3::new(-8.0 * (5.0_f64).cos(), 8.0 * (5.0_f64).sin(), 0.0);
+        let _ = v5; // silence unused warn — this test only needs the vertex case.
+        let v3 = Point3::new(3.061_467_458_920_71_f64, 7.391_036_260_090_294_f64, 0.0);
+        // Edge from v3 (x>0) to v4 (x=0) — the vertex is on the great circle's plane and circle.
+        let hits = c.intersect_segment(v3, v4, 1e-7);
+        assert_eq!(hits.len(), 1, "expected one hit at the polygon vertex");
+        let (p, _) = hits[0];
+        assert!((p - v4).length() < 1e-6, "hit should be at v4");
+    }
+
+    #[test]
+    fn circle_intersect_segment_no_crossing() {
+        // Segment fully on one side of circle's plane, no crossing.
+        let c = Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let hits =
+            c.intersect_segment(Point3::new(0.0, 0.0, 1.0), Point3::new(0.0, 0.0, 2.0), 1e-9);
+        assert!(hits.is_empty());
     }
 
     // ── Ellipse tests ──────────────────────────────────────────────

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -1206,7 +1206,17 @@ pub fn unify_faces(topo: &mut Topology, solid: SolidId) -> Result<usize, crate::
     }
 
     // Only process groups with ≥2 faces.
-    let merge_groups: Vec<Vec<usize>> = groups.into_values().filter(|g| g.len() >= 2).collect();
+    // Sort groups by their lowest face index so downstream processing
+    // (especially `canonical_vtx` first-seen-wins) is deterministic.
+    // Without the sort, `groups.into_values()` returns groups in HashMap
+    // iteration order, and the first group to insert a vertex into
+    // `canonical_vtx` "wins" the canonical mapping — which then drives
+    // different edge re-allocations between runs.
+    let mut merge_groups: Vec<Vec<usize>> = groups.into_values().filter(|g| g.len() >= 2).collect();
+    for g in &mut merge_groups {
+        g.sort_unstable();
+    }
+    merge_groups.sort_unstable_by_key(|g| g.first().copied().unwrap_or(usize::MAX));
 
     if merge_groups.is_empty() {
         return Ok(0);

--- a/crates/operations/tests/profile_intersect.rs
+++ b/crates/operations/tests/profile_intersect.rs
@@ -1,11 +1,53 @@
 //! Diagnostic: time the intersect(box,sphere) path to find the bottleneck.
-#![allow(clippy::unwrap_used, clippy::print_stdout)]
+#![allow(clippy::unwrap_used, clippy::print_stdout, clippy::expect_used)]
 
 use brepkit_operations::boolean::{BooleanOp, boolean};
 use brepkit_operations::primitives;
 use brepkit_topology::Topology;
 use brepkit_topology::explorer;
 use std::time::Instant;
+
+#[test]
+#[ignore = "diagnostic — direct GFA call to inspect 3-face result before fallback"]
+fn profile_gfa_box_sphere_direct() {
+    let _ = env_logger::Builder::from_default_env()
+        .filter_level(log::LevelFilter::Debug)
+        .is_test(true)
+        .try_init();
+    let mut topo = Topology::new();
+    let a = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let sph = primitives::make_sphere(&mut topo, 8.0, 16).unwrap();
+    println!(
+        "box faces: {:?}",
+        brepkit_topology::explorer::solid_faces(&topo, a).unwrap()
+    );
+    println!(
+        "sphere faces: {:?}",
+        brepkit_topology::explorer::solid_faces(&topo, sph).unwrap()
+    );
+    // Direct GFA call, bypassing the validation+fallback in boolean().
+    let result =
+        brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Intersect, a, sph)
+            .expect("GFA should not error");
+    let face_ids = brepkit_topology::explorer::solid_faces(&topo, result).unwrap();
+    println!("GFA-direct intersect(box,sphere): {} faces", face_ids.len());
+    for fid in face_ids {
+        let face = topo.face(fid).unwrap();
+        let kind = match face.surface() {
+            brepkit_topology::face::FaceSurface::Plane { normal, d } => {
+                format!("Plane(n={:?}, d={:.3})", normal, d)
+            }
+            brepkit_topology::face::FaceSurface::Sphere(s) => {
+                format!("Sphere(c={:?}, r={:.3})", s.center(), s.radius())
+            }
+            other => format!("{other:?}"),
+        };
+        let outer = topo.wire(face.outer_wire()).unwrap();
+        let nedges = outer.edges().len();
+        let n_inner = face.inner_wires().len();
+        println!("  {fid:?}: {kind} outer_edges={nedges} inner_wires={n_inner}");
+    }
+}
 
 #[test]
 #[ignore = "diagnostic — explicit-only profile of the box-sphere GFA regression"]

--- a/crates/operations/tests/profile_intersect.rs
+++ b/crates/operations/tests/profile_intersect.rs
@@ -1,0 +1,66 @@
+//! Diagnostic: time the intersect(box,sphere) path to find the bottleneck.
+#![allow(clippy::unwrap_used, clippy::print_stdout)]
+
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::primitives;
+use brepkit_topology::Topology;
+use brepkit_topology::explorer;
+use std::time::Instant;
+
+#[test]
+#[ignore = "diagnostic — explicit-only profile of the box-sphere GFA regression"]
+fn profile_intersect_box_sphere() {
+    let _ = env_logger::Builder::from_default_env()
+        .filter_level(log::LevelFilter::Warn)
+        .is_test(true)
+        .try_init();
+    // Warm up.
+    for _ in 0..3 {
+        let mut topo = Topology::new();
+        let a = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let sph = primitives::make_sphere(&mut topo, 8.0, 16).unwrap();
+        let _ = boolean(&mut topo, BooleanOp::Intersect, a, sph).unwrap();
+    }
+
+    // Time 10 iterations matching the bench inner loop.
+    let t0 = Instant::now();
+    let mut last_result = None;
+    for _ in 0..10 {
+        let mut topo = Topology::new();
+        let a = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let sph = primitives::make_sphere(&mut topo, 8.0, 16).unwrap();
+        let r = boolean(&mut topo, BooleanOp::Intersect, a, sph).unwrap();
+        let (f, e, v) = explorer::solid_entity_counts(&topo, r).unwrap();
+        last_result = Some((f, e, v));
+    }
+    let total_ms = t0.elapsed().as_secs_f64() * 1000.0;
+    let (f, e, v) = last_result.unwrap();
+    println!(
+        "intersect(box,sphere) x10: {total_ms:.1}ms total = {:.1}ms/op",
+        total_ms / 10.0
+    );
+    println!("result: f={f} e={e} v={v}");
+
+    // One more run with surface-kind breakdown.
+    let mut topo = Topology::new();
+    let a = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let sph = primitives::make_sphere(&mut topo, 8.0, 16).unwrap();
+    let r = boolean(&mut topo, BooleanOp::Intersect, a, sph).unwrap();
+    let face_ids = brepkit_topology::explorer::solid_faces(&topo, r).unwrap();
+    let mut counts = std::collections::BTreeMap::new();
+    for fid in face_ids {
+        let surf = topo.face(fid).unwrap().surface();
+        let kind = match surf {
+            brepkit_topology::face::FaceSurface::Plane { .. } => "Plane",
+            brepkit_topology::face::FaceSurface::Sphere(_) => "Sphere",
+            brepkit_topology::face::FaceSurface::Cylinder(_) => "Cylinder",
+            brepkit_topology::face::FaceSurface::Cone(_) => "Cone",
+            brepkit_topology::face::FaceSurface::Torus(_) => "Torus",
+            brepkit_topology::face::FaceSurface::Nurbs(_) => "Nurbs",
+        };
+        *counts.entry(kind).or_insert(0_usize) += 1;
+    }
+    for (kind, n) in &counts {
+        println!("  {kind}: {n}");
+    }
+}


### PR DESCRIPTION
## Summary

Two perf regressions surfaced when comparing against the README's benchmark table:

1. **Multi-boolean variance** (`box - 16 cylinders`) — median **3.87s → 111ms** (35× faster), max **10.5s → 114ms** (variance collapsed from 100× to ~5%). Root cause: two HashMap-iteration sites in the GFA pipeline drove different downstream code paths across runs. Follows the same pattern as #689.
2. **`intersect(box,sphere)`** — diagnosed (PR #382 bisect, root cause in `split_noseam_face_direct`) and foundation laid (`Circle3D::intersect_segment` + closed-curve FF split). End-to-end fix not yet complete — the face_splitter still can't form the spherical octant cap from 2+ intersecting arcs on a sphere hemisphere, so the pipeline continues to fall back to mesh boolean. See [Open follow-up](#open-follow-up) below.

## Commits

| SHA | Title |
|---|---|
| `f7664a4` | `fix(algo)`: convert FaceInfo HashSets to BTreeSets for deterministic iteration |
| `a25ca80` | `fix(heal)`: sort unify_faces merge_groups for deterministic processing |
| `b05d024` | `test(boolean)`: add ignored profile_intersect harness for box-sphere regression |
| `0f93f49` | `feat(algo)`: split closed Circle3D FF sections at face boundaries |

## Measured impact (native bench, `cad_operations`)

| Bench | Before (main) | After (this branch) |
|---|---|---|
| `multi-boolean model` min | 109 ms | 110 ms |
| `multi-boolean model` median | **3.87 s** | **111 ms** |
| `multi-boolean model` max | **10.5 s** | **114 ms** |
| `cut(box,cyl) x10` | 6.8 ms | 7.0 ms (within noise) |
| `intersect(box,sphere) x10` | 273 ms | 273 ms (unchanged — see below) |

## Root cause: multi-boolean variance

PR #689 fixed two HashMap-iteration sites (sd_pairs sort, vv_vertex_seed sorted Vec) but explicitly noted "at least one more HashMap iteration site still drives downstream count divergence." This branch closes two more:

- **`FaceInfo` HashSet → BTreeSet** (`crates/algo/src/ds/face_info.rs`) — `pave_blocks_in: HashSet<PaveBlockId>` was iterated at `fill_images_faces.rs:1011` to build the per-face `SectionSource` list that drives face splitting. HashSet's random iteration order produced different `SectionSource` orderings → different sub-face topologies across runs. All six FaceInfo set fields converted; BTreeSet has matching API and the per-face cardinalities are <100 so the O(log n) overhead vs O(1) is negligible.
- **`unify_faces::merge_groups` sort** (`crates/operations/src/heal.rs:1209`) — `merge_groups` was built from `groups.into_values()` of a HashMap. Downstream `canonical_vtx.entry(...).or_insert(vid)` is first-seen-wins, so HashMap iteration order chose different canonical vertices on different runs, cascading into different edge re-allocations and different face/edge counts. Sort by `(group[0])` after each group's contents are also sorted internally.

## Root cause: intersect(box,sphere) regression

Bisect (full log in commit `0f93f49`) identified PR #382 (commit `6ce3202`, "GFA switchover — delete old pipeline ~15k lines") as the regression-introducing commit. Before #382, GFA failures fell through to the analytic pipeline (~3.5ms/op). After #382 only mesh boolean is the fallback (~27ms/op, losing the analytic sphere surface — result has 215 *Plane* faces, zero *Sphere*).

Tracing GFA-direct (the new \`profile_gfa_box_sphere_direct\` harness in `0f93f49`) shows GFA produces a 3-face Euler-invalid topology because the sphere hemisphere returns unsplit:

\`\`\`
fill_images_faces: face Id(6) has_sections=true sections=3
fill_images_faces: face Id(6) split into 1 sub-faces
\`\`\`

Three section curves on the hemisphere but only 1 sub-face produced. The bug is in `split_noseam_face_direct` (`crates/algo/src/builder/face_splitter/special_cases.rs:55-60`):

\`\`\`rust
// Skip full-circle section edges (start approx end in 3D) -- only use
// the half-arcs produced by build_seam_split_sections.
if (section.start - section.end).length() < tol.linear {
    continue;
}
\`\`\`

Plane-sphere intersections produce `Circle3D` curves where the circle's parameterization starts and ends at the same 3D point. With every section skipped, `cap_edges` is empty and the function returns the face unsplit. The unsplit hemisphere is then classified by sampling a single interior point that may lie outside the box → entire hemisphere classified Outside → spherical sub-face dropped.

### What this PR adds

1. **`Circle3D::intersect_segment`** (`crates/math/src/curves.rs`) — algebraic closed-form solver for Circle3D ∩ line segment in 3D. Handles both the in-plane case (segment lies in the circle's plane → 2D line-circle solve) and the plane-crossing case (segment crosses the circle's plane at one point → check if on circle). 4 unit tests cover the typical configurations used by the box-sphere FF path.
2. **`closed_circle_boundary_crossings`** (`crates/algo/src/pave_filler/phase_ff.rs`) — finds where a closed Circle3D section crosses the *analytic* face's outer-wire boundary. When 16 crossings are reported (one per polygon vertex), the curve is coincident with the boundary itself — that case is detected and skipped to avoid splintering the face into per-polygon-edge arcs.
3. **`emit_split_circle_arcs`** (same file) — for ≥ 2 crossings, splits the closed circle into N open arcs at the crossings. Each arc becomes its own `IntersectionCurveDS` entry with a single pave block whose t_range covers that arc. Arcs whose midpoints fall outside the union of `face_a`'s and `face_b`'s AABBs (with the sphere face's AABB expanded to the sphere bounds) are dropped — those portions of the original closed curve aren't on the face pair.

### Open follow-up

The phase_ff change correctly emits open arcs — GFA now sees 5 sub-faces internally (up from 3), with the box faces properly split by section arcs. But the spherical sub-face is still not produced: when 2+ arcs cross on a sphere hemisphere (e.g. the great circles from x=0 and y=0 planes meeting at the pole), `split_noseam_face_direct` can't fold them into a single closed cap loop and returns the hemisphere unsplit. The pipeline continues to fall back to mesh boolean.

Closing that gap requires generalising the face splitter for multi-arc sphere hemispheres — see `face_splitter/mod.rs:138` dispatch and `special_cases.rs::split_noseam_face_direct`. The infrastructure landed in this PR is the foundation for that next step.

## Test plan

- [x] All 89 `brepkit-algo` tests pass (0 regressions)
- [x] All 596 `brepkit-operations` tests pass (0 regressions)
- [x] 4 new unit tests in `brepkit-math::curves::tests` for `Circle3D::intersect_segment`
- [x] Diagnostic harnesses (`#[ignore]`d): `profile_intersect_box_sphere`, `profile_gfa_box_sphere_direct`
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] Pre-push hook (full workspace tests + cargo-deny) passes