### PR TITLE
fix(fillet): correct corner over-removal in all-edges rolling-ball fillet

### DIFF
--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -49,8 +49,7 @@ use super::helpers::{FacePolygon, extract_inner_wire_positions};
 #[allow(clippy::too_many_lines)]
 #[deprecated(
     since = "2.44.0",
-    note = "Use brepkit_blend::fillet_builder::FilletBuilder (via blend_ops::fillet_v2) instead. \
-            This implementation has known corner overlap issues at multi-edge vertices."
+    note = "Use brepkit_blend::fillet_builder::FilletBuilder (via blend_ops::fillet_v2) instead."
 )]
 pub fn fillet_rolling_ball(
     topo: &mut Topology,
@@ -540,11 +539,96 @@ pub fn fillet_rolling_ball(
         }
     }
 
+    // Setback map: at a junction vertex where this edge meets ANOTHER filleted
+    // edge sharing one of its adjacent faces, the blend strip must stop short
+    // of the vertex by setback = radius / tan(θ/2), where θ is the angle (via
+    // edge tangents at the vertex) between the two filleted edges.  This leaves
+    // a corner gap that the spherical-triangle patch (Phase 5b) fills, rather
+    // than letting full-length strips interpenetrate and over-remove material.
+    //
+    // Key: (edge_index, vertex_index) → setback distance along the edge.
+    let setback_map: HashMap<(usize, usize), f64> = {
+        let mut map = HashMap::new();
+        for &edge_id in &filtered_edges {
+            let edge = topo.edge(edge_id)?;
+            let start_vid = edge.start();
+            let end_vid = edge.end();
+            let p_start = topo.vertex(start_vid)?.point();
+            let p_end = topo.vertex(end_vid)?.point();
+            let curve = edge.curve().clone();
+
+            for &(vid, t_self) in &[(start_vid, 0.0_f64), (end_vid, 1.0_f64)] {
+                let Some(neighbors) = vertex_fillet_edges.get(&vid.index()) else {
+                    continue;
+                };
+                let t_away = sample_edge_tangent(&curve, p_start, p_end, t_self);
+                let t_away = if t_self > 0.5 { -t_away } else { t_away };
+                let Ok(t_self_n) = t_away.normalize() else {
+                    continue;
+                };
+
+                let mut max_setback = 0.0_f64;
+                for &nb in neighbors {
+                    if nb.index() == edge_id.index() {
+                        continue;
+                    }
+                    let nb_edge = topo.edge(nb)?;
+                    let nb_start = nb_edge.start();
+                    let nb_end = nb_edge.end();
+                    let nbp_start = topo.vertex(nb_start)?.point();
+                    let nbp_end = topo.vertex(nb_end)?.point();
+                    let nb_curve = nb_edge.curve().clone();
+                    let t_nb_param = if nb_start.index() == vid.index() {
+                        0.0
+                    } else {
+                        1.0
+                    };
+                    let t_nb_raw = sample_edge_tangent(&nb_curve, nbp_start, nbp_end, t_nb_param);
+                    let t_nb_raw = if t_nb_param > 0.5 {
+                        -t_nb_raw
+                    } else {
+                        t_nb_raw
+                    };
+                    let Ok(t_nb_n) = t_nb_raw.normalize() else {
+                        continue;
+                    };
+
+                    let cos_t = t_self_n.dot(t_nb_n).clamp(-1.0, 1.0);
+                    let theta = cos_t.acos();
+                    let half_tan = (theta / 2.0).tan();
+                    if half_tan > tol.linear {
+                        max_setback = max_setback.max(radius / half_tan);
+                    }
+                }
+
+                if max_setback > tol.linear {
+                    map.insert((edge_id.index(), vid.index()), max_setback);
+                }
+            }
+        }
+        map
+    };
+
+    // Convert a setback distance into a normalised edge parameter for a line
+    // edge of given length.  For curved edges the strip is still sampled in
+    // normalised t, so the fraction is an approximation adequate for the gap.
+    let setback_fraction = |sb: f64, edge_len: f64| -> f64 {
+        if edge_len > tol.linear {
+            (sb / edge_len).clamp(0.0, 0.49)
+        } else {
+            0.0
+        }
+    };
+
     // Pre-pass: precompute fillet strip endpoint contacts using Phase 4's
     // cross-product method.  Phase 3's face trimming will look up these exact
     // values instead of recomputing them from polygon neighbour directions.
     // This ensures both phases produce bitwise-identical positions, preventing
     // duplicate vertices (and thus boundary edges) in assemble_solid_mixed.
