### PR TITLE
fix(algo): within-rank same-domain detection with point-in-face containment (#696)

### DIFF
--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -324,4 +324,46 @@ mod tests {
         let selected = select_faces(&sub_faces, BooleanOp::Intersect, &[], &[]);
         assert_eq!(selected.len(), 2, "Intersect keeps only Inside faces");
     }
+
+    #[test]
+    fn within_rank_dup_drops_duplicate_keeps_representative() {
+        // idx 0 (representative) + idx 1 (duplicate): both rank A, Outside —
+        // would normally both be selected for Fuse. The dup record should
+        // remove idx 1, keep idx 0.
+        let mut topo = Topology::new();
+        let sub_faces = vec![
+            make_sub_face(&mut topo, Rank::A, FaceClass::Outside),
+            make_sub_face(&mut topo, Rank::A, FaceClass::Outside),
+            make_sub_face(&mut topo, Rank::B, FaceClass::Outside),
+        ];
+        let dups = vec![WithinRankDuplicate {
+            representative: 0,
+            duplicate: 1,
+        }];
+        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &[], &dups);
+        assert_eq!(
+            selected.len(),
+            2,
+            "Fuse should keep representative + B-Outside, drop within-rank duplicate"
+        );
+    }
+
+    #[test]
+    fn within_rank_dup_out_of_bounds_skips_gracefully() {
+        let mut topo = Topology::new();
+        let sub_faces = vec![
+            make_sub_face(&mut topo, Rank::A, FaceClass::Outside),
+            make_sub_face(&mut topo, Rank::B, FaceClass::Outside),
+        ];
+        let dups = vec![WithinRankDuplicate {
+            representative: 5,
+            duplicate: 10,
+        }];
+        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &[], &dups);
+        assert_eq!(
+            selected.len(),
+            2,
+            "Out-of-bounds within-rank-dup record should be ignored, not panic"
+        );
+    }
 }

--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashSet;
 
-use crate::builder::same_domain::SameDomainPair;
+use crate::builder::same_domain::{SameDomainPair, WithinRankDuplicate};
 use crate::builder::{FaceClass, SubFace};
 use crate::ds::Rank;
 
@@ -44,6 +44,7 @@ pub(crate) fn select_faces(
     sub_faces: &[SubFace],
     op: BooleanOp,
     sd_pairs: &[SameDomainPair],
+    within_rank_dups: &[WithinRankDuplicate],
 ) -> Vec<SelectedFace> {
     // Step 1: Filter SD pairs to only those with valid (in-bounds) indices.
     // Invalid pairs are logged and excluded so they don't cause valid faces
@@ -65,6 +66,16 @@ pub(crate) fn select_faces(
         })
         .collect();
 
+    // Step 1b: Within-rank duplicates (issue #696) — same-domain faces from
+    // the same input solid. No operation-specific logic: the duplicate is
+    // just removed from the selection. Filter by valid index in case the
+    // upstream pipeline produces stale records after a split.
+    let dup_indices: HashSet<usize> = within_rank_dups
+        .iter()
+        .filter(|d| d.duplicate < sub_faces.len() && d.representative < sub_faces.len())
+        .map(|d| d.duplicate)
+        .collect();
+
     // Step 2: Identify which sub-face indices are part of valid SD pairs
     let sd_indices: HashSet<usize> = valid_sd_pairs
         .iter()
@@ -78,6 +89,12 @@ pub(crate) fn select_faces(
         .filter_map(|(idx, sf)| {
             // Skip SD faces — handled separately below
             if sd_indices.contains(&idx) {
+                return None;
+            }
+            // Skip within-rank SD duplicates (#696). Their representative
+            // (the lowest-indexed face in the group) goes through the normal
+            // truth-table selection; the duplicate is dropped here.
+            if dup_indices.contains(&idx) {
                 return None;
             }
 
@@ -244,7 +261,7 @@ mod tests {
             make_sub_face(&mut topo, Rank::A, FaceClass::Outside),
             make_sub_face(&mut topo, Rank::B, FaceClass::Outside),
         ];
-        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &[]);
+        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &[], &[]);
         assert_eq!(selected.len(), 2);
     }
 
@@ -260,7 +277,7 @@ mod tests {
             b_contained_in_a: false,
         }];
         // Should not panic — out-of-bounds pairs are skipped
-        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &sd_pairs);
+        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &sd_pairs, &[]);
         // The non-SD face should still be selected
         assert_eq!(selected.len(), 1);
     }
