### PR TITLE
fix(tessellate): partial fix for #696 — dedupe coincident triangles + NM diagnostics

### DIFF
--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -478,10 +478,16 @@ fn build_manifold_shell(
     }
 
     // Find non-manifold edges (shared by 3+ faces).
-    let nonmanifold: Vec<(EdgeId, Vec<(usize, bool)>)> = edge_faces
+    // Sort by EdgeId so subsequent face-removal decisions are reproducible
+    // across runs — the same class of HashMap-iteration variance fixed in
+    // #689/#692, propagated to this pass. Order matters because each NM
+    // edge's "remove the opposing-normal face" decision interacts with
+    // others when faces are shared between multiple NM edges.
+    let mut nonmanifold: Vec<(EdgeId, Vec<(usize, bool)>)> = edge_faces
         .into_iter()
         .filter(|(_, faces)| faces.len() > 2)
         .collect();
+    nonmanifold.sort_by_key(|(eid, _)| eid.index());
 
     if nonmanifold.is_empty() {
         return Ok(face_ids.to_vec());
@@ -1369,10 +1375,15 @@ pub(super) fn split_nonmanifold_edges(
     }
 
     // Find non-manifold edges (shared by > 2 faces).
-    let nonmanifold: Vec<(usize, Vec<(usize, bool)>)> = edge_faces
+    // Sort by edge index for deterministic processing order — each NM-edge
+    // split mutates the topology (via edge_replacements), so order changes
+    // the assembly outcome when edges share faces. Same pattern fixed in
+    // #689/#692 for earlier GFA iteration sites.
+    let mut nonmanifold: Vec<(usize, Vec<(usize, bool)>)> = edge_faces
         .into_iter()
         .filter(|(_, faces)| faces.len() > 2)
         .collect();
+    nonmanifold.sort_by_key(|(eid, _)| *eid);
 
     if nonmanifold.is_empty() {
         return Ok(());

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -468,7 +468,15 @@ pub fn boolean(
                 #[allow(clippy::cast_possible_wrap)]
                 let euler_pre2 = (v2 as i64) - (e2 as i64) + (f2 as i64);
 
-                if euler_pre2 != 2 {
+                // Run unify_faces if Euler is off (existing condition) OR if
+                // the topology already has 3+-face junctions, which can occur
+                // with Euler==2 when overlapping coplanar faces cancel in V-E+F
+                // counting. The same-domain detection in the assembler only
+                // pairs faces across opposing ranks with identical edge sets,
+                // so within-rank or different-boundary overlaps slip through;
+                // unify_faces is the safety net for those (issue #696).
+                let needs_unify = euler_pre2 != 2 || !is_closed_manifold(topo, result)?;
+                if needs_unify {
                     for _ in 0..3 {
                         if crate::heal::unify_faces(topo, result)? == 0 {
                             break;

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -84,6 +84,118 @@ pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize {
     edge_count.values().filter(|&&c| c > 2).count()
 }
 
+/// Remove duplicate triangles, cancelling opposing pairs and dedup same-winding pairs.
+///
+/// Workaround for issue #696: when a boolean leaves overlapping coplanar faces
+/// in its output (the GFA path can do this without breaking Euler), tessellating
+/// each face independently produces multiple triangles on the same 3D positions.
+/// Slicers see this as branching (an edge shared by 3+ triangles), then "repair"
+/// it by dropping pieces — turning hollow baseplates into solid blocks.
+///
+/// Triangles are keyed by their **quantized vertex positions** (sorted), not
+/// global vertex IDs — boundary-vertex welding only runs on edges that already
+/// look like boundaries, so two coplanar interior overlaps can survive with
+/// distinct IDs at coincident positions. Pairs with matching winding
+/// (sort-permutation parity equal) deduplicate to one triangle; pairs with
+/// opposite winding cancel (both removed) — that's the signature of two faces
+/// tessellated from opposite sides of the same plane.
+pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh) {
+    use std::collections::HashMap;
+
+    /// 1nm grid: tight enough that legitimately distinct CAD features (down to
+    /// 1µm geometry like thin plates) keep separate keys, while still merging
+    /// post-merge floating-point noise in coincident vertices that
+    /// boundary-vertex welding didn't catch.
+    const POS_GRID: f64 = 1e-6;
+
+    type TriKey = [(i64, i64, i64); 3];
+    type TriRefs = Vec<(usize, bool)>;
+
+    let tri_count = mesh.indices.len() / 3;
+    if tri_count < 2 {
+        return;
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    let quant = |p: Point3| -> (i64, i64, i64) {
+        let s = 1.0 / POS_GRID;
+        (
+            (p.x() * s).round() as i64,
+            (p.y() * s).round() as i64,
+            (p.z() * s).round() as i64,
+        )
+    };
+
+    let mut by_key: HashMap<TriKey, TriRefs> = HashMap::new();
+    for t in 0..tri_count {
+        let (a, b, c) = (
+            mesh.indices[t * 3] as usize,
+            mesh.indices[t * 3 + 1] as usize,
+            mesh.indices[t * 3 + 2] as usize,
+        );
+        let mut tri_pts = [
+            quant(mesh.positions[a]),
+            quant(mesh.positions[b]),
+            quant(mesh.positions[c]),
+        ];
+        // Sort tri_pts ascending; track parity of the sort permutation.
+        let mut parity_even = true;
+        if tri_pts[0] > tri_pts[1] {
+            tri_pts.swap(0, 1);
+            parity_even = !parity_even;
+        }
+        if tri_pts[1] > tri_pts[2] {
+            tri_pts.swap(1, 2);
+            parity_even = !parity_even;
+        }
+        if tri_pts[0] > tri_pts[1] {
+            tri_pts.swap(0, 1);
+            parity_even = !parity_even;
+        }
+        // Skip degenerate triangles (collapsed to <3 distinct positions).
+        if tri_pts[0] == tri_pts[1] || tri_pts[1] == tri_pts[2] {
+            continue;
+        }
+        by_key.entry(tri_pts).or_default().push((t, parity_even));
+    }
+
+    let mut keep = vec![true; tri_count];
+    for tris in by_key.values() {
+        if tris.len() < 2 {
+            continue;
+        }
+        let (even, odd): (Vec<_>, Vec<_>) = tris.iter().partition(|&&(_, p)| p);
+        let cancel_pairs = even.len().min(odd.len());
+        for &(t, _) in even.iter().take(cancel_pairs) {
+            keep[t] = false;
+        }
+        for &(t, _) in odd.iter().take(cancel_pairs) {
+            keep[t] = false;
+        }
+        // Of the surviving same-winding triangles, keep only one.
+        let leftover_even: Vec<_> = even.iter().skip(cancel_pairs).copied().collect();
+        let leftover_odd: Vec<_> = odd.iter().skip(cancel_pairs).copied().collect();
+        for &(t, _) in leftover_even.iter().skip(1) {
+            keep[t] = false;
+        }
+        for &(t, _) in leftover_odd.iter().skip(1) {
+            keep[t] = false;
+        }
+    }
+
+    if keep.iter().all(|&k| k) {
+        return;
+    }
+
+    let mut new_indices = Vec::with_capacity(mesh.indices.len());
+    for (t, &k) in keep.iter().enumerate().take(tri_count) {
+        if k {
+            new_indices.extend_from_slice(&mesh.indices[t * 3..t * 3 + 3]);
+        }
+    }
+    mesh.indices = new_indices;
+}
+
 /// Edge polyline data for wireframe visualization.
 ///
 /// Contains flattened position data for all edges in a solid, plus offsets

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -1,6 +1,6 @@
 //! Mesh validation and boundary operations.
 
-use brepkit_math::vec::Point3;
+use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
 use brepkit_topology::face::FaceSurface;
 use brepkit_topology::solid::SolidId;
@@ -8,32 +8,15 @@ use brepkit_topology::solid::SolidId;
 use super::TriangleMesh;
 use super::edge_sampling::sample_edge;
 
-/// Check if a mesh is watertight (every edge shared by exactly 2 triangles).
+/// Check if a mesh is a closed 2-manifold.
 ///
-/// Returns `true` if the mesh is a closed 2-manifold: every half-edge
-/// `(a, b)` in the mesh has a corresponding reverse half-edge `(b, a)`.
-///
-/// This is useful for validating that `tessellate_solid` produces
-/// gap-free meshes.
+/// Returns `true` iff every edge is shared by exactly 2 triangles: no gaps
+/// (boundary edges), no branching (non-manifold edges). Useful for
+/// validating that `tessellate_solid` produces watertight meshes suitable
+/// for slicers and downstream geometric operations.
 #[must_use]
 pub fn is_watertight(mesh: &TriangleMesh) -> bool {
-    use std::collections::HashSet;
-
-    let mut half_edges: HashSet<(u32, u32)> = HashSet::new();
-    let tri_count = mesh.indices.len() / 3;
-
-    for t in 0..tri_count {
-        let i0 = mesh.indices[t * 3];
-        let i1 = mesh.indices[t * 3 + 1];
-        let i2 = mesh.indices[t * 3 + 2];
-        half_edges.insert((i0, i1));
-        half_edges.insert((i1, i2));
-        half_edges.insert((i2, i0));
-    }
-
-    half_edges
-        .iter()
-        .all(|&(a, b)| half_edges.contains(&(b, a)))
+    boundary_edge_count(mesh) == 0 && non_manifold_edge_count(mesh) == 0
 }
 
 /// Count boundary (one-sided) edges in a mesh.
@@ -102,9 +85,9 @@ pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize {
 pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh) {
     use std::collections::HashMap;
 
-    /// 1nm grid: tight enough that legitimately distinct CAD features (down to
-    /// 1µm geometry like thin plates) keep separate keys, while still merging
-    /// post-merge floating-point noise in coincident vertices that
+    /// 1µm grid: tight enough that legitimately distinct CAD features (down to
+    /// ~10µm geometry like thin plates) keep separate keys, while still
+    /// merging post-merge floating-point noise in coincident vertices that
     /// boundary-vertex welding didn't catch.
     const POS_GRID: f64 = 1e-6;
 
@@ -193,7 +176,32 @@ pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh) {
             new_indices.extend_from_slice(&mesh.indices[t * 3..t * 3 + 3]);
         }
     }
+
+    // Compact the position/normal buffers: drop any vertex no longer
+    // referenced by a surviving triangle. Downstream consumers that iterate
+    // `mesh.positions` directly (e.g. bbox passes, exporters that walk
+    // vertices rather than triangle indices) would otherwise see phantom
+    // vertices from removed triangles.
+    let n_verts = mesh.positions.len();
+    let mut remap: Vec<u32> = vec![u32::MAX; n_verts];
+    let mut new_positions: Vec<Point3> = Vec::new();
+    let mut new_normals: Vec<Vec3> = Vec::new();
+    for idx in &mut new_indices {
+        let old = *idx as usize;
+        if remap[old] == u32::MAX {
+            #[allow(clippy::cast_possible_truncation)]
+            let new_id = new_positions.len() as u32;
+            remap[old] = new_id;
+            new_positions.push(mesh.positions[old]);
+            if old < mesh.normals.len() {
+                new_normals.push(mesh.normals[old]);
+            }
+        }
+        *idx = remap[old];
+    }
     mesh.indices = new_indices;
+    mesh.positions = new_positions;
+    mesh.normals = new_normals;
 }
 
 /// Edge polyline data for wireframe visualization.

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -36,7 +36,7 @@ pub fn is_watertight(mesh: &TriangleMesh) -> bool {
         .all(|&(a, b)| half_edges.contains(&(b, a)))
 }
 
-/// Count boundary (non-manifold) edges in a mesh.
+/// Count boundary (one-sided) edges in a mesh.
 ///
 /// A boundary edge is one where the half-edge `(a, b)` exists but `(b, a)`
 /// does not. Returns the number of such edges. A watertight mesh has 0.
@@ -60,6 +60,28 @@ pub fn boundary_edge_count(mesh: &TriangleMesh) -> usize {
         .iter()
         .filter(|&&(a, b)| !half_edges.contains(&(b, a)))
         .count()
+}
+
+/// Count non-manifold (branching) edges in a mesh.
+///
+/// An undirected edge `{a, b}` is non-manifold when 3 or more triangles
+/// reference it. A 2-manifold mesh has 0 such edges. Distinct from
+/// [`boundary_edge_count`], which counts 1-sided edges. Use both together
+/// to validate that a tessellated solid is a closed 2-manifold.
+#[must_use]
+pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize {
+    use std::collections::HashMap;
+
+    let mut edge_count: HashMap<(u32, u32), u32> = HashMap::new();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (tri[0], tri[1], tri[2]);
+        for (p, q) in [(a, b), (b, c), (c, a)] {
+            let key = if p < q { (p, q) } else { (q, p) };
+            *edge_count.entry(key).or_default() += 1;
+        }
+    }
+
+    edge_count.values().filter(|&&c| c > 2).count()
 }
 
 /// Edge polyline data for wireframe visualization.

--- a/crates/operations/src/tessellate/mod.rs
+++ b/crates/operations/src/tessellate/mod.rs
@@ -36,7 +36,8 @@ use brepkit_topology::face::FaceId;
 // Re-export all public items.
 pub use face::tessellate_with_uvs;
 pub use mesh_ops::{
-    EdgeLines, boundary_edge_count, is_watertight, sample_solid_edges, sample_solid_edges_filtered,
+    EdgeLines, boundary_edge_count, is_watertight, non_manifold_edge_count, sample_solid_edges,
+    sample_solid_edges_filtered,
 };
 pub use solid::tessellate_solid;
 

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -10,7 +10,7 @@ use brepkit_topology::solid::SolidId;
 
 use super::TriangleMesh;
 use super::edge_sampling::{circle_param_range, sample_edge, segments_for_chord_deviation};
-use super::mesh_ops::weld_boundary_vertices;
+use super::mesh_ops::{dedupe_coincident_triangles, weld_boundary_vertices};
 use super::nonplanar::{tessellate_nonplanar_cdt, tessellate_nonplanar_snap};
 use super::nurbs::{compute_angular_range, compute_v_param_range};
 use super::planar::{
@@ -521,6 +521,12 @@ pub fn tessellate_solid(
 
     // Phase 6: Weld boundary vertices.
     weld_boundary_vertices(&mut merged, deflection);
+
+    // Phase 7: Drop coincident/cancelling triangles left by booleans that
+    // produced overlapping coplanar faces (issue #696). Keyed on quantized
+    // positions so position-coincident triangles with distinct vertex IDs
+    // are still caught.
+    dedupe_coincident_triangles(&mut merged);
 
     Ok(merged)
 }

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -413,6 +413,106 @@ fn tessellate_dovetail_trapezoidal_tongue_issue_696() {
     );
 }
 
+/// Direct unit tests for `dedupe_coincident_triangles` — the synthetic
+/// dovetail tests above don't reproduce the upstream symptom and so leave the
+/// new Phase-7 pass untested by itself.
+#[test]
+fn dedupe_cancels_opposing_winding_pair() {
+    let mut mesh = TriangleMesh {
+        positions: vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+        ],
+        normals: vec![Vec3::new(0.0, 0.0, 1.0); 3],
+        indices: vec![0, 1, 2, 0, 2, 1],
+    };
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    assert_eq!(
+        mesh.indices.len(),
+        0,
+        "opposing-winding triangle pair should cancel"
+    );
+    assert_eq!(
+        mesh.positions.len(),
+        0,
+        "unreferenced positions should be dropped after cancel"
+    );
+}
+
+#[test]
+fn dedupe_collapses_same_winding_duplicate() {
+    let mut mesh = TriangleMesh {
+        positions: vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+        ],
+        normals: vec![Vec3::new(0.0, 0.0, 1.0); 3],
+        indices: vec![0, 1, 2, 0, 1, 2],
+    };
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    assert_eq!(
+        mesh.indices.len(),
+        3,
+        "same-winding duplicate should collapse to one triangle"
+    );
+    assert_eq!(mesh.positions.len(), 3, "all 3 vertices still referenced");
+}
+
+#[test]
+fn dedupe_matches_position_coincidence_not_index() {
+    // Two triangles at the same positions but with distinct vertex IDs —
+    // the case where boundary-vertex welding didn't catch them. Same
+    // winding, so dedup keeps one.
+    let p = [
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(1.0, 0.0, 0.0),
+        Point3::new(0.0, 1.0, 0.0),
+    ];
+    let mut mesh = TriangleMesh {
+        positions: vec![p[0], p[1], p[2], p[0], p[1], p[2]],
+        normals: vec![Vec3::new(0.0, 0.0, 1.0); 6],
+        indices: vec![0, 1, 2, 3, 4, 5],
+    };
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    assert_eq!(
+        mesh.indices.len(),
+        3,
+        "position-coincident triangle should collapse even with distinct IDs"
+    );
+    assert_eq!(
+        mesh.positions.len(),
+        3,
+        "duplicate positions should be compacted"
+    );
+}
+
+#[test]
+fn dedupe_preserves_thin_plate_geometry() {
+    // 1e-4mm-thick plate: front face (z=0) and back face (z=1e-4) tessellate
+    // to disjoint triangle pairs that share x/y. The quantization grid must
+    // be tight enough to keep them distinct.
+    let mut mesh = TriangleMesh {
+        positions: vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+            Point3::new(0.0, 0.0, 1e-4),
+            Point3::new(1.0, 0.0, 1e-4),
+            Point3::new(0.0, 1.0, 1e-4),
+        ],
+        normals: vec![Vec3::new(0.0, 0.0, 1.0); 6],
+        indices: vec![0, 1, 2, 3, 5, 4],
+    };
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    assert_eq!(
+        mesh.indices.len(),
+        6,
+        "1e-4mm-apart triangles should NOT collapse"
+    );
+}
+
 #[test]
 fn tessellate_boolean_cut_cylinder_watertight() {
     use brepkit_math::mat::Mat4;

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -273,6 +273,146 @@ fn tessellate_plain_cylinder_watertight() {
     );
 }
 
+/// Regression for issue #696: dovetail-style fuse where a small tongue protrudes
+/// into two adjacent slabs. The downstream consumer (gridfinity-layout-tool)
+/// adds a TONGUE_PROTRUSION specifically to avoid coplanar fuse residue under
+/// OCCT, but brepkit's pipeline produced non-manifold tessellation output. This
+/// minimal case exercises the same topological pattern.
+#[test]
+fn tessellate_dovetail_fuse_manifold_issue_696() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let slab_a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 1.0).unwrap();
+    let slab_b = crate::primitives::make_box(&mut topo, 10.0, 10.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, slab_b, &Mat4::translation(10.0, 0.0, 0.0))
+        .unwrap();
+    // Tongue from x=8 to x=12 — 2mm protrusion into each slab. Centered on
+    // the y axis at y=4..6, full slab height z=0..1.
+    let tongue = crate::primitives::make_box(&mut topo, 4.0, 2.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, tongue, &Mat4::translation(8.0, 4.0, 0.0))
+        .unwrap();
+
+    let ab = crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, slab_a, slab_b)
+        .unwrap();
+    let result =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, ab, tongue).unwrap();
+
+    let mesh = tessellate_solid(&topo, result, 0.1).unwrap();
+    let nm = non_manifold_edge_count(&mesh);
+    let boundary = boundary_edge_count(&mesh);
+    assert_eq!(
+        nm, 0,
+        "dovetail fuse should produce a 2-manifold mesh (0 non-manifold edges), got {nm}"
+    );
+    assert_eq!(
+        boundary, 0,
+        "dovetail fuse should produce a watertight mesh (0 boundary edges), got {boundary}"
+    );
+}
+
+/// Extension of #696 repro: multi-tile chain (3 slabs, 2 tongues) plus a hollow
+/// cut. Approximates the lightweight-floor + multi-join-edge pattern from the
+/// failing 4x4 / 5x4 dovetail baseplates.
+#[test]
+fn tessellate_dovetail_multi_tile_hollow_issue_696() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let slab_a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 1.0).unwrap();
+    let slab_b = crate::primitives::make_box(&mut topo, 10.0, 10.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, slab_b, &Mat4::translation(10.0, 0.0, 0.0))
+        .unwrap();
+    let slab_c = crate::primitives::make_box(&mut topo, 10.0, 10.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, slab_c, &Mat4::translation(20.0, 0.0, 0.0))
+        .unwrap();
+
+    let tongue_ab = crate::primitives::make_box(&mut topo, 4.0, 2.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, tongue_ab, &Mat4::translation(8.0, 4.0, 0.0))
+        .unwrap();
+    let tongue_bc = crate::primitives::make_box(&mut topo, 4.0, 2.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, tongue_bc, &Mat4::translation(18.0, 4.0, 0.0))
+        .unwrap();
+
+    let ab = crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, slab_a, slab_b)
+        .unwrap();
+    let ab2 =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, ab, tongue_ab).unwrap();
+    let abc =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, ab2, slab_c).unwrap();
+    let fused = crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, abc, tongue_bc)
+        .unwrap();
+
+    // Hollow out the floor: cut a thin interior pocket.
+    let pocket = crate::primitives::make_box(&mut topo, 28.0, 8.0, 0.6).unwrap();
+    crate::transform::transform_solid(&mut topo, pocket, &Mat4::translation(1.0, 1.0, 0.2))
+        .unwrap();
+    let result =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Cut, fused, pocket).unwrap();
+
+    let mesh = tessellate_solid(&topo, result, 0.1).unwrap();
+    let nm = non_manifold_edge_count(&mesh);
+    let boundary = boundary_edge_count(&mesh);
+    assert_eq!(
+        nm, 0,
+        "multi-tile dovetail+hollow should be 2-manifold (0 non-manifold edges), got {nm}"
+    );
+    assert_eq!(
+        boundary, 0,
+        "multi-tile dovetail+hollow should be watertight (0 boundary edges), got {boundary}"
+    );
+}
+
+/// Trapezoidal tongue (real dovetail profile — narrow at tip, wider at base)
+/// joining two slabs. The trapezoid creates 45-degree edges where the tongue
+/// meets the slabs, which is where coplanar fuse residue tends to appear.
+#[test]
+fn tessellate_dovetail_trapezoidal_tongue_issue_696() {
+    use brepkit_math::mat::Mat4;
+    use brepkit_topology::builder::{make_face_from_wire, make_polygon_wire};
+
+    let mut topo = Topology::new();
+    let slab_a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 1.0).unwrap();
+    let slab_b = crate::primitives::make_box(&mut topo, 10.0, 10.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, slab_b, &Mat4::translation(10.0, 0.0, 0.0))
+        .unwrap();
+
+    // Trapezoidal tongue extruded in +Z. Wide bases at x=8 and x=12 (each
+    // 2mm inside its slab); narrow waist at x=9.8 / x=10.2. CCW order so
+    // the face normal points up.
+    let pts = vec![
+        Point3::new(8.0, 4.0, 0.0),
+        Point3::new(9.8, 4.8, 0.0),
+        Point3::new(10.2, 4.8, 0.0),
+        Point3::new(12.0, 4.0, 0.0),
+        Point3::new(12.0, 6.0, 0.0),
+        Point3::new(10.2, 5.2, 0.0),
+        Point3::new(9.8, 5.2, 0.0),
+        Point3::new(8.0, 6.0, 0.0),
+    ];
+    let wire_id = make_polygon_wire(&mut topo, &pts, 1e-7).unwrap();
+    let face_id = make_face_from_wire(&mut topo, wire_id).unwrap();
+    let tongue =
+        crate::extrude::extrude(&mut topo, face_id, Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+
+    let ab = crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, slab_a, slab_b)
+        .unwrap();
+    let result =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, ab, tongue).unwrap();
+
+    let mesh = tessellate_solid(&topo, result, 0.1).unwrap();
+    let nm = non_manifold_edge_count(&mesh);
+    let boundary = boundary_edge_count(&mesh);
+    assert_eq!(
+        nm, 0,
+        "trapezoidal-tongue fuse should produce a 2-manifold mesh, got {nm} non-manifold edges"
+    );
+    assert_eq!(
+        boundary, 0,
+        "trapezoidal-tongue fuse should produce a watertight mesh, got {boundary} boundary edges"
+    );
+}
+
 #[test]
 fn tessellate_boolean_cut_cylinder_watertight() {
     use brepkit_math::mat::Mat4;


### PR DESCRIPTION
## Summary

Partial fix for #696 (non-manifold edges in dovetail baseplate STL exports). Diagnostic helpers, regression coverage, deterministic NM-edge processing, a tessellation-level dedup pass, and an extended unify trigger that together close 82–85% of the consumer's symptom.

## Changes

**`test(tessellate): non-manifold diagnostic + dovetail regression coverage`** (`061d2a9`)
- New `non_manifold_edge_count(mesh)` helper, symmetric with `boundary_edge_count`. Both are needed to validate a closed 2-manifold; the existing helper's doc inaccurately claimed to measure non-manifold but only counted 1-sided edges.
- Three dovetail-pattern regression tests in `tessellate/tests.rs` (axis-aligned tongue, multi-tile + hollow, trapezoidal tongue). All pass currently — synthetic geometry doesn't reproduce the consumer's specific bug, but the tests catch any regression in the underlying patterns.
- Deterministic iteration in `build_manifold_shell` and `split_nonmanifold_edges`: both iterated a `HashMap` to collect non-manifold edges. Each iteration mutates topology (face removal / edge replacement), so processing order changed the assembly outcome when edges share faces. Sort by `EdgeId` first. Matches the #689/#692 pattern.

**`fix(tessellate): dedupe coincident triangles from boolean coplanar residue`** (`e96b518`)
- New `dedupe_coincident_triangles` Phase-7 pass in `tessellate_solid`. Keys triangles on quantized vertex positions (sorted) + winding parity. Cancels matching-key/opposite-winding pairs (two faces tessellated from opposite sides of the same plane). Dedupes matching-key/same-winding pairs to one.
- Quantization at **1µm** — tight enough to preserve thin-plate features (verified against the existing 1e-4mm-thick box test), coarse enough to absorb post-merge floating-point noise that boundary-vertex welding can't reach.

**`fix(boolean): also trigger unify when GFA result is non-manifold`** (`3d0214a`)
- The existing `unify_faces` invocation in the GFA success path was gated behind `Euler != 2` — but overlapping coplanar faces can cancel out of V-E+F counting, leaving 3+-face junctions with Euler == 2. Extend the gate to also fire when `is_closed_manifold(result)` is false.

**`review: address PR #697 feedback`** (`b7f8a80`)
- Tighten `is_watertight` to check both boundary and non-manifold edges (was only checking boundary, despite its 2-manifold docstring).
- Fix unit label (was "1nm", should be "1µm" — the constant is `1e-6`).
- Compact `mesh.positions`/`mesh.normals` after dedup; the previous version rebuilt indices but left phantom entries that bbox passes and non-indexed exporters would surface.
- Add four direct unit tests for `dedupe_coincident_triangles`: opposing-winding cancel, same-winding collapse, position-coincidence with distinct IDs, thin-plate preservation.

## Impact

Measured end-to-end against `baseplateGenerator.scenario.dovetail.test.ts` from gridfinity-layout-tool:

| Scenario | Before | After |
|---|---:|---:|
| 5×4 middle-column tile | 142 | **21** |
| 4×4 interior tile | 73 | **12** |
| 5×4 inverted middle | — | **6** |

82–85% reduction in non-manifold mesh edges. The tessellation dedup carries most of the load; the conditional unify is small but additive.

## Why not a full fix

The residual NM edges (6–21) come from **3 truly distinct triangles per edge** in the boolean's topology output — real branching where 3 faces with the same surface meet at one edge. Same root-cause class as the existing `#[ignore]`d `d4_shelled_box_fuse_lip` test.

A reference CAD-kernel design study suggests the architecturally-correct fix: in the assembler's same-domain detection, generalize beyond edge-set matching to use **point-in-face geometric verification**, and allow **within-rank pairing** (faces from the same input solid that overlap after splitting). Brepkit's `detect_same_domain` currently gates on identical edge sets AND opposing ranks — the dovetail residue trips both gates.

Tried and reverted on this branch:
- **Strict NM rejection in `validate_boolean_result`** — broke 15 currently-working ops tests that have 1–97 minor NM edges.
- **Mesh-level "branching resolver"** that drops triangles at 3+-incidence edges — broke `sweep_miter_l_shaped_volume_correct` (volume 10 → 4.8); miter joints legitimately produce 3-face junctions.
- **Relaxing `unify_same_domain`'s `len()==2` gate to `len()>=2`** — passes all tests but doesn't move the dovetail numbers; the merge phase's `edge_count==1` boundary filter then drops 3-shared edges as gaps, so the merge silently aborts.
- **Always invoking `unify_faces`** — broke `unify_boolean_box_reduces_faces` which tests behavior against pre-unify state.

The architectural fix (within-rank SD with point-in-face) is the right next step — too invasive for this PR.

## Verification

- [x] `cargo test -p brepkit-operations` — 603 pass (4 new dedup unit tests)
- [x] `cargo test --workspace --lib` — all pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `./scripts/check-boundaries.sh` — clean
- [x] End-to-end via gridfinity-layout-tool dovetail test — confirmed 82–85% NM-edge reduction across 3 failing scenarios