+    //
+    // The contact is sampled at the setback STATION (not the raw vertex), so
+    // the trimmed flat-face corner coincides with the setback-trimmed strip end
+    // and the spherical-triangle corner-patch boundary.
     //
     // Key: (vertex_index, edge_index, face_index) → contact Point3
     let fillet_contact_map: HashMap<(usize, usize, usize), Point3> = {
@@ -554,6 +638,7 @@ pub fn fillet_rolling_ball(
             let edge = topo.edge(edge_id)?;
             let p_start = topo.vertex(edge.start())?.point();
             let p_end = topo.vertex(edge.end())?.point();
+            let edge_len = (p_end - p_start).length();
 
             let Some(face_list) = edge_to_faces.get(&edge_id.index()) else {
                 continue;
@@ -577,8 +662,18 @@ pub fn fillet_rolling_ball(
                 continue;
             }
 
-            // Compute contacts at start (t=0) and end (t=1).
-            for &(t, vid) in &[(0.0_f64, edge.start()), (1.0_f64, edge.end())] {
+            // Compute contacts at the setback stations near start and end.
+            let sb_start = setback_map
+                .get(&(edge_id.index(), edge.start().index()))
+                .copied()
+                .unwrap_or(0.0);
+            let sb_end = setback_map
+                .get(&(edge_id.index(), edge.end().index()))
+                .copied()
+                .unwrap_or(0.0);
+            let t_lo = setback_fraction(sb_start, edge_len);
+            let t_hi = 1.0 - setback_fraction(sb_end, edge_len);
+            for &(t, vid) in &[(t_lo, edge.start()), (t_hi, edge.end())] {
                 let p = sample_edge_point(&edge_curve, p_start, p_end, t);
                 let tan = sample_edge_tangent(&edge_curve, p_start, p_end, t);
                 let local_dir = match tan.normalize() {
@@ -624,7 +719,6 @@ pub fn fillet_rolling_ball(
 
     // Phase 3: Build modified (trimmed) planar faces.
     let mut all_specs: Vec<FaceSpec> = Vec::new();
-    let mut fillet_face_indices: Vec<usize> = Vec::new();
 
     for &face_id in &shell_face_ids {
         // Non-planar faces: either pass through or trim at fillet contact points.
@@ -1019,13 +1113,28 @@ pub fn fillet_rolling_ball(
             edge_v_samples(&edge_curve).max(7)
         };
 
+        // Setback-trim the swept interval so the strip stops short of any
+        // multi-fillet junction vertex, leaving room for the corner patch.
+        let edge_len = (p_end - p_start).length();
+        let sb_start = setback_map
+            .get(&(edge_id.index(), edge.start().index()))
+            .copied()
+            .unwrap_or(0.0);
+        let sb_end = setback_map
+            .get(&(edge_id.index(), edge.end().index()))
+            .copied()
+            .unwrap_or(0.0);
+        let t_lo = setback_fraction(sb_start, edge_len);
+        let t_hi = 1.0 - setback_fraction(sb_end, edge_len);
+
         // Sample cross-section geometry at each v-station along the edge curve.
         let mut grid: Vec<[Point3; 3]> = Vec::with_capacity(n_v);
         let mut bisector_ref = Vec3::new(0.0, 0.0, 0.0);
 
         #[allow(clippy::cast_precision_loss)]
         for s in 0..n_v {
-            let t = s as f64 / (n_v - 1).max(1) as f64;
+            let frac = s as f64 / (n_v - 1).max(1) as f64;
+            let t = t_lo + (t_hi - t_lo) * frac;
             let p = sample_edge_point(&edge_curve, p_start, p_end, t);
             let tan = sample_edge_tangent(&edge_curve, p_start, p_end, t);
             let local_dir = tan.normalize().unwrap_or(edge_dir);
@@ -1046,8 +1155,6 @@ pub fn fillet_rolling_ball(
             let ld1 = ld1.normalize().unwrap_or(d1_ref);
             let ld2 = ld2.normalize().unwrap_or(d2_ref);
 
-            let local_cos = ld1.dot(ld2).clamp(-1.0, 1.0);
-            let local_half = local_cos.acos() / 2.0;
             let bisector = (ld1 + ld2).normalize().unwrap_or(d1_ref);
 
             if s == 0 {
@@ -1055,9 +1162,14 @@ pub fn fillet_rolling_ball(
             }
 
             let contact1 = p + ld1 * radius;
-            let mid_dist = radius / local_half.cos().max(0.01);
-            let mid_cp = p + bisector * mid_dist;
             let contact2 = p + ld2 * radius;
+            // Rational-quadratic arc middle control point: the intersection of
+            // the face-tangents at the two contacts, which for a rolling-ball
+            // fillet is the original sharp-edge point `p` (the cylinder axis
+            // sits on the opposite side, toward the material interior).  Using
+            // `p` makes the arc bulge toward the edge (a true convex fillet);
+            // placing it at the ball centre would invert the arc and over-cut.
+            let mid_cp = p;
 
             grid.push([contact1, mid_cp, contact2]);
         }
@@ -1120,24 +1232,21 @@ pub fn fillet_rolling_ball(
                 .map_err(crate::OperationsError::Math)?
         };
 
+        // The fillet strip's outward normal must point away from the solid
+        // interior.  `bisector_ref` points from the edge toward the material
+        // (interior), so the surface is reversed when its natural normal agrees
+        // with the bisector.  Setting `reversed` here (instead of patching the
+        // assembled shell afterwards) keeps the flag attached to the spec, which
+        // survives face reordering and merging in assembly.
+        let strip_normal = fillet_surface.normal(0.5, 0.5).unwrap_or(bisector_ref);
+        let strip_reversed = strip_normal.dot(bisector_ref) > 0.0;
+
         all_specs.push(FaceSpec::Surface {
             vertices: vec![contact1_start, contact2_start, contact2_end, contact1_end],
             surface: FaceSurface::Nurbs(fillet_surface),
-            reversed: false,
+            reversed: strip_reversed,
             inner_wires: vec![],
         });
-
-        // Track which faces need normal reversal.
-        let srf_mid_normal = match &all_specs[all_specs.len() - 1] {
-            FaceSpec::Surface {
-                surface: FaceSurface::Nurbs(srf),
-                ..
-            } => srf.normal(0.5, 0.5).unwrap_or(bisector_ref),
-            _ => bisector_ref,
-        };
-        if srf_mid_normal.dot(bisector_ref) > 0.0 {
-            fillet_face_indices.push(all_specs.len() - 1);
-        }
 
         // Record contact points at each vertex for vertex blend detection.
         let start_vi = edge.start().index();
@@ -1385,41 +1494,31 @@ pub fn fillet_rolling_ball(
                     arc_mid_and_weight(p1, p2),
                     arc_mid_and_weight(p2, p0),
                 ) {
-                    // Apex: point on sphere in the average direction of the
-                    // three boundary radial vectors.
-                    let apex = {
-                        let avg = Vec3::new(
-                            (p0 - sphere_center).x()
-                                + (p1 - sphere_center).x()
-                                + (p2 - sphere_center).x(),
-                            (p0 - sphere_center).y()
-                                + (p1 - sphere_center).y()
-                                + (p2 - sphere_center).y(),
-                            (p0 - sphere_center).z()
-                                + (p1 - sphere_center).z()
-                                + (p2 - sphere_center).z(),
-                        );
-                        let len = avg.length().max(1e-15);
-                        let r_actual = (p0 - sphere_center).length();
-                        Point3::new(
-                            sphere_center.x() + avg.x() / len * r_actual,
-                            sphere_center.y() + avg.y() / len * r_actual,
-                            sphere_center.z() + avg.z() / len * r_actual,
-                        )
-                    };
+                    // Interior control point: a single degree-(2,2) rational
+                    // patch over a wide spherical triangle sags inward at its
+                    // centre if the interior control point sits on the sphere.
+                    // Place it instead at the intersection of the three corner
+                    // tangent planes (the apex of the tangent cone), pushed out
+                    // along the average radial direction.  For an orthogonal
+                    // (box) corner this lands at center + r·Σdir (overshoot √3),
+                    // and the rational blend then tracks the sphere within a few
+                    // percent of R — inside the corner-blend deviation budget.
+                    let r_actual = (p0 - sphere_center).length();
+                    let dir0 = (p0 - sphere_center) * (1.0 / r_actual);
+                    let dir1 = (p1 - sphere_center) * (1.0 / r_actual);
+                    let dir2 = (p2 - sphere_center) * (1.0 / r_actual);
+                    let radial_sum = dir0 + dir1 + dir2;
+                    let apex = Point3::new(
+                        sphere_center.x() + radial_sum.x() * r_actual,
+                        sphere_center.y() + radial_sum.y() * r_actual,
+                        sphere_center.z() + radial_sum.z() * r_actual,
+                    );
 
-                    // Apex weight: product of the three edge weights gives
-                    // a consistent rational patch for the spherical triangle.
+                    // Apex weight: the product of the three edge weights yields
+                    // the rational triangle that hugs the sphere most closely.
                     let w_apex = w01 * w12 * w20;
 
-                    // Build a degree (2,2) patch: 3×3 control points.
-                    // u=0: p0→m20→p2, u=0.5: m01→apex→m12, u=1: p1→m12→p2
-                    // v=1 boundary degenerates to single point p2.
-                    //
-                    // Weight grid — per-edge weights on each boundary arc,
-                    // apex weight in the interior, 1.0 at corners.
-                    // Column 2 (degenerate, all CPs = p2) uses 1.0
-                    // for symmetric interior parametrization.
+                    // Degree (2,2) rational patch with a degenerate column.
                     let cap_surface = NurbsSurface::new(
                         2,
                         2,
@@ -1434,26 +1533,26 @@ pub fn fillet_rolling_ball(
                     )
                     .map_err(crate::OperationsError::Math)?;
 
+                    // The cap's outward normal must point away from the sphere
+                    // centre (for a convex corner) so the tessellated patch faces
+                    // outward.  Evaluating the natural normal at an interior
+                    // station and comparing against the radial direction gives a
+                    // robust reversal flag that is stored on the spec (so it is
+                    // not lost when assembly reorders/merges faces).
+                    let cap_mid = cap_surface.evaluate(0.5, 0.5);
+                    let radial = (cap_mid - sphere_center)
+                        .normalize()
+                        .unwrap_or(blend_normal);
+                    let outward = if is_concave { -radial } else { radial };
+                    let cap_norm = cap_surface.normal(0.5, 0.5).unwrap_or(outward);
+                    let cap_reversed = cap_norm.dot(outward) < 0.0;
+
                     all_specs.push(FaceSpec::Surface {
                         vertices: ordered_points,
                         surface: FaceSurface::Nurbs(cap_surface),
-                        reversed: false,
+                        reversed: cap_reversed,
                         inner_wires: vec![],
                     });
-
-                    // Check if we need to flip this face.
-                    let cap_norm = match &all_specs[all_specs.len() - 1] {
-                        FaceSpec::Surface {
-                            surface: FaceSurface::Nurbs(srf),
-                            ..
-                        } => srf.normal(0.5, 0.5).unwrap_or(blend_normal),
-                        _ => blend_normal,
-                    };
-                    // The cap normal should point away from the original vertex.
-                    let to_vertex = v_pos - centroid;
-                    if to_vertex.dot(cap_norm) > 0.0 {
-                        fillet_face_indices.push(all_specs.len() - 1);
-                    }
                     continue;
                 }
             }
@@ -1599,24 +1698,10 @@ pub fn fillet_rolling_ball(
         }
     }
 
-    // Phase 6: Assemble the solid using mixed-surface assembly.
+    // Phase 6: Assemble the solid using mixed-surface assembly.  Each fillet
+    // strip and corner-patch spec already carries the `reversed` flag needed
+    // for an outward-facing normal, so no post-assembly fix-up is required.
     let solid_id = crate::boolean::assemble_solid_mixed(topo, &all_specs, tol)?;
-
-    // Phase 7: Mark fillet faces whose NURBS surface normal points inward
-    // as reversed. This ensures tessellation produces outward-facing
-    // triangles for correct volume computation and rendering.
-    if !fillet_face_indices.is_empty() {
-        let solid_data = topo.solid(solid_id)?;
-        let shell = topo.shell(solid_data.outer_shell())?;
-        let face_ids: Vec<_> = shell.faces().to_vec();
-        for &fi in &fillet_face_indices {
-            if fi < face_ids.len() {
-                let fid = face_ids[fi];
-                let face = topo.face_mut(fid)?;
-                face.set_reversed(true);
-            }
-        }
-    }
 
     // Merge co-surface faces that the fillet may have split. This keeps the
     // face count minimal, preventing the downstream boolean from triggering

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -351,6 +351,40 @@ fn vertex_blend_all_edges_box() {
 }
 
 #[test]
+fn vertex_blend_all_edges_box_volume() {
+    // Fillet all 12 edges of a 10×10×10 box at r=1.0. The result must be a
+    // closed, manifold, genus-0 solid (26 faces) whose volume reflects only
+    // the fillet-arc and corner-blend material removal — not gross corner
+    // excision. Analytic expectation ≈ 975.6:
+    //   1000 − 12·(1−π/4)·1²·8 (edge slivers ≈ 20.6)
+    //        − 8·(1−π/6)·1³    (corner blends ≈ 3.8).
+    let mut topo = Topology::new();
+    let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let edges = solid_edge_ids(&topo, cube);
+    assert_eq!(edges.len(), 12, "box should have 12 edges");
+
+    let result =
+        fillet_rolling_ball(&mut topo, cube, &edges, 1.0).expect("all-edges fillet should succeed");
+
+    let s = topo.solid(result).expect("result solid");
+    let sh = topo.shell(s.outer_shell()).expect("shell");
+    validate_shell_manifold(sh, &topo).expect("filleted box should be manifold");
+    assert_euler_genus0(&topo, result);
+
+    assert_eq!(
+        sh.faces().len(),
+        26,
+        "expected 26 faces (6 planar + 12 fillet + 8 blend)"
+    );
+
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        vol > 974.0 && vol < 978.0,
+        "filleted box volume should be ≈975.6 (in 974..978), got {vol}"
+    );
+}
+
+#[test]
 fn vertex_blend_tessellates_successfully() {
     // Verify the fully-filleted box can be tessellated without error.
     // Watertight stitching at NURBS-to-planar seams is a tessellation-level
@@ -377,14 +411,14 @@ fn vertex_blend_positive_volume() {
     let result =
         fillet_rolling_ball(&mut topo, cube, &edges, 0.1).expect("all-edges fillet should succeed");
 
-    let vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
-    // Unit cube volume = 1.0. Filleting removes corner material, so volume < 1.0 but > 0.5.
-    // TODO: vertex blend volume is inflated (~1.3) after edge fillet contact direction fix.
-    // The vertex blend patches overlap with adjacent geometry when edge fillet positions
-    // change. This only affects all-edges fillet with vertex blends — single-edge fillets
-    // (as used in gridfinity) are correct.
-    assert!(vol > 0.5, "filleted cube volume should be > 0.5, got {vol}");
-    assert!(vol < 1.5, "filleted cube volume should be < 1.5, got {vol}");
+    let vol = crate::measure::solid_volume(&topo, result, 0.005).unwrap();
+    // Analytic rounded-cube volume for s=1, r=0.1 (Minkowski sum of the inner
+    // (s−2r)³ box with a ball of radius r):
+    //   (0.8)³ + 6·(0.8)²·0.1 + 12·0.8·(π/4)·0.1² + (4/3)π·0.1³ ≈ 0.9756.
+    assert!(
+        vol > 0.970 && vol < 0.980,
+        "filleted unit-cube volume should be ≈0.9756 (in 0.970..0.980), got {vol}"
+    );
 }
 
 #[test]

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -142,12 +142,20 @@ pub fn json_f64(val: &serde_json::Value, key: &str) -> Result<f64, JsError> {
 
 // ── Edge/face helpers ─────────────────────────────────────────────
 
-/// Attempt fillet using the blend crate's `FilletBuilder` (primary),
-/// falling back to rolling-ball then flat bevel on failure.
+/// Attempt a fillet, choosing the engine by edge count.
 ///
-/// The blend crate path has correct corner geometry (spherical triangle
-/// patches) for multi-edge fillets. Rolling-ball is kept as fallback
-/// for edge cases where `FilletBuilder` fails.
+/// Multi-edge fillets need per-corner setback trimming and spherical blend
+/// patches so the rounded edges meeting at a vertex remove only the rounded
+/// sliver instead of excising the whole corner octant. The rolling-ball
+/// engine does this; the walking `FilletBuilder` over-removes corner material
+/// on that case (e.g. all 12 box edges drop to ~470 instead of ~975). So
+/// multi-edge inputs go to rolling-ball first.
+///
+/// Single-edge fillets have no shared-corner interaction, and the
+/// `FilletBuilder` output integrates more cleanly with downstream booleans,
+/// so they go to `FilletBuilder` first.
+///
+/// Each engine falls back to the other, then to a flat bevel, on failure.
 #[allow(deprecated)]
 pub fn try_fillet(
     topo: &mut brepkit_topology::Topology,
@@ -155,15 +163,21 @@ pub fn try_fillet(
     edge_ids: &[brepkit_topology::edge::EdgeId],
     radius: f64,
 ) -> Result<brepkit_topology::solid::SolidId, brepkit_operations::OperationsError> {
-    // Primary path: blend crate FilletBuilder (correct corner geometry)
-    brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edge_ids, radius)
-        .map(|r| r.solid)
-        // Fallback 1: rolling-ball (legacy, known corner overlap issues)
-        .or_else(|_| {
-            brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edge_ids, radius)
-        })
-        // Fallback 2: flat bevel (simplest)
-        .or_else(|_| brepkit_operations::fillet::fillet(topo, solid_id, edge_ids, radius))
+    let rolling_ball = |topo: &mut brepkit_topology::Topology| {
+        brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edge_ids, radius)
+    };
+    let builder = |topo: &mut brepkit_topology::Topology| {
+        brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edge_ids, radius).map(|r| r.solid)
+    };
+
+    let result = if edge_ids.len() > 1 {
+        rolling_ball(topo).or_else(|_| builder(topo))
+    } else {
+        builder(topo).or_else(|_| rolling_ball(topo))
+    };
+
+    // Final fallback: flat bevel (simplest).
+    result.or_else(|_| brepkit_operations::fillet::fillet(topo, solid_id, edge_ids, radius))
 }
 
 /// Extract a human-readable message from a `catch_unwind` panic payload.
@@ -464,4 +478,54 @@ pub fn segments_intersect_2d(a1: Point2, a2: Point2, b1: Point2, b2: Point2) -> 
 
     ((d1 > 0.0 && d2 < 0.0) || (d1 < 0.0 && d2 > 0.0))
         && ((d3 > 0.0 && d4 < 0.0) || (d3 < 0.0 && d4 > 0.0))
+}
+
+#[cfg(test)]
+mod fillet_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use std::collections::HashSet;
+
+    use brepkit_topology::Topology;
+    use brepkit_topology::edge::EdgeId;
+    use brepkit_topology::solid::SolidId;
+
+    use super::try_fillet;
+
+    fn solid_edge_ids(topo: &Topology, solid_id: SolidId) -> Vec<EdgeId> {
+        let solid = topo.solid(solid_id).expect("solid");
+        let shell = topo.shell(solid.outer_shell()).expect("shell");
+        let mut seen = HashSet::new();
+        let mut edges = Vec::new();
+        for &fid in shell.faces() {
+            let face = topo.face(fid).expect("face");
+            let wire = topo.wire(face.outer_wire()).expect("wire");
+            for oe in wire.edges() {
+                if seen.insert(oe.edge().index()) {
+                    edges.push(oe.edge());
+                }
+            }
+        }
+        edges
+    }
+
+    // The wasm `fillet` binding (and its batch sibling) route through
+    // `try_fillet`. Filleting all 12 box edges must remove only the rounded
+    // slivers (volume ≈ 975.6 for a 10³ box at r=1), not excise whole corner
+    // octants. This guards the consumer path against regressing to the
+    // over-removing walking engine.
+    #[test]
+    fn try_fillet_all_box_edges_no_corner_over_removal() {
+        let mut topo = Topology::new();
+        let cube = brepkit_operations::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edge_ids(&topo, cube);
+        assert_eq!(edges.len(), 12, "box should have 12 edges");
+
+        let result = try_fillet(&mut topo, cube, &edges, 1.0).expect("all-edges fillet");
+        let vol = brepkit_operations::measure::solid_volume(&topo, result, 0.01).unwrap();
+        assert!(
+            vol > 970.0 && vol < 1000.0,
+            "filleted box volume should be ≈975.6, got {vol}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Filleting all 12 edges of a 10×10×10 box at r=1 produced wrong geometry through the public ``fillet`` binding:

- The wasm/binding ``try_fillet`` routed **multi-edge** fillets through the walking ``FilletBuilder`` (``fillet_v2``) first. On the all-edges box this over-removes corner material — the spherical-blend corners excise whole octants, dropping the enclosed volume to **~473** (or, on older builds, leaving the 8 corner patches off entirely → 18 faces / ~847) instead of the analytic rounded-box ~975.6.
- The rolling-ball corner patches were mis-oriented and a single degree-(2,2) rational patch over a 90° octant sagged ~12% inward.

The result was a native-vs-binding divergence: native rolling-ball gave 26 faces / ~975, while the binding returned the over-removed FilletBuilder solid.

## Fix

- ``try_fillet`` now dispatches **multi-edge** inputs to the rolling-ball engine first (it has the per-corner setback trimming + spherical blend patches), keeping ``FilletBuilder`` primary only for **single-edge** fillets (which integrate more cleanly with downstream booleans). Each engine still falls back to the other, then to a flat bevel.
- Strips and corner patches carry their outward-facing ``reversed`` flag on the spec itself, so it survives assembly reordering/merging.
- The corner-patch interior control point is placed at the tangent-cone apex (``center + r·Σ radial dirs``) so the rational blend tracks the sphere within a few percent of R.

## Verification

- Native: ``vertex_blend_all_edges_box_volume`` and ``try_fillet_all_box_edges_no_corner_over_removal`` pass — **26 faces, volume ≈ 974.96**.
- wasm32 (``wasm-pack build --target nodejs --release``), all-12-edge box r=1 through the ``fillet`` binding: **26 faces, volume 974.9638**, deterministic across 5 runs and bit-identical to native.
- ``cargo fmt --check``, ``cargo clippy -D warnings`` (operations + wasm), ``check-boundaries.sh`` all clean.

Note: the pre-existing ``compound_cut_matches_sequential_4x4_grid`` boolean test is flaky (HashMap iteration-order nondeterminism, unrelated to this change — fails ~1/3 of runs in isolation on this and main).