### PR TITLE
fix(algo): adopt existing boundary vertices as seams for closed section curves

### DIFF
--- a/crates/algo/Cargo.toml
+++ b/crates/algo/Cargo.toml
@@ -15,6 +15,7 @@ log.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+brepkit-check.workspace = true
 brepkit-topology = {workspace = true, features = ["test-utils"]}
 proptest.workspace = true
 

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1071,6 +1071,15 @@ fn build_section_edges(
                     None => continue,
                 };
 
+                // A closed section curve that coincides with one of this
+                // face's own closed boundary edges does not split the face —
+                // it lies entirely on the boundary. Feeding it to the face
+                // splitter would corrupt the wire (the boundary circle gets
+                // re-split against its own geometry).
+                if closed_curve_coincides_with_boundary(topo, face_id, &curve_ds.curve, tol) {
+                    continue;
+                }
+
                 // Find start/end 3D points by evaluating the curve at its
                 // parametric endpoints. For closed curves (circles), start ≈ end.
                 let (start, end) = curve_endpoints(topo, arena, curve_ds);
@@ -1229,6 +1238,63 @@ fn build_section_edges(
     dedup_collinear_sections(&mut sections, tol);
 
     sections
+}
+
+/// Check whether a closed section curve (Circle/Ellipse) coincides with
+/// one of the face's own closed boundary edges.
+fn closed_curve_coincides_with_boundary(
+    topo: &Topology,
+    face_id: FaceId,
+    curve: &brepkit_topology::edge::EdgeCurve,
+    tol: f64,
+) -> bool {
+    use brepkit_topology::edge::EdgeCurve;
+
+    let circles_match = |a: &brepkit_math::curves::Circle3D, b: &brepkit_math::curves::Circle3D| {
+        (a.center() - b.center()).length() < tol
+            && (a.radius() - b.radius()).abs() < tol
+            && a.normal().dot(b.normal()).abs() > 1.0 - 1e-9
+    };
+    let ellipses_match = |a: &brepkit_math::curves::Ellipse3D,
+                          b: &brepkit_math::curves::Ellipse3D| {
+        (a.center() - b.center()).length() < tol
+            && (a.semi_major() - b.semi_major()).abs() < tol
+            && (a.semi_minor() - b.semi_minor()).abs() < tol
+            && a.normal().dot(b.normal()).abs() > 1.0 - 1e-9
+    };
+
+    if !matches!(curve, EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_)) {
+        return false;
+    }
+
+    let Ok(face) = topo.face(face_id) else {
+        return false;
+    };
+    let wires: Vec<_> = std::iter::once(face.outer_wire())
+        .chain(face.inner_wires().iter().copied())
+        .collect();
+    for wid in wires {
+        let Ok(wire) = topo.wire(wid) else {
+            continue;
+        };
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            if edge.start() != edge.end() {
+                continue;
+            }
+            let coincides = match (curve, edge.curve()) {
+                (EdgeCurve::Circle(a), EdgeCurve::Circle(b)) => circles_match(a, b),
+                (EdgeCurve::Ellipse(a), EdgeCurve::Ellipse(b)) => ellipses_match(a, b),
+                _ => false,
+            };
+            if coincides {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Find the overall 3D start/end points of an intersection curve

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1257,10 +1257,21 @@ fn closed_curve_coincides_with_boundary(
     };
     let ellipses_match = |a: &brepkit_math::curves::Ellipse3D,
                           b: &brepkit_math::curves::Ellipse3D| {
-        (a.center() - b.center()).length() < tol
+        let geometry_matches = (a.center() - b.center()).length() < tol
             && (a.semi_major() - b.semi_major()).abs() < tol
             && (a.semi_minor() - b.semi_minor()).abs() < tol
-            && a.normal().dot(b.normal()).abs() > 1.0 - 1e-9
+            && a.normal().dot(b.normal()).abs() > 1.0 - 1e-9;
+        if !geometry_matches {
+            return false;
+        }
+        // When the semi-axes are equal the ellipse is a circle and the
+        // major-axis direction is undefined, so only its length matters.
+        if (a.semi_major() - a.semi_minor()).abs() < tol {
+            return true;
+        }
+        // The major axis and its negation describe the same ellipse, so
+        // compare directions up to sign.
+        a.u_axis().dot(b.u_axis()).abs() > 1.0 - 1e-9
     };
 
     if !matches!(curve, EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_)) {

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -325,6 +325,49 @@ fn sample_face_interior(
         )));
     }
 
