### PR TITLE
fix(topology): orient planar face normal by wire winding

### DIFF
--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -1221,3 +1221,61 @@ fn center_of_mass_from_faces(
     let denom = 4.0 * total_vol;
     Ok(Point3::new(cx / denom, cy / denom, cz / denom))
 }
+
+#[cfg(test)]
+mod regression_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use brepkit_topology::builder::{make_face_from_wire, make_polygon_wire};
+    use brepkit_topology::face::FaceSurface;
+
+    fn unit_square_extrude_volume() -> (f64, bool) {
+        let mut topo = Topology::new();
+        let pts = vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(1.0, 1.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+        ];
+        let wire = make_polygon_wire(&mut topo, &pts, 1e-7).unwrap();
+        let face = make_face_from_wire(&mut topo, wire).unwrap();
+        let cap_is_plane = matches!(
+            topo.face(face).unwrap().surface(),
+            FaceSurface::Plane { .. }
+        );
+        let solid =
+            crate::extrude::extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let vol = solid_volume(&topo, solid, 0.01).unwrap();
+        (vol, cap_is_plane)
+    }
+
+    #[test]
+    fn unit_square_extrude_volume_is_one() {
+        let (vol, cap_is_plane) = unit_square_extrude_volume();
+        assert!(
+            cap_is_plane,
+            "axis-aligned square cap must be a planar face"
+        );
+        assert!((vol - 1.0).abs() < 1e-6, "expected 1.0, got {vol}");
+    }
+
+    #[test]
+    fn rectangle_extrude_volume_matches_box() {
+        // A non-square, non-unit axis-aligned rectangle whose winding-derived
+        // cap normal must still come out correct.
+        let mut topo = Topology::new();
+        let pts = vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(5.0, 0.0, 0.0),
+            Point3::new(5.0, 2.0, 0.0),
+            Point3::new(0.0, 2.0, 0.0),
+        ];
+        let wire = make_polygon_wire(&mut topo, &pts, 1e-7).unwrap();
+        let face = make_face_from_wire(&mut topo, wire).unwrap();
+        let solid =
+            crate::extrude::extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+        let vol = solid_volume(&topo, solid, 0.01).unwrap();
+        assert!((vol - 30.0).abs() < 1e-6, "expected 30.0, got {vol}");
+    }
+}

