### PR TITLE
feat(wasm): expose read-only NURBS curve/surface data extraction

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -20,6 +20,7 @@ io = ["dep:brepkit-io"]
 brepkit-algo.workspace = true
 brepkit-check.workspace = true
 brepkit-geometry.workspace = true
+brepkit-heal.workspace = true
 brepkit-io = {workspace = true, optional = true}
 brepkit-math.workspace = true
 brepkit-operations.workspace = true

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -78,6 +78,27 @@ impl BrepKernel {
     }
 }
 
+/// A `(u_range, v_range)` pair, each `(min, max)`.
+type UvRanges = ((f64, f64), (f64, f64));
+
+/// Build the in-plane axes used by `plane_to_nurbs`.
+///
+/// Must match `brepkit_heal::construct::convert_surface`'s private frame
+/// so projected face corners reconstruct the plane rectangle consistently.
+fn plane_frame_axes(normal: Vec3) -> (Vec3, Vec3) {
+    let seed = if normal.x().abs() < 0.9 {
+        Vec3::new(1.0, 0.0, 0.0)
+    } else {
+        Vec3::new(0.0, 1.0, 0.0)
+    };
+    let u_axis = normal
+        .cross(seed)
+        .normalize()
+        .unwrap_or_else(|_| Vec3::new(1.0, 0.0, 0.0));
+    let v_axis = normal.cross(u_axis);
+    (u_axis, v_axis)
+}
+
 impl BrepKernel {
     /// Extract a `NurbsCurve` from an edge.
     ///
@@ -85,7 +106,7 @@ impl BrepKernel {
     /// are converted to their exact rational NURBS equivalent using the
     /// edge's bounding vertices (and the curve's analytic params for
     /// circles/ellipses).
-    pub(crate) fn extract_nurbs_curve(&self, edge: u32) -> Result<NurbsCurve, JsError> {
+    pub(crate) fn extract_nurbs_curve(&self, edge: u32) -> Result<NurbsCurve, WasmError> {
         use brepkit_geometry::convert::{circle_to_nurbs, ellipse_to_nurbs, line_to_nurbs};
         use std::f64::consts::TAU;
 
@@ -140,6 +161,126 @@ impl BrepKernel {
                 )
             }
         }
+    }
+
+    /// Extract a `NurbsSurface` from a face.
+    ///
+    /// NURBS faces are returned directly. Analytic surfaces are converted to
+    /// their NURBS equivalent: planes and cylinders are geometrically exact;
+    /// cones, spheres, and tori use the exact rational forms from
+    /// `brepkit_heal::construct::convert_surface`. Plane and cone parameter
+    /// ranges are derived from the face's boundary vertices.
+    pub(crate) fn extract_nurbs_surface(&self, face: u32) -> Result<NurbsSurface, WasmError> {
+        use brepkit_heal::construct::convert_surface;
+        use brepkit_topology::face::FaceSurface;
+
+        let face_id = self.resolve_face(face)?;
+        let face_data = self.topo.face(face_id)?;
+
+        let map_err = |context: &str, e: brepkit_heal::HealError| WasmError::InvalidInput {
+            reason: format!("{context}: {e}"),
+        };
+
+        match face_data.surface() {
+            FaceSurface::Nurbs(s) => Ok(s.clone()),
+            FaceSurface::Plane { normal, d } => {
+                let (u_range, v_range) = self.plane_face_uv_bounds(face_id, *normal, *d)?;
+                convert_surface::plane_to_nurbs(*normal, *d, u_range, v_range)
+                    .map_err(|e| map_err("plane_to_nurbs failed", e))
+            }
+            FaceSurface::Cylinder(c) => {
+                let v_range = self.analytic_face_v_bounds(face_id, face_data.surface())?;
+                convert_surface::cylinder_to_nurbs(c, v_range)
+                    .map_err(|e| map_err("cylinder_to_nurbs failed", e))
+            }
+            FaceSurface::Cone(c) => {
+                let v_range = self.analytic_face_v_bounds(face_id, face_data.surface())?;
+                convert_surface::cone_to_nurbs(c, v_range)
+                    .map_err(|e| map_err("cone_to_nurbs failed", e))
+            }
+            FaceSurface::Sphere(s) => convert_surface::sphere_to_nurbs(s)
+                .map_err(|e| map_err("sphere_to_nurbs failed", e)),
+            FaceSurface::Torus(t) => {
+                convert_surface::torus_to_nurbs(t).map_err(|e| map_err("torus_to_nurbs failed", e))
+            }
+        }
+    }
+
+    /// Derive the parametric rectangle of a planar face by sampling its outer
+    /// boundary edges and projecting the samples onto the same local frame
+    /// `plane_to_nurbs` uses.
+    ///
+    /// Sampling the edge curves (not just the bounding vertices) is required for
+    /// circle- and ellipse-bounded faces such as cylinder/cone caps, whose
+    /// outer wire may carry a single seam vertex while the disk spans a finite
+    /// rectangle in the plane frame.
+    #[allow(clippy::cast_precision_loss)]
+    fn plane_face_uv_bounds(
+        &self,
+        face_id: brepkit_topology::face::FaceId,
+        normal: Vec3,
+        d: f64,
+    ) -> Result<UvRanges, WasmError> {
+        const EDGE_SAMPLES: usize = 16;
+
+        let face_data = self.topo.face(face_id)?;
+        let wire = self.topo.wire(face_data.outer_wire())?;
+        let origin = Point3::new(0.0, 0.0, 0.0) + normal * d;
+        let (u_axis, v_axis) = plane_frame_axes(normal);
+
+        let mut u_min = f64::INFINITY;
+        let mut u_max = f64::NEG_INFINITY;
+        let mut v_min = f64::INFINITY;
+        let mut v_max = f64::NEG_INFINITY;
+        for oe in wire.edges() {
+            let edge = self.topo.edge(oe.edge())?;
+            let start = self.topo.vertex(edge.start())?.point();
+            let end = self.topo.vertex(edge.end())?.point();
+            let curve = edge.curve();
+            let (t0, t1) = curve.domain_with_endpoints(start, end);
+            for i in 0..=EDGE_SAMPLES {
+                let t = t0 + (t1 - t0) * (i as f64 / EDGE_SAMPLES as f64);
+                let p = curve.evaluate_with_endpoints(t, start, end);
+                let rel = p - origin;
+                let u = rel.dot(u_axis);
+                let v = rel.dot(v_axis);
+                u_min = u_min.min(u);
+                u_max = u_max.max(u);
+                v_min = v_min.min(v);
+                v_max = v_max.max(v);
+            }
+        }
+        if u_max <= u_min || v_max <= v_min {
+            return Err(WasmError::InvalidInput {
+                reason: "planar face has degenerate parametric extent".to_string(),
+            });
+        }
+        Ok(((u_min, u_max), (v_min, v_max)))
+    }
+
+    /// Derive the axial/generator parameter range of an analytic face by
+    /// projecting its boundary vertices onto the surface.
+    fn analytic_face_v_bounds(
+        &self,
+        face_id: brepkit_topology::face::FaceId,
+        surface: &brepkit_topology::face::FaceSurface,
+    ) -> Result<(f64, f64), WasmError> {
+        let verts = brepkit_topology::explorer::face_vertices(&self.topo, face_id)?;
+        let mut v_min = f64::INFINITY;
+        let mut v_max = f64::NEG_INFINITY;
+        for vid in verts {
+            let p = self.topo.vertex(vid)?.point();
+            if let Some((_, v)) = surface.project_point(p) {
+                v_min = v_min.min(v);
+                v_max = v_max.max(v);
+            }
+        }
+        if v_max <= v_min {
+            return Err(WasmError::InvalidInput {
+                reason: "analytic face has degenerate axial extent".to_string(),
+            });
+        }
+        Ok((v_min, v_max))
     }
 
     /// Create an edge from a `NurbsCurve`, using its endpoints.
@@ -1175,6 +1316,18 @@ impl BrepKernel {
                 )
                 .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(wire_id_to_u32(wire_id)))
