### PR TITLE
refactor(ci): pin taiki-e/install-action by SHA + tool input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@132b6d4aaab26f88e6372807be16a43977a9b0cb # nextest
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2.62.30
+        with:
+          tool: nextest
       - run: cargo nextest run --workspace
       # nextest doesn't run doc tests, so run them separately
       - run: cargo test --workspace --doc
@@ -57,7 +59,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@746b11920844c2e70d8ffeae9868a564abe127ab # cargo-llvm-cov
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2.62.30
+        with:
+          tool: cargo-llvm-cov
       - name: Generate coverage
         run: |
           cargo llvm-cov --workspace --no-report
@@ -97,7 +101,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@9298de362fe84bbfbde4cea75ef84b5e54ed12e4 # wasm-pack
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2.62.30
+        with:
+          tool: wasm-pack
       - name: Build and validate WASM
         run: cargo xtask wasm-build --skip-opt
 

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -19,7 +19,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: taiki-e/install-action@132b6d4aaab26f88e6372807be16a43977a9b0cb # nextest
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2.62.30
+        with:
+          tool: nextest
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
       - name: Run mutation testing on critical modules

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,9 @@ jobs:
       # rust-toolchain.toml provides the pinned Rust version + wasm32 target
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: taiki-e/install-action@9298de362fe84bbfbde4cea75ef84b5e54ed12e4 # wasm-pack
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2.62.30
+        with:
+          tool: wasm-pack
 
       - name: Build WASM (bundler target for browsers)
         run: wasm-pack build crates/wasm --target bundler --release --out-dir pkg


### PR DESCRIPTION
## Summary

Closes #713 by fixing the underlying issue.

The hardening PR (#712) SHA-pinned 5 `taiki-e/install-action` references using the tool-name branch refs (`@nextest`, `@cargo-llvm-cov`, `@wasm-pack`). Dependabot saw them all as the same action and tried to consolidate them to one SHA — which broke tool selection because the branch name was both the version pin AND the tool selector.

This PR refactors to the proper pattern: one SHA pin for the action + `with: tool: <name>` per call. Dependabot can now bump the action SHA across all 5 uses without breaking anything.

## Changes

- `ci.yml`: 3 calls — nextest, cargo-llvm-cov, wasm-pack
- `mutants.yml`: 1 call — nextest
- `publish.yml`: 1 call — wasm-pack

All now point at `taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2.62.30` with the tool specified via input.