--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -314,6 +314,11 @@ pub fn make_planar_face_from_wire(
 /// Sample points and tolerance gathered from a wire for planarity testing.
 struct WireSamples {
     points: Vec<Point3>,
+    /// Boundary points in wire-traversal order, used to orient the plane
+    /// normal consistently with the wire winding (right-hand rule). Unlike
+    /// `points`, these are strictly ordered along the loop so Newell's method
+    /// yields the correct winding sign.
+    ordered: Vec<Point3>,
     /// Squared effective tolerance: `max(base linear, max edge tolerance)²`.
     tol_sq: f64,
     /// Plane derived directly from the first conic edge, if any. A conic is
@@ -330,6 +335,7 @@ fn sample_wire_for_planarity(
     edges: &[OrientedEdge],
 ) -> Result<WireSamples, crate::TopologyError> {
     let mut points = Vec::with_capacity(edges.len() * 4);
+    let mut ordered = Vec::with_capacity(edges.len() * 4);
     let mut tol = Tolerance::new().linear;
     let mut conic_plane = None;
 
@@ -350,11 +356,13 @@ fn sample_wire_for_planarity(
                 points.push(start_pt);
                 points.push(end_pt);
                 points.push(start_pt + (end_pt - start_pt) * 0.5);
+                ordered.push(start_pt);
             }
             EdgeCurve::Circle(c) => {
                 if conic_plane.is_none() {
                     conic_plane = Some(plane_from(c.center(), c.normal()));
                 }
+                let before = points.len();
                 sample_conic(
                     start_pt,
                     end_pt,
@@ -363,11 +371,13 @@ fn sample_wire_for_planarity(
                     |t| c.evaluate(t),
                     |p| c.project(p),
                 );
+                ordered.extend_from_slice(&points[before..]);
             }
             EdgeCurve::Ellipse(e) => {
                 if conic_plane.is_none() {
                     conic_plane = Some(plane_from(e.center(), e.normal()));
                 }
+                let before = points.len();
                 sample_conic(
                     start_pt,
                     end_pt,
@@ -376,15 +386,19 @@ fn sample_wire_for_planarity(
                     |t| e.evaluate(t),
                     |p| e.project(p),
                 );
+                ordered.extend_from_slice(&points[before..]);
             }
             EdgeCurve::NurbsCurve(nc) => {
                 points.extend_from_slice(nc.control_points());
+                ordered.push(start_pt);
+                ordered.push(start_pt + (end_pt - start_pt) * 0.5);
             }
         }
     }
 
     Ok(WireSamples {
         points,
+        ordered,
         tol_sq: tol * tol,
         conic_plane,
     })
@@ -430,7 +444,7 @@ fn plane_from(point: Point3, normal: Vec3) -> (Vec3, f64) {
 /// every sample lies within tolerance of it. Returns `None` when no plane
 /// can be formed or verification fails.
 fn verified_plane(samples: &WireSamples) -> Option<(Vec3, f64)> {
-    let (normal, d) = samples
+    let (mut normal, mut d) = samples
         .conic_plane
         .or_else(|| fit_plane(&samples.points, samples.tol_sq))?;
 
@@ -441,7 +455,40 @@ fn verified_plane(samples: &WireSamples) -> Option<(Vec3, f64)> {
             return None;
         }
     }
+
+    // Orient the normal consistently with the wire winding (right-hand rule).
+    // `fit_plane` and a conic's intrinsic plane both yield a normal whose sign
+    // is independent of traversal order; downstream consumers (e.g. extrude)
+    // require the normal to follow the boundary's CCW winding so cap and wall
+    // orientations come out correct.
+    if let Some(winding_normal) = newell_normal(&samples.ordered) {
+        if normal.dot(winding_normal) < 0.0 {
+            normal = -normal;
+            d = -d;
+        }
+    }
     Some((normal, d))
+}
+
+/// Newell's-method normal for an ordered loop of boundary points. The result
+/// follows the winding (CCW gives the right-hand-rule normal). Returns `None`
+/// for fewer than 3 points or a degenerate (collinear) loop.
+fn newell_normal(ordered: &[Point3]) -> Option<Vec3> {
+    if ordered.len() < 3 {
+        return None;
+    }
+    let mut nx = 0.0_f64;
+    let mut ny = 0.0_f64;
+    let mut nz = 0.0_f64;
+    let n = ordered.len();
+    for i in 0..n {
+        let curr = ordered[i];
+        let next = ordered[(i + 1) % n];
+        nx += (curr.y() - next.y()) * (curr.z() + next.z());
+        ny += (curr.z() - next.z()) * (curr.x() + next.x());
+        nz += (curr.x() - next.x()) * (curr.y() + next.y());
+    }
+    Vec3::new(nx, ny, nz).normalize().ok()
 }
 
 /// Fit a candidate plane from scattered sample points using the most
@@ -683,7 +730,7 @@ pub fn make_nurbs_face(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::panic)]
 
     use brepkit_math::tolerance::Tolerance;
     use brepkit_math::vec::Point3;
@@ -974,10 +1021,43 @@ mod tests {
 
         let fid = make_face_from_wire(&mut topo, wid).unwrap();
         let face = topo.face(fid).unwrap();
-        if let FaceSurface::Plane { normal, .. } = face.surface() {
-            let tol = Tolerance::new();
-            assert!(tol.approx_eq(normal.z().abs(), 1.0), "normal should be ±Z");
-        }
+        let FaceSurface::Plane { normal, .. } = face.surface() else {
+            panic!("square wire must produce a planar face");
+        };
+        let tol = Tolerance::new();
+        // CCW square in the XY plane: right-hand rule normal must point +Z.
+        // A sign-agnostic plane fit would (incorrectly) allow -Z here, which
+        // flips extruded caps and collapses solid volume.
+        assert!(
+            tol.approx_eq(normal.z(), 1.0),
+            "CCW square normal must be +Z"
+        );
+    }
+
+    #[test]
+    fn make_face_from_wire_cw_square_normal_is_minus_z() {
+        let mut topo = Topology::new();
+        // CW winding (reverse of the CCW square): normal must point -Z.
+        let wid = make_polygon_wire(
+            &mut topo,
+            &[
+                Point3::new(0.0, 0.0, 0.0),
+                Point3::new(0.0, 1.0, 0.0),
+                Point3::new(1.0, 1.0, 0.0),
+                Point3::new(1.0, 0.0, 0.0),
+            ],
+            TOL,
+        )
+        .unwrap();
+        let fid = make_face_from_wire(&mut topo, wid).unwrap();
+        let FaceSurface::Plane { normal, .. } = topo.face(fid).unwrap().surface() else {
+            panic!("square wire must produce a planar face");
+        };
+        let tol = Tolerance::new();
+        assert!(
+            tol.approx_eq(normal.z(), -1.0),
+            "CW square normal must be -Z"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A planar rectangle cap built via \`make_face_from_wire\` was getting an **inverted normal**, collapsing extruded-solid volume to exactly **1/3** of the true value. Introduced in #722 and shipped in \`brepkit-wasm@2.97.0\`.

\`sketchRectangle(1,1).extrude(1)\` returned volume \`0.333\` instead of \`1.0\` (67% error). All \`sketchRectangle\` and rectangle-loft volume parity cases failed this way; ellipse and circle cases were unaffected.

## Root cause

#722 reworked \`make_face_from_wire\` to verify planarity. In doing so it replaced the old winding-consistent Newell normal with a **sign-agnostic** plane source (\`fit_plane\` picks an extreme/least-collinear triple; a conic uses its intrinsic axis-system plane). The resulting normal's sign no longer follows the wire's traversal order.

For a CCW axis-aligned square \`[(0,0,0),(1,0,0),(1,1,0),(0,1,0)]\`, \`fit_plane\` yields \`v1 = (1,1,0)\` (the diagonal), \`v2 = (1,0,0)\`, so \`normal = v1 × v2 = (0,0,-1)\` — pointing into the solid. \`extrude\` only re-flips the normal when it independently detects a CW wire (\`is_cw_winding\`), which is false here, so the wrong-signed cap propagates to both caps and the signed-tetrahedra volume integration degenerates to 1/3.

Ellipse/circle caps were unaffected because a closed conic carries its intrinsic plane and its caps come out evenly oriented.

## Fix

After coplanarity verification, flip the candidate normal (and \`d\`) to agree with the **Newell normal of the ordered boundary loop**, restoring the original winding-consistent contract. Planarity **verification** from #722 is untouched: non-coplanar wires still fall back to a non-planar surface and never report surface type \`plane\`.

## Tests

- \`make_face_from_wire_square\`: CCW square cap normal is **+Z** (strengthened from the old \`.abs()\` check that missed the sign bug).
- \`make_face_from_wire_cw_square_normal_is_minus_z\`: CW square → **-Z**.
- \`unit_square_extrude_volume_is_one\` / \`rectangle_extrude_volume_matches_box\`: extruded planar rectangles measure the correct volume.
- #722's planarity / surface-type tests (\`make_face_from_wire_noncoplanar_is_not_plane_surface\`, \`make_planar_face_from_wire_rejects_noncoplanar_wire\`, near-miss boundary, wasm \`surface_type_*\`) all continue to pass.

## Verification

- Native: unit-square extrude volume 0.333 → 1.0; cap normal (0,0,-1) → (0,0,1).
- Cross-kernel (brepjs parity, \`TEST_KERNEL=brepkit\`): all rectangle + rectangle-loft + circle + makeFace volume cases pass; 89 surface-type/planar tests pass.
- \`cargo fmt\`, \`clippy -D warnings\`, \`check-boundaries.sh\`, full workspace tests green.