### PR TITLE
fix(offset): make planar wire/polygon offset sign winding-robust

### DIFF
--- a/crates/math/src/polygon_offset.rs
+++ b/crates/math/src/polygon_offset.rs
@@ -40,6 +40,16 @@ pub fn offset_polygon_2d(
 
     let miter_limit_dist = distance.abs() * DEFAULT_MITER_LIMIT;
 
+    // The outward-normal convention below assumes CCW winding. For a CW
+    // loop the same perpendicular points inward, inverting the sign of
+    // `distance`. Detect the actual winding via the signed area and flip
+    // the effective distance so that negative always shrinks the loop.
+    let area2 = signed_area_2x(vertices);
+    if area2.abs() < tolerance {
+        return Err(MathError::EmptyInput);
+    }
+    let distance = if area2 < 0.0 { -distance } else { distance };
+
     // Compute offset edge lines: each edge shifts by distance along its outward normal.
     // For a CCW polygon, the outward normal of edge (A→B) is (dy, -dx) normalized.
     let mut result = Vec::with_capacity(n);
@@ -209,6 +219,19 @@ fn segment_intersection_2d(
     }
 }
 
+/// Twice the signed area of a closed 2D polygon (shoelace formula).
+///
+/// Positive for CCW winding, negative for CW.
+fn signed_area_2x(vertices: &[Point2]) -> f64 {
+    let n = vertices.len();
+    let mut acc = 0.0;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        acc += vertices[i].x() * vertices[j].y() - vertices[j].x() * vertices[i].y();
+    }
+    acc
+}
+
 /// Compute the outward normal of a 2D edge (assuming CCW winding).
 ///
 /// For edge A→B, the outward normal is the left-perpendicular of (B-A),
@@ -293,5 +316,42 @@ mod tests {
     fn too_few_vertices() {
         let pts = vec![Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)];
         assert!(offset_polygon_2d(&pts, 0.1, 1e-10).is_err());
+    }
+
+    fn signed_area(poly: &[Point2]) -> f64 {
+        let n = poly.len();
+        let mut acc = 0.0;
+        for i in 0..n {
+            let j = (i + 1) % n;
+            acc += poly[i].x() * poly[j].y() - poly[j].x() * poly[i].y();
+        }
+        acc * 0.5
+    }
+
+    #[test]
+    fn offset_cw_square_inward() {
+        // Clockwise-wound 20x20 square. A negative distance must shrink it
+        // (area 256), regardless of winding.
+        let cw_square = vec![
+            Point2::new(20.0, 0.0),
+            Point2::new(0.0, 0.0),
+            Point2::new(0.0, 20.0),
+            Point2::new(20.0, 20.0),
+        ];
+        let inward = offset_polygon_2d(&cw_square, -2.0, 1e-10).unwrap();
+        assert_eq!(inward.len(), 4);
+        assert!(
+            (signed_area(&inward).abs() - 256.0).abs() < 1e-6,
+            "CW square offset -2 should enclose area 256, got {}",
+            signed_area(&inward).abs()
+        );
+
+        let outward = offset_polygon_2d(&cw_square, 2.0, 1e-10).unwrap();
+        assert_eq!(outward.len(), 4);
+        assert!(
+            (signed_area(&outward).abs() - 576.0).abs() < 1e-6,
+            "CW square offset +2 should enclose area 576, got {}",
+            signed_area(&outward).abs()
+        );
     }
 }

--- a/crates/operations/src/offset_wire.rs
+++ b/crates/operations/src/offset_wire.rs
@@ -105,6 +105,29 @@ pub fn offset_wire_with_join(
         });
     }
 
+    // The `edge_dir x face_normal` convention below points outward only
+    // when the loop winds CCW as seen from the +face_normal side. The
+    // loop's traversal order comes from stored edge orientations and is
+    // not guaranteed to match the face normal's sign, so detect the
+    // actual winding and flip the effective distance to keep negative =
+    // inward. Twice the signed area as seen from +N is sum((Vi x Vj).N).
+    let area2 = {
+        let mut acc = Vec3::new(0.0, 0.0, 0.0);
+        for i in 0..n {
+            let j = (i + 1) % n;
+            let vi = Vec3::new(verts[i].x(), verts[i].y(), verts[i].z());
+            let vj = Vec3::new(verts[j].x(), verts[j].y(), verts[j].z());
+            acc += vi.cross(vj);
+        }
+        acc.dot(face_normal)
+    };
+    if area2.abs() < tol.linear {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "wire loop has degenerate (zero) signed area".into(),
+        });
+    }
+    let distance = if area2 < 0.0 { -distance } else { distance };
+
     // Compute edge normals (outward-pointing, in the face plane).
     // For a CCW-wound wire viewed from the face normal direction,
     // the outward normal of edge (i -> i+1) is edge_direction x face_normal.