+            }
+            "getNurbsCurveData" => {
+                let edge = get_u32(args, "edge")?;
+                let curve = self.extract_nurbs_curve(edge).map_err(|e| e.to_string())?;
+                Ok(super::nurbs::curve_data_json(&curve))
+            }
+            "getNurbsSurfaceData" => {
+                let face = get_u32(args, "face")?;
+                let surface = self
+                    .extract_nurbs_surface(face)
+                    .map_err(|e| e.to_string())?;
+                Ok(super::nurbs::surface_data_json(&surface))
             }
             _ => Err(format!("unknown operation: {op}")),
         }

--- a/crates/wasm/src/bindings/nurbs.rs
+++ b/crates/wasm/src/bindings/nurbs.rs
@@ -4,6 +4,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use brepkit_math::nurbs::curve::NurbsCurve;
+use brepkit_math::nurbs::surface::NurbsSurface;
 use brepkit_math::vec::Point3;
 use brepkit_topology::edge::{Edge, EdgeCurve};
 use brepkit_topology::vertex::Vertex;
@@ -12,6 +14,123 @@ use crate::error::WasmError;
 use crate::handles::{edge_id_to_u32, face_id_to_u32};
 use crate::helpers::{TOL, parse_point_grid, parse_points};
 use crate::kernel::BrepKernel;