@@ -274,7 +291,7 @@ mod tests {
             make_sub_face(&mut topo, Rank::B, FaceClass::Outside),
             make_sub_face(&mut topo, Rank::B, FaceClass::Inside),
         ];
-        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &[]);
+        let selected = select_faces(&sub_faces, BooleanOp::Fuse, &[], &[]);
         assert_eq!(selected.len(), 2, "Fuse keeps only Outside faces");
     }
 
@@ -287,7 +304,7 @@ mod tests {
             make_sub_face(&mut topo, Rank::B, FaceClass::Outside),
             make_sub_face(&mut topo, Rank::B, FaceClass::Inside),
         ];
-        let selected = select_faces(&sub_faces, BooleanOp::Cut, &[]);
+        let selected = select_faces(&sub_faces, BooleanOp::Cut, &[], &[]);
         assert_eq!(selected.len(), 2, "Cut keeps A-Outside + B-Inside");
         assert!(
             selected.iter().any(|s| s.reversed),
@@ -304,7 +321,7 @@ mod tests {
             make_sub_face(&mut topo, Rank::B, FaceClass::Outside),
             make_sub_face(&mut topo, Rank::B, FaceClass::Inside),
         ];
-        let selected = select_faces(&sub_faces, BooleanOp::Intersect, &[]);
+        let selected = select_faces(&sub_faces, BooleanOp::Intersect, &[], &[]);
         assert_eq!(selected.len(), 2, "Intersect keeps only Inside faces");
     }
 }

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -78,6 +78,9 @@ pub struct Builder {
     face_ranks: HashMap<FaceId, Rank>,
     /// Same-domain face pairs detected by `same_domain`.
     sd_pairs: Vec<same_domain::SameDomainPair>,
+    /// Within-rank SD duplicates (boolean residue accumulated across
+    /// sequential operations — issue #696). Excluded before classification.
+    sd_within_rank_dups: Vec<same_domain::WithinRankDuplicate>,
 }
 
 impl Builder {
@@ -99,6 +102,7 @@ impl Builder {
             sub_faces: Vec::new(),
             face_ranks: HashMap::new(),
             sd_pairs: Vec::new(),
+            sd_within_rank_dups: Vec::new(),
         }
     }
 
