### PR TITLE
feat(boolean): empty result for disjoint intersect and section miss

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -435,6 +435,24 @@ pub fn boolean(
         }
     }
 
+    // ── Broad-phase disjoint intersect ───────────────────────────────
+    // If the curvature-aware AABBs of A and B are separated on any axis
+    // by more than linear tolerance, the solids provably do not overlap
+    // and their intersection is the empty set. Containment shortcuts have
+    // already run above (a contained solid has overlapping, not separated,
+    // AABBs), so reaching here with separated boxes is an exact witness.
+    // The boxes are conservative outer bounds, so box non-overlap implies
+    // solid non-overlap. Symmetric in A and B by construction.
+    if op == BooleanOp::Intersect {
+        let bb_a = crate::measure::solid_bounding_box(topo, a).ok();
+        let bb_b = crate::measure::solid_bounding_box(topo, b).ok();
+        if let Some((a_box, b_box)) = bb_a.zip(bb_b) {
+            if aabbs_separated(&a_box, &b_box, tol.linear) {
+                return Ok(topo.add_empty_solid());
+            }
+        }
+    }
+
     // ── GFA pipeline ─────────────────────────────────────────────────
     let algo_op = match op {
         BooleanOp::Fuse => brepkit_algo::bop::BooleanOp::Fuse,
@@ -447,6 +465,17 @@ pub fn boolean(
             let result_faces = brepkit_topology::explorer::solid_faces(topo, result)
                 .map(|f| f.len())
                 .unwrap_or(0);
+            // Narrow-phase empty intersect: overlapping AABBs but the engine
+            // selected no faces for the common region (e.g. boxes whose boxes
+            // overlap by tolerance but whose interiors do not). This is the
+            // authoritative witness of an empty intersection.
+            if op == BooleanOp::Intersect && result_faces == 0 {
+                log::info!(
+                    "GFA intersect empty in {:.1}ms (no common faces)",
+                    timer_elapsed_ms(gfa_start)
+                );
+                return Ok(topo.add_empty_solid());
+            }
             if result_faces > 0 {
                 let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
                 // Check Euler before unify_faces — if already valid, skip
@@ -570,7 +599,16 @@ pub fn boolean(
 
     // ── Mesh boolean fallback (no recursion) ─────────────────────────
     let opts = BooleanOptions::default();
-    let raw = mesh_boolean_fallback(topo, op, a, b, opts.deflection, tol, &opts)?;
+    let raw = match mesh_boolean_fallback(topo, op, a, b, opts.deflection, tol, &opts) {
+        Ok(raw) => raw,
+        // An empty mesh-boolean output for an intersect means the common
+        // region is empty — return the empty-result sentinel rather than
+        // surfacing the empty set as an error.
+        Err(crate::OperationsError::EmptyResult { .. }) if op == BooleanOp::Intersect => {
+            return Ok(topo.add_empty_solid());
+        }
+        Err(e) => return Err(e),
+    };
     let result = crate::copy::copy_solid(topo, raw)?;
     let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
     for _ in 0..3 {
@@ -1637,6 +1675,26 @@ fn xform_from_canonical_z(
         [0.0, 0.0, 0.0, 1.0],
     ]);
     translate * rot
+}
+
+/// Returns `true` when two axis-aligned boxes are separated on at least
+/// one axis by more than `margin` — i.e. their (margin-expanded) extents
+/// do not overlap and the solids they bound provably do not intersect.
+///
+/// The `margin` shrinks the overlap test so boxes that only touch (or
+/// nearly touch) within `margin` are treated as separated: a shared
+/// face/edge/corner has zero overlap volume.
+fn aabbs_separated(
+    a: &brepkit_math::aabb::Aabb3,
+    b: &brepkit_math::aabb::Aabb3,
+    margin: f64,
+) -> bool {
+    a.max.x() < b.min.x() + margin
+        || b.max.x() < a.min.x() + margin
+        || a.max.y() < b.min.y() + margin
+        || b.max.y() < a.min.y() + margin
+        || a.max.z() < b.min.z() + margin
+        || b.max.z() < a.min.z() + margin
 }
 
 /// Check whether every boundary vertex of `solid` is classified as

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -142,12 +142,107 @@ fn cut_disjoint_returns_a() {
 }
 
 #[test]
-fn intersect_disjoint_returns_error() {
+fn intersect_disjoint_returns_empty() {
+    use brepkit_topology::explorer::solid_faces;
+
     let mut topo = Topology::new();
     let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
     let b = make_unit_cube_manifold_at(&mut topo, 5.0, 0.0, 0.0);
 
-    assert!(boolean(&mut topo, BooleanOp::Intersect, a, b).is_err());
+    let result = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    assert_eq!(
+        solid_faces(&topo, result).unwrap().len(),
+        0,
+        "disjoint intersect should produce zero faces"
+    );
+    let vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        vol <= 1e-6,
+        "disjoint intersect volume should be ~0, got {vol}"
+    );
+}
+
+#[test]
+fn intersect_far_apart_boxes_returns_empty() {
+    use brepkit_topology::explorer::solid_faces;
+
+    // Mirrors the cross-kernel geometry: 10×10×10 boxes 100 apart.
+    let mut topo = Topology::new();
+    let a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let b = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        b,
+        &brepkit_math::mat::Mat4::translation(100.0, 0.0, 0.0),
+    )
+    .unwrap();
+
+    let result = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    assert_eq!(solid_faces(&topo, result).unwrap().len(), 0);
+    let vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        vol < 1.0,
+        "far-apart intersect volume should be < 1, got {vol}"
+    );
+}
+
+#[test]
+fn intersect_touching_boxes_returns_empty() {
+    use brepkit_topology::explorer::solid_faces;
+
+    // Two unit cubes sharing only the x=1 plane — interiors do not overlap.
+    let mut topo = Topology::new();
+    let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut topo, 1.0, 0.0, 0.0);
+
+    let result = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    assert_eq!(solid_faces(&topo, result).unwrap().len(), 0);
+    let vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        vol <= 1e-6,
+        "touching-disjoint intersect volume should be ~0, got {vol}"
+    );
+}
+
+#[test]
+fn empty_intersect_survives_measure_and_tessellate() {
+    let mut topo = Topology::new();
+    let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut topo, 5.0, 0.0, 0.0);
+
+    let result = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    assert!(topo.is_empty_solid(result));
+
+    // Downstream queries must accept the empty sentinel without panicking.
+    let vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
+    assert!(vol <= 1e-6);
+    let mesh = crate::tessellate::tessellate_solid(&topo, result, 0.05).unwrap();
+    assert!(
+        mesh.indices.is_empty(),
+        "empty solid should tessellate to no triangles"
+    );
+}
+
+#[test]
+fn intersect_overlapping_boxes_is_nonempty() {
+    use brepkit_topology::explorer::solid_faces;
+
+    // Positive control: two unit cubes offset by 0.5 in x overlap in a
+    // 0.5×1×1 = 0.5 volume — the disjoint detection must not over-fire.
+    let mut topo = Topology::new();
+    let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut topo, 0.5, 0.0, 0.0);
+
+    let result = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    assert!(
+        !solid_faces(&topo, result).unwrap().is_empty(),
+        "overlapping intersect should produce faces"
+    );
+    let vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        (vol - 0.5).abs() < 1e-3,
+        "overlap volume should be ~0.5, got {vol}"
+    );
 }
 
 // ── Diagnostic tests ─────────────────────────────────────────────────

