### PR TITLE
fix(operations): planarity-aware tessellation-artifact dedup in mesh_boolean (#696)

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -1697,7 +1697,22 @@ fn mesh_boolean_fallback(
     let mesh_a = crate::tessellate::tessellate_solid(topo, a, deflection)?;
     let mesh_b = crate::tessellate::tessellate_solid(topo, b, deflection)?;
 
-    let mb_result = crate::mesh_boolean::mesh_boolean(&mesh_a, &mesh_b, op, tol.linear)?;
+    // Compute per-triangle "is on a planar face" flags by matching each
+    // triangle's centroid + normal against the input solid's planar
+    // face equations. Used by mesh_boolean to drop tessellation-diagonal
+    // artifacts on planar faces while keeping load-bearing intermediates
+    // on curved surfaces (issue #696).
+    let planar_a = infer_planar_triangle_flags(topo, a, &mesh_a, tol);
+    let planar_b = infer_planar_triangle_flags(topo, b, &mesh_b, tol);
+
+    let mb_result = crate::mesh_boolean::mesh_boolean_with_metadata(
+        &mesh_a,
+        Some(&planar_a),
+        &mesh_b,
+        Some(&planar_b),
+        op,
+        tol.linear,
+    )?;
     let face_specs = mesh_result_to_face_specs(&mb_result);
     if face_specs.is_empty() {
         return Err(crate::OperationsError::EmptyResult {
@@ -1719,6 +1734,82 @@ fn mesh_boolean_fallback(
         face_specs.len()
     );
     Ok(result)
+}
+
+/// For each triangle in `mesh`, return `true` iff the triangle is coplanar
+/// with one of `solid`'s planar topology faces. Used by mesh_boolean to
+/// gate the collinear-midpoint drop (issue #696): the drop is safe only
+/// for triangles on planar input faces, where the dropped intermediate is
+/// a tessellation diagonal artifact rather than a load-bearing tessellation
+/// vertex.
+///
+/// Matching criterion: triangle's face normal aligns with the topology
+/// plane's normal AND the triangle centroid lies on the plane within
+/// linear tolerance. Triangles whose source is curved (cylinder, sphere,
+/// NURBS, etc.) won't match any planar face and get `false`.
+fn infer_planar_triangle_flags(
+    topo: &Topology,
+    solid: SolidId,
+    mesh: &crate::tessellate::TriangleMesh,
+    tol: brepkit_math::tolerance::Tolerance,
+) -> Vec<bool> {
+    let tri_count = mesh.indices.len() / 3;
+    let mut flags = vec![false; tri_count];
+
+    // Collect planar topology faces with their plane equations. Empty
+    // collection ⇒ all flags stay false (boolean falls back to baseline
+    // behavior).
+    let mut planes: Vec<(brepkit_math::vec::Vec3, f64)> = Vec::new();
+    if let Ok(face_ids) = brepkit_topology::explorer::solid_faces(topo, solid) {
+        for fid in face_ids {
+            if let Ok(face) = topo.face(fid) {
+                if let brepkit_topology::face::FaceSurface::Plane { normal, d } = face.surface() {
+                    planes.push((*normal, *d));
+                }
+            }
+        }
+    }
+    if planes.is_empty() {
+        return flags;
+    }
+
+    let lin_tol = tol.linear;
+    let ang_tol = tol.angular.max(1e-9);
+
+    for t in 0..tri_count {
+        let i0 = mesh.indices[t * 3] as usize;
+        let i1 = mesh.indices[t * 3 + 1] as usize;
+        let i2 = mesh.indices[t * 3 + 2] as usize;
+        let v0 = mesh.positions[i0];
+        let v1 = mesh.positions[i1];
+        let v2 = mesh.positions[i2];
+        let face_normal = (v1 - v0).cross(v2 - v0);
+        let fn_len = face_normal.dot(face_normal).sqrt();
+        if fn_len < lin_tol {
+            continue; // degenerate triangle
+        }
+        let unit = face_normal * (1.0 / fn_len);
+        let centroid_x = (v0.x() + v1.x() + v2.x()) / 3.0;
+        let centroid_y = (v0.y() + v1.y() + v2.y()) / 3.0;
+        let centroid_z = (v0.z() + v1.z() + v2.z()) / 3.0;
+        for &(plane_normal, d) in &planes {
+            // Normals parallel (within angular tolerance, either direction).
+            let cos = plane_normal.dot(unit);
+            if cos.abs() < 1.0 - ang_tol {
+                continue;
+            }
+            // Centroid on plane: |n·c - d| ≤ lin_tol.
+            let dist = plane_normal.x() * centroid_x
+                + plane_normal.y() * centroid_y
+                + plane_normal.z() * centroid_z
+                - d;
+            if dist.abs() <= lin_tol.max(fn_len * 1e-6) {
+                flags[t] = true;
+                break;
+            }
+        }
+    }
+    flags
 }
 
 /// Convert a mesh boolean result into `FaceSpec` entries for solid assembly.

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -1756,15 +1756,21 @@ fn infer_planar_triangle_flags(
     let tri_count = mesh.indices.len() / 3;
     let mut flags = vec![false; tri_count];
 
-    // Collect planar topology faces with their plane equations. Empty
-    // collection ⇒ all flags stay false (boolean falls back to baseline
-    // behavior).
+    // Collect planar topology faces with their plane equations, normalized
+    // to unit normals so the comparisons below can use exact cos thresholds
+    // and point-on-plane distances. `validate_solid_relaxed_with_options`
+    // allows non-unit normals in the topology, so we can't assume the
+    // stored `normal` has magnitude 1 — divide through here. Empty
+    // collection ⇒ all flags stay false (boolean falls back to baseline).
     let mut planes: Vec<(brepkit_math::vec::Vec3, f64)> = Vec::new();
     if let Ok(face_ids) = brepkit_topology::explorer::solid_faces(topo, solid) {
         for fid in face_ids {
             if let Ok(face) = topo.face(fid) {
                 if let brepkit_topology::face::FaceSurface::Plane { normal, d } = face.surface() {
-                    planes.push((*normal, *d));
+                    let len = normal.dot(*normal).sqrt();
+                    if len > tol.linear {
+                        planes.push((*normal * (1.0 / len), *d / len));
+                    }
                 }
             }
         }
@@ -1775,6 +1781,10 @@ fn infer_planar_triangle_flags(
 
     let lin_tol = tol.linear;
     let ang_tol = tol.angular.max(1e-9);
+    // Degenerate-area threshold: the cross-product magnitude is parallelogram
+    // area (length²), so compare against length² to match dimensions. A
+    // triangle with edge length below `lin_tol` has area below `lin_tol²`.
+    let degen_area_sq = lin_tol * lin_tol;
 
     for t in 0..tri_count {
         let i0 = mesh.indices[t * 3] as usize;
@@ -1784,26 +1794,29 @@ fn infer_planar_triangle_flags(
         let v1 = mesh.positions[i1];
         let v2 = mesh.positions[i2];
         let face_normal = (v1 - v0).cross(v2 - v0);
-        let fn_len = face_normal.dot(face_normal).sqrt();
-        if fn_len < lin_tol {
-            continue; // degenerate triangle
+        let area_sq = face_normal.dot(face_normal);
+        if area_sq < degen_area_sq {
+            continue; // degenerate triangle: no reliable normal direction.
         }
+        let fn_len = area_sq.sqrt();
         let unit = face_normal * (1.0 / fn_len);
         let centroid_x = (v0.x() + v1.x() + v2.x()) / 3.0;
         let centroid_y = (v0.y() + v1.y() + v2.y()) / 3.0;
         let centroid_z = (v0.z() + v1.z() + v2.z()) / 3.0;
         for &(plane_normal, d) in &planes {
             // Normals parallel (within angular tolerance, either direction).
+            // Plane normal is unit-normalized above.
             let cos = plane_normal.dot(unit);
             if cos.abs() < 1.0 - ang_tol {
                 continue;
             }
-            // Centroid on plane: |n·c - d| ≤ lin_tol.
+            // Centroid on plane: |n·c - d| ≤ lin_tol (both n and d are
+            // unit-normalized, so this is the true point-to-plane distance).
             let dist = plane_normal.x() * centroid_x
                 + plane_normal.y() * centroid_y
                 + plane_normal.z() * centroid_z
                 - d;
-            if dist.abs() <= lin_tol.max(fn_len * 1e-6) {
+            if dist.abs() <= lin_tol {
                 flags[t] = true;
                 break;
             }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -3438,7 +3438,6 @@ fn n_iteration_repro_dovetail_pipeline_issue_696() {
 /// If this passes, the dovetail bug should mostly resolve since the rest
 /// of the pipeline depends on each boolean being clean.
 #[test]
-#[ignore = "diagnostic — currently fails; minimal repro for #696"]
 fn minimal_box_cut_pocket_should_be_manifold() {
     use brepkit_math::mat::Mat4;
 
@@ -3465,9 +3464,10 @@ fn minimal_box_cut_pocket_should_be_manifold() {
 
     eprintln!("box - pocket: F={f} E={e} V={v} Euler={euler} NM={nm} boundary={bd}");
 
-    // The single-pocket cut should produce a closed manifold solid.
-    // Expected: F=11, E=24, V=16, Euler=2, NM=0, boundary=0.
-    assert_eq!(euler, 2, "Euler should be 2, got {euler}");
+    // Manifoldness: every edge shared by exactly 2 faces. Euler = 2 + L
+    // (where L is the inner-loop count) — one blind pocket gives L=1, so
+    // Euler == 3 is the correct invariant here. Edge-incidence counts
+    // are the right thing to assert.
     assert_eq!(nm, 0, "result should have 0 non-manifold edges, got {nm}");
     assert_eq!(bd, 0, "result should have 0 boundary edges, got {bd}");
 }

--- a/crates/operations/src/mesh_boolean.rs
+++ b/crates/operations/src/mesh_boolean.rs
@@ -105,10 +105,8 @@ pub fn mesh_boolean_with_metadata(
     let intersections = compute_all_intersections(mesh_a, mesh_b, &pairs, tolerance);
 
     // Step 3: Split meshes by intersection edges
-    let split_a =
-        split_mesh_by_intersections(mesh_a, mesh_b, planar_a, &intersections, true, tolerance);
-    let split_b =
-        split_mesh_by_intersections(mesh_b, mesh_a, planar_b, &intersections, false, tolerance);
+    let split_a = split_mesh_by_intersections(mesh_a, planar_a, &intersections, true, tolerance);
+    let split_b = split_mesh_by_intersections(mesh_b, planar_b, &intersections, false, tolerance);
 
     // Step 4: Classify sub-triangles
     let classify_a = classify_triangles(&split_a, mesh_b, tolerance);
@@ -666,7 +664,6 @@ struct SplitMesh {
 #[allow(clippy::too_many_lines)]
 fn split_mesh_by_intersections(
     mesh: &TriangleMesh,
-    other_mesh: &TriangleMesh,
     planar: Option<&[bool]>,
     intersections: &[TriTriIntersection],
     is_mesh_a: bool,
@@ -735,8 +732,6 @@ fn split_mesh_by_intersections(
             if this_planar && !any_coplanar {
                 drop_collinear_midpoints(&mut insert_pts, tolerance);
             }
-            // Reserved for future cross-mesh planarity checks.
-            let _ = other_mesh;
 
             // Split the triangle by inserting these points.
             let sub_tris = split_triangle_by_points(v0, v1, v2, &insert_pts, tolerance);
@@ -782,6 +777,16 @@ fn split_mesh_by_intersections(
 /// Callers gate this by the host triangle's planarity flag: for curved
 /// inputs (cylinder, sphere), the intermediates are load-bearing
 /// tessellation vertices and dropping them creates T-junctions.
+///
+/// Algorithmically O(n³) over candidate points. A naïve O(n²) version
+/// using the extreme pair was tried and rejected — when a triangle is
+/// crossed by intersection segments along multiple distinct lines (e.g.,
+/// a planar face cut by all four sides of a rectangular hole), the
+/// extreme pair only captures one diagonal and misses the per-side
+/// midpoints. The triple loop scans every collinear triple, so each
+/// intersection line's midpoints are caught regardless of orientation.
+/// In practice n is 2–8 (one segment endpoint per intersecting opposing-
+/// mesh triangle), so the cubic bound stays cheap.
 fn drop_collinear_midpoints(pts: &mut Vec<Point3>, tolerance: f64) {
     if pts.len() < 3 {
         return;

--- a/crates/operations/src/mesh_boolean.rs
+++ b/crates/operations/src/mesh_boolean.rs
@@ -47,6 +47,56 @@ pub fn mesh_boolean(
     op: BooleanOp,
     tolerance: f64,
 ) -> Result<MeshBooleanResult, OperationsError> {
+    mesh_boolean_with_metadata(mesh_a, None, mesh_b, None, op, tolerance)
+}
+
+/// Like [`mesh_boolean`] but accepts optional per-triangle planarity
+/// metadata (issue #696).
+///
+/// `planar_a`/`planar_b`, when provided, contain one `bool` per triangle
+/// in the corresponding input mesh; `true` means the triangle lies on a
+/// planar input face. The splitter uses these flags to drop collinear
+/// midpoints introduced by tessellation-diagonal-vs-plane intersections
+/// (planar-face tessellation artifacts) while leaving curved-surface
+/// intersections untouched. Passing `None` for both is equivalent to
+/// calling [`mesh_boolean`].
+///
+/// # Errors
+/// Returns an error if the operation cannot be completed (e.g. the
+/// intersection of disjoint meshes is empty), or if a planarity slice
+/// length doesn't match the corresponding mesh's triangle count.
+#[allow(clippy::too_many_lines)]
+pub fn mesh_boolean_with_metadata(
+    mesh_a: &TriangleMesh,
+    planar_a: Option<&[bool]>,
+    mesh_b: &TriangleMesh,
+    planar_b: Option<&[bool]>,
+    op: BooleanOp,
+    tolerance: f64,
+) -> Result<MeshBooleanResult, OperationsError> {
+    let tri_count_a = mesh_a.indices.len() / 3;
+    let tri_count_b = mesh_b.indices.len() / 3;
+    if let Some(p) = planar_a {
+        if p.len() != tri_count_a {
+            return Err(OperationsError::InvalidInput {
+                reason: format!(
+                    "mesh_boolean_with_metadata: planar_a length {} != triangle count {tri_count_a}",
+                    p.len()
+                ),
+            });
+        }
+    }
+    if let Some(p) = planar_b {
+        if p.len() != tri_count_b {
+            return Err(OperationsError::InvalidInput {
+                reason: format!(
+                    "mesh_boolean_with_metadata: planar_b length {} != triangle count {tri_count_b}",
+                    p.len()
+                ),
+            });
+        }
+    }
+
     // Step 1: BVH broad-phase
     let (bvh_b, _aabbs_b) = build_triangle_bvh(mesh_b);
     let pairs = find_intersecting_pairs(mesh_a, &bvh_b);
@@ -55,8 +105,10 @@ pub fn mesh_boolean(
     let intersections = compute_all_intersections(mesh_a, mesh_b, &pairs, tolerance);
 
     // Step 3: Split meshes by intersection edges
-    let split_a = split_mesh_by_intersections(mesh_a, &intersections, true, tolerance);
-    let split_b = split_mesh_by_intersections(mesh_b, &intersections, false, tolerance);
+    let split_a =
+        split_mesh_by_intersections(mesh_a, mesh_b, planar_a, &intersections, true, tolerance);
+    let split_b =
+        split_mesh_by_intersections(mesh_b, mesh_a, planar_b, &intersections, false, tolerance);
 
     // Step 4: Classify sub-triangles
     let classify_a = classify_triangles(&split_a, mesh_b, tolerance);
@@ -127,6 +179,12 @@ struct TriTriIntersection {
     tri_a: usize,
     /// Index of the triangle in mesh B.
     tri_b: usize,
+    /// `true` when the two source triangles lay in the same plane and the
+    /// intersection came from `intersect_coplanar_triangles`. The
+    /// downstream collinear-midpoint drop (issue #696) skips coplanar
+    /// segments — those intermediates are along the shared plane and
+    /// represent real cap-on-cap geometry, not tessellation artifacts.
+    from_coplanar: bool,
 }
 
 /// Compute all triangle-triangle intersections for the given candidate pairs.
@@ -244,6 +302,7 @@ fn intersect_triangles(
         p1,
         tri_a: 0,
         tri_b: 0,
+        from_coplanar: false,
     })
 }
 
@@ -344,6 +403,7 @@ fn intersect_coplanar_triangles(
         p1: best_p1,
         tri_a: 0,
         tri_b: 0,
+        from_coplanar: true,
     })
 }
 
@@ -606,20 +666,27 @@ struct SplitMesh {
 #[allow(clippy::too_many_lines)]
 fn split_mesh_by_intersections(
     mesh: &TriangleMesh,
+    other_mesh: &TriangleMesh,
+    planar: Option<&[bool]>,
     intersections: &[TriTriIntersection],
     is_mesh_a: bool,
     tolerance: f64,
 ) -> SplitMesh {
     let tri_count = mesh.indices.len() / 3;
 
-    // Group intersection segments by triangle index.
+    // Group intersection segments by triangle index. Track whether ANY of
+    // a triangle's segments came from coplanar-triangle intersections —
+    // those need special handling for the issue-#696 midpoint drop below.
     let mut tri_segments: HashMap<usize, Vec<(Point3, Point3)>> = HashMap::new();
+    let mut tri_has_coplanar_segment: HashMap<usize, bool> = HashMap::new();
     for isect in intersections {
         let tri_idx = if is_mesh_a { isect.tri_a } else { isect.tri_b };
         tri_segments
             .entry(tri_idx)
             .or_default()
             .push((isect.p0, isect.p1));
+        let entry = tri_has_coplanar_segment.entry(tri_idx).or_insert(false);
+        *entry |= isect.from_coplanar;
     }
 
     let mut positions = mesh.positions.clone();
@@ -644,6 +711,32 @@ fn split_mesh_by_intersections(
                 maybe_add_unique(&mut insert_pts, p0, tolerance);
                 maybe_add_unique(&mut insert_pts, p1, tolerance);
             }
+
+            // Drop tessellation-artifact collinear midpoints (issue #696):
+            // when this triangle is on a planar input face and the OTHER
+            // mesh has triangles whose tessellation-diagonal crosses our
+            // plane, the diagonal-vs-plane intersection appears as an
+            // extra insertion point collinear with two corner crossings.
+            // Removing it makes the split produce one straight hole edge
+            // instead of two collinear sub-edges, which is what the BREP
+            // boundary actually wants.
+            //
+            // Safety gates:
+            //   * `planar[i]` — only fires for triangles on planar input
+            //     faces. Curved surfaces (cylinder, sphere) need their
+            //     intermediates as load-bearing tessellation vertices.
+            //   * no coplanar segments — if ANY segment on this triangle
+            //     came from `intersect_coplanar_triangles`, intermediates
+            //     along it represent real cap-on-cap geometry (e.g. two
+            //     cylinder caps overlapping at z=0) and must not be
+            //     dropped.
+            let this_planar = planar.is_some_and(|p| p[i]);
+            let any_coplanar = tri_has_coplanar_segment.get(&i).copied().unwrap_or(false);
+            if this_planar && !any_coplanar {
+                drop_collinear_midpoints(&mut insert_pts, tolerance);
+            }
+            // Reserved for future cross-mesh planarity checks.
+            let _ = other_mesh;
 
             // Split the triangle by inserting these points.
             let sub_tris = split_triangle_by_points(v0, v1, v2, &insert_pts, tolerance);
@@ -673,6 +766,78 @@ fn split_mesh_by_intersections(
         normals,
         triangles,
     }
+}
+
+/// Remove points that lie strictly collinear between two other points.
+///
+/// Issue #696: when a triangle in this mesh (on a planar input face) is
+/// crossed by two triangles in the OTHER mesh that share a tessellation-
+/// diagonal edge, each contributes a segment ending at the diagonal-vs-
+/// plane crossing. That crossing is mathematically collinear with the
+/// segments' outer endpoints — it's a tessellation artifact, not a
+/// BREP topology vertex. Keeping it splits the triangle into extra
+/// collinear sub-edges that don't pair with anything on the other side,
+/// leaving boundary edges in the assembled solid.
+///
+/// Callers gate this by the host triangle's planarity flag: for curved
+/// inputs (cylinder, sphere), the intermediates are load-bearing
+/// tessellation vertices and dropping them creates T-junctions.
+fn drop_collinear_midpoints(pts: &mut Vec<Point3>, tolerance: f64) {
+    if pts.len() < 3 {
+        return;
+    }
+    let tol_sq = tolerance * tolerance;
+    let mut keep = vec![true; pts.len()];
+    for i in 0..pts.len() {
+        if !keep[i] {
+            continue;
+        }
+        for j in 0..pts.len() {
+            if !keep[j] || i == j {
+                continue;
+            }
+            for k in (j + 1)..pts.len() {
+                if !keep[k] || i == k {
+                    continue;
+                }
+                if point_strictly_between(pts[i], pts[j], pts[k], tol_sq) {
+                    keep[i] = false;
+                    break;
+                }
+            }
+            if !keep[i] {
+                break;
+            }
+        }
+    }
+    let filtered: Vec<Point3> = pts
+        .iter()
+        .copied()
+        .zip(keep.iter())
+        .filter_map(|(p, &k)| if k { Some(p) } else { None })
+        .collect();
+    *pts = filtered;
+}
+
+/// True iff `p` lies strictly between `a` and `b` on their segment
+/// (collinear, with `p` not within tolerance of either endpoint).
+fn point_strictly_between(p: Point3, a: Point3, b: Point3, tol_sq: f64) -> bool {
+    let ab = b - a;
+    let ap = p - a;
+    let ab_len_sq = ab.dot(ab);
+    if ab_len_sq < tol_sq {
+        return false;
+    }
+    // Collinearity: |cross(ab, ap)|² ≤ tol² · |ab|² ⇔ distance² ≤ tol².
+    let cross = ab.cross(ap);
+    if cross.dot(cross) > tol_sq * ab_len_sq {
+        return false;
+    }
+    // "Between": projection parameter t = (ap·ab)/|ab|² in (0, 1) with
+    // tolerance margins so endpoints don't qualify.
+    let t = ap.dot(ab) / ab_len_sq;
+    let tol_t = (tol_sq / ab_len_sq).sqrt();
+    t > tol_t && t < 1.0 - tol_t
 }
 
 /// Add a point to a list if no existing point is within tolerance.


### PR DESCRIPTION
## Summary

Closes the minimal box-pocket repro from PR #705 (single 168×168×8 slab cut by 37×37×6 pocket → 4 boundary edges before, 0 after) and moves the dovetail end-to-end NM-edge counts further down without regressing any of the existing 603 ops + 48 stress + 184 wasm tests. Builds on the threading direction from #696 issue thread.

## What

The bug: when one mesh's planar face is crossed by two triangles from the other mesh that share a tessellation-diagonal edge, each contributes an intersection segment ending at the diagonal-vs-plane crossing. That crossing is mathematically collinear with the segments' outer endpoints but isn't a real BREP vertex — purely a side-effect of the diagonalization. Keeping it splits the triangle into two collinear sub-edges that don't pair with anything on the other side, leaving boundary edges in the assembled solid.

The prior naive "drop any collinear midpoint" attempt (investigated in #696 issue thread) regressed \`fuse_two_cylinders\`: cylinder-touch-line intermediates ARE load-bearing tessellation vertices, and dropping them created T-junctions on the cylinder sides.

## How

Two safety gates make the drop selective:

1. **Per-triangle planarity flag**, computed from topology by matching each tessellated triangle's centroid + face normal against the input solid's planar face plane equations. Triangles whose source surface is curved (cylinder, sphere, NURBS) don't match any planar face and stay flagged \`false\` — their intermediates pass through.

2. **Coplanar segment guard**: when ANY intersection segment on this triangle came from \`intersect_coplanar_triangles\` (e.g. two cylinder caps overlapping at z=0), skip the drop. Coplanar intersections produce intermediates that represent real cap-on-cap geometry, not tessellation diagonals.

## API additions

- \`mesh_boolean_with_metadata(mesh_a, planar_a, mesh_b, planar_b, op, tolerance)\` accepts optional per-triangle planarity slices. \`mesh_boolean\` (unchanged signature) is now a thin wrapper that calls it with \`None\` for both — no behavior change for direct callers.
- \`TriTriIntersection\` gains a \`from_coplanar: bool\` field so the splitter can identify coplanar-source segments.
- \`infer_planar_triangle_flags(topo, solid, mesh, tol)\` (private helper in \`boolean/mod.rs\`) derives the planarity slice for a tessellated solid via face-equation matching.
- \`mesh_boolean_fallback\` computes per-mesh planarity and threads it through.

## Impact

End-to-end against gridfinity-layout-tool dovetail tests, cumulative from pre-#697:

| Scenario | main | post-#697+#699+#703 | **this PR** |
|---|---:|---:|---:|
| 5×4 middle-column | 142 | 20 | **15** |
| 4×4 interior | 73 | 10 | **4** |
| 5×4 inverted middle | — | 6 | 8 |

4×4 interior dropped significantly (10 → 4); 5×4 middle improved (20 → 15); 5×4 inverted ticked up by 2 (6 → 8) — likely points at a different residue pattern this fix doesn't address.

## Test fixup

\`minimal_box_cut_pocket_should_be_manifold\` (added \`#[ignore]\`d in #705) is un-\`#[ignore]\`d and now passes: \`F=11 E=28 V=20 Euler=3 NM=0 boundary=0\`. Its strict \`Euler == 2\` assertion was loosened to \`NM == 0 && bd == 0\` — Euler equals \`2 + inner_loop_count\` (3 here for the slab top's one inner wire), so the strict check would have failed even for a fully-correct result.

## Verification

- [x] 604 ops tests pass (was 603 + the now-enabled minimal test)
- [x] 48 boolean_stress tests pass — no regression on fuse_two_cylinders, cut_cylinder_from_cylinder, etc.
- [x] Full workspace test passes (940+ tests, zero failures)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] End-to-end gridfinity dovetail test confirms the NM reductions above

## Test plan

- [ ] CI passes
- [ ] No regression in volume / face-count assertions across the pre-existing ops tests
- [ ] Consumer integration confirms the dovetail NM reductions