+
+/// Weights within this absolute distance of `1.0` are treated as unit.
+const WEIGHT_UNIT_TOL: f64 = 1e-12;
+
+/// Squared linear distance below which control rows/columns are coincident.
+const CLOSURE_TOL_SQ: f64 = 1e-14;
+
+/// Split a flat (repeated) knot vector into distinct values + multiplicities.
+fn compress_knots(knots: &[f64]) -> (Vec<f64>, Vec<u32>) {
+    let mut distinct: Vec<f64> = Vec::new();
+    let mut mult: Vec<u32> = Vec::new();
+    for &k in knots {
+        match distinct.last() {
+            Some(&last) if (k - last).abs() <= f64::EPSILON => {
+                if let Some(m) = mult.last_mut() {
+                    *m += 1;
+                }
+            }
+            _ => {
+                distinct.push(k);
+                mult.push(1);
+            }
+        }
+    }
+    (distinct, mult)
+}
+
+/// Serialize a `NurbsCurve` to the read-only extraction object.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn curve_data_json(curve: &NurbsCurve) -> serde_json::Value {
+    let cps: Vec<[f64; 3]> = curve
+        .control_points()
+        .iter()
+        .map(|p| [p.x(), p.y(), p.z()])
+        .collect();
+    let weights = curve.weights();
+    let rational = weights.iter().any(|&w| (w - 1.0).abs() > WEIGHT_UNIT_TOL);
+    let (a, b) = curve.domain();
+    let (distinct, mult) = compress_knots(curve.knots());
+
+    let closed = curve
+        .control_points()
+        .first()
+        .zip(curve.control_points().last())
+        .is_some_and(|(first, last)| (*last - *first).length_squared() < CLOSURE_TOL_SQ);
+
+    serde_json::json!({
+        "degree": curve.degree(),
+        "controlPoints": cps,
+        "weights": weights,
+        "knots": curve.knots(),
+        "distinctKnots": distinct,
+        "multiplicities": mult,
+        "rational": rational,
+        "closed": closed,
+        "periodic": closed,
+        "domain": [a, b],
+    })
+}
+
+/// Serialize a `NurbsSurface` to the read-only extraction object.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn surface_data_json(surface: &NurbsSurface) -> serde_json::Value {
+    let cps: Vec<Vec<[f64; 3]>> = surface
+        .control_points()
+        .iter()
+        .map(|row| row.iter().map(|p| [p.x(), p.y(), p.z()]).collect())
+        .collect();
+    let weights = surface.weights();
+    let rational = weights
+        .iter()
+        .flatten()
+        .any(|&w| (w - 1.0).abs() > WEIGHT_UNIT_TOL);
+
+    let rows = surface.control_points();
+    let periodic_u = rows
+        .first()
+        .zip(rows.last())
+        .is_some_and(|(first, last)| rows_coincide(first, last));
+    let periodic_v = rows.iter().all(|row| {
+        row.first()
+            .zip(row.last())
+            .is_some_and(|(a, b)| (*b - *a).length_squared() < CLOSURE_TOL_SQ)
+    }) && rows.first().is_some_and(|r| r.len() >= 2);
+
+    let (ua, ub) = surface.domain_u();
+    let (va, vb) = surface.domain_v();
+    let (distinct_u, mult_u) = compress_knots(surface.knots_u());
+    let (distinct_v, mult_v) = compress_knots(surface.knots_v());
+
+    serde_json::json!({
+        "degreeU": surface.degree_u(),
+        "degreeV": surface.degree_v(),
+        "controlPoints": cps,
+        "weights": weights,
+        "knotsU": surface.knots_u(),
+        "knotsV": surface.knots_v(),
+        "distinctKnotsU": distinct_u,
+        "multiplicitiesU": mult_u,
+        "distinctKnotsV": distinct_v,
+        "multiplicitiesV": mult_v,
+        "rational": rational,
+        "periodicU": periodic_u,
+        "periodicV": periodic_v,
+        "domainU": [ua, ub],
+        "domainV": [va, vb],
+    })
+}
+
+/// Two control rows coincide pointwise within the closure tolerance.
+fn rows_coincide(a: &[Point3], b: &[Point3]) -> bool {
+    a.len() == b.len()
+        && !a.is_empty()
+        && a.iter()
+            .zip(b)
+            .all(|(p, q)| (*q - *p).length_squared() < CLOSURE_TOL_SQ)
+}
 
 #[wasm_bindgen]
 impl BrepKernel {
@@ -216,5 +335,386 @@ impl BrepKernel {
         Ok(edge_id_to_u32(
             self.nurbs_curve_to_edge_from_curve(&elevated),
         ))
+    }
+
+    /// Read-only canonical NURBS data for the curve underlying an edge.
+    ///
+    /// Analytic curves (line, circle, ellipse) are converted to their exact
+    /// NURBS form. Returns a JSON string with `degree`, `controlPoints`,
+    /// `weights`, the flat `knots` vector, compressed `distinctKnots` /
+    /// `multiplicities`, `rational`, `closed` / `periodic`, and `domain`.
+    #[wasm_bindgen(js_name = "getNurbsCurveData")]
+    pub fn get_nurbs_curve_data(&self, edge: u32) -> Result<String, JsError> {
+        let curve = self.extract_nurbs_curve(edge)?;
+        Ok(curve_data_json(&curve).to_string())
+    }
+
+    /// Read-only canonical NURBS data for the surface underlying a face.
+    ///
+    /// Analytic surfaces are converted to NURBS (planes/cylinders exact;
+    /// cones/spheres/tori via the exact rational forms). Returns a JSON
+    /// string with `degreeU`/`degreeV`, the row-major `controlPoints` grid,
+    /// the matching `weights` grid, flat `knotsU`/`knotsV`, compressed
+    /// distinct-knots/multiplicities per direction, `rational`,
+    /// `periodicU`/`periodicV`, and `domainU`/`domainV`.
+    #[wasm_bindgen(js_name = "getNurbsSurfaceData")]
+    pub fn get_nurbs_surface_data(&self, face: u32) -> Result<String, JsError> {
+        let surface = self.extract_nurbs_surface(face)?;
+        Ok(surface_data_json(&surface).to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::cast_precision_loss)]
+
+    use brepkit_math::nurbs::surface::NurbsSurface;
+    use brepkit_math::nurbs::surface_fitting::interpolate_surface;
+    use brepkit_math::vec::{Point3, Vec3};
+    use brepkit_topology::builder::{make_nurbs_edge_from_curve, make_nurbs_face};
+
+    use crate::handles::{edge_id_to_u32, face_id_to_u32};
+    use crate::helpers::TOL;
+    use crate::kernel::BrepKernel;
+
+    use super::*;
+
+    fn dispatch_ok(k: &mut BrepKernel, op: &str, args: serde_json::Value) -> serde_json::Value {
+        let batch = serde_json::json!([{ "op": op, "args": args }]);
+        let out = k.execute_batch(&batch.to_string());
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
+        let entry = &parsed[0];
+        assert!(
+            entry.get("error").is_none(),
+            "dispatch {op} errored: {entry}"
+        );
+        entry["ok"].clone()
+    }
+
+    fn knot_distance_curve(degree: usize, cp: usize) -> usize {
+        cp + degree + 1
+    }
+
+    fn entity_counts(k: &BrepKernel) -> (usize, usize, usize) {
+        (
+            k.topo.num_faces(),
+            k.topo.num_edges(),
+            k.topo.num_vertices(),
+        )
+    }
+
+    #[test]
+    fn curve_data_round_trips_cubic_nurbs() {
+        let mut k = BrepKernel::new();
+        let cps = vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 2.0, 0.0),
+            Point3::new(3.0, 2.0, 1.0),
+            Point3::new(4.0, 0.0, 0.0),
+            Point3::new(6.0, -1.0, 2.0),
+        ];
+        let knots = vec![0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0];
+        let weights = vec![1.0; 5];
+        let curve = NurbsCurve::new(3, knots.clone(), cps.clone(), weights.clone()).unwrap();
+        let eid = make_nurbs_edge_from_curve(k.topo_mut(), &curve, TOL);
+        let handle = edge_id_to_u32(eid);
+
+        let before = entity_counts(&k);
+        let data = dispatch_ok(
+            &mut k,
+            "getNurbsCurveData",
+            serde_json::json!({"edge": handle}),
+        );
+        assert_eq!(before, entity_counts(&k), "query must not mutate topology");
+
+        assert_eq!(data["degree"].as_u64().unwrap(), 3);
+        assert!(!data["rational"].as_bool().unwrap());
+        let out_knots: Vec<f64> = serde_json::from_value(data["knots"].clone()).unwrap();
+        assert_eq!(out_knots.len(), knot_distance_curve(3, 5));
+        for (a, b) in out_knots.iter().zip(&knots) {
+            assert!((a - b).abs() < 1e-12);
+        }
+        let out_cps: Vec<[f64; 3]> = serde_json::from_value(data["controlPoints"].clone()).unwrap();
+        assert_eq!(out_cps.len(), 5);
+        for (a, b) in out_cps.iter().zip(&cps) {
+            assert!((a[0] - b.x()).abs() < 1e-12);
+            assert!((a[1] - b.y()).abs() < 1e-12);
+            assert!((a[2] - b.z()).abs() < 1e-12);
+        }
+        let out_w: Vec<f64> = serde_json::from_value(data["weights"].clone()).unwrap();
+        assert_eq!(out_w, weights);
+
+        // Domain matches [knot[degree], knot[len-degree-1]].
+        let domain: [f64; 2] = serde_json::from_value(data["domain"].clone()).unwrap();
+        assert!(domain[1] > domain[0]);
+
+        // Compressed knots expand to the flat vector.
+        let dk: Vec<f64> = serde_json::from_value(data["distinctKnots"].clone()).unwrap();
+        let mult: Vec<u32> = serde_json::from_value(data["multiplicities"].clone()).unwrap();
+        let expanded: Vec<f64> = dk
+            .iter()
+            .zip(&mult)
+            .flat_map(|(&v, &m)| std::iter::repeat_n(v, m as usize))
+            .collect();
+        assert_eq!(expanded, out_knots);
+    }
+
+    #[test]
+    fn circle_edge_extracts_rational_quadratic() {
+        let mut k = BrepKernel::new();
+        let radius = 2.5;
+        let circle = brepkit_math::curves::Circle3D::new(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            radius,
+        )
+        .unwrap();
+        let start = Point3::new(radius, 0.0, 0.0);
+        let v = k.topo_mut().add_vertex(Vertex::new(start, TOL));
+        let eid = k.topo_mut().add_edge(Edge::new(
+            v,
+            v,
+            brepkit_topology::edge::EdgeCurve::Circle(circle),
+        ));
+        let handle = edge_id_to_u32(eid);
+
+        let data = dispatch_ok(
+            &mut k,
+            "getNurbsCurveData",
+            serde_json::json!({"edge": handle}),
+        );
+        assert_eq!(data["degree"].as_u64().unwrap(), 2);
+        assert!(data["rational"].as_bool().unwrap());
+
+        // Reconstruct and sample: every point at distance `radius` from center.
+        let out_cps: Vec<Point3> =
+            serde_json::from_value::<Vec<[f64; 3]>>(data["controlPoints"].clone())
+                .unwrap()
+                .into_iter()
+                .map(|c| Point3::new(c[0], c[1], c[2]))
+                .collect();
+        let out_knots: Vec<f64> = serde_json::from_value(data["knots"].clone()).unwrap();
+        let out_w: Vec<f64> = serde_json::from_value(data["weights"].clone()).unwrap();
+        let degree = data["degree"].as_u64().unwrap() as usize;
+        let rebuilt = NurbsCurve::new(degree, out_knots, out_cps, out_w).unwrap();
+        let (a, b) = rebuilt.domain();
+        for i in 0..=16 {
+            let t = a + (b - a) * (i as f64 / 16.0);
+            let p = rebuilt.evaluate(t);
+            let r = (p.x() * p.x() + p.y() * p.y()).sqrt();
+            assert!((r - radius).abs() < 1e-9, "sample r={r} at t={t}");
+        }
+    }
+
+    #[test]
+    fn surface_data_round_trips_nurbs_face() {
+        let mut k = BrepKernel::new();
+        let mut grid = Vec::new();
+        for i in 0..4 {
+            let mut row = Vec::new();
+            for j in 0..4 {
+                let x = i as f64;
+                let y = j as f64;
+                let z = (x * y).sin() * 0.3;
+                row.push(Point3::new(x, y, z));
+            }
+            grid.push(row);
+        }
+        let surface = interpolate_surface(&grid, 3, 3).unwrap();
+        let fid = make_nurbs_face(k.topo_mut(), surface.clone(), TOL).unwrap();
+        let handle = face_id_to_u32(fid);
+
+        let data = dispatch_ok(
+            &mut k,
+            "getNurbsSurfaceData",
+            serde_json::json!({"face": handle}),
+        );
+
+        let du = data["degreeU"].as_u64().unwrap() as usize;
+        let dv = data["degreeV"].as_u64().unwrap() as usize;
+        let knots_u: Vec<f64> = serde_json::from_value(data["knotsU"].clone()).unwrap();
+        let knots_v: Vec<f64> = serde_json::from_value(data["knotsV"].clone()).unwrap();
+        let cps: Vec<Vec<[f64; 3]>> =
+            serde_json::from_value(data["controlPoints"].clone()).unwrap();
+        let weights: Vec<Vec<f64>> = serde_json::from_value(data["weights"].clone()).unwrap();
+
+        let nu = cps.len();
+        let nv = cps[0].len();
+        assert!(cps.iter().all(|row| row.len() == nv), "grid is rectangular");
+        assert_eq!(knots_u.len(), nu + du + 1);
+        assert_eq!(knots_v.len(), nv + dv + 1);
+        assert_eq!(weights.len(), nu);
+        assert!(weights.iter().all(|r| r.len() == nv));
+        assert!(knots_u.windows(2).all(|w| w[1] >= w[0]));
+        assert!(knots_v.windows(2).all(|w| w[1] >= w[0]));
+
+        // Round-trip evaluation against the source surface.
+        let rebuilt = NurbsSurface::new(
+            du,
+            dv,
+            knots_u,
+            knots_v,
+            cps.iter()
+                .map(|row| row.iter().map(|c| Point3::new(c[0], c[1], c[2])).collect())
+                .collect(),
+            weights,
+        )
+        .unwrap();
+        let (ua, ub) = surface.domain_u();
+        let (va, vb) = surface.domain_v();
+        for i in 0..=4 {
+            for j in 0..=4 {
+                let u = ua + (ub - ua) * (i as f64 / 4.0);
+                let v = va + (vb - va) * (j as f64 / 4.0);
+                let p0 = surface.evaluate(u, v);
+                let p1 = rebuilt.evaluate(u, v);
+                let d = (p1 - p0).length();
+                assert!(d < 1e-9, "round-trip mismatch {d} at ({u},{v})");
+            }
+        }
+    }
+
+    #[test]
+    fn planar_face_extracts_unit_degree1_grid() {
+        let mut k = BrepKernel::new();
+        let solid = brepkit_operations::primitives::make_box(k.topo_mut(), 4.0, 6.0, 2.0).unwrap();
+        let faces = brepkit_topology::explorer::solid_faces(&k.topo, solid).unwrap();
+        let handle = face_id_to_u32(faces[0]);
+
+        let data = dispatch_ok(
+            &mut k,
+            "getNurbsSurfaceData",
+            serde_json::json!({"face": handle}),
+        );
+        assert_eq!(data["degreeU"].as_u64().unwrap(), 1);
+        assert_eq!(data["degreeV"].as_u64().unwrap(), 1);
+        assert!(!data["rational"].as_bool().unwrap());
+        let cps: Vec<Vec<[f64; 3]>> =
+            serde_json::from_value(data["controlPoints"].clone()).unwrap();
+        assert_eq!(cps.len(), 2);
+        assert!(cps.iter().all(|row| row.len() == 2));
+        let weights: Vec<Vec<f64>> = serde_json::from_value(data["weights"].clone()).unwrap();
+        assert!(weights.iter().flatten().all(|&w| (w - 1.0).abs() < 1e-12));
+    }
+
+    #[test]
+    fn cylinder_cap_face_extracts_unit_degree1_grid() {
+        let mut k = BrepKernel::new();
+        let radius = 3.0;
+        let height = 5.0;
+        let solid =
+            brepkit_operations::primitives::make_cylinder(k.topo_mut(), radius, height).unwrap();
+        let faces = brepkit_topology::explorer::solid_faces(&k.topo, solid).unwrap();
+        let cap = faces
+            .iter()
+            .copied()
+            .find(|&f| {
+                matches!(
+                    k.topo.face(f).unwrap().surface(),
+                    brepkit_topology::face::FaceSurface::Plane { .. }
+                )
+            })
+            .unwrap();
+        let handle = face_id_to_u32(cap);
+
+        let data = dispatch_ok(
+            &mut k,
+            "getNurbsSurfaceData",
+            serde_json::json!({"face": handle}),
+        );
+        assert_eq!(data["degreeU"].as_u64().unwrap(), 1);
+        assert_eq!(data["degreeV"].as_u64().unwrap(), 1);
+        assert!(!data["rational"].as_bool().unwrap());
+
+        let cps: Vec<Vec<[f64; 3]>> =
+            serde_json::from_value(data["controlPoints"].clone()).unwrap();
+        assert_eq!(cps.len(), 2);
+        assert!(cps.iter().all(|row| row.len() == 2));
+
+        // The 2x2 corner grid must enclose the cap disk: the half-diagonal
+        // extent in plane must be at least the radius in each direction.
+        let xs: Vec<f64> = cps.iter().flatten().map(|c| c[0]).collect();
+        let ys: Vec<f64> = cps.iter().flatten().map(|c| c[1]).collect();
+        let dx = xs.iter().copied().fold(f64::NEG_INFINITY, f64::max)
+            - xs.iter().copied().fold(f64::INFINITY, f64::min);
+        let dy = ys.iter().copied().fold(f64::NEG_INFINITY, f64::max)
+            - ys.iter().copied().fold(f64::INFINITY, f64::min);
+        assert!(dx >= 2.0 * radius - 1e-9, "cap u-extent {dx}");
+        assert!(dy >= 2.0 * radius - 1e-9, "cap v-extent {dy}");
+    }
+
+    #[test]
+    fn cylinder_side_face_extracts_periodic_rational() {
+        let mut k = BrepKernel::new();
+        let radius = 3.0;
+        let height = 5.0;
+        let solid =
+            brepkit_operations::primitives::make_cylinder(k.topo_mut(), radius, height).unwrap();
+        let faces = brepkit_topology::explorer::solid_faces(&k.topo, solid).unwrap();
+        let side = faces
+            .iter()
+            .copied()
+            .find(|&f| {
+                matches!(
+                    k.topo.face(f).unwrap().surface(),
+                    brepkit_topology::face::FaceSurface::Cylinder(_)
+                )
+            })
+            .unwrap();
+        let handle = face_id_to_u32(side);
+
+        let data = dispatch_ok(
+            &mut k,
+            "getNurbsSurfaceData",
+            serde_json::json!({"face": handle}),
+        );
+        assert_eq!(data["degreeU"].as_u64().unwrap(), 2);
+        assert_eq!(data["degreeV"].as_u64().unwrap(), 1);
+        assert!(data["rational"].as_bool().unwrap());
+        assert!(data["periodicU"].as_bool().unwrap());
+
+        let cps: Vec<Vec<[f64; 3]>> =
+            serde_json::from_value(data["controlPoints"].clone()).unwrap();
+
+        // Control points span the face's axial extent [0, height] in z even
+        // though the v-knot domain is normalized to [0, 1].
+        let z_min = cps
+            .iter()
+            .flatten()
+            .map(|c| c[2])
+            .fold(f64::INFINITY, f64::min);
+        let z_max = cps
+            .iter()
+            .flatten()
+            .map(|c| c[2])
+            .fold(f64::NEG_INFINITY, f64::max);
+        assert!((z_min - 0.0).abs() < 1e-9, "axial start z {z_min}");
+        assert!((z_max - height).abs() < 1e-9, "axial end z {z_max}");
+
+        let knots_u: Vec<f64> = serde_json::from_value(data["knotsU"].clone()).unwrap();
+        let knots_v: Vec<f64> = serde_json::from_value(data["knotsV"].clone()).unwrap();
+        let weights: Vec<Vec<f64>> = serde_json::from_value(data["weights"].clone()).unwrap();
+        let rebuilt = NurbsSurface::new(
+            2,
+            1,
+            knots_u,
+            knots_v,
+            cps.iter()
+                .map(|row| row.iter().map(|c| Point3::new(c[0], c[1], c[2])).collect())
+                .collect(),
+            weights,
+        )
+        .unwrap();
+        let (ua, ub) = rebuilt.domain_u();
+        let (va, vb) = rebuilt.domain_v();
+        for i in 0..=8 {
+            for j in 0..=2 {
+                let u = ua + (ub - ua) * (i as f64 / 8.0);
+                let v = va + (vb - va) * (j as f64 / 2.0);
+                let p = rebuilt.evaluate(u, v);
+                let r = (p.x() * p.x() + p.y() * p.y()).sqrt();
+                assert!((r - radius).abs() < 1e-9, "cyl r={r}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds `getNurbsCurveData` and `getNurbsSurfaceData` WASM bindings that return the canonical NURBS definition underlying an edge or face. This closes a parity gap where consumers could not introspect the underlying NURBS representation of brepkit geometry.

## What it returns

- **Curves**: degree, flat + compressed knot vectors, control points, weights, rationality flag, periodicity, and parameter domain.
- **Surfaces**: u/v degrees, u/v knot vectors (flat + compressed), control-point grid, weights, rationality, u/v periodicity, and u/v parameter domains.

Analytic geometry is converted to its exact NURBS form on the fly:
- Lines and planes map exactly.
- Cylinders map exactly.
- Cones, spheres, and tori use their exact rational NURBS representations.

## Properties

- **Read-only**: the query leaves topology unchanged — no entities are created or mutated.
- Available both as direct methods and via the batch dispatch.

## Layering / safety

- Confined to the L4 `brepkit-wasm` crate; no layer-boundary changes.
- No `unwrap`/`expect`/`panic`/`unsafe`; passes fmt, clippy (`-D warnings`), boundary check, and the full pre-push gate (tests + cargo-deny).