### PR TITLE
fix(tessellate): use max curvature radius for ellipse facet density

### DIFF
--- a/crates/operations/src/tessellate/edge_sampling.rs
+++ b/crates/operations/src/tessellate/edge_sampling.rs
@@ -77,12 +77,15 @@ pub(super) fn edge_sample_count(
             }
         }
         EdgeCurve::Ellipse(ellipse) => {
-            // The tightest bend governs: an ellipse's smallest radius of
-            // curvature is b^2/a at the major-axis ends, so the criterion
-            // evaluated there yields the finest (correct) segment count.
+            // Density is driven by the LARGEST radius of curvature (a^2/b, at the
+            // minor-axis ends). Under uniform-parameter sampling the per-segment
+            // chord deviation is set by how far the parameter sweeps in arc length,
+            // which peaks where curvature is lowest; the small-radius criterion
+            // (b^2/a) satisfies pointwise sag but lets the integrated (area/volume)
+            // error grow ~15x. Using a^2/b keeps both bounded.
             let a = ellipse.semi_major();
             let b = ellipse.semi_minor();
-            let min_curv_radius = b * b / a;
+            let max_curv_radius = a * a / b;
             let arc_range = if edge.is_closed() {
                 std::f64::consts::TAU
             } else if let (Ok(sp), Ok(ep)) = (
@@ -100,7 +103,7 @@ pub(super) fn edge_sample_count(
             } else {
                 std::f64::consts::TAU
             };
-            segments_for_chord_deviation_a(min_curv_radius, arc_range, deflection, angular_tol)
+            segments_for_chord_deviation_a(max_curv_radius, arc_range, deflection, angular_tol)
                 .min(4096)
         }
         EdgeCurve::NurbsCurve(nurbs) => {
@@ -344,10 +347,12 @@ pub(super) fn sample_wire_positions(
                     (ts, te)
                 };
                 let arc_range = t_end - t_start;
-                let min_curv_radius =
-                    ellipse.semi_minor() * ellipse.semi_minor() / ellipse.semi_major();
+                // Largest radius of curvature (a^2/b) governs uniform-parameter
+                // sampling density; see edge_sample_count for the rationale.
+                let max_curv_radius =
+                    ellipse.semi_major() * ellipse.semi_major() / ellipse.semi_minor();
                 let n_samples = segments_for_chord_deviation_a(
-                    min_curv_radius,
+                    max_curv_radius,
                     arc_range,
                     deflection,
                     angular_tol,

--- a/crates/operations/src/tessellate/planar.rs
+++ b/crates/operations/src/tessellate/planar.rs
@@ -332,10 +332,13 @@ pub(super) fn tessellate_planar(
                     (ts, te)
                 };
                 let arc_range = t_end - t_start;
-                let min_curv_radius =
-                    ellipse.semi_minor() * ellipse.semi_minor() / ellipse.semi_major();
+                // Largest radius of curvature (a^2/b) governs uniform-parameter
+                // sampling density; matches the wall edge sampling so the cap
+                // boundary stays watertight against the side faces.
+                let max_curv_radius =
+                    ellipse.semi_major() * ellipse.semi_major() / ellipse.semi_minor();
                 let n_samples = segments_for_chord_deviation_a(
-                    min_curv_radius,
+                    max_curv_radius,
                     arc_range,
                     deflection,
                     angular_tol,

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -1500,3 +1500,101 @@ fn fillet_cylinder_triangle_count() {
         );
     }
 }
+
+/// Build a solid by extruding a closed ellipse (`semi_major`, `semi_minor`) in
+/// the XY plane by `height` along +Z. The boundary is a single closed
+/// `Ellipse` edge, matching what `sketchEllipse(a, b).extrude(h)` produces.
+fn extrude_ellipse(
+    topo: &mut Topology,
+    semi_major: f64,
+    semi_minor: f64,
+    height: f64,
+) -> brepkit_topology::solid::SolidId {
+    let center = Point3::new(0.0, 0.0, 0.0);
+    let normal = Vec3::new(0.0, 0.0, 1.0);
+    let ellipse =
+        brepkit_math::curves::Ellipse3D::new(center, normal, semi_major, semi_minor).unwrap();
+
+    // A single closed edge (start == end) at the major-axis vertex (t = 0).
+    let seam = ellipse.evaluate(0.0);
+    let vid = topo.add_vertex(Vertex::new(seam, 1e-7));
+    let edge = topo.add_edge(Edge::new(vid, vid, EdgeCurve::Ellipse(ellipse)));
+    let wire = topo.add_wire(Wire::new(vec![OrientedEdge::new(edge, true)], true).unwrap());
+    let face = topo.add_face(Face::new(
+        wire,
+        vec![],
+        FaceSurface::Plane { normal, d: 0.0 },
+    ));
+
+    crate::extrude::extrude(topo, face, Vec3::new(0.0, 0.0, 1.0), height).unwrap()
+}
+
+#[test]
+fn eccentric_ellipse_extrude_volume_matches_analytic() {
+    use std::f64::consts::PI;
+
+    // Regression guard for the #717 ellipse tessellation density drop.
+    // sketchEllipse(5, 2).extrude(10) must mesh densely enough that the
+    // tessellation-derived volume matches the analytic pi*a*b*h within the
+    // brepjs parity tolerance (toBeCloseTo(vol, 0) => |err| < 0.5 absolute).
+    let cases = [
+        (5.0_f64, 2.0_f64, 10.0_f64),
+        (10.0, 1.0, 4.0),
+        (8.0, 3.0, 2.0),
+    ];
+    for (a, b, h) in cases {
+        let mut topo = Topology::new();
+        let solid = extrude_ellipse(&mut topo, a, b, h);
+        // brepjs measureVolume uses DEFAULT_DEFLECTION = 0.01.
+        let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+        let analytic = PI * a * b * h;
+        assert!(
+            (vol - analytic).abs() < 0.5,
+            "ellipse({a},{b}).extrude({h}): mesh volume {vol:.4} vs analytic {analytic:.4} \
+             (err {:.4}); eccentric ellipse wall under-tessellated",
+            (vol - analytic).abs()
+        );
+    }
+}
+
+#[test]
+fn ellipse_wall_facet_count_is_curvature_appropriate() {
+    // The elliptical wall must carry enough facets to resolve its curvature
+    // at the default deflection. For ellipse(5, 2) at deflection 0.01 a
+    // curvature-faithful sampler needs ~200 segments around the loop; assert a
+    // conservative floor so a future density regression is caught directly at
+    // the tessellation layer (not only via the volume check).
+    let mut topo = Topology::new();
+    let solid = extrude_ellipse(&mut topo, 5.0, 2.0, 10.0);
+    let mesh = tessellate_solid(&topo, solid, 0.01).unwrap();
+    let n_pos = mesh.positions.len();
+    assert!(
+        n_pos >= 200,
+        "ellipse(5,2) wall under-tessellated: only {n_pos} mesh vertices at deflection 0.01"
+    );
+}
+
+#[test]
+fn circle_and_degenerate_ellipse_do_not_over_tessellate() {
+    // The fix must not blow up density on near-circular or circular inputs.
+    // A near-circular ellipse(5, 5) extrude should produce a similar facet
+    // count to a true circle of the same radius, and stay well bounded.
+    let mut topo_e = Topology::new();
+    let solid_e = extrude_ellipse(&mut topo_e, 5.0, 5.0, 10.0);
+    let mesh_e = tessellate_solid(&topo_e, solid_e, 0.01).unwrap();
+    let n_e = mesh_e.positions.len();
+
+    let mut topo_c = Topology::new();
+    let solid_c = crate::primitives::make_cylinder(&mut topo_c, 5.0, 10.0).unwrap();
+    let mesh_c = tessellate_solid(&topo_c, solid_c, 0.01).unwrap();
+    let n_c = mesh_c.positions.len();
+
+    assert!(
+        n_e < 4 * n_c.max(1),
+        "near-circular ellipse over-tessellates: {n_e} verts vs cylinder {n_c}"
+    );
+    assert!(
+        n_e < 5_000,
+        "near-circular ellipse(5,5) over-tessellates: {n_e} mesh vertices"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a tessellation regression shipped in #717 (released 2.94.0): eccentric ellipses extruded into solids under-tessellate at the default deflection, producing a mesh-derived volume ~0.21% low. `sketchEllipse(5, 2).extrude(10)` measured 313.49 vs analytic π·5·2·10 = 314.16, failing the brepjs `sketchToSolid` parity spec (`toBeCloseTo(vol, 0)` ⇒ |err| < 0.5).

## Root cause

#717 switched the ellipse segment-count radius from `a²/b` (the **largest** radius of curvature, at the minor-axis ends) to `b²/a` (the **smallest**, at the major-axis ends), reasoning "the tightest bend governs." That is correct for a circle, but the segment count is distributed **uniformly in the ellipse parameter `t`**, and under uniform-parameter sampling the per-segment chord deviation is set by how far the parameter sweeps in arc length — which peaks where curvature is *lowest*. The small-radius criterion satisfies pointwise chord sag but lets the integrated area/volume error grow ~15× (deficit/deflection ≈ 6.4 for `b²/a` vs ≈ 0.42 for `a²/b`).

Both choices yield volume error that scales linearly with deflection (both are valid samplers), but only `a²/b` keeps the integrated error bounded at the scale the deflection tolerance implies.

## Fix

Restore `a²/b` at all three ellipse sampling sites:
- `edge_sampling.rs` — `edge_sample_count` (segment count)
- `edge_sampling.rs` — `sample_wire_positions` (extruded wall wire)
- `planar.rs` — planar cap wire sampling (kept in sync so caps stay watertight against the walls)

At deflection 0.01 the ellipse(5,2) loop goes from 57 → 223 segments — the curvature-faithful density. Circular and near-circular inputs are unaffected (they already use the equal-radius case).

## Verification

Native (new tests in `tessellate/tests.rs`):
- `eccentric_ellipse_extrude_volume_matches_analytic` — ellipse(5,2)/(10,1)/(8,3) volumes within 0.5 of analytic
- `ellipse_wall_facet_count_is_curvature_appropriate` — ≥200 mesh verts at deflection 0.01
- `circle_and_degenerate_ellipse_do_not_over_tessellate` — near-circular ellipse stays bounded (< 4× cylinder, < 5000 verts)

Before fix: ellipse(5,2) volume 313.4875 (fail). After: passes.

Cross-kernel: built brepkit-wasm, swapped into a disposable brepjs worktree, ran `tests/parity/sketchToSolid.test.ts` under `TEST_KERNEL=brepkit` — all `sketchEllipse` cases pass.

Gate: `cargo fmt --check`, `cargo clippy -p brepkit-operations -p brepkit-math --all-targets -- -D warnings`, `./scripts/check-boundaries.sh`, `cargo test -p brepkit-operations -p brepkit-math`, golden regression — all clean. Pre-commit + pre-push hooks passed.