### PR TITLE
feat(heal): cross-face collinear-vertex collapse pass (#696 follow-up)

### DIFF
--- a/crates/heal/src/upgrade/collapse_collinear_vertices.rs
+++ b/crates/heal/src/upgrade/collapse_collinear_vertices.rs
@@ -1,0 +1,620 @@
+//! Collapse collinear interior wire vertices that are structurally orphan
+//! across the solid.
+//!
+//! After mesh-fallback boolean assembly, adjacent faces can carry
+//! asymmetric tessellation residue at shared edges: face A's wire goes
+//! `… → P → V → Q → …` (V being a tessellation-diagonal artifact) while
+//! face B's wire jumps `… → P → Q → …` directly. Calls to
+//! `unify_faces`/`merge_collinear_edges` only smooth wires of faces that
+//! the unifier itself merged, leaving the asymmetry intact whenever the
+//! two faces remain separate topological entities.
+//!
+//! When `V` is incident to exactly two edges across the entire solid AND
+//! both are Line curves AND V is collinear strictly between P and Q,
+//! every wire that traverses V must do so as the consecutive pair
+//! (`E1`, `E2`) in some orientation. The vertex is structurally
+//! collapsible: replace the pair with a single oriented edge `E_new(P,Q)`
+//! in every wire that referenced it, reusing an existing `Edge(P,Q,Line)`
+//! when one is already present (so adjacent faces end up sharing the
+//! same `EdgeId` rather than two parallel ones, which is what downstream
+//! face-adjacency counting needs).
+//!
+//! Conservative gates: only Line curves, only when V's two neighbours
+//! are distinct, only when V is strictly between them, only when V has
+//! exactly two incident edges in the solid. Vertices that fail any gate
+//! are left untouched.
+
+use std::collections::{HashMap, HashSet};
+
+use brepkit_math::tolerance::Tolerance;
+use brepkit_topology::Topology;
+use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
+use brepkit_topology::face::{FaceId, FaceSurface};
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::vertex::VertexId;
+use brepkit_topology::wire::{OrientedEdge, Wire, WireId};
+
+use crate::HealError;
+
+/// Collapse interior wire vertices that are collinear between their two
+/// neighbours and have no other edges anchoring them.
+///
+/// Returns the number of vertices collapsed.
+///
+/// # Errors
+///
+/// Returns [`HealError`] if entity lookups fail. Best-effort: a single
+/// failure mid-pass does not abort already-applied collapses.
+pub fn collapse_collinear_wire_vertices(
+    topo: &mut Topology,
+    solid_id: SolidId,
+    tol: Tolerance,
+) -> Result<usize, HealError> {
+    // 1. Gather every (face_id, wire_id) pair in the solid. Faces hold
+    //    one outer wire plus zero-or-more inner wires (holes); both are
+    //    in scope.
+    let face_ids = brepkit_topology::explorer::solid_faces(topo, solid_id)?;
+    let mut wire_ids: Vec<WireId> = Vec::new();
+    for &fid in &face_ids {
+        let face = topo.face(fid)?;
+        wire_ids.push(face.outer_wire());
+        wire_ids.extend(face.inner_wires().iter().copied());
+    }
+    if wire_ids.is_empty() {
+        return Ok(0);
+    }
+
+    // 2. Snapshot every edge that participates in any solid wire, indexed
+    //    by EdgeId so vertex→edge counting below stays O(unique edges)
+    //    rather than O(sum of wire lengths). Edges that appear in 2 wires
+    //    (a healthy manifold edge) only count once toward vertex incidence.
+    //    Also record which faces reference each edge so the planarity gate
+    //    below can confirm every face touching V is planar before collapse.
+    let mut edges_in_solid: HashMap<EdgeId, (VertexId, VertexId)> = HashMap::new();
+    let mut edge_to_faces: HashMap<EdgeId, HashSet<FaceId>> = HashMap::new();
+    for &fid in &face_ids {
+        let face = topo.face(fid)?;
+        let mut all_wires: Vec<WireId> = vec![face.outer_wire()];
+        all_wires.extend(face.inner_wires().iter().copied());
+        for wid in all_wires {
+            let wire = topo.wire(wid)?;
+            for oe in wire.edges() {
+                let eid = oe.edge();
+                if let std::collections::hash_map::Entry::Vacant(slot) = edges_in_solid.entry(eid) {
+                    let edge = topo.edge(eid)?;
+                    slot.insert((edge.start(), edge.end()));
+                }
+                edge_to_faces.entry(eid).or_default().insert(fid);
+            }
+        }
+    }
+
+    // 3. Build vertex → incident-edges map from the snapshot.
+    let mut vertex_edges: HashMap<VertexId, Vec<EdgeId>> = HashMap::new();
+    for (&eid, &(start, end)) in &edges_in_solid {
+        vertex_edges.entry(start).or_default().push(eid);
+        if end != start {
+            vertex_edges.entry(end).or_default().push(eid);
+        }
+    }
+
+    // 4. Identify candidate vertices: exactly two incident edges, both
+    //    Lines, and the vertex strictly between the two far endpoints.
+    let lin_tol = tol.linear.max(1e-12);
+    let lin_tol_sq = lin_tol * lin_tol;
+
+    let mut plans: Vec<CollapsePlan> = Vec::new();
+    // Track which existing edges we've already reused so a chain of
+    // collinear vertices on the same line doesn't all try to claim
+    // overlapping P→Q edges that the prior plan already consumed.
+    // (Rare in practice — guard via per-iteration topology reads.)
+    for (&vertex, incident) in &vertex_edges {
+        if incident.len() != 2 {
+            continue;
+        }
+        let eid1 = incident[0];
+        let eid2 = incident[1];
+        let edge1 = topo.edge(eid1)?;
+        let edge2 = topo.edge(eid2)?;
+        if !matches!(edge1.curve(), EdgeCurve::Line) || !matches!(edge2.curve(), EdgeCurve::Line) {
+            continue;
+        }
+        // Determine the far endpoints P and Q (the non-V end of each edge).
+        let p_vid = if edge1.start() == vertex {
+            edge1.end()
+        } else if edge1.end() == vertex {
+            edge1.start()
+        } else {
+            continue; // V not actually on edge1 — defensive
+        };
+        let q_vid = if edge2.start() == vertex {
+            edge2.end()
+        } else if edge2.end() == vertex {
+            edge2.start()
+        } else {
+            continue;
+        };
+        if p_vid == q_vid || p_vid == vertex || q_vid == vertex {
+            continue;
+        }
+        // Topological gate: E1 and E2 must be shared by the same face set.
+        // Anything else means V's two-edge pair has inconsistent
+        // membership and collapsing it would re-asymmetrize the wires.
+        //
+        //   * 2 faces — "symmetric" case, both faces register V on their
+        //     wire. Common when mesh fallback splits the same chord on
+        //     both sides; coplanar pair required so the chord doesn't
+        //     diverge from the underlying geometry on either side.
+        //   * 1 face — "asymmetric residue" case (#696), only one face
+        //     carries V; the neighbour already references a direct P→Q
+        //     edge via a separate `EdgeId`. Re-unifying onto that edge
+        //     requires it to exist and to live on a face that is
+        //     coplanar with — or perpendicular to (a different planar
+        //     face altogether) — the V-bearing face. We check this
+        //     after the planarity pass below.
+        let faces_e1 = edge_to_faces.get(&eid1).cloned().unwrap_or_default();
+        let faces_e2 = edge_to_faces.get(&eid2).cloned().unwrap_or_default();
+        if faces_e1 != faces_e2 || !(1..=2).contains(&faces_e1.len()) {
+            continue;
+        }
+
+        // Planarity gate: a vertex on a chord between curved-surface samples
+        // is load-bearing for the curved face's tessellation — removing it
+        // breaks watertightness against the adjacent face. Only collapse
+        // when both faces are coplanar (planes match in normal direction
+        // and offset) so the chord and the underlying surface coincide.
+        let ang_tol_cos = (1.0 - tol.angular).max(1.0 - 1e-9);
+        let mut plane_ref: Option<(brepkit_math::vec::Vec3, f64)> = None;
+        let mut all_planar = true;
+        for &fid in &faces_e1 {
+            let face = topo.face(fid)?;
+            let FaceSurface::Plane { normal, d } = face.surface() else {
+                all_planar = false;
+                break;
+            };
+            let n_len = normal.dot(*normal).sqrt();
+            if n_len < tol.linear {
+                all_planar = false;
+                break;
+            }
+            let n_unit = *normal * (1.0 / n_len);
+            let d_norm = *d / n_len;
+            if let Some((prev_n, prev_d)) = plane_ref {
+                let dot = prev_n.dot(n_unit).abs();
+                if dot < ang_tol_cos {
+                    all_planar = false;
+                    break;
+                }
+                let signed_d = if prev_n.dot(n_unit) >= 0.0 {
+                    d_norm
+                } else {
+                    -d_norm
+                };
+                if (signed_d - prev_d).abs() > tol.linear {
+                    all_planar = false;
+                    break;
+                }
+            } else {
+                plane_ref = Some((n_unit, d_norm));
+            }
+        }
+        if !all_planar {
+            continue;
+        }
+
+        // Strict-between collinearity check in 3D.
+        let v_pt = topo.vertex(vertex)?.point();
+        let p_pt = topo.vertex(p_vid)?.point();
+        let q_pt = topo.vertex(q_vid)?.point();
+        let pq = q_pt - p_pt;
+        let pq_len_sq = pq.dot(pq);
+        if pq_len_sq < lin_tol_sq {
+            continue; // P and Q coincident
+        }
+        let pv = v_pt - p_pt;
+        let t = pv.dot(pq) / pq_len_sq;
+        // Strictly between: 0 < t < 1, with a tolerance margin so end
+        // collisions don't masquerade as interior.
+        if t <= lin_tol || t >= 1.0 - lin_tol {
+            continue;
+        }
+        // Perpendicular distance from V to line PQ, scaled by pq length.
+        let projection = p_pt + pq * t;
+        let perp = v_pt - projection;
+        if perp.dot(perp) > lin_tol_sq {
+            continue;
+        }
+
+        // Find-or-create the merged edge so the two faces keep
+        // referencing the same `EdgeId` after the collapse. For the
+        // asymmetric (size-1) case, *require* an existing direct edge
+        // on a face the V-bearing face isn't using — otherwise we'd be
+        // either creating an orphan edge (no benefit) or unifying a
+        // face with itself.
+        let existing = find_line_edge(topo, p_vid, q_vid);
+        let new_edge = match (existing, faces_e1.len()) {
+            (Some(eid), _) => {
+                // Check the existing edge is on a face NOT in faces_e1.
+                let neighbour_faces = edge_to_faces.get(&eid).cloned().unwrap_or_default();
+                if neighbour_faces.is_subset(&faces_e1) {
+                    // No genuine "other side" to re-unify onto.
+                    continue;
+                }
+                eid
+            }
+            (None, 2) => topo.add_edge(Edge::new(p_vid, q_vid, EdgeCurve::Line)),
+            (None, _) => continue,
+        };
+        if new_edge == eid1 || new_edge == eid2 {
+            continue; // Defensive — should not match the V-touching edges
+        }
+        plans.push(CollapsePlan {
+            vertex,
+            old_edges: [eid1, eid2],
+            new_edge,
+        });
+    }
+
+    if plans.is_empty() {
+        return Ok(0);
+    }
+
+    // 5. Apply plans: for each wire, scan for consecutive edges that match
+    //    a (V, E1, E2) pair and rewrite the oriented-edge list. A wire's
+    //    edge list shrinks by 1 for each match; rebuild via `Wire::new`
+    //    + `*wire_mut = new_wire` (matches `merge_collinear_edges` pattern
+    //    in `unify_same_domain`).
+    let plan_by_vertex: HashMap<VertexId, &CollapsePlan> =
+        plans.iter().map(|p| (p.vertex, p)).collect();
+
+    let mut applied: usize = 0;
+    // Track which vertices were actually consumed by at least one wire
+    // rewrite — the plan-vertex count is the upper bound, but a vertex
+    // unreachable from any wire (orphaned by a prior pass) shouldn't
+    // count as "collapsed".
+    let mut consumed: std::collections::HashSet<VertexId> = std::collections::HashSet::new();
+
+    for &wid in &wire_ids {
+        let new_edges_opt = try_rewrite_wire(topo, wid, &plan_by_vertex, &mut consumed)?;
+        if let Some(new_edges) = new_edges_opt {
+            let is_closed = topo.wire(wid)?.is_closed();
+            match Wire::new(new_edges, is_closed) {
+                Ok(new_wire) => {
+                    let wire_mut = topo.wire_mut(wid)?;
+                    *wire_mut = new_wire;
+                }
+                Err(e) => {
+                    log::warn!(
+                        "collapse_collinear_wire_vertices: skipped wire {wid:?} \
+                         after rewrite — {e}"
+                    );
+                }
+            }
+        }
+    }
+    applied += consumed.len();
+
+    Ok(applied)
+}
+
+/// Find an existing `Line` edge whose endpoints are `{a, b}` (in either
+/// order), or create one. Reuse keeps neighbouring faces on the same
+/// `EdgeId`; creation handles the case where no face already carried the
+/// short-circuit edge.
+fn find_line_edge(topo: &Topology, a: VertexId, b: VertexId) -> Option<EdgeId> {
+    for (eid, edge) in topo.edges().iter() {
+        if !matches!(edge.curve(), EdgeCurve::Line) {
+            continue;
+        }
+        let (s, e) = (edge.start(), edge.end());
+        if (s == a && e == b) || (s == b && e == a) {
+            return Some(eid);
+        }
+    }
+    None
+}
+
+/// Walk `wire`'s edges; whenever two consecutive edges touch a plan's
+/// vertex with both plan edges accounted for, emit a single oriented
+/// edge for the plan's `new_edge` and skip ahead. Returns `None` if the
+/// wire is unchanged (avoids reallocating untouched wires).
+fn try_rewrite_wire(
+    topo: &Topology,
+    wid: WireId,
+    plans: &HashMap<VertexId, &CollapsePlan>,
+    consumed: &mut std::collections::HashSet<VertexId>,
+) -> Result<Option<Vec<OrientedEdge>>, HealError> {
+    let wire = topo.wire(wid)?;
+    let edges = wire.edges();
+    let n = edges.len();
+    if n < 2 {
+        return Ok(None);
+    }
+    let mut rewritten: Vec<OrientedEdge> = Vec::with_capacity(n);
+    let mut changed = false;
+    let mut i = 0;
+    while i < n {
+        // Try to pair edges[i] with edges[(i+1) % n] across a plan vertex.
+        let next_idx = if i + 1 < n {
+            i + 1
+        } else if wire.is_closed() && n > 1 {
+            0
+        } else {
+            // Open wire, last edge — no pair to consider.
+            rewritten.push(edges[i]);
+            i += 1;
+            continue;
+        };
+
+        let oe_cur = edges[i];
+        let oe_next = edges[next_idx];
+        let edge_cur = topo.edge(oe_cur.edge())?;
+        let edge_next = topo.edge(oe_next.edge())?;
+
+        let end_v = oe_cur.oriented_end(edge_cur);
+        let start_v_next = oe_next.oriented_start(edge_next);
+        if end_v != start_v_next {
+            rewritten.push(oe_cur);
+            i += 1;
+            continue;
+        }
+
+        let Some(plan) = plans.get(&end_v) else {
+            rewritten.push(oe_cur);
+            i += 1;
+            continue;
+        };
+
+        // Verify both wire edges are this plan's old edges (either order).
+        let cur_eid = oe_cur.edge();
+        let nxt_eid = oe_next.edge();
+        let matches_plan = (cur_eid == plan.old_edges[0] && nxt_eid == plan.old_edges[1])
+            || (cur_eid == plan.old_edges[1] && nxt_eid == plan.old_edges[0]);
+        if !matches_plan {
+            rewritten.push(oe_cur);
+            i += 1;
+            continue;
+        }
+
+        // Determine orientation: the merged oriented edge should run
+        // from oe_cur.oriented_start(...) to oe_next.oriented_end(...).
+        let start_v = oe_cur.oriented_start(edge_cur);
+        let final_v = oe_next.oriented_end(edge_next);
+        let new_edge = topo.edge(plan.new_edge)?;
+        let forward = if new_edge.start() == start_v && new_edge.end() == final_v {
+            true
+        } else if new_edge.start() == final_v && new_edge.end() == start_v {
+            false
+        } else {
+            // Shouldn't happen — the new edge was created or found with
+            // endpoints {P, Q}. If it somehow doesn't match, bail on this
+            // pair rather than corrupt the wire.
+            rewritten.push(oe_cur);
+            i += 1;
+            continue;
+        };
+
+        rewritten.push(OrientedEdge::new(plan.new_edge, forward));
+        changed = true;
+        consumed.insert(end_v);
+        // Skip the consumed pair. For closed-wire wrap (next_idx == 0),
+        // we must avoid re-processing edges[0] later; mark by jumping
+        // past the array.
+        if next_idx == 0 {
+            // Replace the first emitted edge (which was the previous
+            // edges[0]) by removing the trailing position. Closed-wrap
+            // case is rare and benign — break out.
+            // Pop the previously-pushed first edge so we don't double-count.
+            // Actually since we emitted starting from i=0 normally, when
+            // we wrap, the consumed pair is (edges[n-1], edges[0]); we
+            // emit the new merged edge here and need to drop the first
+            // entry of `rewritten` (which was edges[0]).
+            if !rewritten.is_empty() {
+                rewritten.remove(0);
+            }
+            break;
+        }
+        i += 2;
+    }
+
+    Ok(if changed { Some(rewritten) } else { None })
+}
+
+struct CollapsePlan {
+    vertex: VertexId,
+    old_edges: [EdgeId; 2],
+    new_edge: EdgeId,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use brepkit_math::vec::{Point3, Vec3};
+    use brepkit_topology::Topology;
+    use brepkit_topology::edge::{Edge, EdgeCurve};
+    use brepkit_topology::face::{Face, FaceId, FaceSurface};
+    use brepkit_topology::shell::Shell;
+    use brepkit_topology::solid::Solid;
+    use brepkit_topology::vertex::Vertex;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    use super::*;
+
+    fn vertex(topo: &mut Topology, p: Point3) -> VertexId {
+        topo.add_vertex(Vertex::new(p, 1e-7))
+    }
+
+    /// Build a face whose outer wire is a 4-edge polyline A→V→B→…→A
+    /// where `v` is collinear-strictly-between `a` and `b`.
+    fn face_with_split_edge(
+        topo: &mut Topology,
+        a: VertexId,
+        v: VertexId,
+        b: VertexId,
+        c: VertexId,
+    ) -> FaceId {
+        let e_av = topo.add_edge(Edge::new(a, v, EdgeCurve::Line));
+        let e_vb = topo.add_edge(Edge::new(v, b, EdgeCurve::Line));
+        let e_bc = topo.add_edge(Edge::new(b, c, EdgeCurve::Line));
+        let e_ca = topo.add_edge(Edge::new(c, a, EdgeCurve::Line));
+        let wire = topo.add_wire(
+            Wire::new(
+                vec![
+                    OrientedEdge::new(e_av, true),
+                    OrientedEdge::new(e_vb, true),
+                    OrientedEdge::new(e_bc, true),
+                    OrientedEdge::new(e_ca, true),
+                ],
+                true,
+            )
+            .unwrap(),
+        );
+        let surface = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+        topo.add_face(Face::new(wire, Vec::new(), surface))
+    }
+
+    fn wrap_in_solid(topo: &mut Topology, faces: Vec<FaceId>) -> SolidId {
+        let shell = topo.add_shell(Shell::new(faces).unwrap());
+        topo.add_solid(Solid::new(shell, Vec::new()))
+    }
+
+    #[test]
+    fn vertex_strictly_between_collapses() {
+        // Two coplanar faces share the chord A-V-B. The chord vertex V
+        // sits collinearly between A and B; both faces have wire
+        // A→V→B→{C or D}→A. Edges E1=(A,V) and E2=(V,B) are shared by
+        // BOTH faces (the symmetric / structurally-collapsible case).
+        let mut topo = Topology::new();
+        let a = vertex(&mut topo, Point3::new(0.0, 0.0, 0.0));
+        let b = vertex(&mut topo, Point3::new(2.0, 0.0, 0.0));
+        let v = vertex(&mut topo, Point3::new(1.0, 0.0, 0.0));
+        let c = vertex(&mut topo, Point3::new(0.0, -1.0, 0.0));
+        let d = vertex(&mut topo, Point3::new(2.0, 1.0, 0.0));
+
+        // Shared edges across both faces.
+        let e_av = topo.add_edge(Edge::new(a, v, EdgeCurve::Line));
+        let e_vb = topo.add_edge(Edge::new(v, b, EdgeCurve::Line));
+
+        let surface = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+
+        // Face 1: A→V→B→D→A (uses shared e_av, e_vb)
+        let e_bd = topo.add_edge(Edge::new(b, d, EdgeCurve::Line));
+        let e_da = topo.add_edge(Edge::new(d, a, EdgeCurve::Line));
+        let wire1 = topo.add_wire(
+            Wire::new(
+                vec![
+                    OrientedEdge::new(e_av, true),
+                    OrientedEdge::new(e_vb, true),
+                    OrientedEdge::new(e_bd, true),
+                    OrientedEdge::new(e_da, true),
+                ],
+                true,
+            )
+            .unwrap(),
+        );
+        let f1 = topo.add_face(Face::new(wire1, Vec::new(), surface.clone()));
+
+        // Face 2: B→V→A→C→B (reverse traversal of e_vb, e_av; uses shared edges)
+        let e_ac = topo.add_edge(Edge::new(a, c, EdgeCurve::Line));
+        let e_cb = topo.add_edge(Edge::new(c, b, EdgeCurve::Line));
+        let wire2 = topo.add_wire(
+            Wire::new(
+                vec![
+                    OrientedEdge::new(e_vb, false),
+                    OrientedEdge::new(e_av, false),
+                    OrientedEdge::new(e_ac, true),
+                    OrientedEdge::new(e_cb, true),
+                ],
+                true,
+            )
+            .unwrap(),
+        );
+        let f2 = topo.add_face(Face::new(wire2, Vec::new(), surface));
+
+        let solid = wrap_in_solid(&mut topo, vec![f1, f2]);
+
+        let collapsed =
+            collapse_collinear_wire_vertices(&mut topo, solid, Tolerance::new()).unwrap();
+        assert_eq!(
+            collapsed, 1,
+            "single shared interior vertex should collapse"
+        );
+
+        // Both wires should now be 3 edges (was 4) and both should
+        // reference the same merged A↔B edge (find_or_create_line_edge
+        // creates one and reuses it for the second wire).
+        let w1 = topo.wire(topo.face(f1).unwrap().outer_wire()).unwrap();
+        let w2 = topo.wire(topo.face(f2).unwrap().outer_wire()).unwrap();
+        assert_eq!(w1.edges().len(), 3);
+        assert_eq!(w2.edges().len(), 3);
+        assert_eq!(
+            w1.edges()[0].edge(),
+            w2.edges()[0].edge(),
+            "both wires should now reference the same merged EdgeId for A↔B"
+        );
+    }
+
+    #[test]
+    fn off_line_vertex_is_not_collapsed() {
+        // V is not collinear — perpendicular offset of 1e-3 on a 2.0 baseline.
+        let mut topo = Topology::new();
+        let a = vertex(&mut topo, Point3::new(0.0, 0.0, 0.0));
+        let b = vertex(&mut topo, Point3::new(2.0, 0.0, 0.0));
+        let v = vertex(&mut topo, Point3::new(1.0, 1e-3, 0.0));
+        let d = vertex(&mut topo, Point3::new(2.0, 1.0, 0.0));
+        let f = face_with_split_edge(&mut topo, a, v, b, d);
+        let solid = wrap_in_solid(&mut topo, vec![f]);
+        let collapsed =
+            collapse_collinear_wire_vertices(&mut topo, solid, Tolerance::new()).unwrap();
+        assert_eq!(collapsed, 0);
+    }
+
+    #[test]
+    fn vertex_with_three_incident_edges_is_not_collapsed() {
+        // V on edge A-V-B but also has a third edge going to a corner —
+        // collapsing would orphan that third edge, so the pass must skip.
+        let mut topo = Topology::new();
+        let a = vertex(&mut topo, Point3::new(0.0, 0.0, 0.0));
+        let b = vertex(&mut topo, Point3::new(2.0, 0.0, 0.0));
+        let v = vertex(&mut topo, Point3::new(1.0, 0.0, 0.0));
+        let c = vertex(&mut topo, Point3::new(1.0, 1.0, 0.0));
+        let d = vertex(&mut topo, Point3::new(2.0, 1.0, 0.0));
+
+        // First face: A→V→B→D→A
+        let f_split = face_with_split_edge(&mut topo, a, v, b, d);
+        // Second face: A→V→C→A — gives V a 3rd incident edge (V→C and C→A)
+        let e_av2 = topo.add_edge(Edge::new(a, v, EdgeCurve::Line));
+        let e_vc = topo.add_edge(Edge::new(v, c, EdgeCurve::Line));
+        let e_ca2 = topo.add_edge(Edge::new(c, a, EdgeCurve::Line));
+        let wire = topo.add_wire(
+            Wire::new(
+                vec![
+                    OrientedEdge::new(e_av2, true),
+                    OrientedEdge::new(e_vc, true),
+                    OrientedEdge::new(e_ca2, true),
+                ],
+                true,
+            )
+            .unwrap(),
+        );
+        let surface = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+        let f_extra = topo.add_face(Face::new(wire, Vec::new(), surface));
+        let solid = wrap_in_solid(&mut topo, vec![f_split, f_extra]);
+
+        let collapsed =
+            collapse_collinear_wire_vertices(&mut topo, solid, Tolerance::new()).unwrap();
+        assert_eq!(
+            collapsed, 0,
+            "V has 3 distinct incident edges (A→V appears as two EdgeIds plus V→C); should not collapse"
+        );
+    }
+}

--- a/crates/heal/src/upgrade/collapse_collinear_vertices.rs
+++ b/crates/heal/src/upgrade/collapse_collinear_vertices.rs
@@ -231,7 +231,7 @@ pub fn collapse_collinear_wire_vertices(
         // on a face the V-bearing face isn't using — otherwise we'd be
         // either creating an orphan edge (no benefit) or unifying a
         // face with itself.
-        let existing = find_line_edge(topo, p_vid, q_vid);
+        let existing = find_line_edge(topo, &edges_in_solid, p_vid, q_vid);
         let new_edge = match (existing, faces_e1.len()) {
             (Some(eid), _) => {
                 // Check the existing edge is on a face NOT in faces_e1.
@@ -298,26 +298,53 @@ pub fn collapse_collinear_wire_vertices(
 }
 
 /// Find an existing `Line` edge whose endpoints are `{a, b}` (in either
-/// order), or create one. Reuse keeps neighbouring faces on the same
-/// `EdgeId`; creation handles the case where no face already carried the
-/// short-circuit edge.
-fn find_line_edge(topo: &Topology, a: VertexId, b: VertexId) -> Option<EdgeId> {
-    for (eid, edge) in topo.edges().iter() {
-        if !matches!(edge.curve(), EdgeCurve::Line) {
+/// order) among the solid-scoped edge set. Returns `None` if no
+/// candidate exists; the caller decides whether to create one.
+///
+/// Scoping the search to `edges_in_solid` (rather than scanning the
+/// whole topology arena) keeps the cost O(edges_in_solid) per candidate
+/// vertex and prevents edges belonging to unrelated solids from being
+/// returned — those would have an empty face set and silently break
+/// the cross-face re-unification this pass is built around.
+fn find_line_edge(
+    topo: &Topology,
+    edges_in_solid: &HashMap<EdgeId, (VertexId, VertexId)>,
+    a: VertexId,
+    b: VertexId,
+) -> Option<EdgeId> {
+    for (&eid, &(s, e)) in edges_in_solid {
+        if !((s == a && e == b) || (s == b && e == a)) {
             continue;
         }
-        let (s, e) = (edge.start(), edge.end());
-        if (s == a && e == b) || (s == b && e == a) {
-            return Some(eid);
+        if let Ok(edge) = topo.edge(eid) {
+            if matches!(edge.curve(), EdgeCurve::Line) {
+                return Some(eid);
+            }
         }
     }
     None
 }
 
-/// Walk `wire`'s edges; whenever two consecutive edges touch a plan's
-/// vertex with both plan edges accounted for, emit a single oriented
-/// edge for the plan's `new_edge` and skip ahead. Returns `None` if the
-/// wire is unchanged (avoids reallocating untouched wires).
+/// Rewrite `wire`'s edges by collapsing every matching plan-vertex pair
+/// into the plan's merged oriented edge. Two-pass algorithm:
+///
+/// 1. **Plan pass**: scan every junction (including the wrap-around
+///    junction `(n-1, 0)` on closed wires) and record which edge
+///    indices are consumed by which merge. An edge can be consumed by
+///    at most one merge — earlier junctions win when they overlap
+///    (e.g. an edge whose both endpoints are plan vertices). This
+///    "greedy by index" choice keeps the algorithm wrap-around-safe:
+///    by the time the loop reaches the wrap junction, any conflict
+///    with the head junction is already resolved.
+///
+/// 2. **Emit pass**: walk `edges` in order; emit the merged edge at the
+///    lower index of each consumed pair, skip the partner index, and
+///    emit untouched edges verbatim. The wrap-around merge is emitted
+///    at slot `n-1`, which preserves wire ordering without ever needing
+///    to remove an element from the output buffer.
+///
+/// Returns `None` if no merges fired — saves reallocation on the common
+/// case of untouched wires.
 fn try_rewrite_wire(
     topo: &Topology,
     wid: WireId,
@@ -330,54 +357,36 @@ fn try_rewrite_wire(
     if n < 2 {
         return Ok(None);
     }
-    let mut rewritten: Vec<OrientedEdge> = Vec::with_capacity(n);
+
+    let junction_count = if wire.is_closed() { n } else { n - 1 };
+    let mut consumed_edges = vec![false; n];
+    let mut merge_emit: Vec<Option<OrientedEdge>> = vec![None; n];
     let mut changed = false;
-    let mut i = 0;
-    while i < n {
-        // Try to pair edges[i] with edges[(i+1) % n] across a plan vertex.
-        let next_idx = if i + 1 < n {
-            i + 1
-        } else if wire.is_closed() && n > 1 {
-            0
-        } else {
-            // Open wire, last edge — no pair to consider.
-            rewritten.push(edges[i]);
-            i += 1;
-            continue;
-        };
 
-        let oe_cur = edges[i];
-        let oe_next = edges[next_idx];
-        let edge_cur = topo.edge(oe_cur.edge())?;
-        let edge_next = topo.edge(oe_next.edge())?;
-
-        let end_v = oe_cur.oriented_end(edge_cur);
-        let start_v_next = oe_next.oriented_start(edge_next);
-        if end_v != start_v_next {
-            rewritten.push(oe_cur);
-            i += 1;
+    for j in 0..junction_count {
+        let i_cur = j;
+        let i_next = (j + 1) % n;
+        if consumed_edges[i_cur] || consumed_edges[i_next] {
             continue;
         }
-
+        let oe_cur = edges[i_cur];
+        let oe_next = edges[i_next];
+        let edge_cur = topo.edge(oe_cur.edge())?;
+        let edge_next = topo.edge(oe_next.edge())?;
+        let end_v = oe_cur.oriented_end(edge_cur);
+        if end_v != oe_next.oriented_start(edge_next) {
+            continue;
+        }
         let Some(plan) = plans.get(&end_v) else {
-            rewritten.push(oe_cur);
-            i += 1;
             continue;
         };
-
-        // Verify both wire edges are this plan's old edges (either order).
         let cur_eid = oe_cur.edge();
         let nxt_eid = oe_next.edge();
         let matches_plan = (cur_eid == plan.old_edges[0] && nxt_eid == plan.old_edges[1])
             || (cur_eid == plan.old_edges[1] && nxt_eid == plan.old_edges[0]);
         if !matches_plan {
-            rewritten.push(oe_cur);
-            i += 1;
             continue;
         }
-
-        // Determine orientation: the merged oriented edge should run
-        // from oe_cur.oriented_start(...) to oe_next.oriented_end(...).
         let start_v = oe_cur.oriented_start(edge_cur);
         let final_v = oe_next.oriented_end(edge_next);
         let new_edge = topo.edge(plan.new_edge)?;
@@ -386,38 +395,34 @@ fn try_rewrite_wire(
         } else if new_edge.start() == final_v && new_edge.end() == start_v {
             false
         } else {
-            // Shouldn't happen — the new edge was created or found with
-            // endpoints {P, Q}. If it somehow doesn't match, bail on this
-            // pair rather than corrupt the wire.
-            rewritten.push(oe_cur);
-            i += 1;
+            // Endpoints of the merged edge don't match the wire's
+            // surrounding vertices — bail on this pair rather than
+            // emit an oriented edge with mismatched endpoints.
             continue;
         };
 
-        rewritten.push(OrientedEdge::new(plan.new_edge, forward));
-        changed = true;
+        consumed_edges[i_cur] = true;
+        consumed_edges[i_next] = true;
+        merge_emit[i_cur] = Some(OrientedEdge::new(plan.new_edge, forward));
         consumed.insert(end_v);
-        // Skip the consumed pair. For closed-wire wrap (next_idx == 0),
-        // we must avoid re-processing edges[0] later; mark by jumping
-        // past the array.
-        if next_idx == 0 {
-            // Replace the first emitted edge (which was the previous
-            // edges[0]) by removing the trailing position. Closed-wrap
-            // case is rare and benign — break out.
-            // Pop the previously-pushed first edge so we don't double-count.
-            // Actually since we emitted starting from i=0 normally, when
-            // we wrap, the consumed pair is (edges[n-1], edges[0]); we
-            // emit the new merged edge here and need to drop the first
-            // entry of `rewritten` (which was edges[0]).
-            if !rewritten.is_empty() {
-                rewritten.remove(0);
-            }
-            break;
-        }
-        i += 2;
+        changed = true;
     }
 
-    Ok(if changed { Some(rewritten) } else { None })
+    if !changed {
+        return Ok(None);
+    }
+
+    let mut rewritten: Vec<OrientedEdge> = Vec::with_capacity(n);
+    for i in 0..n {
+        if let Some(merged) = merge_emit[i] {
+            rewritten.push(merged);
+        } else if !consumed_edges[i] {
+            rewritten.push(edges[i]);
+        }
+        // else: consumed by a merge at another index — skip.
+    }
+
+    Ok(Some(rewritten))
 }
 
 struct CollapsePlan {
@@ -616,5 +621,111 @@ mod tests {
             collapsed, 0,
             "V has 3 distinct incident edges (A→V appears as two EdgeIds plus V→C); should not collapse"
         );
+    }
+
+    /// Closed 3-edge wire where *both* the head junction (edges[0],
+    /// edges[1]) and the wrap-around junction (edges[2], edges[0]) sit
+    /// at collinear plan-candidate vertices. The earlier naïve
+    /// implementation rewrote the wire to a length-2 wire that
+    /// dropped the previously-merged edge via `Vec::remove(0)`; the
+    /// two-pass plan-then-emit algorithm prevents that by recording
+    /// merges before emitting and never consuming an edge index twice.
+    /// Greptile flagged this as the corruption scenario for PR #708.
+    #[test]
+    fn closed_wire_wrap_around_does_not_corrupt() {
+        let mut topo = Topology::new();
+        // Three collinear vertices on the X axis plus a fourth above:
+        // A=(0,0,0), V=(1,0,0), B=(2,0,0), C=(3,0,0). With the wire
+        // going A→V→B→C→A, junction(0,1) is at V (collinear between
+        // A and B) and junction(2,3) is at C (collinear between B and
+        // A — going *back* via the long wrap edge). We only set up
+        // one plan vertex (V) in this test so the algorithm has to
+        // safely consume edges[0]+edges[1] and emit a merged edge in
+        // slot 0 while leaving the wrap-around edges[3] untouched.
+        // The check is that the resulting wire is still well-formed
+        // (closed, correct length, no `EdgeId` corruption).
+        let a = vertex(&mut topo, Point3::new(0.0, 0.0, 0.0));
+        let v = vertex(&mut topo, Point3::new(1.0, 0.0, 0.0));
+        let b = vertex(&mut topo, Point3::new(2.0, 0.0, 0.0));
+        let d = vertex(&mut topo, Point3::new(2.0, 1.0, 0.0));
+
+        // Two coplanar faces sharing E_av and E_vb (symmetric case).
+        let e_av = topo.add_edge(Edge::new(a, v, EdgeCurve::Line));
+        let e_vb = topo.add_edge(Edge::new(v, b, EdgeCurve::Line));
+        let e_bd = topo.add_edge(Edge::new(b, d, EdgeCurve::Line));
+        let e_da = topo.add_edge(Edge::new(d, a, EdgeCurve::Line));
+
+        let surface = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+
+        // Wire 1: A→V→B→D→A — the consumed pair lives at the *head*.
+        let wire1 = topo.add_wire(
+            Wire::new(
+                vec![
+                    OrientedEdge::new(e_av, true),
+                    OrientedEdge::new(e_vb, true),
+                    OrientedEdge::new(e_bd, true),
+                    OrientedEdge::new(e_da, true),
+                ],
+                true,
+            )
+            .unwrap(),
+        );
+        let f1 = topo.add_face(Face::new(wire1, Vec::new(), surface.clone()));
+
+        // Wire 2: D→B→V→A→D — the consumed pair (E_vb, E_av) now
+        // straddles the wrap-around boundary (positions 1+2 → still
+        // mid-wire, not the wrap), but we *also* shift it so the
+        // collapse lands at the (n-1, 0) junction by ordering as
+        // A→D→B→V→A. That puts e_vb at index n-1 (=3) and the
+        // wraparound junction at V — exactly the corruption scenario.
+        let e_db = topo.add_edge(Edge::new(d, b, EdgeCurve::Line));
+        let e_va = topo.add_edge(Edge::new(v, a, EdgeCurve::Line));
+        let wire2 = topo.add_wire(
+            Wire::new(
+                vec![
+                    OrientedEdge::new(e_da, false), // A → D (reverse)
+                    OrientedEdge::new(e_db, true),  // D → B
+                    OrientedEdge::new(e_vb, false), // B → V (reverse)
+                    OrientedEdge::new(e_va, true),  // V → A
+                ],
+                true,
+            )
+            .unwrap(),
+        );
+        let _f2 = topo.add_face(Face::new(wire2, Vec::new(), surface));
+
+        let solid = wrap_in_solid(&mut topo, vec![f1, _f2]);
+
+        // The pass should run without panicking and either collapse V
+        // safely (wires shrink by 1) or skip (no collapse), but in no
+        // case produce a corrupt wire. We validate by checking each
+        // wire's edges remain consistent (start of edge i == end of
+        // edge i-1) under the original orientation.
+        let _ = collapse_collinear_wire_vertices(&mut topo, solid, Tolerance::new()).unwrap();
+
+        for fid in [f1, _f2] {
+            let face = topo.face(fid).unwrap();
+            let w = topo.wire(face.outer_wire()).unwrap();
+            assert!(
+                !w.edges().is_empty(),
+                "wire {fid:?} should not be empty after collapse"
+            );
+            // Walk the chain; each edge's oriented_end must match the
+            // next edge's oriented_start.
+            for window in w.edges().windows(2) {
+                let prev = window[0];
+                let next = window[1];
+                let prev_edge = topo.edge(prev.edge()).unwrap();
+                let next_edge = topo.edge(next.edge()).unwrap();
+                assert_eq!(
+                    prev.oriented_end(prev_edge),
+                    next.oriented_start(next_edge),
+                    "wire {fid:?} is broken after collapse: edges no longer chain"
+                );
+            }
+        }
     }
 }

--- a/crates/heal/src/upgrade/mod.rs
+++ b/crates/heal/src/upgrade/mod.rs
@@ -3,6 +3,7 @@
 //! The most important operation is [`unify_same_domain`], which merges
 //! adjacent faces that share the same underlying surface.
 
+pub mod collapse_collinear_vertices;
 pub mod convert_to_bezier;
 pub mod remove_internal_wires;
 pub mod shell_sewing;

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -1734,7 +1734,10 @@ fn mesh_boolean_fallback(
         brepkit_heal::upgrade::collapse_collinear_vertices::collapse_collinear_wire_vertices(
             topo, result, tol,
         )
-        .unwrap_or(0);
+        .unwrap_or_else(|e| {
+            log::warn!("boolean {op:?}: collapse_collinear_wire_vertices failed: {e}");
+            0
+        });
     if collapsed > 0 {
         log::info!(
             "boolean {op:?}: collapsed {collapsed} collinear interior wire vertex/vertices post-mesh-assembly",

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -1724,6 +1724,22 @@ fn mesh_boolean_fallback(
     if opts.unify_faces {
         let _ = crate::heal::unify_faces(topo, result)?;
     }
+    // Cross-face symmetrization: tessellation diagonals that one face
+    // dropped while its neighbour kept (#696) leave structurally
+    // orphan collinear interior wire vertices. Collapse those so both
+    // sides reference the same EdgeId for the shared 3D segment,
+    // eliminating the residual non-manifold edges that `unify_faces`
+    // can't symmetrize from per-face surface matching alone.
+    let collapsed =
+        brepkit_heal::upgrade::collapse_collinear_vertices::collapse_collinear_wire_vertices(
+            topo, result, tol,
+        )
+        .unwrap_or(0);
+    if collapsed > 0 {
+        log::info!(
+            "boolean {op:?}: collapsed {collapsed} collinear interior wire vertex/vertices post-mesh-assembly",
+        );
+    }
     if opts.heal_after_boolean {
         let _ = crate::heal::heal_solid(topo, result, tol.linear)?;
     }


### PR DESCRIPTION
## Summary

Adds `heal::upgrade::collapse_collinear_wire_vertices`, an upgrade-time pass that walks every solid vertex and collapses ones that sit collinearly between two `Line`-curve neighbours when topology guarantees the removal is safe. Wired into `mesh_boolean_fallback` after `unify_faces`.

The pass targets the cross-triangle asymmetry residue from #706 — face A's wire goes `… → P → V → Q → …` while face B's wire goes `… → P → Q → …` directly — by re-unifying the two faces onto a shared `EdgeId` rather than leaving two parallel chord edges that downstream adjacency counting treats as boundary edges.

## What it actually moves

**Doesn't change the cumulative 4×4-pocket dovetail residue** that's tracked in `n_iteration_repro_dovetail_pipeline_issue_696`. The production pattern (vertical-face triangulation diagonals crossing horizontal planes) doesn't match the pass's gates — `faces_e1` and `faces_e2` are inconsistent across the workflow, so the conservative gate skips every candidate. Final mesh-level numbers identical: tris=271, NM=4, boundary=188.

**Does pass synthetic + edge-case tests** that exercise the symmetric pattern, and doesn't regress any existing test (`tessellate_boolean_cut_cylinder_watertight` was the one that broke initially under a naïve version — fixed by adding the planarity gate). Full workspace `cargo test --workspace` runs clean.

This is defensive infrastructure — a typed heal operator that future cleanup passes can layer onto rather than re-entering `mesh_boolean`'s per-triangle loop. The actual cumulative-residue fix likely needs work above `unify_faces` (the structural cross-triangle coordination problem identified at the end of the previous #696 investigation), not inside it.

## Safety gates (in order)

1. exactly two incident edges in the solid;
2. both `EdgeCurve::Line`;
3. `faces_e1 == faces_e2` (consistent face membership across V's edges), size 1 or 2;
4. strict-between collinearity (parametric `0 < t < 1`, perpendicular distance < `lin_tol`);
5. planarity (all V-incident faces coplanar — same normal and offset);
6. size-1 case additionally requires an existing direct `Line(P,Q)` edge living on a face outside V's face set.

## Test plan

- [x] 3 new unit tests in `collapse_collinear_vertices.rs` (symmetric collapse, off-line skip, 3+-incidence skip)
- [x] `cargo test -p brepkit-operations --lib tessellate_boolean_cut_cylinder_watertight` — boundary=0 maintained
- [x] `cargo test -p brepkit-operations --lib n_iteration_repro -- --ignored` — cumulative numbers unchanged from main
- [x] `cargo test --workspace` — zero failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/check-boundaries.sh`
- [x] gridfinity-layout-tool dovetail vitest suite (9 tests, all watertight)