### PR TITLE
test(boolean): un-ignore recovered boolean tests

### DIFF
--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1657,6 +1657,11 @@ fn compound_cut_matches_sequential_2x2_grid() {
 
 /// 3×3 grid (9 tools) exercises the compound path (threshold = 8).
 #[test]
+#[ignore = "flaky — multi-tool compound/sequential cuts through the mesh-boolean \
+            fallback are non-deterministic across processes (seed-dependent vertex \
+            welding); with the oracle's box volume corrected to the actual \
+            make_box(10,10,2) = 200, both paths intermittently remove little or \
+            nothing. Tracked in #747; revisit under the GFA rewrite."]
 fn compound_cut_matches_sequential_3x3_grid() {
     use brepkit_math::mat::Mat4;
 
@@ -1700,7 +1705,7 @@ fn compound_cut_matches_sequential_3x3_grid() {
     // Both paths use mesh boolean fallback for cylinder-box cuts, which
     // can produce different volumes under different execution conditions.
     // Assert each path individually: volume must be less than the uncut box.
-    let box_vol = 15.0 * 15.0 * 2.0;
+    let box_vol = 10.0 * 10.0 * 2.0;
     assert!(
         compound_vol < box_vol * 0.99,
         "compound_cut should reduce volume: {compound_vol:.1} vs box {box_vol:.1}"

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1780,7 +1780,7 @@ fn compound_cut_matches_sequential_4x4_grid() {
 
 /// Test compound_cut with a shelled target + many box cutters.
 /// This simulates the gridfinity honeycomb scenario where the target
-/// has cylindrical fillets (rounded corners) and the tools are hex prisms.
+/// has cylindrical fillets (rounded corners) and the tools are boxes.
 #[test]
 fn compound_cut_shelled_target_many_tools() {
     use brepkit_math::mat::Mat4;

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1657,10 +1657,6 @@ fn compound_cut_matches_sequential_2x2_grid() {
 
 /// 3×3 grid (9 tools) exercises the compound path (threshold = 8).
 #[test]
-#[ignore = "flaky — multi-tool compound/sequential cuts through the mesh-boolean \
-            fallback are non-deterministic across processes (seed-dependent vertex \
-            welding) and under-cut faceted re-input; the `< box*0.99` oracle passes \
-            on garbage. Tracked in #747; revisit under the GFA rewrite."]
 fn compound_cut_matches_sequential_3x3_grid() {
     use brepkit_math::mat::Mat4;
 
@@ -1781,7 +1777,6 @@ fn compound_cut_matches_sequential_4x4_grid() {
 /// This simulates the gridfinity honeycomb scenario where the target
 /// has cylindrical fillets (rounded corners) and the tools are hex prisms.
 #[test]
-#[ignore = "flaky — vertex merge non-determinism for complex compound operations"]
 fn compound_cut_shelled_target_many_tools() {
     use brepkit_math::mat::Mat4;
 
@@ -2541,7 +2536,6 @@ fn test_boolean_concave_face_chord_clip() {
 // does not break the common convex-face case. A large box minus a half-
 // overlapping smaller box: expected volume = 8.0 - 0.5 = 7.5.
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn test_boolean_convex_face_chord_clip_regression() {
     let mut topo = Topology::new();
 
@@ -2628,7 +2622,6 @@ fn boolean_fuse_overlapping_boxes_positive_volume() {
 /// Sequential compound cut with many tools should produce a valid solid
 /// with bounded face count (unify_faces prevents explosion).
 #[test]
-#[ignore = "flaky — compound boolean non-determinism can produce zero-volume result on CI"]
 fn compound_cut_sequential_reduces_volume() {
     let mut topo = Topology::new();
     let target = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();

--- a/crates/operations/tests/boolean_edge_cases.rs
+++ b/crates/operations/tests/boolean_edge_cases.rs
@@ -273,7 +273,6 @@ fn test_sequential_cuts_volume() {
 }
 
 #[test]
-#[ignore = "vertex drift 6.7% after 10 fuse+cut cycles on disjoint addons (threshold 5%)"]
 fn test_sequential_boolean_vertex_drift() {
     // Perform 10 fuse+cut cycles. Volume should return to original each time.
     let mut topo = Topology::new();
@@ -303,7 +302,6 @@ fn test_sequential_boolean_vertex_drift() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn test_alternating_union_cut() {
     // A|B - C pattern.
     // A: (0-2, 0-1, 0-1), B: (1-3, 0-1, 0-1), C: (1-2, 0-1, 0-1).

--- a/crates/operations/tests/boolean_invariants.rs
+++ b/crates/operations/tests/boolean_invariants.rs
@@ -619,7 +619,6 @@ fn fuse_thin_shell_with_containing_solid_preserves_larger_volume() {
 // -- Cut cylinder from box ------------------------------------------------
 
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn cut_cylinder_from_box_volume() {
     // Cylinder centered in box, protruding above and below.
     let mut topo = Topology::new();

--- a/crates/operations/tests/boolean_stress.rs
+++ b/crates/operations/tests/boolean_stress.rs
@@ -193,7 +193,6 @@ fn near_miss_cut_barely_touching() {
 // ===========================================================================
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn thin_wall_cut() {
     // Cut a thin slice from a box — result has very thin geometry.
     let mut topo = Topology::new();
@@ -538,7 +537,6 @@ fn small_overlap_1_percent() {
 // ===========================================================================
 
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn fuse_asymmetric_boxes() {
     let mut topo = Topology::new();
     let a = box_at(&mut topo, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0);

--- a/crates/operations/tests/coincident_proptest.rs
+++ b/crates/operations/tests/coincident_proptest.rs
@@ -53,14 +53,8 @@ proptest! {
     }
 
     // Rotation invariance: rotating both boxes of a face-stack by the
-    // same Z rotation should preserve volume. The boolean exhibits up
-    // to ~15% volume drift at certain non-axis-aligned angles, which
-    // is a known gap (see ignored cylinder/cone/torus SD tests for the
-    // related GFA-integration weakness on non-axis-aligned shapes).
+    // same Z rotation should preserve volume.
     #[test]
-    #[ignore = "Gap: face-stack fuse exhibits up to ~15% volume drift at certain \
-                Z-rotation angles (e.g. 3.98 rad). Likely related to GFA face-splitting \
-                producing an extra internal face at off-axis rotations."]
     fn prop_face_stack_z_rotation_invariant(angle in 0.0f64..std::f64::consts::TAU) {
         let mut topo = Topology::default();
         let a = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();


### PR DESCRIPTION
A full re-run of every ignored boolean test showed several now pass reliably — their ignore attributes were stale after recent determinism and same-domain fixes (#748 et al).

## Changes
- Un-ignores 9 tests across `boolean_stress`, `boolean_edge_cases`, `boolean_invariants`, `coincident_proptest`, and the lib boolean suite. Formerly-flaky compound-cut tests were gated on 10/10 passes in fresh processes before un-ignoring.
- `compound_cut_matches_sequential_3x3_grid`: corrects its volume oracle (`box_vol` was 15·15·2=450 against an actual 10×10×2 box, so the `< box*0.99` assertions could never fail) and keeps it ignored — with the honest oracle it flakes ~2/3 of runs (#747).
- Left ignored: `compound_cut_matches_sequential_4x4_grid` (borderline under-cut, intermittent) and `staircase_fuse_with_cylinders` (~125s, CI-time choice).

## Verification
fmt, clippy `-D warnings`, boundary check, full operations lib + 4 integration targets green.