### PR TITLE
chore: harden supply chain against npm + actions attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       actions:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
       minor-and-patch:
         update-types: [minor, patch]
@@ -13,6 +16,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
       npm:
         patterns: ["*"]
@@ -22,6 +28,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+      semver-major-days: 14
     groups:
       actions:
         patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@132b6d4aaab26f88e6372807be16a43977a9b0cb # nextest
       - run: cargo nextest run --workspace
       # nextest doesn't run doc tests, so run them separately
       - run: cargo test --workspace --doc
@@ -57,7 +57,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@746b11920844c2e70d8ffeae9868a564abe127ab # cargo-llvm-cov
       - name: Generate coverage
         run: |
           cargo llvm-cov --workspace --no-report
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Override rust-toolchain.toml to test the declared minimum version
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv
@@ -97,7 +97,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@wasm-pack
+      - uses: taiki-e/install-action@9298de362fe84bbfbde4cea75ef84b5e54ed12e4 # wasm-pack
       - name: Build and validate WASM
         run: cargo xtask wasm-build --skip-opt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-targets --all-features -- -D warnings
@@ -40,8 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
@@ -53,8 +53,8 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@cargo-llvm-cov
@@ -72,7 +72,7 @@ jobs:
             echo "::error::Coverage ${COVERAGE}% is below the 60% threshold"
             exit 1
           fi
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: always()
         with:
           files: lcov.info
@@ -81,10 +81,10 @@ jobs:
     name: MSRV (1.85)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Override rust-toolchain.toml to test the declared minimum version
       - uses: dtolnay/rust-toolchain@1.85.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv
       - run: cargo check --workspace --all-features
@@ -93,8 +93,8 @@ jobs:
     name: WASM Build & Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@wasm-pack
@@ -108,8 +108,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build WASM (PR)
@@ -118,7 +118,7 @@ jobs:
           PR_SIZE=$(stat --printf="%s" target/wasm32-unknown-unknown/release/brepkit_wasm.wasm)
           echo "PR_SIZE=$PR_SIZE" >> "$GITHUB_ENV"
           echo "PR_SIZE_MB=$(echo "scale=2; $PR_SIZE / 1048576" | bc)" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.base_ref }}
           clean: false
@@ -170,14 +170,14 @@ jobs:
             echo "WASM_EOF"
           } >> "$GITHUB_ENV"
       - name: Find existing comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
           body-includes: "## WASM Binary Size"
       - name: Post or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -188,24 +188,24 @@ jobs:
     name: Layer Boundaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: ./scripts/check-boundaries.sh
 
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2.0.19
 
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Cargo.lock is gitignored (library crate), generate it for audit
       - run: cargo generate-lockfile
-      - uses: rustsec/audit-check@v2
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ github.token }}
 
@@ -213,8 +213,8 @@ jobs:
     name: Rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo doc --no-deps --all-features
@@ -225,7 +225,7 @@ jobs:
     name: Unused Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install cargo-machete
         run: cargo install cargo-machete --version 0.9.1 --locked
       - run: cargo machete