@@ -125,7 +129,12 @@ impl Builder {
     /// Returns [`AlgoError`] if face selection produces no faces or
     /// assembly fails.
     pub fn build_result(mut self, op: BooleanOp) -> Result<(Topology, SolidId), AlgoError> {
-        let selected = bop::select_faces(&self.sub_faces, op, &self.sd_pairs);
+        let selected = bop::select_faces(
+            &self.sub_faces,
+            op,
+            &self.sd_pairs,
+            &self.sd_within_rank_dups,
+        );
         let solid_id = assemble::assemble_solid(&mut self.topo, &selected)?;
         Ok((self.topo, solid_id))
     }
@@ -171,13 +180,15 @@ impl Builder {
         log::debug!("Builder: {} sub-faces created", self.sub_faces.len());
 
         // Step 3: same-domain detection (records pairs, does NOT set FaceClass)
-        self.sd_pairs = same_domain::detect_same_domain(
+        let sd_result = same_domain::detect_same_domain(
             &self.topo,
             &self.arena,
             &self.sub_faces,
             &self.face_ranks,
             self.tol,
         );
+        self.sd_pairs = sd_result.pairs;
+        self.sd_within_rank_dups = sd_result.within_rank_dups;
 
         // Note: SD representative replacement (replacing B's face_id with
         // A's face_id) was attempted but produces degenerate 2-edge faces
@@ -199,14 +210,21 @@ impl Builder {
         //
         // Skip SD index construction entirely when no SD pairs exist
         // (common case for non-overlapping solids).
-        let sd_indices: std::collections::HashSet<usize> = if self.sd_pairs.is_empty() {
-            std::collections::HashSet::new()
-        } else {
-            self.sd_pairs
-                .iter()
-                .flat_map(|p| [p.idx_a, p.idx_b])
-                .collect()
-        };
+        // Only the cross-rank SD pair indices and the within-rank duplicates
+        // (NOT their representatives) should bypass ray-cast classification.
+        // The representative still needs normal IN/OUT classification because
+        // `select_faces` routes it through the standard truth table — adding
+        // it to `sd_indices` would force it to "On" with no matching pair
+        // record, so `apply_sd_selection` would never pick it up and the
+        // face would silently drop out.
+        let sd_indices: std::collections::HashSet<usize> =
+            if self.sd_pairs.is_empty() && self.sd_within_rank_dups.is_empty() {
+                std::collections::HashSet::new()
+            } else {
+                let cross = self.sd_pairs.iter().flat_map(|p| [p.idx_a, p.idx_b]);
+                let within = self.sd_within_rank_dups.iter().map(|d| d.duplicate);
+                cross.chain(within).collect()
+            };
 
         for (idx, sf) in self.sub_faces.iter_mut().enumerate() {
             if !sd_indices.is_empty() && sd_indices.contains(&idx) {

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -132,6 +132,11 @@ pub fn detect_same_domain<S: BuildHasher>(
 
     let mut uf = UnionFind::new(n);
     let mut pair_data: HashMap<(usize, usize), bool> = HashMap::new(); // (min,max) → same_orientation
+    // Tracks pairs unioned by the geometric containment pass (Step 3b).
+    // Cross-rank groups containing such pairs are "overlapping" same-domain
+    // faces, not "touching" — `b_contained_in_a` must be true for them so
+    // `apply_sd_selection` cancels both faces under Cut instead of keeping A.
+    let mut geometric_overlap_groups: HashSet<usize> = HashSet::new();
 
     for members in groups.values() {
         if members.len() < 2 {
@@ -201,6 +206,10 @@ pub fn detect_same_domain<S: BuildHasher>(
                     uf.union(i, j);
                     let key = (i.min(j), i.max(j));
                     pair_data.insert(key, same_dir);
+                    // Mark the post-union root so the emission code knows
+                    // this group came from geometric containment, not from
+                    // boundary-identical edge sets.
+                    geometric_overlap_groups.insert(uf.find(i));
                 }
             }
         }
@@ -226,7 +235,7 @@ pub fn detect_same_domain<S: BuildHasher>(
     let mut pairs = Vec::new();
     let mut within_rank_dups = Vec::new();
 
-    for members in sd_groups.values() {
+    for (root, members) in &sd_groups {
         if members.len() < 2 {
             continue;
         }
@@ -242,6 +251,13 @@ pub fn detect_same_domain<S: BuildHasher>(
             .min()
             .copied();
 
+        // True if any pair in this group was unioned by the geometric
+        // containment pass. Cross-rank groups flagged here have actual
+        // interior overlap (one face fully contained in another), not just
+        // a shared boundary — `apply_sd_selection` needs `b_contained_in_a`
+        // to be true so Cut cancels both faces instead of keeping A.
+        let geometric_overlap = geometric_overlap_groups.contains(root);
+
         match (repr_a, repr_b) {
             // Cross-rank: classic SD pair — emit for operation-specific selection.
             (Some(idx_a), Some(idx_b)) => {
@@ -252,7 +268,7 @@ pub fn detect_same_domain<S: BuildHasher>(
                     idx_a,
                     idx_b,
                     same_orientation,
-                    b_contained_in_a: false,
+                    b_contained_in_a: geometric_overlap,
                 });
 
                 // The group may also contain additional same-rank members
@@ -425,9 +441,14 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
     let poly_i: Vec<_> = pts_i.iter().map(|&p| frame.project(p)).collect();
     let poly_j: Vec<_> = pts_j.iter().map(|&p| frame.project(p)).collect();
 
-    // Containment test using a small inward tolerance on the boundary —
-    // point_in_polygon_2d's strict ray-cast treats on-boundary points
-    // inconsistently, so we also accept "close to boundary" as inside.
+    // NOTE: `point_in_polygon_2d` uses a strict ray-cast with no boundary
+    // tolerance. Vertices that land exactly on the containing polygon's
+    // edge (e.g., two faces that share a boundary segment) may return false
+    // unpredictably and cause `all_inside` below to silently miss the pair.
+    // The edge-set pass above already handles identical-boundary cases, so
+    // Step 3b only reaches pairs with different outlines — contained-face
+    // vertices that lie exactly on the container's edge are rare in
+    // practice, but worth keeping in mind when extending this check.
     let p_i_2d = frame.project(p_i);
     let p_j_2d = frame.project(p_j);
 
@@ -600,8 +621,169 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
 
     use super::*;
+    use crate::builder::FaceClass;
+    use crate::ds::Rank;
     use brepkit_math::tolerance::Tolerance;
     use brepkit_math::vec::{Point3, Vec3};
+    use brepkit_topology::builder::{make_face_from_wire, make_polygon_wire};
+
+    /// Build a planar rectangular sub-face on the z=0 plane.
+    fn rect_sub_face(
+        topo: &mut Topology,
+        min_x: f64,
+        max_x: f64,
+        min_y: f64,
+        max_y: f64,
+        rank: Rank,
+        interior: Point3,
+    ) -> SubFace {
+        let pts = vec![
+            Point3::new(min_x, min_y, 0.0),
+            Point3::new(max_x, min_y, 0.0),
+            Point3::new(max_x, max_y, 0.0),
+            Point3::new(min_x, max_y, 0.0),
+        ];
+        let wire = make_polygon_wire(topo, &pts, 1e-7).unwrap();
+        let face_id = make_face_from_wire(topo, wire).unwrap();
+        SubFace {
+            face_id,
+            classification: FaceClass::Unknown,
+            rank,
+            interior_point: Some(interior),
+        }
+    }
+
+    /// Regression test for issue #696: two same-rank planar faces with one
+    /// fully contained inside the other should be reported as a
+    /// within-rank duplicate, not as a cross-rank SD pair.
+    #[test]
+    fn detects_within_rank_planar_containment() {
+        let mut topo = Topology::new();
+        let arena = GfaArena::new();
+        let face_ranks: HashMap<FaceId, Rank> = HashMap::new();
+        let tol = Tolerance::new();
+
+        // Large outer face (rank A) and small contained face (also rank A).
+        // Edge sets differ (different vertex sets), so the edge-set pass
+        // skips them — the geometric containment pass catches the dup.
+        let large = rect_sub_face(
+            &mut topo,
+            0.0,
+            10.0,
+            0.0,
+            10.0,
+            Rank::A,
+            Point3::new(5.0, 5.0, 0.0),
+        );
+        let small = rect_sub_face(
+            &mut topo,
+            3.0,
+            5.0,
+            3.0,
+            5.0,
+            Rank::A,
+            Point3::new(4.0, 4.0, 0.0),
+        );
+        let sub_faces = vec![large, small];
+
+        let result = detect_same_domain(&topo, &arena, &sub_faces, &face_ranks, tol);
+
+        assert!(result.pairs.is_empty(), "no cross-rank pair expected");
+        assert_eq!(
+            result.within_rank_dups.len(),
+            1,
+            "expected exactly one within-rank duplicate"
+        );
+        let dup = &result.within_rank_dups[0];
+        assert_eq!(dup.representative, 0, "large face (idx 0) is the rep");
+        assert_eq!(dup.duplicate, 1, "small face (idx 1) is the duplicate");
+    }
+
+    /// Two adjacent non-overlapping coplanar faces should NOT be unioned —
+    /// regression guard against the over-aggressive interior-only test
+    /// that broke `fuse_ring_overlapping_shelled_box_height`.
+    #[test]
+    fn adjacent_coplanar_faces_not_duplicates() {
+        let mut topo = Topology::new();
+        let arena = GfaArena::new();
+        let face_ranks: HashMap<FaceId, Rank> = HashMap::new();
+        let tol = Tolerance::new();
+
+        // Two side-by-side rectangles, sharing one edge but not overlapping.
+        let left = rect_sub_face(
+            &mut topo,
+            0.0,
+            5.0,
+            0.0,
+            10.0,
+            Rank::A,
+            Point3::new(2.5, 5.0, 0.0),
+        );
+        let right = rect_sub_face(
+            &mut topo,
+            5.0,
+            10.0,
+            0.0,
+            10.0,
+            Rank::A,
+            Point3::new(7.5, 5.0, 0.0),
+        );
+        let sub_faces = vec![left, right];
+
+        let result = detect_same_domain(&topo, &arena, &sub_faces, &face_ranks, tol);
+
+        assert!(result.pairs.is_empty(), "no cross-rank pair expected");
+        assert!(
+            result.within_rank_dups.is_empty(),
+            "adjacent non-overlapping faces should not be unioned, got {} dup(s)",
+            result.within_rank_dups.len()
+        );
+    }
+
+    /// Cross-rank geometric containment should set `b_contained_in_a=true`
+    /// so `apply_sd_selection` cancels the pair under Cut. Regression for
+    /// the P1 review comment on the original PR.
+    #[test]
+    fn cross_rank_geometric_containment_marks_overlapping() {
+        let mut topo = Topology::new();
+        let arena = GfaArena::new();
+        let face_ranks: HashMap<FaceId, Rank> = HashMap::new();
+        let tol = Tolerance::new();
+
+        // Rank A: large face. Rank B: small face fully inside A's outline,
+        // with a different boundary (the edge-set pass misses it).
+        let large_a = rect_sub_face(
+            &mut topo,
+            0.0,
+            10.0,
+            0.0,
+            10.0,
+            Rank::A,
+            Point3::new(5.0, 5.0, 0.0),
+        );
+        let small_b = rect_sub_face(
+            &mut topo,
+            3.0,
+            5.0,
+            3.0,
+            5.0,
+            Rank::B,
+            Point3::new(4.0, 4.0, 0.0),
+        );
+        let sub_faces = vec![large_a, small_b];
+
+        let result = detect_same_domain(&topo, &arena, &sub_faces, &face_ranks, tol);
+
+        assert!(
+            result.within_rank_dups.is_empty(),
+            "cross-rank pair should not be reported as within-rank dup"
+        );
+        assert_eq!(result.pairs.len(), 1, "expected one cross-rank SD pair");
+        assert!(
+            result.pairs[0].b_contained_in_a,
+            "geometric containment must set b_contained_in_a=true so Cut cancels both"
+        );
+    }
 
     #[test]
     fn planes_same_domain_same_direction() {

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -38,6 +38,33 @@ pub struct SameDomainPair {
     pub b_contained_in_a: bool,
 }
 
+/// A within-rank duplicate sub-face: same edge set, same surface, same input
+/// solid as another face. Issue #696: sequential boolean operations
+/// (`booleanPipeline` in the consumer) accumulate stale coincident faces in
+/// the input solid; when the next boolean splits its inputs into sub-faces,
+/// these duplicates produce 3+-face junctions in the output topology that
+/// tessellate as branching mesh edges. The `representative` is the lowest-
+/// indexed sub-face in the group; `duplicate` should be excluded from the
+/// boolean result.
+#[derive(Debug, Clone, Copy)]
+pub struct WithinRankDuplicate {
+    /// Sub-face index that stays in the result.
+    pub representative: usize,
+    /// Sub-face index that should be dropped.
+    pub duplicate: usize,
+}
+
+/// Output of [`detect_same_domain`].
+#[derive(Debug, Default, Clone)]
+pub struct SameDomainResult {
+    /// Cross-rank pairs (one face from A, one from B).
+    pub pairs: Vec<SameDomainPair>,
+    /// Within-rank duplicates (multiple faces from the same input solid
+    /// occupying the same domain — boolean residue that needs removing
+    /// before classification).
+    pub within_rank_dups: Vec<WithinRankDuplicate>,
+}
+
 /// Quantized 3D grid position — collision-free vertex identity.
 type QVert = (i64, i64, i64);
 
@@ -64,10 +91,10 @@ pub fn detect_same_domain<S: BuildHasher>(
     sub_faces: &[SubFace],
     _face_ranks: &HashMap<FaceId, Rank, S>,
     tol: Tolerance,
-) -> Vec<SameDomainPair> {
+) -> SameDomainResult {
     let n = sub_faces.len();
     if n < 2 {
-        return Vec::new();
+        return SameDomainResult::default();
     }
 
     // Step 1: Compute canonical edge sets for each sub-face.
@@ -111,24 +138,66 @@ pub fn detect_same_domain<S: BuildHasher>(
             continue;
         }
 
-        // Check all pairs within this edge-set group
+        // Check all pairs within this edge-set group. Pairs can be cross-rank
+        // (the classic SD case — same domain across two input solids) or
+        // within-rank (issue #696 — boolean residue accumulated in one input
+        // across sequential operations). Both unify into the same group; the
+        // representative-emission step below splits them by rank composition.
         for (mi, &i) in members.iter().enumerate() {
-            let rank_i = sub_faces[i].rank;
             let Some(surf_i) = surfaces[i] else {
                 continue;
             };
 
             for &j in &members[mi + 1..] {
-                // Only pair faces from opposing solids
-                if sub_faces[j].rank == rank_i {
-                    continue;
-                }
                 let Some(surf_j) = surfaces[j] else {
                     continue;
                 };
 
-                // Verify surface equivalence
+                // Verify surface equivalence.
                 if let Some(same_dir) = surfaces_same_domain(surf_i, surf_j, tol) {
+                    uf.union(i, j);
+                    let key = (i.min(j), i.max(j));
+                    pair_data.insert(key, same_dir);
+                }
+            }
+        }
+    }
+
+    // Step 3b (issue #696): geometric containment pass for planar faces.
+    // Edge-set hashing alone misses the common boolean-residue pattern where
+    // one face is fully contained inside another with a different boundary
+    // (e.g., a stale nub-bottom face filling the hole in a slab-top face).
+    // For planar faces with the same surface, test whether one's
+    // pre-computed interior point lies inside the other's wire — if so, the
+    // contained face is a duplicate. Limited to planar faces because the
+    // analytic surfaces (cylinder/sphere/etc) produce well-defined trimmed
+    // patches that rarely accumulate residue, and a 2D containment test on
+    // their parametric domains needs surface-specific handling.
+    {
+        let mut planar_indices: Vec<usize> = Vec::new();
+        for (idx, surf) in surfaces.iter().enumerate() {
+            if matches!(surf, Some(FaceSurface::Plane { .. })) {
+                planar_indices.push(idx);
+            }
+        }
+        for (mi, &i) in planar_indices.iter().enumerate() {
+            if sub_faces[i].interior_point.is_none() {
+                continue;
+            }
+            for &j in &planar_indices[mi + 1..] {
+                if sub_faces[j].interior_point.is_none() {
+                    continue;
+                }
+                // Cheap surface-match guard first.
+                let same_dir = match (surfaces[i], surfaces[j]) {
+                    (Some(si), Some(sj)) => surfaces_same_domain(si, sj, tol),
+                    _ => None,
+                };
+                let Some(same_dir) = same_dir else { continue };
+                if uf.find(i) == uf.find(j) {
+                    continue; // already grouped
+                }
+                if planar_faces_overlap(topo, sub_faces, i, j) {
                     uf.union(i, j);
                     let key = (i.min(j), i.max(j));
                     pair_data.insert(key, same_dir);
@@ -155,13 +224,13 @@ pub fn detect_same_domain<S: BuildHasher>(
     }
 
     let mut pairs = Vec::new();
+    let mut within_rank_dups = Vec::new();
 
     for members in sd_groups.values() {
         if members.len() < 2 {
             continue;
         }
 
-        // Find the best representative from Rank::A (smallest index)
         let repr_a = members
             .iter()
             .filter(|&&idx| sub_faces[idx].rank == Rank::A)
@@ -173,40 +242,72 @@ pub fn detect_same_domain<S: BuildHasher>(
             .min()
             .copied();
 
-        // Build a pair for each A-B combination in the group.
-        // For simple cases (1 from A, 1 from B), this produces exactly 1 pair.
-        if let (Some(idx_a), Some(idx_b)) = (repr_a, repr_b) {
-            let key = (idx_a.min(idx_b), idx_a.max(idx_b));
-            let same_orientation = pair_data.get(&key).copied().unwrap_or(true);
+        match (repr_a, repr_b) {
+            // Cross-rank: classic SD pair — emit for operation-specific selection.
+            (Some(idx_a), Some(idx_b)) => {
+                let key = (idx_a.min(idx_b), idx_a.max(idx_b));
+                let same_orientation = pair_data.get(&key).copied().unwrap_or(true);
 
-            pairs.push(SameDomainPair {
-                idx_a,
-                idx_b,
-                same_orientation,
-                // Edge-set matched faces have identical boundaries.
-                // b_contained_in_a=false → touching (default for same-boundary faces).
-                b_contained_in_a: false,
-            });
+                pairs.push(SameDomainPair {
+                    idx_a,
+                    idx_b,
+                    same_orientation,
+                    b_contained_in_a: false,
+                });
+
+                // The group may also contain additional same-rank members
+                // (rare — a 3+ member group spanning both ranks). Treat those
+                // as within-rank duplicates against the matching-rank repr.
+                for &idx in members {
+                    if idx == idx_a || idx == idx_b {
+                        continue;
+                    }
+                    let rep = if sub_faces[idx].rank == Rank::A {
+                        idx_a
+                    } else {
+                        idx_b
+                    };
+                    within_rank_dups.push(WithinRankDuplicate {
+                        representative: rep,
+                        duplicate: idx,
+                    });
+                }
+            }
+            // Within-rank only (A-only or B-only): cumulative boolean residue.
+            // Keep the lowest-indexed face as representative; mark the rest
+            // as duplicates so the BOP selector can drop them before
+            // classification (issue #696).
+            (Some(rep), None) | (None, Some(rep)) => {
+                for &idx in members {
+                    if idx != rep {
+                        within_rank_dups.push(WithinRankDuplicate {
+                            representative: rep,
+                            duplicate: idx,
+                        });
+                    }
+                }
+            }
+            (None, None) => {}
         }
     }
 
-    // Sort pairs by (idx_a, idx_b) — `sd_groups.values()` above iterates
-    // a HashMap, so `pairs` was being assembled in random order.
-    // Downstream `apply_sd_selection` in bop.rs iterates pairs and pushes
-    // to the `selected` faces Vec; the random order propagated into face
-    // ordering in the result shell and drove 100-500× perf variance in
-    // `bench_boolean_64_holes`. Sorting recovers determinism without
-    // changing semantics (pairs is a logical set, not an ordered list).
-    // Unstable sort is fine — keys (idx_a, idx_b) are unique within
-    // the per-group representative pick above, so no ties exist to
-    // reorder.
+    // Sort outputs deterministically — `sd_groups.values()` iterates a
+    // HashMap, so without sorting the pair order varies per run and
+    // propagates into face ordering in the result shell (drove 100–500×
+    // perf variance in `bench_boolean_64_holes`).
     pairs.sort_unstable_by_key(|p| (p.idx_a, p.idx_b));
+    within_rank_dups.sort_unstable_by_key(|d| (d.representative, d.duplicate));
 
     log::debug!(
-        "detect_same_domain: {} same-domain pairs found (edge-set hash)",
-        pairs.len()
+        "detect_same_domain: {} cross-rank pairs, {} within-rank duplicates (edge-set hash)",
+        pairs.len(),
+        within_rank_dups.len()
     );
-    pairs
+
+    SameDomainResult {
+        pairs,
+        within_rank_dups,
+    }
 }
 
 /// Compute the canonical edge set for a face using quantized vertex positions.
@@ -260,6 +361,93 @@ fn compute_edge_set_quantized(
 
     pairs.sort_unstable();
     Some(pairs)
+}
+
+/// Test whether two planar sub-faces are geometrically coincident or one
+/// is fully contained inside the other.
+///
+/// Returns `true` only when ALL outer-wire vertices of one face lie inside
+/// or on the boundary of the other face's outer polygon (and the interior
+/// sample point confirms it). A weaker "interior-only" containment test was
+/// tried and rejected: adjacent coplanar faces with concave geometry could
+/// have an interior point that happens to land inside a neighbor's polygon
+/// without the faces actually overlapping. Requiring whole-wire containment
+/// is the conservative criterion that catches boolean residue (issue #696)
+/// — typically a small "filling" face inside a larger face's outer
+/// boundary — without firing on legitimate adjacent face pairs.
+fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usize) -> bool {
+    let Some(p_i) = sub_faces[i].interior_point else {
+        return false;
+    };
+    let Some(p_j) = sub_faces[j].interior_point else {
+        return false;
+    };
+    let Ok(face_i) = topo.face(sub_faces[i].face_id) else {
+        return false;
+    };
+    let Ok(face_j) = topo.face(sub_faces[j].face_id) else {
+        return false;
+    };
+    let FaceSurface::Plane {
+        normal: normal_i, ..
+    } = *face_i.surface()
+    else {
+        return false;
+    };
+
+    let wire_points = |face: &brepkit_topology::face::Face| -> Vec<brepkit_math::vec::Point3> {
+        let mut pts = Vec::new();
+        let Ok(wire) = topo.wire(face.outer_wire()) else {
+            return pts;
+        };
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            let vid = if oe.is_forward() {
+                edge.start()
+            } else {
+                edge.end()
+            };
+            if let Ok(v) = topo.vertex(vid) {
+                pts.push(v.point());
+            }
+        }
+        pts
+    };
+
+    let pts_i = wire_points(face_i);
+    let pts_j = wire_points(face_j);
+    if pts_i.len() < 3 || pts_j.len() < 3 {
+        return false;
+    }
+    let frame = super::plane_frame::PlaneFrame::from_plane_face(normal_i, &pts_i);
+    let poly_i: Vec<_> = pts_i.iter().map(|&p| frame.project(p)).collect();
+    let poly_j: Vec<_> = pts_j.iter().map(|&p| frame.project(p)).collect();
+
+    // Containment test using a small inward tolerance on the boundary —
+    // point_in_polygon_2d's strict ray-cast treats on-boundary points
+    // inconsistently, so we also accept "close to boundary" as inside.
+    let p_i_2d = frame.project(p_i);
+    let p_j_2d = frame.project(p_j);
+
+    let all_inside =
+        |verts: &[brepkit_math::vec::Point2], poly: &[brepkit_math::vec::Point2]| -> bool {
+            verts
+                .iter()
+                .all(|&v| super::classify_2d::point_in_polygon_2d(v, poly))
+        };
+
+    // i fully contained in j: every vertex of i (plus its interior sample)
+    // is inside j's polygon.
+    if super::classify_2d::point_in_polygon_2d(p_i_2d, &poly_j) && all_inside(&poly_i, &poly_j) {
+        return true;
+    }
+    // j fully contained in i.
+    if super::classify_2d::point_in_polygon_2d(p_j_2d, &poly_i) && all_inside(&poly_j, &poly_i) {
+        return true;
+    }
+    false
 }
 
 /// Quantize a 3D point to integer grid coordinates.

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -855,7 +855,7 @@ fn trace_builder_overlapping_box_fuse() {
     }
 
     // Simulate BOP selection
-    let selected = crate::bop::select_faces(sub_faces, crate::bop::BooleanOp::Fuse, sd_pairs);
+    let selected = crate::bop::select_faces(sub_faces, crate::bop::BooleanOp::Fuse, sd_pairs, &[]);
     eprintln!("BOP selected: {} faces", selected.len());
     for (i, sf) in selected.iter().enumerate() {
         let n_edges = topo
@@ -1072,7 +1072,7 @@ fn trace_builder_z_axis_overlap() {
         );
     }
 
-    let selected = crate::bop::select_faces(sub_faces, crate::bop::BooleanOp::Fuse, sd_pairs);
+    let selected = crate::bop::select_faces(sub_faces, crate::bop::BooleanOp::Fuse, sd_pairs, &[]);
     eprintln!("BOP selected: {} faces", selected.len());
 }
 


### PR DESCRIPTION
## Summary

Architectural follow-up to PR #697 for issue #696. The assembler's same-domain detection only paired faces across opposing ranks with identical edge sets — boolean residue from sequential operations slips through both gates. This PR generalizes the SD model to also detect within-rank duplicates, including the common case of one planar face fully contained inside another's outer boundary.

## Why this matters

Each \`boolean()\` call's input A inherits faces from prior operations. When the consumer's \`booleanPipeline\` does many fuses + cuts in sequence, stale coincident faces accumulate in A. The previous \`detect_same_domain\` skipped them with \`if sub_faces[j].rank == rank_i { continue; }\`. Within-rank semantics are actually simpler than across-rank — no operation-specific selection logic needed, just "keep the representative, drop the duplicates."

## Changes

- **Generalize \`SameDomainResult\`**: returns both cross-rank \`pairs\` (unchanged semantics) and a new \`within_rank_dups: Vec<WithinRankDuplicate>\`.
- **Remove the rank skip** in the edge-set union pass so members from any rank combination can union when edge sets match and \`surfaces_same_domain\` agrees.
- **Add a planar containment pass** (\`planar_faces_overlap\`) for residue with different outer boundaries: for each pair of planar sub-faces sharing the same plane, test whether all of one face's outer-wire vertices (plus its interior sample) lie inside the other face's polygon. The conservative full-containment criterion is required — see "Tried and reverted" below.
- **Plumb \`within_rank_dups\` through \`bop::select_faces\`**: duplicates are dropped before the truth-table selection runs. Only the duplicate is forced to "On" classification; the representative goes through normal IN/OUT — otherwise it would silently fall out of selection.

## Impact

Cumulative end-to-end against \`baseplateGenerator.scenario.dovetail.test.ts\`, starting from main pre-#697:

| Scenario | main (pre-#697) | post-#697 | **This PR** |
|---|---:|---:|---:|
| 5×4 middle-column tile | 142 | 21 | **20** |
| 4×4 interior tile | 73 | 12 | **10** |
| 5×4 inverted middle | — | 6 | **6** |

The within-rank infrastructure catches the planar-full-containment subset of residue. Remaining NM edges follow patterns this PR doesn't address: non-planar surfaces (cylindrical nub side faces), and 3-face junctions with mixed surfaces. Those need different detection strategies and are left for follow-up.

## Tried and reverted

- **Interior-only overlap test** (\`A.interior in B.polygon OR B.interior in A.polygon\`) — broke \`fuse_ring_overlapping_shelled_box_height\` (volume 1972 → 1175). Adjacent coplanar faces with concave outlines can have an interior point that happens to land inside a neighbor's polygon without the faces actually overlapping. Switched to whole-wire-vertex containment which is the strict subset that catches residue without false positives.
- **Add both \`representative\` and \`duplicate\` to \`sd_indices\` in classify_sub_faces** — broke \`cut_box_by_translated_sphere\` (volume 0 → 1000). Forcing the representative to "On" classification removes it from normal selection but it has no matching \`SameDomainPair\`, so \`apply_sd_selection\` doesn't pick it up. Fixed by only adding the duplicate.

## Verification

- [x] \`cargo test --workspace\` — 603 ops tests pass, 0 regressions
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`./scripts/check-boundaries.sh\` — clean
- [x] End-to-end via gridfinity-layout-tool dovetail test — measurements above

## Test plan

- [ ] CI passes
- [ ] Existing analytic/GFA boolean tests show stable face counts and volumes
- [ ] Consumer integration confirms the dovetail NM-edge reductions