+    // Periodic faces bounded by closed curves (e.g. an unsplit cylinder
+    // lateral wall between two full boundary circles): the closed-edge
+    // midpoint lies on a v-extreme of the face, and the tangent-cross-normal
+    // offset direction is unreliable there. Sample at the closed edge's u
+    // and the midpoint of the face's v-range instead — interior in v by
+    // construction, interior in u because the boundary curve spans the
+    // full period.
+    if !face.surface().is_planar() {
+        let mut closed_mid: Option<Point3> = None;
+        let mut v_min = f64::MAX;
+        let mut v_max = f64::MIN;
+        for oe in edges {
+            let e = topo.edge(oe.edge())?;
+            let sp = topo.vertex(e.start())?.point();
+            let ep = topo.vertex(e.end())?.point();
+            let (t0, t1) = e.curve().domain_with_endpoints(sp, ep);
+            let mid = e
+                .curve()
+                .evaluate_with_endpoints(0.5_f64.mul_add(t1 - t0, t0), sp, ep);
+            if e.start() == e.end()
+                && !matches!(e.curve(), brepkit_topology::edge::EdgeCurve::Line)
+                && closed_mid.is_none()
+            {
+                closed_mid = Some(mid);
+            }
+            for p in [sp, ep, mid] {
+                if let Some((_, v)) = face.surface().project_point(p) {
+                    v_min = v_min.min(v);
+                    v_max = v_max.max(v);
+                }
+            }
+        }
+        if let Some(mid) = closed_mid {
+            if v_max - v_min > tol.linear {
+                if let Some((u, _)) = face.surface().project_point(mid) {
+                    if let Some(pt) = face.surface().evaluate(u, 0.5 * (v_min + v_max)) {
+                        return Ok(pt);
+                    }
+                }
+            }
+        }
+    }
+
     // Compute face bounding box diagonal for size-relative offset.
     // Sample all edge endpoints to estimate face extent.
     let mut min_pt = Point3::new(f64::MAX, f64::MAX, f64::MAX);

--- a/crates/algo/src/pave_filler/link_existing.rs
+++ b/crates/algo/src/pave_filler/link_existing.rs
@@ -20,6 +20,37 @@ use crate::error::AlgoError;
 /// Quantized 3D position pair for endpoint matching.
 type QPair = ((i64, i64, i64), (i64, i64, i64));
 
+/// Quantized circle geometry (center, radius, axis up to sign) for
+/// matching full closed blocks whose seam vertices differ.
+type QCircle = ((i64, i64, i64), i64, (i64, i64, i64));
+
+/// Quantization scale for unit axis directions.
+const AXIS_SCALE: f64 = 1.0e7;
+
+fn circle_key(
+    c: &brepkit_math::curves::Circle3D,
+    qpt: impl Fn(brepkit_math::vec::Point3) -> (i64, i64, i64),
+    linear_scale: f64,
+) -> QCircle {
+    let n = c.normal();
+    // Canonicalize axis sign so opposite-facing but coincident circles match.
+    let flip = match (n.x().abs() > 0.5, n.y().abs() > 0.5) {
+        (true, _) => n.x() < 0.0,
+        (false, true) => n.y() < 0.0,
+        (false, false) => n.z() < 0.0,
+    };
+    let n = if flip { -n } else { n };
+    #[allow(clippy::cast_possible_truncation)]
+    let qaxis = (
+        (n.x() * AXIS_SCALE).round() as i64,
+        (n.y() * AXIS_SCALE).round() as i64,
+        (n.z() * AXIS_SCALE).round() as i64,
+    );
+    #[allow(clippy::cast_possible_truncation)]
+    let qr = (c.radius() * linear_scale).round() as i64;
+    (qpt(c.center()), qr, qaxis)
+}
+
 /// Link section PBs to coincident boundary PBs via CommonBlocks.
 ///
 /// For each leaf section PB (from `arena.curves`), resolves its vertex
@@ -47,6 +78,12 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
     let mut boundary_index: std::collections::HashMap<QPair, Vec<PaveBlockId>> =
         std::collections::HashMap::new();
 
+    // Secondary index for full closed circle blocks (start == end vertex):
+    // their endpoint is an arbitrary seam vertex, so endpoint-pair keys
+    // cannot match across differently-seamed but coincident circles.
+    let mut closed_index: std::collections::HashMap<QCircle, Vec<PaveBlockId>> =
+        std::collections::HashMap::new();
+
     let all_edge_pbs: Vec<Vec<PaveBlockId>> = arena
         .edge_pave_blocks
         .values()
@@ -70,6 +107,17 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
             let qe = qpt(ep);
             let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
             boundary_index.entry(key).or_default().push(pb_id);
+
+            if sv == ev {
+                if let Ok(edge) = topo.edge(pb.original_edge) {
+                    if let EdgeCurve::Circle(c) = edge.curve() {
+                        closed_index
+                            .entry(circle_key(c, qpt, scale))
+                            .or_default()
+                            .push(pb_id);
+                    }
+                }
+            }
         }
     }
 
@@ -106,11 +154,6 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
             let qe = qpt(ep);
             let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
 
-            let Some(candidates) = boundary_index.get(&key) else {
-                log::trace!("link_existing: no boundary PB at position");
-                continue;
-            };
-
             // Check curve compatibility with each candidate.
             // Use graceful skip (not `?`) for edge lookups — consistent with
             // vertex lookups above. A stale original_edge should skip the PB,
@@ -120,51 +163,48 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
             };
             let section_curve = section_edge.curve().clone();
 