@@ -234,7 +234,7 @@ jobs:
     name: TOML Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install taplo
         run: |
           mkdir -p "$HOME/.local/bin"

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: taiki-e/install-action@nextest
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
@@ -35,7 +35,7 @@ jobs:
             --output=mutants-output
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutants-report
           path: mutants-output/

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@132b6d4aaab26f88e6372807be16a43977a9b0cb # nextest
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
       - name: Run mutation testing on critical modules

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,44 @@
+name: OSV Scan
+
+# Complements the Dependabot cooldown: cooldown blocks fresh-but-untrusted,
+# OSV blocks old-but-known-bad. Covers both Cargo and npm lockfiles.
+# PRs are report-only; main + weekly schedule fail closed.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-pr:
+    name: OSV Scan (report-only)
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=Cargo.lock
+        --lockfile=package-lock.json
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+  scan-main:
+    name: OSV Scan (blocking)
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=Cargo.lock
+        --lockfile=package-lock.json
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -14,7 +14,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't cancel in-progress main/schedule scans — a rapid second push would
+  # otherwise leave the older commit's lockfile unscanned.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   scan-pr:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,13 +25,13 @@ jobs:
       prs_created: ${{ steps.release.outputs['prs_created'] }}
       pr: ${{ steps.release.outputs['pr'] }}
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.BREPKIT_BOT_APP_ID }}
           private-key: ${{ secrets.BREPKIT_BOT_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         # release-please can fail with "duplicate tag" (release already exists)
         # or "issue is locked" (can't comment on auto-merged PR). Both are
@@ -49,7 +49,7 @@ jobs:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.prs_created == 'true' }}
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.BREPKIT_BOT_APP_ID }}
@@ -82,15 +82,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       # rust-toolchain.toml provides the pinned Rust version + wasm32 target
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - uses: taiki-e/install-action@wasm-pack
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
       # rust-toolchain.toml provides the pinned Rust version + wasm32 target
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: taiki-e/install-action@wasm-pack
+      - uses: taiki-e/install-action@9298de362fe84bbfbde4cea75ef84b5e54ed12e4 # wasm-pack
 
       - name: Build WASM (bundler target for browsers)
         run: wasm-pack build crates/wasm --target bundler --release --out-dir pkg

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, use [GitHub Security Advisories](https://github.com/andymai/brepkit/security/advisories/new) for private disclosure.
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+Expect an initial response within 48 hours.
+
+## Supply Chain
+
+In response to the 2025–2026 wave of npm and GitHub Actions supply-chain
+attacks (Shai-Hulud worm, chalk/debug compromise, tj-actions tag retag,
+prt-scan AI campaign), the build is configured to fail closed on the
+patterns those attacks exploited:
+
+| Defense | Where | What it blocks |
+|---|---|---|
+| All GitHub Actions pinned to commit SHA | `.github/workflows/*.yml` | Tag-retag attacks (tj-actions class). |
+| OSV scan against `Cargo.lock` + `package-lock.json` (PRs report-only, main blocking) | `.github/workflows/osv-scan.yml` | Known-CVE versions in either ecosystem. |
+| Dependabot cooldown (7d default / 14d major) across cargo, npm, github-actions | `.github/dependabot.yml` | Fresh malicious uploads. |
+
+Direct install-time cooldown via `.npmrc` `min-release-age` is not enabled
+here: npm bundled with Node 24 is 11.6.1, which silently ignores the field
+(added in npm 11.10). Add it once Node ships a newer npm.


### PR DESCRIPTION
## Summary

Defense-in-depth against the 2025-2026 wave of supply-chain attacks (Shai-Hulud worm, chalk/debug, tj-actions tag-retag, durabletask, prt-scan). Same hardening pattern landed in the gridfinity-layout-tool reference PR; adapted for a Rust+npm workspace.

| Defense | What it blocks |
|---|---|
| All Actions SHA-pinned across `ci.yml`, `mutants.yml`, `publish.yml` | tj-actions tag-retag class. |
| OSV scan against `Cargo.lock` + `package-lock.json` (PRs report-only, main blocking) | Known-CVE versions in either ecosystem. |
| Dependabot cooldown (7d default / 14d major) across cargo, npm, github-actions | Fresh malicious version proposals. |

## Changes

- 11 unique `uses:` references pinned to commit SHAs (`actions/*`, `Swatinem/rust-cache`, `codecov/codecov-action`, `peter-evans/*`, `EmbarkStudios/cargo-deny-action`, `rustsec/audit-check`, `googleapis/release-please-action`). All Dependabot-trackable.
- `.github/dependabot.yml`: added `cooldown` to cargo, npm, github-actions blocks.
- `.github/workflows/osv-scan.yml`: new.
- `SECURITY.md`: new — defense matrix + note on npm-CLI cooldown gap (npm 11.6.1 silently ignores `min-release-age`; revisit when Node ships 11.10+).

## Test plan

- [ ] CI green
- [ ] OSV scan workflow runs (first invocation)