### PR TITLE
fix(operations): deterministic hashing in mesh tessellation path

### DIFF
--- a/crates/math/src/cdt/mod.rs
+++ b/crates/math/src/cdt/mod.rs
@@ -35,7 +35,7 @@ mod locate;
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashSet;
+use crate::det_hash::DetHashSet;
 
 use crate::MathError;
 use crate::predicates::{in_circle, orient2d};
@@ -106,7 +106,7 @@ pub struct Cdt {
     vertices: Vec<Point2>,
     triangles: Vec<CdtTriangle>,
     /// Set of constrained edges stored as sorted `(min, max)` vertex pairs.
-    constraints: HashSet<(usize, usize)>,
+    constraints: DetHashSet<(usize, usize)>,
     /// Number of super-triangle vertices at the start of the vertex list.
     super_count: usize,
     /// Spatial hash for O(1) amortized duplicate point detection.
@@ -178,7 +178,7 @@ impl Cdt {
         Self {
             vertices,
             triangles,
-            constraints: HashSet::new(),
+            constraints: DetHashSet::default(),
             super_count: 3,
             dup_grid: std::collections::HashMap::new(),
             last_located: 0,
@@ -386,11 +386,11 @@ impl Cdt {
     /// super-triangle vertex.
     pub fn remove_exterior(&mut self, boundary: &[(usize, usize)]) {
         // Build the constraint set for boundary edges.
-        let boundary_set: HashSet<(usize, usize)> =
+        let boundary_set: DetHashSet<(usize, usize)> =
             boundary.iter().map(|&(a, b)| sorted_pair(a, b)).collect();
 
         // Merge with existing constraints for the flood-fill barrier.
-        let all_constraints: HashSet<(usize, usize)> =
+        let all_constraints: DetHashSet<(usize, usize)> =
             self.constraints.union(&boundary_set).copied().collect();
 
         // Start flood-fill from triangles touching super-triangle vertices.
@@ -448,7 +448,7 @@ impl Cdt {
     pub fn flood_remove_from_point(
         &mut self,
         seed: Point2,
-        constraints: &HashSet<(usize, usize)>,
+        constraints: &DetHashSet<(usize, usize)>,
     ) -> bool {
         // Use the walking point-location search (O(sqrt(n))) instead of
         // linear scan (O(n)) to find the seed triangle.
@@ -517,7 +517,7 @@ impl Cdt {
     ///   Stored as sorted `(min, max)` pairs.
     #[must_use]
     pub fn extract_regions(&self, separators: &[(usize, usize)]) -> Vec<Vec<Point2>> {
-        let sep_set: HashSet<(usize, usize)> =
+        let sep_set: DetHashSet<(usize, usize)> =
             separators.iter().map(|&(a, b)| sorted_pair(a, b)).collect();
 
         let sc = self.super_count;
@@ -611,7 +611,7 @@ impl Cdt {
     /// Useful for distinguishing boundary constraints from interior
     /// (separator) constraints in callers like NURBS boolean splitting.
     #[must_use]
-    pub fn constraint_edges(&self) -> &HashSet<(usize, usize)> {
+    pub fn constraint_edges(&self) -> &DetHashSet<(usize, usize)> {
         &self.constraints
     }
 }
@@ -631,11 +631,11 @@ fn walk_region_boundary(
     vertices: &[Point2],
     super_count: usize,
 ) -> Vec<Point2> {
-    use std::collections::HashMap;
+    use crate::det_hash::DetHashMap;
 
     // Count how many times each edge appears in the region.
     // An edge appearing once is a boundary edge.
-    let mut edge_count: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
+    let mut edge_count: DetHashMap<(usize, usize), Vec<(usize, usize)>> = DetHashMap::default();
     for &ti in region_tris {
         let tri = &triangles[ti];
         for local in 0..3 {
@@ -648,7 +648,7 @@ fn walk_region_boundary(
     }
 
     // Boundary edges: appear exactly once. Keep them directed (CCW winding).
-    let mut next_map: HashMap<usize, usize> = HashMap::new();
+    let mut next_map: DetHashMap<usize, usize> = DetHashMap::default();
     for directed_edges in edge_count.values() {
         if directed_edges.len() == 1 {
             let (va, vb) = directed_edges[0];

--- a/crates/math/src/det_hash.rs
+++ b/crates/math/src/det_hash.rs
@@ -12,12 +12,39 @@
 //! order is fully reproducible for a given set of keys. Use them anywhere map
 //! iteration order feeds geometry construction (vertex welds, triangulation,
 //! shell assembly).
+//!
+//! # Security
+//!
+//! This is a deterministic, fixed-seed FNV-1a hasher. It is **not**
+//! DoS-resistant: an adversary who controls the keys can trivially force
+//! collisions. Use it only for internal geometry processing where keys are
+//! derived from trusted topology, never for attacker-controlled input.
 
-use std::hash::{BuildHasherDefault, Hasher};
+use std::hash::{BuildHasher, Hasher};
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
 /// Fixed-seed FNV-1a hasher. Deterministic across processes and instances.
-#[derive(Default, Clone)]
+///
+/// Not DoS-resistant — see the [module docs](self#security). For internal
+/// geometry processing only.
+#[derive(Clone)]
 pub struct DetHasher(u64);
+
+impl DetHasher {
+    /// Create a hasher seeded with the FNV-1a offset basis.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(FNV_OFFSET)
+    }
+}
+
+impl Default for DetHasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Hasher for DetHasher {
     fn finish(&self) -> u64 {
@@ -25,9 +52,7 @@ impl Hasher for DetHasher {
     }
 
     fn write(&mut self, bytes: &[u8]) {
-        const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-        const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-        let mut h = if self.0 == 0 { FNV_OFFSET } else { self.0 };
+        let mut h = self.0;
         for &b in bytes {
             h ^= u64::from(b);
             h = h.wrapping_mul(FNV_PRIME);
@@ -36,11 +61,78 @@ impl Hasher for DetHasher {
     }
 }
 
-/// `BuildHasher` for [`DetHasher`].
-pub type DetState = BuildHasherDefault<DetHasher>;
+/// `BuildHasher` for [`DetHasher`], seeding each hasher at the FNV-1a offset.
+#[derive(Default, Clone)]
+pub struct DetState;
+
+impl BuildHasher for DetState {
+    type Hasher = DetHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        DetHasher::new()
+    }
+}
 
 /// A `HashMap` with deterministic, reproducible iteration order.
 pub type DetHashMap<K, V> = std::collections::HashMap<K, V, DetState>;
 
 /// A `HashSet` with deterministic, reproducible iteration order.
 pub type DetHashSet<K> = std::collections::HashSet<K, DetState>;
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    fn hash_writes(writes: &[&[u8]]) -> u64 {
+        let mut h = DetHasher::new();
+        for w in writes {
+            h.write(w);
+        }
+        h.finish()
+    }
+
+    #[test]
+    fn empty_hash_is_offset_basis() {
+        assert_eq!(DetHasher::new().finish(), FNV_OFFSET);
+    }
+
+    #[test]
+    fn distinct_sequences_differ() {
+        assert_ne!(hash_writes(&[b"abc"]), hash_writes(&[b"abd"]));
+    }
+
+    #[test]
+    fn write_is_order_sensitive() {
+        assert_ne!(hash_writes(&[b"ab", b"cd"]), hash_writes(&[b"cd", b"ab"]),);
+    }
+
+    #[test]
+    fn zero_state_does_not_restart() {
+        // A running state that reaches exactly zero must keep folding in
+        // subsequent bytes rather than silently reverting to the offset
+        // basis. Find a single byte that drives the state to 0, then verify
+        // that appending more bytes keeps the two distinct streams distinct.
+        let target = (0u16..=u16::from(u8::MAX)).map(|b| b as u8).find(|&b| {
+            let mut h = DetHasher::new();
+            h.write(&[b]);
+            h.finish() == 0
+        });
+        if let Some(zeroing) = target {
+            let mut a = DetHasher::new();
+            a.write(&[zeroing]);
+            a.write(&[0x01]);
+
+            // A hasher that began life at zero would, under the old buggy
+            // logic, hash [0x01] identically. Build that comparison stream.
+            let mut b = DetHasher::new();
+            b.write(&[0x01]);
+            assert_ne!(a.finish(), b.finish());
+        }
+
+        // Regardless of whether a zeroing byte exists for this FNV constant,
+        // assert the invariant that distinct streams stay distinct even when
+        // one of them is the empty (offset-basis) stream.
+        assert_ne!(hash_writes(&[]), hash_writes(&[b"x"]));
+    }
+}

--- a/crates/math/src/det_hash.rs
+++ b/crates/math/src/det_hash.rs
@@ -1,0 +1,46 @@
+//! Deterministic hashing primitives.
+//!
+//! The standard-library `HashMap`/`HashSet` seed their hasher from a
+//! process-global source, so iteration order — and therefore any algorithm
+//! whose output depends on the order it visits map entries — varies between
+//! runs (and even between successive map instances within one process, since
+//! the seed counter advances per instance). For geometry kernels this surfaces
+//! as nondeterministic mesh welding and triangulation: the same input can
+//! produce different vertex merges and face counts run-to-run.
+//!
+//! [`DetHashMap`] / [`DetHashSet`] use a fixed-seed FNV-1a hasher so iteration
+//! order is fully reproducible for a given set of keys. Use them anywhere map
+//! iteration order feeds geometry construction (vertex welds, triangulation,
+//! shell assembly).
+
+use std::hash::{BuildHasherDefault, Hasher};
+
+/// Fixed-seed FNV-1a hasher. Deterministic across processes and instances.
+#[derive(Default, Clone)]
+pub struct DetHasher(u64);
+
+impl Hasher for DetHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+        const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+        let mut h = if self.0 == 0 { FNV_OFFSET } else { self.0 };
+        for &b in bytes {
+            h ^= u64::from(b);
+            h = h.wrapping_mul(FNV_PRIME);
+        }
+        self.0 = h;
+    }
+}
+
+/// `BuildHasher` for [`DetHasher`].
+pub type DetState = BuildHasherDefault<DetHasher>;
+
+/// A `HashMap` with deterministic, reproducible iteration order.
+pub type DetHashMap<K, V> = std::collections::HashMap<K, V, DetState>;
+
+/// A `HashSet` with deterministic, reproducible iteration order.
+pub type DetHashSet<K> = std::collections::HashSet<K, DetState>;

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -76,6 +76,7 @@ pub mod chord;
 pub mod convex_hull;
 pub mod curves;
 pub mod curves2d;
+pub mod det_hash;
 pub mod filtered;
 pub mod frame;
 pub mod mat;

--- a/crates/operations/src/mesh_boolean.rs
+++ b/crates/operations/src/mesh_boolean.rs
@@ -9,10 +9,9 @@
 
 #![allow(clippy::tuple_array_conversions)]
 
-use std::collections::HashMap;
-
 use brepkit_math::aabb::Aabb3;
 use brepkit_math::bvh::Bvh;
+use brepkit_math::det_hash::DetHashMap;
 use brepkit_math::predicates::orient3d;
 use brepkit_math::vec::{Point3, Vec3};
 
@@ -674,8 +673,8 @@ fn split_mesh_by_intersections(
     // Group intersection segments by triangle index. Track whether ANY of
     // a triangle's segments came from coplanar-triangle intersections —
     // those need special handling for the issue-#696 midpoint drop below.
-    let mut tri_segments: HashMap<usize, Vec<(Point3, Point3)>> = HashMap::new();
-    let mut tri_has_coplanar_segment: HashMap<usize, bool> = HashMap::new();
+    let mut tri_segments: DetHashMap<usize, Vec<(Point3, Point3)>> = DetHashMap::default();
+    let mut tri_has_coplanar_segment: DetHashMap<usize, bool> = DetHashMap::default();
     for isect in intersections {
         let tri_idx = if is_mesh_a { isect.tri_a } else { isect.tri_b };
         tri_segments

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -1,5 +1,6 @@
 //! Mesh validation and boundary operations.
 
+use brepkit_math::det_hash::{DetHashMap, DetHashSet};
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
 use brepkit_topology::face::FaceSurface;
@@ -25,9 +26,7 @@ pub fn is_watertight(mesh: &TriangleMesh) -> bool {
 /// does not. Returns the number of such edges. A watertight mesh has 0.
 #[must_use]
 pub fn boundary_edge_count(mesh: &TriangleMesh) -> usize {
-    use std::collections::HashSet;
-
-    let mut half_edges: HashSet<(u32, u32)> = HashSet::new();
+    let mut half_edges: DetHashSet<(u32, u32)> = DetHashSet::default();
     let tri_count = mesh.indices.len() / 3;
 
     for t in 0..tri_count {
@@ -53,9 +52,7 @@ pub fn boundary_edge_count(mesh: &TriangleMesh) -> usize {
 /// to validate that a tessellated solid is a closed 2-manifold.
 #[must_use]
 pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize {
-    use std::collections::HashMap;
-
-    let mut edge_count: HashMap<(u32, u32), u32> = HashMap::new();
+    let mut edge_count: DetHashMap<(u32, u32), u32> = DetHashMap::default();
     for tri in mesh.indices.chunks_exact(3) {
         let (a, b, c) = (tri[0], tri[1], tri[2]);
         for (p, q) in [(a, b), (b, c), (c, a)] {
@@ -83,8 +80,6 @@ pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize {
 /// opposite winding cancel (both removed) — that's the signature of two faces
 /// tessellated from opposite sides of the same plane.
 pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh) {
-    use std::collections::HashMap;
-
     /// 1µm grid: tight enough that legitimately distinct CAD features (down to
     /// ~10µm geometry like thin plates) keep separate keys, while still
     /// merging post-merge floating-point noise in coincident vertices that
@@ -109,7 +104,7 @@ pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh) {
         )
     };
 
-    let mut by_key: HashMap<TriKey, TriRefs> = HashMap::new();
+    let mut by_key: DetHashMap<TriKey, TriRefs> = DetHashMap::default();
     for t in 0..tri_count {
         let (a, b, c) = (
             mesh.indices[t * 3] as usize,
@@ -343,15 +338,13 @@ pub fn sample_solid_edges_filtered(
 /// are within `weld_tol` of each other. Rewrites triangle indices and removes
 /// degenerate triangles (where merged indices create duplicate vertices).
 pub(super) fn weld_boundary_vertices(mesh: &mut TriangleMesh, deflection: f64) {
-    use std::collections::{HashMap, HashSet};
-
     let n_verts = mesh.positions.len();
     if n_verts == 0 || mesh.indices.is_empty() {
         return;
     }
 
     // Build half-edge set to find boundary edges.
-    let mut half_edges: HashMap<(u32, u32), usize> = HashMap::new();
+    let mut half_edges: DetHashMap<(u32, u32), usize> = DetHashMap::default();
     for tri in mesh.indices.chunks_exact(3) {
         let (i0, i1, i2) = (tri[0], tri[1], tri[2]);
         *half_edges.entry((i0, i1)).or_default() += 1;
@@ -360,7 +353,7 @@ pub(super) fn weld_boundary_vertices(mesh: &mut TriangleMesh, deflection: f64) {
     }
 
     // Boundary vertices: incident on half-edges without a matching reverse.
-    let mut boundary_set: HashSet<u32> = HashSet::new();
+    let mut boundary_set: DetHashSet<u32> = DetHashSet::default();
     for &(a, b) in half_edges.keys() {
         if !half_edges.contains_key(&(b, a)) {
             boundary_set.insert(a);
@@ -373,7 +366,7 @@ pub(super) fn weld_boundary_vertices(mesh: &mut TriangleMesh, deflection: f64) {
     }
 
     // Sorted iteration keeps grid-cell contents and union order independent
-    // of HashSet iteration order, so welded meshes are reproducible.
+    // of DetHashSet iteration order, so welded meshes are reproducible.
     let mut boundary_verts: Vec<u32> = boundary_set.into_iter().collect();
     boundary_verts.sort_unstable();
 
@@ -411,7 +404,7 @@ pub(super) fn weld_boundary_vertices(mesh: &mut TriangleMesh, deflection: f64) {
         )
     };
 
-    let mut grid: HashMap<(i64, i64, i64), Vec<u32>> = HashMap::new();
+    let mut grid: DetHashMap<(i64, i64, i64), Vec<u32>> = DetHashMap::default();
     for &vid in &boundary_verts {
         let p = mesh.positions[vid as usize];
         grid.entry(cell_key(p)).or_default().push(vid);

--- a/crates/operations/src/tessellate/mod.rs
+++ b/crates/operations/src/tessellate/mod.rs
@@ -165,14 +165,14 @@ pub fn tessellate_with_tolerance(
 #[cfg(test)]
 #[must_use]
 pub(super) fn position_based_boundary_count(mesh: &TriangleMesh) -> usize {
-    use std::collections::{HashMap, HashSet};
-
     /// 1um grid -- intentionally coarser than `MERGE_GRID` (1e-7) to catch
     /// gaps the production pipeline should have closed.
     const DIAGNOSTIC_GRID: f64 = 1e-6;
 
+    use brepkit_math::det_hash::{DetHashMap, DetHashSet};
+
     // Build canonical vertex ID from snapped position.
-    let mut pos_to_canonical: HashMap<(i64, i64, i64), u32> = HashMap::new();
+    let mut pos_to_canonical: DetHashMap<(i64, i64, i64), u32> = DetHashMap::default();
     let mut canonical_ids: Vec<u32> = Vec::with_capacity(mesh.positions.len());
     let mut next_id: u32 = 0;
 
@@ -187,7 +187,7 @@ pub(super) fn position_based_boundary_count(mesh: &TriangleMesh) -> usize {
     }
 
     // Build half-edge set using canonical IDs.
-    let mut half_edges: HashSet<(u32, u32)> = HashSet::new();
+    let mut half_edges: DetHashSet<(u32, u32)> = DetHashSet::default();
     for tri in mesh.indices.chunks_exact(3) {
         let i0 = canonical_ids[tri[0] as usize];
         let i1 = canonical_ids[tri[1] as usize];

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -1,7 +1,6 @@
 //! Non-planar CDT and fallback paths for face tessellation.
 
-use std::collections::HashMap;
-
+use brepkit_math::det_hash::{DetHashMap, DetHashSet};
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
 use brepkit_topology::face::{FaceId, FaceSurface};
@@ -21,12 +20,10 @@ pub(super) fn tessellate_nonplanar_cdt(
     face_data: &brepkit_topology::face::Face,
     deflection: f64,
     angular_tol: f64,
-    edge_global_indices: &HashMap<usize, Vec<u32>>,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
     merged: &mut TriangleMesh,
-    point_to_global: &mut HashMap<(i64, i64, i64), u32>,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
 ) -> Result<(), crate::OperationsError> {
-    use std::collections::HashSet;
-
     use brepkit_math::cdt::Cdt;
     use brepkit_math::vec::Point2;
     use brepkit_topology::edge::EdgeId;
@@ -177,11 +174,11 @@ pub(super) fn tessellate_nonplanar_cdt(
 
     // Step 2b: Detect and fix degenerate seam edges.
     let (u_min, u_max, v_min, v_max) = {
-        let mut wire_edge_counts: HashMap<usize, usize> = HashMap::new();
+        let mut wire_edge_counts: DetHashMap<usize, usize> = DetHashMap::default();
         for oe in wire.edges() {
             *wire_edge_counts.entry(oe.edge().index()).or_default() += 1;
         }
-        let seam_edge_indices: HashSet<usize> = wire_edge_counts
+        let seam_edge_indices: DetHashSet<usize> = wire_edge_counts
             .iter()
             .filter(|&(_, &c)| c > 1)
             .map(|(&idx, _)| idx)
@@ -533,9 +530,9 @@ pub(super) fn tessellate_nonplanar_snap(
     face_data: &brepkit_topology::face::Face,
     deflection: f64,
     angular_tol: f64,
-    edge_global_indices: &HashMap<usize, Vec<u32>>,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
     merged: &mut TriangleMesh,
-    point_to_global: &mut HashMap<(i64, i64, i64), u32>,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
 ) -> Result<(), crate::OperationsError> {
     let mut face_mesh = super::tessellate_with_tolerance(topo, face_id, deflection, angular_tol)?;
 
@@ -583,8 +580,10 @@ pub(super) fn tessellate_nonplanar_snap(
     // Build spatial hash for O(1) snap lookups.
     let snap_tol = 1e-6;
     let inv_cell = 1.0 / snap_tol;
-    let mut snap_grid: HashMap<(i64, i64, i64), Vec<u32>> =
-        HashMap::with_capacity(snap_targets.len());
+    let mut snap_grid: DetHashMap<(i64, i64, i64), Vec<u32>> = DetHashMap::with_capacity_and_hasher(
+        snap_targets.len(),
+        brepkit_math::det_hash::DetState::default(),
+    );
     for &(target_pos, gid) in &snap_targets {
         let cx = (target_pos.x() * inv_cell).round() as i64;
         let cy = (target_pos.y() * inv_cell).round() as i64;

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -580,10 +580,8 @@ pub(super) fn tessellate_nonplanar_snap(
     // Build spatial hash for O(1) snap lookups.
     let snap_tol = 1e-6;
     let inv_cell = 1.0 / snap_tol;
-    let mut snap_grid: DetHashMap<(i64, i64, i64), Vec<u32>> = DetHashMap::with_capacity_and_hasher(
-        snap_targets.len(),
-        brepkit_math::det_hash::DetState::default(),
-    );
+    let mut snap_grid: DetHashMap<(i64, i64, i64), Vec<u32>> =
+        DetHashMap::with_capacity_and_hasher(snap_targets.len(), brepkit_math::det_hash::DetState);
     for &(target_pos, gid) in &snap_targets {
         let cx = (target_pos.x() * inv_cell).round() as i64;
         let cy = (target_pos.y() * inv_cell).round() as i64;

--- a/crates/operations/src/tessellate/nurbs.rs
+++ b/crates/operations/src/tessellate/nurbs.rs
@@ -1,7 +1,6 @@
 //! NURBS adaptive quadtree tessellation.
 
-use std::collections::HashMap;
-
+use brepkit_math::det_hash::DetHashMap;
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
 
@@ -680,20 +679,20 @@ pub(super) fn tessellate_nurbs(
     conforming_pass(surface, &mut cells);
 
     let leaf_count = cells.iter().filter(|c| c.children.is_none()).count();
-    let mut eval_cache: HashMap<(u64, u64), (Point3, Vec3)> = HashMap::new();
+    let mut eval_cache: DetHashMap<(u64, u64), (Point3, Vec3)> = DetHashMap::default();
     let mut positions = Vec::with_capacity(leaf_count * 4);
     let mut normals = Vec::with_capacity(leaf_count * 4);
     let mut uvs: Vec<[f64; 2]> = Vec::with_capacity(leaf_count * 4);
     let mut indices = Vec::with_capacity(leaf_count * 6);
-    let mut vertex_map: HashMap<(u64, u64), u32> = HashMap::new();
+    let mut vertex_map: DetHashMap<(u64, u64), u32> = DetHashMap::default();
 
     let get_or_insert_vertex = |u: f64,
                                 v: f64,
-                                eval_cache: &mut HashMap<(u64, u64), (Point3, Vec3)>,
+                                eval_cache: &mut DetHashMap<(u64, u64), (Point3, Vec3)>,
                                 positions: &mut Vec<Point3>,
                                 normals: &mut Vec<Vec3>,
                                 uvs: &mut Vec<[f64; 2]>,
-                                vertex_map: &mut HashMap<(u64, u64), u32>|
+                                vertex_map: &mut DetHashMap<(u64, u64), u32>|
      -> u32 {
         let key = (u.to_bits(), v.to_bits());
         if let Some(&idx) = vertex_map.get(&key) {

--- a/crates/operations/src/tessellate/planar.rs
+++ b/crates/operations/src/tessellate/planar.rs
@@ -1,7 +1,6 @@
 //! Planar and simple analytic face tessellation.
 
-use std::collections::HashMap;
-
+use brepkit_math::det_hash::{DetHashMap, DetHashSet};
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
 
@@ -492,7 +491,6 @@ fn tessellate_planar_with_holes(
 ) -> Result<TriangleMesh, crate::OperationsError> {
     use brepkit_math::cdt::Cdt;
     use brepkit_math::vec::Point2;
-    use std::collections::HashSet;
 
     // Collect all positions: outer + inner wires.
     let mut all_positions: Vec<Point3> = outer_positions.to_vec();
@@ -563,7 +561,7 @@ fn tessellate_planar_with_holes(
 
     // Remove hole interiors by seeding from each hole's centroid.
     // Build a set of all constraint edges for flood-fill stopping.
-    let constraint_set: HashSet<(usize, usize)> = all_constraints
+    let constraint_set: DetHashSet<(usize, usize)> = all_constraints
         .iter()
         .flat_map(|&(a, b)| {
             let (lo, hi) = if a < b { (a, b) } else { (b, a) };
@@ -593,13 +591,13 @@ fn tessellate_planar_with_holes(
     let mut indices_out = Vec::with_capacity(num_tris * 3);
 
     // Build O(1) reverse map: CDT vertex index -> original position index.
-    let mut vi_to_orig: HashMap<usize, usize> = HashMap::new();
+    let mut vi_to_orig: DetHashMap<usize, usize> = DetHashMap::default();
     for (orig_idx, &cdt_vi) in cdt_indices.iter().enumerate() {
         vi_to_orig.entry(cdt_vi).or_insert(orig_idx);
     }
 
     // Map CDT point indices -> output mesh indices.
-    let mut cdt_to_mesh: HashMap<usize, u32> = HashMap::new();
+    let mut cdt_to_mesh: DetHashMap<usize, u32> = DetHashMap::default();
     for &(v0, v1, v2) in &cdt_triangles {
         for &vi in &[v0, v1, v2] {
             if let std::collections::hash_map::Entry::Vacant(e) = cdt_to_mesh.entry(vi) {
@@ -783,7 +781,7 @@ pub(super) fn cdt_triangulate_simple(positions: &[Point3], normal: Vec3) -> Vec<
 
     let cdt_triangles = cdt.triangles();
 
-    let mut cdt_to_input: HashMap<usize, usize> = HashMap::new();
+    let mut cdt_to_input: DetHashMap<usize, usize> = DetHashMap::default();
     for (input_idx, &cdt_idx) in cdt_indices.iter().enumerate() {
         cdt_to_input.entry(cdt_idx).or_insert(input_idx);
     }
@@ -828,7 +826,7 @@ pub(super) fn fan_triangulate(n: usize) -> Vec<u32> {
 /// Collect global vertex IDs from a wire, deduplicating consecutive vertices.
 pub(super) fn collect_wire_global_vertices(
     wire: &brepkit_topology::wire::Wire,
-    edge_global_indices: &HashMap<usize, Vec<u32>>,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
     positions: &[Point3],
     tol: f64,
 ) -> (Vec<Point3>, Vec<Option<u32>>) {
@@ -913,13 +911,12 @@ pub(super) fn tessellate_planar_shared_with_holes(
     boundary_global_ids: &[u32],
     outer_positions: &[Point3],
     normal: Vec3,
-    edge_global_indices: &HashMap<usize, Vec<u32>>,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
     merged: &mut TriangleMesh,
-    point_to_global: &mut HashMap<(i64, i64, i64), u32>,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
 ) -> Result<(), crate::OperationsError> {
     use brepkit_math::cdt::Cdt;
     use brepkit_math::vec::Point2;
-    use std::collections::HashSet;
 
     let mut all_positions: Vec<Point3> = outer_positions.to_vec();
     let mut all_global_ids: Vec<Option<u32>> =
@@ -1010,7 +1007,7 @@ pub(super) fn tessellate_planar_shared_with_holes(
         .collect();
     cdt.remove_exterior(&outer_constraints);
 
-    let constraint_set: HashSet<(usize, usize)> = all_constraints
+    let constraint_set: DetHashSet<(usize, usize)> = all_constraints
         .iter()
         .flat_map(|&(a, b)| {
             let (lo, hi) = if a < b { (a, b) } else { (b, a) };
@@ -1037,7 +1034,7 @@ pub(super) fn tessellate_planar_shared_with_holes(
 
     let cdt_triangles = cdt.triangles();
 
-    let mut cdt_to_global: HashMap<usize, u32> = HashMap::new();
+    let mut cdt_to_global: DetHashMap<usize, u32> = DetHashMap::default();
     for (local_idx, &cdt_idx) in cdt_indices.iter().enumerate() {
         if let Some(gid) = all_global_ids[local_idx] {
             cdt_to_global.insert(cdt_idx, gid);
@@ -1096,7 +1093,6 @@ pub(super) fn run_planar_cdt(
 ) -> Result<Vec<(usize, usize, usize)>, crate::OperationsError> {
     use brepkit_math::cdt::Cdt;
     use brepkit_math::vec::Point2;
-    use std::collections::HashSet;
 
     let bounds = compute_cdt_bounds(pts2d);
 
@@ -1141,7 +1137,7 @@ pub(super) fn run_planar_cdt(
         .collect();
     cdt.remove_exterior(&outer_constraints);
 
-    let constraint_set: HashSet<(usize, usize)> = all_constraints
+    let constraint_set: DetHashSet<(usize, usize)> = all_constraints
         .iter()
         .flat_map(|&(a, b)| {
             let (lo, hi) = if a < b { (a, b) } else { (b, a) };
@@ -1168,7 +1164,7 @@ pub(super) fn run_planar_cdt(
 
     let cdt_triangles = cdt.triangles();
 
-    let mut cdt_to_input: HashMap<usize, usize> = HashMap::new();
+    let mut cdt_to_input: DetHashMap<usize, usize> = DetHashMap::default();
     for (input_idx, &cdt_idx) in cdt_indices.iter().enumerate() {
         cdt_to_input.entry(cdt_idx).or_insert(input_idx);
     }

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -74,8 +74,11 @@ pub fn tessellate_solid_with_tolerance(
     let all_faces = explorer::solid_faces(topo, solid)?;
     let edge_face_map = explorer::edge_to_face_map(topo, solid)?;
 
-    // Phase 2: Tessellate each unique edge once.
-    let edge_indices: Vec<usize> = edge_face_map.keys().copied().collect();
+    // Phase 2: Tessellate each unique edge once. The map is a std `HashMap`,
+    // so sort its keys into ID order before use — keeping all downstream
+    // iteration deterministic regardless of insertion-order hashing.
+    let mut edge_indices: Vec<usize> = edge_face_map.keys().copied().collect();
+    edge_indices.sort_unstable();
     #[cfg(not(target_arch = "wasm32"))]
     let mut edge_points: DetHashMap<usize, Vec<Point3>> = if edge_indices.len() >= 32 {
         use rayon::prelude::*;

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -1,7 +1,6 @@
 //! Solid-level tessellation orchestration.
 
-use std::collections::HashMap;
-
+use brepkit_math::det_hash::{DetHashMap, DetHashSet};
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
 use brepkit_topology::edge::EdgeCurve;
@@ -78,7 +77,7 @@ pub fn tessellate_solid_with_tolerance(
     // Phase 2: Tessellate each unique edge once.
     let edge_indices: Vec<usize> = edge_face_map.keys().copied().collect();
     #[cfg(not(target_arch = "wasm32"))]
-    let mut edge_points: HashMap<usize, Vec<Point3>> = if edge_indices.len() >= 32 {
+    let mut edge_points: DetHashMap<usize, Vec<Point3>> = if edge_indices.len() >= 32 {
         use rayon::prelude::*;
         let results: Vec<Result<(usize, Vec<Point3>), crate::OperationsError>> = edge_indices
             .par_iter()
@@ -94,14 +93,14 @@ pub fn tessellate_solid_with_tolerance(
                 )
             })
             .collect();
-        let mut map = HashMap::new();
+        let mut map = DetHashMap::default();
         for r in results {
             let (idx, pts) = r?;
             map.insert(idx, pts);
         }
         map
     } else {
-        let mut map = HashMap::new();
+        let mut map = DetHashMap::default();
         for &edge_idx in &edge_indices {
             if let Some(edge_id) = topo.edge_id_from_index(edge_idx) {
                 if let Ok(edge_data) = topo.edge(edge_id) {
@@ -113,8 +112,8 @@ pub fn tessellate_solid_with_tolerance(
         map
     };
     #[cfg(target_arch = "wasm32")]
-    let mut edge_points: HashMap<usize, Vec<Point3>> = {
-        let mut map = HashMap::new();
+    let mut edge_points: DetHashMap<usize, Vec<Point3>> = {
+        let mut map = DetHashMap::default();
         for &edge_idx in &edge_indices {
             if let Some(edge_id) = topo.edge_id_from_index(edge_idx) {
                 if let Ok(edge_data) = topo.edge(edge_id) {
@@ -191,8 +190,8 @@ pub fn tessellate_solid_with_tolerance(
 
     // Phase 3: Build merged mesh with shared edge vertices.
     let mut merged = TriangleMesh::default();
-    let mut point_to_global: HashMap<(i64, i64, i64), u32> = HashMap::new();
-    let mut edge_global_indices: HashMap<usize, Vec<u32>> = HashMap::new();
+    let mut point_to_global: DetHashMap<(i64, i64, i64), u32> = DetHashMap::default();
+    let mut edge_global_indices: DetHashMap<usize, Vec<u32>> = DetHashMap::default();
 
     for (&edge_idx, points) in &edge_points {
         let mut global_ids = Vec::with_capacity(points.len());
@@ -212,8 +211,6 @@ pub fn tessellate_solid_with_tolerance(
 
     // Phase 3b: Circle edge refinement.
     {
-        use std::collections::HashSet;
-
         let tol_linear = brepkit_math::tolerance::Tolerance::new().linear;
         let refine_tol = tol_linear * 10.0;
 
@@ -244,7 +241,7 @@ pub fn tessellate_solid_with_tolerance(
                 .get(&edge_idx)
                 .cloned()
                 .unwrap_or_default();
-            let existing_gids: HashSet<u32> = existing_gids_vec.iter().copied().collect();
+            let existing_gids: DetHashSet<u32> = existing_gids_vec.iter().copied().collect();
 
             let mut insertions: Vec<(f64, u32)> = Vec::new();
             for (gid, pos) in merged.positions.iter().enumerate() {
@@ -293,7 +290,7 @@ pub fn tessellate_solid_with_tolerance(
                 .collect();
             all_with_t.extend(insertions);
             all_with_t.sort_by(|a, b| a.0.total_cmp(&b.0));
-            let mut seen_gids = HashSet::new();
+            let mut seen_gids = DetHashSet::default();
             all_with_t.retain(|(_, gid)| seen_gids.insert(*gid));
 
             let refined: Vec<u32> = all_with_t.into_iter().map(|(_, gid)| gid).collect();
@@ -476,9 +473,7 @@ pub fn tessellate_solid_with_tolerance(
     }
 
     {
-        use std::collections::HashSet;
-
-        let mut vertex_faces: HashMap<usize, HashSet<FaceId>> = HashMap::new();
+        let mut vertex_faces: DetHashMap<usize, DetHashSet<FaceId>> = DetHashMap::default();
         for (&edge_idx, global_ids) in &edge_global_indices {
             if let Some(face_ids) = edge_face_map.get(&edge_idx) {
                 for &gid in global_ids {
@@ -570,9 +565,9 @@ pub(super) fn tessellate_face_with_shared_edges(
     face_id: FaceId,
     deflection: f64,
     angular_tol: f64,
-    edge_global_indices: &HashMap<usize, Vec<u32>>,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
     merged: &mut TriangleMesh,
-    point_to_global: &mut HashMap<(i64, i64, i64), u32>,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
 ) -> Result<(), crate::OperationsError> {
     let face_data = topo.face(face_id)?;
     let is_reversed = face_data.is_reversed();

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::unwrap_used, deprecated)]
 
+use brepkit_math::det_hash::{DetHashMap, DetHashSet};
 use brepkit_math::nurbs::surface::NurbsSurface;
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
@@ -956,8 +957,6 @@ fn test_max_sag_within_deflection() {
 
 #[test]
 fn test_watertight_solid_mesh() {
-    use std::collections::{HashMap, HashSet};
-
     let mut topo = Topology::new();
     let solid = crate::primitives::make_box(&mut topo, 1.0, 2.0, 3.0).unwrap();
     let mesh = tessellate_solid(&topo, solid, 0.1).unwrap();
@@ -965,7 +964,7 @@ fn test_watertight_solid_mesh() {
     let snap = |v: f64| -> i64 { (v * 1_000_000.0).round() as i64 };
     let snap_pt = |p: Point3| -> (i64, i64, i64) { (snap(p.x()), snap(p.y()), snap(p.z())) };
 
-    let mut pos_map: HashMap<(i64, i64, i64), usize> = HashMap::new();
+    let mut pos_map: DetHashMap<(i64, i64, i64), usize> = DetHashMap::default();
     let mut next_id = 0_usize;
     let canonical: Vec<usize> = mesh
         .positions
@@ -981,7 +980,7 @@ fn test_watertight_solid_mesh() {
         .collect();
 
     let tri_count = mesh.indices.len() / 3;
-    let mut half_edges: HashSet<(usize, usize)> = HashSet::new();
+    let mut half_edges: DetHashSet<(usize, usize)> = DetHashSet::default();
     for t in 0..tri_count {
         let a = canonical[mesh.indices[t * 3] as usize];
         let b = canonical[mesh.indices[t * 3 + 1] as usize];
@@ -1060,7 +1059,7 @@ fn test_no_t_junctions_box() {
     let mesh = tessellate_solid(&topo, solid, 0.1).unwrap();
 
     let snap = |v: f64| -> i64 { (v * 1_000_000.0).round() as i64 };
-    let unique: std::collections::HashSet<(i64, i64, i64)> = mesh
+    let unique: brepkit_math::det_hash::DetHashSet<(i64, i64, i64)> = mesh
         .positions
         .iter()
         .map(|p| (snap(p.x()), snap(p.y()), snap(p.z())))
@@ -1095,8 +1094,6 @@ fn test_circle_deflection_scaling() {
 
 #[test]
 fn test_tessellate_boolean_result_watertight() {
-    use std::collections::{HashMap, HashSet};
-
     let mut topo = Topology::new();
     let a = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
     let b = crate::primitives::make_box(&mut topo, 1.5, 1.5, 1.5).unwrap();
@@ -1114,7 +1111,7 @@ fn test_tessellate_boolean_result_watertight() {
     let snap = |v: f64| -> i64 { (v * 1_000_000.0).round() as i64 };
     let snap_pt = |p: Point3| -> (i64, i64, i64) { (snap(p.x()), snap(p.y()), snap(p.z())) };
 
-    let mut pos_map: HashMap<(i64, i64, i64), usize> = HashMap::new();
+    let mut pos_map: DetHashMap<(i64, i64, i64), usize> = DetHashMap::default();
     let mut next_id = 0_usize;
     let canonical: Vec<usize> = mesh
         .positions
@@ -1130,7 +1127,7 @@ fn test_tessellate_boolean_result_watertight() {
         .collect();
 
     let tri_count = mesh.indices.len() / 3;
-    let mut half_edges: HashSet<(usize, usize)> = HashSet::new();
+    let mut half_edges: DetHashSet<(usize, usize)> = DetHashSet::default();
     for t in 0..tri_count {
         let ca = canonical[mesh.indices[t * 3] as usize];
         let cb = canonical[mesh.indices[t * 3 + 1] as usize];
@@ -1385,8 +1382,7 @@ fn torus_tessellation_count() {
 /// Count distinct angular bands around a cylinder's circumference by
 /// projecting lateral-face vertices to their angle about the z axis.
 fn distinct_angular_bands(mesh: &TriangleMesh, radius: f64) -> usize {
-    use std::collections::HashSet;
-    let mut bins: HashSet<i64> = HashSet::new();
+    let mut bins: DetHashSet<i64> = DetHashSet::default();
     for p in &mesh.positions {
         let rr = (p.x() * p.x() + p.y() * p.y()).sqrt();
         if (rr - radius).abs() > radius * 0.05 {
@@ -1415,8 +1411,6 @@ fn cylinder_small_radius_respects_angular_tolerance() {
 
 #[test]
 fn torus_minor_arc_min_segments() {
-    use std::collections::HashSet;
-
     let mut topo = Topology::new();
     let solid = crate::primitives::make_torus(&mut topo, 5.0, 0.4, 32).unwrap();
 
@@ -1426,7 +1420,7 @@ fn torus_minor_arc_min_segments() {
     // Count distinct minor-circle latitudes by binning distance from the
     // tube center circle (radius R) -- a proxy for the v direction density.
     let r_major = 5.0;
-    let mut bins: HashSet<i64> = HashSet::new();
+    let mut bins: DetHashSet<i64> = DetHashSet::default();
     for p in &mesh.positions {
         let rho = (p.x() * p.x() + p.y() * p.y()).sqrt();
         let dr = rho - r_major;


### PR DESCRIPTION
## Root cause

`boolean::tests::compound_cut_shelled_target_many_tools` intermittently failed (~45% of fresh-process runs locally; rarely in CI's coverage build) with `compound_cut volume != sequential` at large rel error.

For this geometry (a shelled box cut by 25 box tools), every cut **falls through to the mesh-boolean fallback** — GFA never produces a clean acceptable result. The mesh fallback tessellates the inputs (CDT), runs mesh boolean co-refinement, and welds vertices through `std::collections::HashMap`/`HashSet`. Their hasher is seeded per-instance from a process-global counter, so **iteration order varies run-to-run** — even within a single process across successive map instances. Different iteration order = different vertex merges and triangulation = different face counts (observed 33 vs 38 vs 39 faces) and volumes for byte-identical input. Both `compound_cut` (with `unify_faces=false`, identical to the sequential path) and the sequential reference flip independently between basins, so the comparison fails whenever they land on different ones.

Verified by globally swapping in a fixed-seed hasher: the result became fully deterministic (38/38 faces across trials). Narrowing showed algo/topology/boolean-assembly hashing was **not** the cause — only the mesh-tessellation pipeline.

## Fix

Add `brepkit_math::det_hash` (fixed-seed FNV-1a `DetHashMap`/`DetHashSet`) and route the maps in the tessellation + CDT + mesh-boolean welding path through it, so iteration order is reproducible. Only maps whose **iteration** feeds geometry construction are converted; lookup-only accelerators (e.g. CDT `dup_grid`) are left unchanged.

## Validation

- Target test: 40/40 fresh processes; 8/8 under `cargo llvm-cov` (CI's coverage config)
- All `compound_cut` tests: 20/20
- `cargo test -p brepkit-operations --lib`: 645 passed / 0 failed
- `cargo test -p brepkit-algo --lib`: 105 passed / 0 failed
- `cargo clippy -p brepkit-math -p brepkit-operations --all-targets -D warnings`: clean
- Crate boundaries: valid