-            for &boundary_pb_id in candidates {
-                // Self-match guard: coplanar FF section PBs can appear in both
-                // arena.curves and arena.edge_pave_blocks. Skip self-pairing.
-                if boundary_pb_id == section_pb_id {
-                    continue;
-                }
-
-                // Already in same CB
-                if arena.pb_to_cb.get(&boundary_pb_id) == arena.pb_to_cb.get(&section_pb_id)
-                    && arena.pb_to_cb.contains_key(&section_pb_id)
-                {
-                    continue;
-                }
-
-                let Some(boundary_pb) = arena.pave_blocks.get(boundary_pb_id) else {
-                    continue;
-                };
-
-                let Ok(boundary_edge) = topo.edge(boundary_pb.original_edge) else {
-                    continue;
-                };
-                let boundary_curve = boundary_edge.curve();
-
-                if !curves_compatible(&section_curve, boundary_curve, tol) {
-                    continue;
-                }
-
-                // Link: add section PB to boundary PB's CB, or create new CB
-                if let Some(&cb_id) = arena.pb_to_cb.get(&boundary_pb_id) {
-                    // Add section PB to existing CB
-                    if let Some(cb) = arena.common_blocks.get_mut(cb_id) {
-                        cb.pave_blocks.push(section_pb_id);
+            let mut linked_this = false;
+            if let Some(candidates) = boundary_index.get(&key) {
+                for &boundary_pb_id in candidates {
+                    if try_link(
+                        topo,
+                        tol,
+                        arena,
+                        section_pb_id,
+                        &section_curve,
+                        boundary_pb_id,
+                    ) {
+                        linked += 1;
+                        linked_this = true;
+                        break; // One match is sufficient
                     }
-                    arena.pb_to_cb.insert(section_pb_id, cb_id);
-                } else {
-                    // Create new CB for the pair
-                    arena.create_common_block(vec![boundary_pb_id, section_pb_id], tol.linear);
                 }
+            } else {
+                log::trace!("link_existing: no boundary PB at position");
+            }
 
-                linked += 1;
-                log::debug!(
-                    "link_existing: linked section PB {section_pb_id:?} with boundary PB \
-                     {boundary_pb_id:?}"
-                );
-                break; // One match is sufficient
+            // Fallback for full closed circles: the endpoint-pair key uses
+            // the seam vertex, which is arbitrary, so coincident circles
+            // with different seams never share a key. Match on quantized
+            // circle geometry instead.
+            if !linked_this && sv == ev {
+                if let EdgeCurve::Circle(c) = &section_curve {
+                    if let Some(candidates) = closed_index.get(&circle_key(c, qpt, scale)) {
+                        for &boundary_pb_id in candidates {
+                            if try_link(
+                                topo,
+                                tol,
+                                arena,
+                                section_pb_id,
+                                &section_curve,
+                                boundary_pb_id,
+                            ) {
+                                linked += 1;
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -178,6 +218,60 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
     }
 
     Ok(())
+}
+
+/// Attempt to link a section PB with a boundary PB into a CommonBlock.
+///
+/// Returns `true` if the pair was linked. Skips self-pairs, pairs already
+/// sharing a CB, and geometrically incompatible curves.
+fn try_link(
+    topo: &Topology,
+    tol: Tolerance,
+    arena: &mut GfaArena,
+    section_pb_id: PaveBlockId,
+    section_curve: &EdgeCurve,
+    boundary_pb_id: PaveBlockId,
+) -> bool {
+    // Self-match guard: coplanar FF section PBs can appear in both
+    // arena.curves and arena.edge_pave_blocks. Skip self-pairing.
+    if boundary_pb_id == section_pb_id {
+        return false;
+    }
+
+    // Already in same CB
+    if arena.pb_to_cb.get(&boundary_pb_id) == arena.pb_to_cb.get(&section_pb_id)
+        && arena.pb_to_cb.contains_key(&section_pb_id)
+    {
+        return false;
+    }
+
+    let Some(boundary_pb) = arena.pave_blocks.get(boundary_pb_id) else {
+        return false;
+    };
+
+    let Ok(boundary_edge) = topo.edge(boundary_pb.original_edge) else {
+        return false;
+    };
+    let boundary_curve = boundary_edge.curve();
+
+    if !curves_compatible(section_curve, boundary_curve, tol) {
+        return false;
+    }
+
+    // Link: add section PB to boundary PB's CB, or create new CB
+    if let Some(&cb_id) = arena.pb_to_cb.get(&boundary_pb_id) {
+        if let Some(cb) = arena.common_blocks.get_mut(cb_id) {
+            cb.pave_blocks.push(section_pb_id);
+        }
+        arena.pb_to_cb.insert(section_pb_id, cb_id);
+    } else {
+        arena.create_common_block(vec![boundary_pb_id, section_pb_id], tol.linear);
+    }
+
+    log::debug!(
+        "link_existing: linked section PB {section_pb_id:?} with boundary PB {boundary_pb_id:?}"
+    );
+    true
 }
 
 /// Check if two edge curves are geometrically compatible.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -138,6 +138,7 @@ pub fn perform(
             };
 
             for raw in raw_curves {
+                let mut raw = raw;
                 // Closed Circle3D sections — produced by plane-sphere
                 // intersections — get split at face-boundary crossings so
                 // downstream face splitters see open arcs they can match
@@ -180,11 +181,41 @@ pub fn perform(
                 // endpoints share vertices with face boundaries, so the face
                 // splitter produces sub-faces with consistent vertex identity.
                 let is_closed = (raw.p_start - raw.p_end).length() < tol.linear;
-                let start_vid =
+
+                // For closed curves the start/end point is at an arbitrary
+                // curve parameter. If an existing boundary vertex of either
+                // face already lies on the curve (e.g. the seam vertex of a
+                // coincident cap circle), adopt it as the seam and shift the
+                // parameter range to start there — so the section edge and
+                // the existing boundary edge share endpoint identity and can
+                // be linked into a CommonBlock by `link_existing`.
+                //
+                // Only safe when the circle stays inside (or on) both faces:
+                // a circle that properly crosses a face boundary must keep
+                // the legacy fresh-seam path so the downstream splitter can
+                // trim it to the in-face arcs.
+                let adopted_seam = match &raw.curve {
+                    EdgeCurve::Circle(c)
+                        if is_closed
+                            && !closed_circle_crosses_face_boundaries(topo, fa, fb, c, tol) =>
+                    {
+                        find_boundary_vertex_on_curve(topo, fa, fb, &raw.curve, tol)
+                    }
+                    _ => None,
+                };
+                if let Some((_, t_seam, p_seam)) = adopted_seam {
+                    let span = raw.t_range.1 - raw.t_range.0;
+                    raw.t_range = (t_seam, t_seam + span);
+                    raw.p_start = p_seam;
+                    raw.p_end = p_seam;
+                }
+
+                let start_vid = adopted_seam.map(|(vid, _, _)| vid).unwrap_or_else(|| {
                     super::helpers::find_nearby_pave_vertex(topo, arena, raw.p_start, tol)
                         .or_else(|| find_nearby_face_vertex(topo, fa, raw.p_start, tol))
                         .or_else(|| find_nearby_face_vertex(topo, fb, raw.p_start, tol))
-                        .unwrap_or_else(|| topo.add_vertex(Vertex::new(raw.p_start, tol.linear)));
+                        .unwrap_or_else(|| topo.add_vertex(Vertex::new(raw.p_start, tol.linear)))
+                });
                 let end_vid = if is_closed {
                     start_vid
                 } else {
@@ -676,6 +707,132 @@ fn find_nearby_face_vertex(
         }
     }
     None
+}
+
+/// Find an existing boundary vertex of either face that lies on a closed
+/// section curve, returning the vertex, its curve parameter, and its 3D
+/// position.
+///
+/// Scans the outer and inner wires of both faces and returns the first
+/// vertex whose distance to the curve is within `tol.linear`. Only
+/// analytic closed curves (Circle, Ellipse) are supported.
+fn find_boundary_vertex_on_curve(
+    topo: &Topology,
+    face_a: FaceId,
+    face_b: FaceId,
+    curve: &EdgeCurve,
+    tol: Tolerance,
+) -> Option<(brepkit_topology::vertex::VertexId, f64, Point3)> {
+    let project_eval = |p: Point3| -> Option<(f64, Point3)> {
+        match curve {
+            EdgeCurve::Circle(c) => {
+                let t = c.project(p);
+                Some((t, c.evaluate(t)))
+            }
+            EdgeCurve::Ellipse(e) => {
+                let t = e.project(p);
+                Some((t, e.evaluate(t)))
+            }
+            EdgeCurve::Line | EdgeCurve::NurbsCurve(_) => None,
+        }
+    };
+
+    for fid in [face_a, face_b] {
+        let Ok(face) = topo.face(fid) else {
+            continue;
+        };
+        let wires: Vec<brepkit_topology::wire::WireId> = std::iter::once(face.outer_wire())
+            .chain(face.inner_wires().iter().copied())
+            .collect();
+        for wid in wires {
+            let Ok(wire) = topo.wire(wid) else {
+                continue;
+            };
+            for oe in wire.edges() {
+                let Ok(edge) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                for vid in [edge.start(), edge.end()] {
+                    let Ok(v) = topo.vertex(vid) else {
+                        continue;
+                    };
+                    let p = v.point();
+                    let (t, foot) = project_eval(p)?;
+                    if (foot - p).length() < tol.linear {
+                        return Some((vid, t, p));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Check whether a closed section circle properly crosses any boundary
+/// edge (outer or inner wire) of either face.
+///
+/// Line boundary edges count via segment intersection, ignoring hits at
+/// the segment endpoints (a seam line legitimately starts on the circle).
+/// Circle boundary edges count via the coplanar circle-circle relation:
+/// two distinct coplanar circles cross when the in-plane center distance
+/// lies strictly between `|r1 - r2|` and `r1 + r2`. Other curve types are
+/// not checked.
+fn closed_circle_crosses_face_boundaries(
+    topo: &Topology,
+    face_a: FaceId,
+    face_b: FaceId,
+    circle: &brepkit_math::curves::Circle3D,
+    tol: Tolerance,
+) -> bool {
+    for fid in [face_a, face_b] {
+        let Ok(face) = topo.face(fid) else {
+            continue;
+        };
+        let wires: Vec<brepkit_topology::wire::WireId> = std::iter::once(face.outer_wire())
+            .chain(face.inner_wires().iter().copied())
+            .collect();
+        for wid in wires {
+            let Ok(wire) = topo.wire(wid) else {
+                continue;
+            };
+            for oe in wire.edges() {
+                let Ok(edge) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                match edge.curve() {
+                    EdgeCurve::Line => {
+                        let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+                        else {
+                            continue;
+                        };
+                        let (sp, ep) = (sv.point(), ev.point());
+                        for (p, _) in circle.intersect_segment(sp, ep, tol.linear) {
+                            let at_endpoint = (p - sp).length() < tol.linear * 10.0
+                                || (p - ep).length() < tol.linear * 10.0;
+                            if !at_endpoint {
+                                return true;
+                            }
+                        }
+                    }
+                    EdgeCurve::Circle(b) => {
+                        let coplanar = circle.normal().dot(b.normal()).abs() > 1.0 - 1e-9
+                            && (b.center() - circle.center()).dot(circle.normal()).abs()
+                                < tol.linear;
+                        if !coplanar {
+                            continue;
+                        }
+                        let d = (b.center() - circle.center()).length();
+                        let (r1, r2) = (circle.radius(), b.radius());
+                        if d > (r1 - r2).abs() + tol.linear && d < r1 + r2 - tol.linear {
+                            return true;
+                        }
+                    }
+                    EdgeCurve::Ellipse(_) | EdgeCurve::NurbsCurve(_) => {}
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Find where a closed `Circle3D` section crosses the outer-wire

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -1415,3 +1415,126 @@ fn gfa_cut_box_cylinder_grid_through_sequential_produces_valid_topology() {
         "Euler V-E+F should be 2 for closed manifold, got V={v} E={e} F={f} euler={euler}",
     );
 }
+
+/// Coplanar-cap cylinder cut: the tool's caps lie exactly on the box's
+/// z=0 and z=2 planes. The wall-plane section circles coincide with the
+/// tool's existing cap boundary circles, so the section edges must adopt
+/// the cap circles' seam vertices (or be geometrically linked) — otherwise
+/// duplicate coincident circle edges survive, SD pairing finds nothing,
+/// and the result is non-manifold.
+#[test]
+fn gfa_cut_box_cylinder_coplanar_caps_produces_valid_topology() {
+    let mut topo = Topology::default();
+    let box_id = make_box(&mut topo, [0.0, 0.0, 0.0], [4.0, 4.0, 2.0]);
+    let cyl = make_cylinder(&mut topo, 1.0, 1.0, 0.0, 0.3, 2.0);
+
+    let result = crate::gfa::boolean(&mut topo, crate::bop::BooleanOp::Cut, box_id, cyl)
+        .expect("GFA cut of box with coplanar-cap cylinder should succeed");
+
+    let (f, e, v, euler) = solid_topology_summary(&topo, result);
+    eprintln!("coplanar-cap cut: faces={f}, edges={e}, verts={v}, euler={euler}");
+
+    // Manifold: every edge shared by exactly 2 oriented-edge uses.
+    let mut edge_use_count: std::collections::HashMap<brepkit_topology::edge::EdgeId, usize> =
+        std::collections::HashMap::new();
+    let s = topo.solid(result).unwrap();
+    let sh = topo.shell(s.outer_shell()).unwrap();
+    for &fid in sh.faces() {
+        let face = topo.face(fid).unwrap();
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            let wire = topo.wire(wid).unwrap();
+            for oe in wire.edges() {
+                *edge_use_count.entry(oe.edge()).or_default() += 1;
+            }
+        }
+    }
+    for &fid in sh.faces() {
+        let face = topo.face(fid).unwrap();
+        let surf = match face.surface() {
+            FaceSurface::Plane { normal, d } => format!(
+                "Plane(n=({:.0},{:.0},{:.0}),d={d:.1})",
+                normal.x(),
+                normal.y(),
+                normal.z()
+            ),
+            FaceSurface::Cylinder(_) => "Cylinder".to_string(),
+            _ => "Other".to_string(),
+        };
+        eprintln!("  face {fid:?} {surf}:");
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            let wire = topo.wire(wid).unwrap();
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge()).unwrap();
+                let sp = topo.vertex(edge.start()).unwrap().point();
+                let ep = topo.vertex(edge.end()).unwrap().point();
+                eprintln!(
+                    "    edge {:?} {} fwd={} ({:.2},{:.2},{:.2})->({:.2},{:.2},{:.2})",
+                    oe.edge(),
+                    edge.curve().type_tag(),
+                    oe.is_forward(),
+                    sp.x(),
+                    sp.y(),
+                    sp.z(),
+                    ep.x(),
+                    ep.y(),
+                    ep.z()
+                );
+            }
+        }
+    }
+    for (&eid, &count) in &edge_use_count {
+        assert_eq!(
+            count, 2,
+            "edge {eid:?} is used by {count} face-wire slots (expected 2)"
+        );
+    }
+
+    assert_eq!(
+        euler, 2,
+        "Euler V-E+F should be 2, got V={v} E={e} F={f} euler={euler}"
+    );
+
+    // No two coincident full-circle edges (same center/radius/axis).
+    let mut full_circles: Vec<(
+        brepkit_topology::edge::EdgeId,
+        brepkit_math::curves::Circle3D,
+    )> = Vec::new();
+    for &eid in edge_use_count.keys() {
+        let edge = topo.edge(eid).unwrap();
+        if edge.start() == edge.end() {
+            if let EdgeCurve::Circle(c) = edge.curve() {
+                full_circles.push((eid, c.clone()));
+            }
+        }
+    }
+    for i in 0..full_circles.len() {
+        for j in (i + 1)..full_circles.len() {
+            let (ea, ca) = &full_circles[i];
+            let (eb, cb) = &full_circles[j];
+            let coincident = (ca.center() - cb.center()).length() < 1e-7
+                && (ca.radius() - cb.radius()).abs() < 1e-7
+                && ca.normal().dot(cb.normal()).abs() > 1.0 - 1e-9;
+            assert!(
+                !coincident,
+                "coincident full-circle edges {ea:?} and {eb:?} (center={:?}, r={})",
+                ca.center(),
+                ca.radius()
+            );
+        }
+    }
+
+    let expected_vol = 32.0 - std::f64::consts::PI * 0.09 * 2.0;
+    // Order 5 is too coarse for full-period trig integrands on the
+    // cylindrical hole wall; 16 keeps quadrature error far below the
+    // 0.1% assertion budget.
+    let options = brepkit_check::properties::PropertiesOptions {
+        gauss_order: 16,
+        ..Default::default()
+    };
+    let vol = brepkit_check::properties::solid_volume(&topo, result, &options).unwrap();
+    let rel = (vol - expected_vol).abs() / expected_vol;
+    assert!(
+        rel < 0.001,
+        "volume {vol:.6} should be within 0.1% of {expected_vol:.6} (rel={rel:.5})"
+    );
+}

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -1426,7 +1426,9 @@ fn gfa_cut_box_cylinder_grid_through_sequential_produces_valid_topology() {
 fn gfa_cut_box_cylinder_coplanar_caps_produces_valid_topology() {
     let mut topo = Topology::default();
     let box_id = make_box(&mut topo, [0.0, 0.0, 0.0], [4.0, 4.0, 2.0]);
-    let cyl = make_cylinder(&mut topo, 1.0, 1.0, 0.0, 0.3, 2.0);
+    let cyl_radius = 0.3;
+    let cyl_height = 2.0;
+    let cyl = make_cylinder(&mut topo, 1.0, 1.0, 0.0, cyl_radius, cyl_height);
 
     let result = crate::gfa::boolean(&mut topo, crate::bop::BooleanOp::Cut, box_id, cyl)
         .expect("GFA cut of box with coplanar-cap cylinder should succeed");
@@ -1523,7 +1525,7 @@ fn gfa_cut_box_cylinder_coplanar_caps_produces_valid_topology() {
         }
     }
 
-    let expected_vol = 32.0 - std::f64::consts::PI * 0.09 * 2.0;
+    let expected_vol = 32.0 - std::f64::consts::PI * (cyl_radius * cyl_radius) * cyl_height;
     // Order 5 is too coarse for full-period trig integrands on the
     // cylindrical hole wall; 16 keeps quadrature error far below the
     // 0.1% assertion budget.

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -224,10 +224,10 @@ fn face_uv_bounds<S: ParametricSurface>(
     // collapse that axis's range to zero — the face actually spans the
     // full period.
     if periodic_u && u_max - u_min < 1e-9 {
-        u_max = u_min + std::f64::consts::TAU;
+        u_max = u_min + (full_domain.0.1 - full_domain.0.0);
     }
     if periodic_v && v_max - v_min < 1e-9 {
-        v_max = v_min + std::f64::consts::TAU;
+        v_max = v_min + (full_domain.1.1 - full_domain.1.0);
     }
 
     if u_min >= u_max || v_min >= v_max {

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -215,9 +215,20 @@ fn face_uv_bounds<S: ParametricSurface>(
     }
 
     let u_min = uvs.iter().map(|uv| uv.0).fold(f64::INFINITY, f64::min);
-    let u_max = uvs.iter().map(|uv| uv.0).fold(f64::NEG_INFINITY, f64::max);
+    let mut u_max = uvs.iter().map(|uv| uv.0).fold(f64::NEG_INFINITY, f64::max);
     let v_min = uvs.iter().map(|uv| uv.1).fold(f64::INFINITY, f64::min);
-    let v_max = uvs.iter().map(|uv| uv.1).fold(f64::NEG_INFINITY, f64::max);
+    let mut v_max = uvs.iter().map(|uv| uv.1).fold(f64::NEG_INFINITY, f64::max);
+
+    // All boundary vertices on the seam of a periodic axis (e.g. a
+    // full-revolution lateral face whose circles start/end at the seam)
+    // collapse that axis's range to zero — the face actually spans the
+    // full period.
+    if periodic_u && u_max - u_min < 1e-9 {
+        u_max = u_min + std::f64::consts::TAU;
+    }
+    if periodic_v && v_max - v_min < 1e-9 {
+        v_max = v_min + std::f64::consts::TAU;
+    }
 
     if u_min >= u_max || v_min >= v_max {
         return Err(CheckError::IntegrationFailed(
@@ -239,14 +250,39 @@ fn unwrap_angle(prev: f64, next: f64) -> f64 {
 }
 
 /// Integrate a planar face using polygon fan triangulation.
+///
+/// Inner wires (holes) are integrated the same way and subtracted from the
+/// outer-wire contribution.
 fn integrate_planar_face(
     topo: &Topology,
     face_id: FaceId,
     normal: Vec3,
 ) -> Result<FaceContribution, CheckError> {
     let polygon = crate::util::face_polygon(topo, face_id)?;
+    let mut contrib = integrate_planar_polygon(&polygon, normal);
+
+    let face = topo.face(face_id)?;
+    let inner: Vec<_> = face.inner_wires().to_vec();
+    for wid in inner {
+        let hole = crate::util::wire_polygon(topo, wid)?;
+        let h = integrate_planar_polygon(&hole, normal);
+        contrib.area -= h.area;
+        contrib.volume -= h.volume;
+        contrib.volume_moment_x -= h.volume_moment_x;
+        contrib.volume_moment_y -= h.volume_moment_y;
+        contrib.volume_moment_z -= h.volume_moment_z;
+        contrib.centroid_x -= h.centroid_x;
+        contrib.centroid_y -= h.centroid_y;
+        contrib.centroid_z -= h.centroid_z;
+    }
+
+    Ok(contrib)
+}
+
+/// Integrate a planar polygon's contribution via fan triangulation.
+fn integrate_planar_polygon(polygon: &[Point3], normal: Vec3) -> FaceContribution {
     if polygon.len() < 3 {
-        return Ok(FaceContribution {
+        return FaceContribution {
             area: 0.0,
             volume: 0.0,
             volume_moment_x: 0.0,
@@ -255,7 +291,7 @@ fn integrate_planar_face(
             centroid_x: 0.0,
             centroid_y: 0.0,
             centroid_z: 0.0,
-        });
+        };
     }
 
     // Fan triangulation from vertex 0
@@ -323,7 +359,7 @@ fn integrate_planar_face(
         cz += centroid.z() * tri_area;
     }
 
-    Ok(FaceContribution {
+    FaceContribution {
         area,
         volume: vol,
         volume_moment_x: mx,
@@ -332,7 +368,7 @@ fn integrate_planar_face(
         centroid_x: cx,
         centroid_y: cy,
         centroid_z: cz,
-    })
+    }
 }
 
 /// Integrate a parametric surface using Gauss quadrature over the UV domain.

--- a/crates/check/src/util.rs
+++ b/crates/check/src/util.rs
@@ -77,28 +77,92 @@ pub fn sample_edge_curve(curve: &EdgeCurve, n: usize) -> Vec<Point3> {
 /// Returns an error if any topology entity referenced by the face is missing.
 pub fn face_polygon(topo: &Topology, face_id: FaceId) -> Result<Vec<Point3>, CheckError> {
     let face = topo.face(face_id)?;
-    let wire = topo.wire(face.outer_wire())?;
+    wire_polygon(topo, face.outer_wire())
+}
+
+/// Build a polygon from a wire by sampling vertex positions and closed-edge
+/// curves.
+///
+/// Wires store edges in loop order, but the per-edge orientation flags are
+/// not guaranteed to chain head-to-tail; each edge's traversal direction is
+/// re-derived from vertex connectivity with the previous edge so the polygon
+/// follows the actual loop.
+///
+/// # Errors
+///
+/// Returns an error if any topology entity referenced by the wire is missing.
+pub fn wire_polygon(
+    topo: &Topology,
+    wire_id: brepkit_topology::wire::WireId,
+) -> Result<Vec<Point3>, CheckError> {
+    let wire = topo.wire(wire_id)?;
     let mut pts = Vec::new();
+    let mut prev_end: Option<brepkit_topology::vertex::VertexId> = None;
 
     for oe in wire.edges() {
         let edge = topo.edge(oe.edge())?;
         let curve = edge.curve();
         let start_vid = edge.start();
         let end_vid = edge.end();
+        let forward = match prev_end {
+            Some(pe) if start_vid == pe && end_vid != pe => true,
+            Some(pe) if end_vid == pe && start_vid != pe => false,
+            _ => oe.is_forward(),
+        };
         let is_closed_edge = start_vid == end_vid
             && matches!(
                 curve,
                 EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) | EdgeCurve::NurbsCurve(_)
             );
         if is_closed_edge {
-            let mut sampled = sample_edge_curve(curve, CLOSED_CURVE_SAMPLES);
-            if !oe.is_forward() {
-                sampled.reverse();
-            }
+            // Start sampling at the edge's seam vertex so the polygon chains
+            // cleanly with adjacent edges; the curve's own parameter origin
+            // is unrelated to the vertex.
+            let seam_pt = topo.vertex(start_vid)?.point();
+            let t0 = match curve {
+                EdgeCurve::Circle(c) => Some(c.project(seam_pt)),
+                EdgeCurve::Ellipse(e) => Some(e.project(seam_pt)),
+                EdgeCurve::NurbsCurve(_) | EdgeCurve::Line => None,
+            };
+            // Traversal must start at the seam vertex in both directions:
+            // forward covers [t0, t0 + TAU), reversed covers (t0, t0 + TAU]
+            // walked backwards — the next edge supplies the closing point.
+            #[allow(clippy::cast_precision_loss)]
+            let params = |n: usize| -> Vec<f64> {
+                if forward {
+                    (0..n)
+                        .map(|i| std::f64::consts::TAU.mul_add((i as f64) / (n as f64), 0.0))
+                        .collect()
+                } else {
+                    (1..=n)
+                        .rev()
+                        .map(|i| std::f64::consts::TAU.mul_add((i as f64) / (n as f64), 0.0))
+                        .collect()
+                }
+            };
+            let sampled: Vec<Point3> = match (curve, t0) {
+                (EdgeCurve::Circle(c), Some(t0)) => params(CLOSED_CURVE_SAMPLES)
+                    .into_iter()
+                    .map(|dt| c.evaluate(t0 + dt))
+                    .collect(),
+                (EdgeCurve::Ellipse(e), Some(t0)) => params(CLOSED_CURVE_SAMPLES)
+                    .into_iter()
+                    .map(|dt| e.evaluate(t0 + dt))
+                    .collect(),
+                _ => {
+                    let mut s = sample_edge_curve(curve, CLOSED_CURVE_SAMPLES);
+                    if !forward {
+                        s.reverse();
+                    }
+                    s
+                }
+            };
             pts.extend(sampled);
+            prev_end = Some(start_vid);
         } else {
-            let vid = oe.oriented_start(edge);
+            let vid = if forward { start_vid } else { end_vid };
             pts.push(topo.vertex(vid)?.point());
+            prev_end = Some(if forward { end_vid } else { start_vid });
         }
     }
 

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1607,7 +1607,12 @@ fn compound_cut_all_tools_disjoint_returns_unchanged_volume() {
 }
 
 #[test]
-#[ignore = "flaky ~25% — SD non-determinism at coplanar boundaries"]
+#[ignore = "Gap: cuts after the first lose the cap faces — the face splitter \
+            drops faces that carry pre-existing internal hole loops when a new \
+            coplanar closed section arrives, so cuts 2-4 fall back to the mesh \
+            path and the absolute volume lands ~27% low. The first coplanar-cap \
+            cut is fixed (seam adoption); re-enable when internal-loop face \
+            splitting lands."]
 fn compound_cut_matches_sequential_2x2_grid() {
     use brepkit_math::mat::Mat4;
 
@@ -1648,10 +1653,17 @@ fn compound_cut_matches_sequential_2x2_grid() {
     let result = compound_cut(&mut topo, target, &tools, BooleanOptions::default()).unwrap();
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
 
-    let rel = (compound_vol - seq_vol).abs() / seq_vol;
+    // 4x4x2 box minus four full-height r=0.3 cylinders.
+    let expected = 2.0f64.mul_add(4.0 * 4.0, -(4.0 * std::f64::consts::PI * r * r * 2.0));
+    let seq_rel = (seq_vol - expected).abs() / expected;
     assert!(
-        rel < 0.05,
-        "compound_cut volume {compound_vol:.4} != sequential {seq_vol:.4} (rel={rel:.4})"
+        seq_rel < 0.01,
+        "sequential volume {seq_vol:.4} should be within 1% of {expected:.4} (rel={seq_rel:.4})"
+    );
+    let rel = (compound_vol - expected).abs() / expected;
+    assert!(
+        rel < 0.01,
+        "compound_cut volume {compound_vol:.4} should be within 1% of {expected:.4} (rel={rel:.4})"
     );
 }
 


### PR DESCRIPTION
Closed section circles (e.g. a cylinder cap coplanar with a box face) were created with a fresh seam vertex at an arbitrary angle. `link_existing` matches section-to-boundary pave blocks by quantized endpoint-pair key, so the new circle never linked with the coincident existing boundary circle: duplicate coincident edges survived, same-domain detection found zero pairs, and the result failed validation (orphan cap disc, 3-face edges, Euler 5) and fell through to the mesh fallback.

## Changes
- `phase_ff`: when a closed section curve carries an existing boundary vertex on it (within tolerance), adopt that vertex as the seam and re-anchor `t_range` there — gated to circles that do not properly cross either face's boundary (the un-gated version regressed `fuse_two_cylinders`).
- `link_existing`: secondary geometric index for full closed circle blocks keyed by quantized center/radius/axis-up-to-sign.
- `fill_images_faces`: skip closed sections coincident with a face's own closed boundary edge; builder interior-point sampling handles unsplit periodic faces bounded by closed curves.
- Fixes three `brepkit-check` face-integration bugs the new absolute-volume assertion exposed: wire chaining by connectivity instead of orientation flags, planar inner-wire hole subtraction, seam-aligned closed-edge sampling.
- New regression test `gfa_cut_box_cylinder_coplanar_caps_produces_valid_topology` (closed manifold, exact volume); each algo change verified load-bearing by selective revert.
- `compound_cut_matches_sequential_2x2_grid`: oracle tightened to absolute volume (the old two-path relative check passed on garbage); stays ignored — cuts 2–4 still drop faces carrying pre-existing hole loops (the band-splitter PR addresses that path).

## Verification
Full workspace suite green; algo 95, check 44, operations 629 lib; fmt, clippy `-D warnings`, boundary check (check added as algo dev-dependency only).