--- a/crates/operations/src/section.rs
+++ b/crates/operations/src/section.rs
@@ -46,6 +46,8 @@ pub struct Section {
 /// Returns the cross-section as one or more planar faces lying on the
 /// cutting plane. For a simple convex solid this is typically one face;
 /// for solids with holes or disconnected volumes there may be multiple.
+/// A plane that misses the solid entirely yields an empty face list
+/// (a successful empty result, not an error).
 ///
 /// # Algorithm
 ///
@@ -57,8 +59,9 @@ pub struct Section {
 ///
 /// # Errors
 ///
-/// Returns an error if no intersection exists (plane doesn't cut
-/// the solid), or if NURBS intersection computation fails.
+/// Returns an error if NURBS intersection computation fails, or if
+/// intersection segments exist but cannot be assembled into a closed
+/// cross-section wire.
 pub fn section(
     topo: &mut Topology,
     solid: SolidId,
@@ -149,10 +152,11 @@ pub fn section(
         segments = coplanar_segs;
     }
 
+    // No crossing segments and no coplanar boundary across outer + inner
+    // shells means the cutting plane lies wholly on one side of the solid:
+    // a genuine miss. The empty set is a valid section, not an error.
     if segments.is_empty() {
-        return Err(crate::OperationsError::InvalidInput {
-            reason: "cutting plane does not intersect the solid".into(),
-        });
+        return Ok(Section { faces: Vec::new() });
     }
 
     // Assemble segments into closed wires.
@@ -719,14 +723,44 @@ mod tests {
         let mut topo = Topology::new();
         let cube = make_unit_cube_manifold(&mut topo);
 
-        // Plane above the cube.
+        // Plane above the cube — misses entirely.
         let result = section(
             &mut topo,
             cube,
             Point3::new(0.0, 0.0, 5.0),
             Vec3::new(0.0, 0.0, 1.0),
+        )
+        .unwrap();
+        assert!(
+            result.faces.is_empty(),
+            "plane above cube should produce an empty section"
         );
-        assert!(result.is_err(), "plane above cube should produce error");
+    }
+
+    #[test]
+    fn section_plane_flush_with_top_face() {
+        let mut topo = Topology::new();
+        let cube = make_unit_cube_manifold(&mut topo);
+
+        // Plane coincident with the cube's top face at z=1 — the coplanar
+        // boundary fallback must yield the face outline, not a miss.
+        let result = section(
+            &mut topo,
+            cube,
+            Point3::new(0.0, 0.0, 1.0),
+            Vec3::new(0.0, 0.0, 1.0),
+        )
+        .unwrap();
+        assert_eq!(
+            result.faces.len(),
+            1,
+            "flush plane should yield the face outline"
+        );
+        let area = crate::measure::face_area(&topo, result.faces[0], 0.1).unwrap();
+        assert!(
+            (area - 1.0).abs() < 1e-6,
+            "flush-face section area should be ~1.0, got {area}"
+        );
     }
 
     #[test]

--- a/crates/operations/tests/boolean_edge_cases.rs
+++ b/crates/operations/tests/boolean_edge_cases.rs
@@ -222,16 +222,25 @@ fn test_cut_removes_all() {
 
 #[test]
 fn test_intersect_disjoint() {
-    // Two disjoint boxes with no overlap.
+    // Two disjoint boxes with no overlap — the intersection is the empty
+    // set, returned as a successful zero-face, zero-volume result.
     let mut topo = Topology::new();
     let a = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
     let b = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
     transform_solid(&mut topo, b, &Mat4::translation(5.0, 5.0, 5.0)).unwrap();
 
-    let result = boolean(&mut topo, BooleanOp::Intersect, a, b);
+    let result = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    assert_eq!(
+        brepkit_topology::explorer::solid_faces(&topo, result)
+            .unwrap()
+            .len(),
+        0,
+        "disjoint intersect should produce zero faces"
+    );
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
     assert!(
-        result.is_err(),
-        "intersecting disjoint solids should return Err"
+        vol <= 1e-6,
+        "disjoint intersect volume should be ~0, got {vol}"
     );
 }
 

--- a/crates/operations/tests/boolean_stress.rs
+++ b/crates/operations/tests/boolean_stress.rs
@@ -445,9 +445,20 @@ fn disjoint_intersect_empty() {
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
     let b = box_at(&mut topo, 10.0, 0.0, 0.0, 1.0, 1.0, 1.0);
 
-    // Should error (empty result).
-    let result = boolean(&mut topo, BooleanOp::Intersect, a, b);
-    assert!(result.is_err(), "disjoint intersect should fail");
+    // The empty intersection succeeds with a zero-face, zero-volume result.
+    let result = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    assert_eq!(
+        brepkit_topology::explorer::solid_faces(&topo, result)
+            .unwrap()
+            .len(),
+        0,
+        "disjoint intersect should produce zero faces"
+    );
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        vol <= 1e-6,
+        "disjoint intersect volume should be ~0, got {vol}"
+    );
 }
 
 // ===========================================================================

--- a/crates/topology/src/shell.rs
+++ b/crates/topology/src/shell.rs
@@ -30,6 +30,26 @@ impl Shell {
         Ok(Self { faces })
     }
 
+    /// Creates a faceless shell backing an empty-result sentinel.
+    ///
+    /// A regular shell rejects an empty face list because an ordinary
+    /// surface boundary must enclose something. The empty shell exists
+    /// only so a boolean whose algebraic outcome is the empty set
+    /// (e.g. the intersection of disjoint solids) can be represented as
+    /// a valid, queryable solid handle reporting zero faces and zero
+    /// volume — distinct from a malformed-input error.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self { faces: Vec::new() }
+    }
+
+    /// Returns `true` when this shell has no faces (the empty-result
+    /// sentinel — see [`Shell::empty`]).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.faces.is_empty()
+    }
+
     /// Returns the faces of this shell.
     #[must_use]
     pub fn faces(&self) -> &[FaceId] {

--- a/crates/topology/src/topology.rs
+++ b/crates/topology/src/topology.rs
@@ -270,6 +270,35 @@ impl Topology {
         Id = CompSolidId
     );
 
+    // ── Empty-result sentinel ─────────────────────────────────────
+
+    /// Allocates an empty-result solid: a solid backed by a faceless
+    /// [`Shell::empty`].
+    ///
+    /// Booleans whose algebraic outcome is the empty set (e.g. the
+    /// intersection of disjoint solids) return this so the result is a
+    /// valid, queryable handle reporting zero faces and zero volume,
+    /// distinct from a malformed-input error. A shell cannot otherwise
+    /// hold zero faces, so this is the only path that produces one.
+    pub fn add_empty_solid(&mut self) -> SolidId {
+        let shell = self.add_shell(Shell::empty());
+        self.add_solid(Solid::new(shell, Vec::new()))
+    }
+
+    /// Returns `true` when `solid` is an empty-result sentinel — its
+    /// outer shell is faceless and it has no inner shells (see
+    /// [`Topology::add_empty_solid`]).
+    #[must_use]
+    pub fn is_empty_solid(&self, solid: SolidId) -> bool {
+        self.solids.get(solid).is_some_and(|s| {
+            s.inner_shells().is_empty()
+                && self
+                    .shells
+                    .get(s.outer_shell())
+                    .is_some_and(Shell::is_empty)
+        })
+    }
+
     // ── PCurve registry ───────────────────────────────────────────
 
     /// Returns a shared reference to the pcurve registry.


### PR DESCRIPTION
## Summary

Aligns the boolean engine with the reference kernel: when the algebraic outcome of an operation is the empty set, return a successful empty result instead of an error.

- **intersect(A, B)** of disjoint solids now yields a zero-face, zero-volume empty-solid sentinel. Detection is broad-phase (curvature-aware AABB separation) then narrow-phase (engine selects no common faces).
- **section(solid, plane)** for a plane that misses the solid returns an empty face list instead of erroring.

## Representation

The empty result is a topology-level sentinel: a solid backed by a faceless shell (`Topology::add_empty_solid` / `is_empty_solid`). It reports zero faces, zero volume, and tessellates to an empty mesh, so downstream `measure` / `tessellate` / export accept it without panicking.

## Invariants preserved

- Containment shortcuts still win.
- Touching / disjoint configurations report empty.
- Genuine overlaps remain non-empty.
- Segment-assembly failures on genuinely intersecting section geometry stay real errors (only true misses go empty).

## Tests

Added coverage in `boolean/tests.rs`, `section.rs`, and the `boolean_edge_cases` / `boolean_stress` integration suites for disjoint intersect and non-intersecting section.