@@ -464,6 +487,85 @@ mod tests {
                 d: 0.0,
             },
         ))
+    }
+
+    /// Helper: make a 20x20 face whose loop winds clockwise in the (x, y)
+    /// projection and whose surface normal points -Z, mirroring the bottom
+    /// face of a box. Loop order: (20,0) -> (0,0) -> (0,20) -> (20,20).
+    fn make_cw_bottom_face(topo: &mut Topology) -> brepkit_topology::face::FaceId {
+        let tol_val = 1e-7;
+        let v0 = topo.add_vertex(Vertex::new(Point3::new(20.0, 0.0, 0.0), tol_val));
+        let v1 = topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 0.0), tol_val));
+        let v2 = topo.add_vertex(Vertex::new(Point3::new(0.0, 20.0, 0.0), tol_val));
+        let v3 = topo.add_vertex(Vertex::new(Point3::new(20.0, 20.0, 0.0), tol_val));
+
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
+        let e2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
+        let e3 = topo.add_edge(Edge::new(v3, v0, EdgeCurve::Line));
+
+        let wire = Wire::new(
+            vec![
+                OrientedEdge::new(e0, true),
+                OrientedEdge::new(e1, true),
+                OrientedEdge::new(e2, true),
+                OrientedEdge::new(e3, true),
+            ],
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+
+        topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, -1.0),
+                d: 0.0,
+            },
+        ))
+    }
+
+    fn wire_signed_area(topo: &Topology, wid: brepkit_topology::wire::WireId) -> f64 {
+        let wire = topo.wire(wid).unwrap();
+        let pts: Vec<Point3> = wire
+            .edges()
+            .iter()
+            .map(|oe| {
+                let edge = topo.edge(oe.edge()).unwrap();
+                topo.vertex(edge.start()).unwrap().point()
+            })
+            .collect();
+        let n = pts.len();
+        let mut acc = 0.0;
+        for i in 0..n {
+            let j = (i + 1) % n;
+            acc += pts[i].x() * pts[j].y() - pts[j].x() * pts[i].y();
+        }
+        acc * 0.5
+    }
+
+    #[test]
+    fn offset_cw_bottom_face_inward() {
+        let mut topo = Topology::new();
+        let face = make_cw_bottom_face(&mut topo);
+
+        let inward = offset_wire(&mut topo, face, -2.0).unwrap();
+        let wire = topo.wire(inward).unwrap();
+        assert!(wire.is_closed());
+        assert_eq!(wire.edges().len(), 4);
+        assert!(
+            (wire_signed_area(&topo, inward).abs() - 256.0).abs() < 1e-6,
+            "CW bottom face offset -2 should enclose area 256, got {}",
+            wire_signed_area(&topo, inward).abs()
+        );
+
+        let outward = offset_wire(&mut topo, face, 2.0).unwrap();
+        assert!(
+            (wire_signed_area(&topo, outward).abs() - 576.0).abs() < 1e-6,
+            "CW bottom face offset +2 should enclose area 576, got {}",
+            wire_signed_area(&topo, outward).abs()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Negative offset distance now always shrinks a planar loop and positive always grows it, regardless of the loop's traversal winding or the face normal's sign.

Previously the perpendicular convention (`edge_dir x face_normal`) only pointed outward when the loop wound CCW as seen from the +normal side. A clockwise-projected loop — e.g. a box bottom face whose surface normal points -Z — inverted the sign, so an inward offset of -2 on a 20x20 face *expanded* it to 24x24 (area 576) instead of shrinking it to 16x16 (area 256).

## Fix

Both the 2D polygon path (`offset_polygon_2d`) and the face-based path (`offset_wire`) now compute the source loop's signed area relative to the offset plane normal and normalize the effective offset sign before applying the fixed perpendicular convention. A degenerate (zero-area) loop is rejected explicitly.

## Tests

- `offset_wire::offset_cw_bottom_face_inward` — CW-wound, -Z-normal 20x20 face, inward offset shrinks the loop.
- `polygon_offset::offset_cw_square_inward` — CW polygon, inward offset shrinks.
- All existing offset tests continue to pass (CCW outward/inward, arc, chamfer, legacy-match).