### PR TITLE
fix(algo): preserve dropped holes in face splitter (#696 diagnostic)

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -486,58 +486,65 @@ pub fn split_face_2d(
     }
 
     // Distribute original inner wires (holes from the source face) to sub-faces.
-    // Each hole is assigned to the sub-face whose outer wire contains it.
-    //
-    // Test with the hole's interior sample (a point inside the hole's enclosed
-    // area), not its first vertex — when the splitter cuts the face along a
-    // line that passes through a hole vertex, that vertex sits exactly on a
-    // sub-face boundary and `point_in_polygon_2d`'s strict ray-cast returns
-    // false for every sub-face. The earlier code logged a warning and
-    // silently dropped the hole, leaving the sub-face missing its cutout.
-    // Falling back to the largest-area sub-face when even the interior
-    // sample doesn't match keeps the geometry intact for the rare residual
-    // cases (e.g., hole straddling multiple sub-faces); a warning still fires
-    // so the case is visible.
+    // Each hole is assigned to the sub-face whose outer wire contains its
+    // interior sample point (a point inside the hole's enclosed area, not
+    // its first vertex — that vertex often sits exactly on a sub-face
+    // boundary when the split passes through it, and `point_in_polygon_2d`'s
+    // strict ray-cast returns false for every sub-face). If no sub-face
+    // claims the hole — degenerate UV sample, hole straddling multiple
+    // sub-faces, etc. — fall back to the largest-area sub-face. A warning
+    // fires for the fallback so the case stays visible; what we never do is
+    // silently drop the hole as the earlier code did.
     if !original_inner_wires.is_empty() {
+        let largest_sub_face_idx = |sub_faces: &[SplitSubFace]| -> Option<usize> {
+            sub_faces
+                .iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| {
+                    let area_a =
+                        super::classify_2d::signed_area_2d(&sample_wire_loop_uv(&a.outer_wire))
+                            .abs();
+                    let area_b =
+                        super::classify_2d::signed_area_2d(&sample_wire_loop_uv(&b.outer_wire))
+                            .abs();
+                    area_a
+                        .partial_cmp(&area_b)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .map(|(i, _)| i)
+        };
+
         for hole in &original_inner_wires {
             let hole_pts = sample_wire_loop_uv(hole);
-            if hole_pts.len() < 3 {
+            let assigned = if hole_pts.len() >= 3 {
+                let probe = super::classify_2d::sample_interior_point(&hole_pts);
+                sub_faces.iter_mut().find_map(|sf| {
+                    let outer_pts = sample_wire_loop_uv(&sf.outer_wire);
+                    super::classify_2d::point_in_polygon_2d(probe, &outer_pts).then(|| {
+                        sf.inner_wires.push(hole.clone());
+                    })
+                })
+            } else {
+                None
+            };
+            if assigned.is_some() {
                 continue;
             }
-            let probe = super::classify_2d::sample_interior_point(&hole_pts);
-            let mut assigned = false;
-            for sf in &mut sub_faces {
-                let outer_pts = sample_wire_loop_uv(&sf.outer_wire);
-                if super::classify_2d::point_in_polygon_2d(probe, &outer_pts) {
-                    sf.inner_wires.push(hole.clone());
-                    assigned = true;
-                    break;
-                }
-            }
-            if !assigned {
-                log::warn!(
-                    "face_splitter: hole with {} edges did not contain-test in any \
-                     sub-face; attaching to largest sub-face as fallback",
-                    hole.len()
-                );
-                let target_idx = sub_faces
-                    .iter()
-                    .enumerate()
-                    .max_by(|(_, a), (_, b)| {
-                        let area_a =
-                            super::classify_2d::signed_area_2d(&sample_wire_loop_uv(&a.outer_wire))
-                                .abs();
-                        let area_b =
-                            super::classify_2d::signed_area_2d(&sample_wire_loop_uv(&b.outer_wire))
-                                .abs();
-                        area_a
-                            .partial_cmp(&area_b)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    })
-                    .map(|(i, _)| i);
-                if let Some(idx) = target_idx {
-                    sub_faces[idx].inner_wires.push(hole.clone());
-                }
+            // Fallback path: degenerate sample OR no sub-face contained the
+            // probe point. Attach to the largest sub-face so the geometry is
+            // preserved.
+            let reason = if hole_pts.len() < 3 {
+                "produced a degenerate UV sample (<3 pts)"
+            } else {
+                "did not contain-test in any sub-face"
+            };
+            log::warn!(
+                "face_splitter: hole with {} edges {reason}; attaching to largest sub-face \
+                 as fallback",
+                hole.len()
+            );
+            if let Some(idx) = largest_sub_face_idx(&sub_faces) {
+                sub_faces[idx].inner_wires.push(hole.clone());
             }
         }
     }

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -487,23 +487,56 @@ pub fn split_face_2d(
 
     // Distribute original inner wires (holes from the source face) to sub-faces.
     // Each hole is assigned to the sub-face whose outer wire contains it.
+    //
+    // Test with the hole's interior sample (a point inside the hole's enclosed
+    // area), not its first vertex — when the splitter cuts the face along a
+    // line that passes through a hole vertex, that vertex sits exactly on a
+    // sub-face boundary and `point_in_polygon_2d`'s strict ray-cast returns
+    // false for every sub-face. The earlier code logged a warning and
+    // silently dropped the hole, leaving the sub-face missing its cutout.
+    // Falling back to the largest-area sub-face when even the interior
+    // sample doesn't match keeps the geometry intact for the rare residual
+    // cases (e.g., hole straddling multiple sub-faces); a warning still fires
+    // so the case is visible.
     if !original_inner_wires.is_empty() {
         for hole in &original_inner_wires {
-            if let Some(first_pt) = hole.first().map(|e| e.start_uv) {
-                let mut assigned = false;
-                for sf in &mut sub_faces {
-                    let outer_pts = sample_wire_loop_uv(&sf.outer_wire);
-                    if super::classify_2d::point_in_polygon_2d(first_pt, &outer_pts) {
-                        sf.inner_wires.push(hole.clone());
-                        assigned = true;
-                        break;
-                    }
+            let hole_pts = sample_wire_loop_uv(hole);
+            if hole_pts.len() < 3 {
+                continue;
+            }
+            let probe = super::classify_2d::sample_interior_point(&hole_pts);
+            let mut assigned = false;
+            for sf in &mut sub_faces {
+                let outer_pts = sample_wire_loop_uv(&sf.outer_wire);
+                if super::classify_2d::point_in_polygon_2d(probe, &outer_pts) {
+                    sf.inner_wires.push(hole.clone());
+                    assigned = true;
+                    break;
                 }
-                if !assigned {
-                    log::warn!(
-                        "face_splitter: hole with {} edges could not be assigned to any sub-face",
-                        hole.len()
-                    );
+            }
+            if !assigned {
+                log::warn!(
+                    "face_splitter: hole with {} edges did not contain-test in any \
+                     sub-face; attaching to largest sub-face as fallback",
+                    hole.len()
+                );
+                let target_idx = sub_faces
+                    .iter()
+                    .enumerate()
+                    .max_by(|(_, a), (_, b)| {
+                        let area_a =
+                            super::classify_2d::signed_area_2d(&sample_wire_loop_uv(&a.outer_wire))
+                                .abs();
+                        let area_b =
+                            super::classify_2d::signed_area_2d(&sample_wire_loop_uv(&b.outer_wire))
+                                .abs();
+                        area_a
+                            .partial_cmp(&area_b)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    })
+                    .map(|(i, _)| i);
+                if let Some(idx) = target_idx {
+                    sub_faces[idx].inner_wires.push(hole.clone());
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fix for the \`face_splitter: hole with 8 edges could not be assigned to any sub-face\` warning surfaced by PR #701's diagnostic logging. The face splitter was silently dropping holes whose first vertex landed on a sub-face boundary after splitting — geometry was lost without an error.

## Bug

The "original holes" distribution loop in \`split_face_2d\` tested only the hole's first vertex against each sub-face's outer polygon. When the splitter cuts the face along a line that passes through a hole vertex (common at split intersections), that vertex sits exactly on a sub-face boundary and \`point_in_polygon_2d\`'s strict ray-cast returns false for every sub-face. The hole was logged and dropped — the sub-face ended up without its cutout, producing wrong topology downstream.

The "new holes" loop just above had a fallback (\`sub_faces.first_mut().inner_wires.push(hole)\`); the "original holes" loop forgot it.

## Fix

Two changes:

1. **Test the hole's interior sample** (\`sample_interior_point\` of the hole's UV polygon) instead of its first vertex. A point inside the hole's enclosed area is robust against split lines passing through the hole's boundary vertices.

2. **Fall back to the largest-area sub-face** when even the interior sample doesn't match (rare: hole straddling multiple sub-faces, numerical edge case). A warning still fires for visibility, but the hole is preserved instead of dropped.

## Impact

End-to-end against the dovetail consumer test:

- Warning changes from \`could not be assigned to any sub-face\` to \`did not contain-test in any sub-face; attaching to largest sub-face as fallback\` — the hole is preserved.
- NM-edge counts shift slightly: 20→21 (5×4 middle), 10→12 (4×4 interior), 6→6 (5×4 inverted). This is the expected cost of converting silent data loss into visible (and topologically faithful) output — the previously-dropped hole now contributes geometry that downstream passes have to deal with.

The proper next step is to **split the straddling hole at the cut line** so it can be distributed across sub-faces correctly, but that's a deeper refactor; this PR is the immediate "stop silently dropping geometry" fix.

## Verification

- [x] 603 ops tests pass, full workspace clean (0 regressions)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`./scripts/check-boundaries.sh\` — clean
- [x] End-to-end consumer test confirms the fallback fires once (matches the single original warning)

## Test plan

- [ ] CI passes
- [ ] No regression in volume / face-count assertions in other ops tests