### PR TITLE
fix(algo): filter section curves to mutual face footprints; fix(operations): loft cap winding

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -45,6 +45,7 @@ pub fn build_solid(topo: &mut Topology, selected: &[SelectedFace]) -> Result<Sol
     if selected.is_empty() {
         return Err(AlgoError::AssemblyFailed("no faces selected".into()));
     }
+    log::debug!("BuilderSolid: {} faces selected", selected.len());
 
     // Step 0: Create reversed copies for Cut B-faces
     let mut face_ids: Vec<FaceId> = Vec::with_capacity(selected.len());
@@ -60,6 +61,31 @@ pub fn build_solid(topo: &mut Topology, selected: &[SelectedFace]) -> Result<Sol
             face_ids.push(sf.face_id);
         }
     }
+
+    // Step 0a-pre: Drop degenerate sliver faces — all-Line outer wires with
+    // fewer than 3 distinct vertex positions enclose zero area (e.g. a loft
+    // band built over a duplicated profile point, giving [e, e-reversed]).
+    // Keeping them turns their edges non-manifold in an otherwise valid
+    // result. Faces with curved edges are exempt (two half-circles bound a
+    // real disc with only 2 vertices).
+    face_ids.retain(|&fid| !is_degenerate_line_sliver(topo, fid));
+    if face_ids.is_empty() {
+        return Err(AlgoError::AssemblyFailed(
+            "all faces degenerate slivers".into(),
+        ));
+    }
+
+    // Step 0a-pre2: Strip zero-length Line edges from wires (duplicated
+    // input vertices produce them; their twin lives only on the degenerate
+    // slivers removed above, so they would survive as free edges).
+    remove_zero_length_edges(topo, &mut face_ids)?;
+
+    // Step 0a: Split Line edges at intermediate collinear vertices.
+    // Adjacent faces can partition the same geometric boundary differently
+    // (one whole edge vs several sub-edges split at paves); refining every
+    // Line edge against the global vertex set gives both sides identical
+    // partitions so the merge below can unify them.
+    split_edges_at_collinear_vertices(topo, &mut face_ids)?;
 
     // Step 0b: Merge duplicate edges across selected faces.
     // Faces from different input solids may have separate edge entities for the
@@ -822,6 +848,279 @@ struct EdgeEntry {
     edge_id: brepkit_topology::edge::EdgeId,
     face_idx: usize,
     qpair: QPosEdge,
+}
+
+/// Rebuild faces whose wires contain zero-length Line edges (quantized
+/// start == end), dropping those edges. Closed curved edges (full circles)
+/// legitimately have coincident endpoints and are kept.
+fn remove_zero_length_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result<(), AlgoError> {
+    use brepkit_topology::edge::{EdgeCurve, EdgeId};
+
+    for fid in face_ids.iter_mut() {
+        let (surface, is_reversed, outer_oes, inner_oes_list, has_zero) = {
+            let face = topo.face(*fid)?;
+            let surface = face.surface().clone();
+            let is_reversed = face.is_reversed();
+            let collect = |wid| -> Result<Vec<(EdgeId, bool, bool)>, AlgoError> {
+                let mut out = Vec::new();
+                let wire = topo.wire(wid)?;
+                for oe in wire.edges() {
+                    let edge = topo.edge(oe.edge())?;
+                    let zero = matches!(edge.curve(), EdgeCurve::Line) && {
+                        let sp = topo.vertex(edge.start())?.point();
+                        let ep = topo.vertex(edge.end())?.point();
+                        quantize_point(sp, MERGE_TOL) == quantize_point(ep, MERGE_TOL)
+                    };
+                    out.push((oe.edge(), oe.is_forward(), zero));
+                }
+                Ok(out)
+            };
+            let outer_oes = collect(face.outer_wire())?;
+            let inner_wids = face.inner_wires().to_vec();
+            let mut inner_oes_list = Vec::new();
+            for iw in inner_wids {
+                inner_oes_list.push(collect(iw)?);
+            }
+            let has_zero = outer_oes
+                .iter()
+                .chain(inner_oes_list.iter().flatten())
+                .any(|&(_, _, z)| z);
+            (surface, is_reversed, outer_oes, inner_oes_list, has_zero)
+        };
+        if !has_zero {
+            continue;
+        }
+
+        let strip = |oes: &[(EdgeId, bool, bool)]| -> Vec<OrientedEdge> {
+            oes.iter()
+                .filter(|&&(_, _, z)| !z)
+                .map(|&(eid, fwd, _)| OrientedEdge::new(eid, fwd))
+                .collect()
+        };
+        let new_outer = strip(&outer_oes);
+        if new_outer.len() < 2 {
+            continue;
+        }
+        let Ok(new_outer_wire) = brepkit_topology::wire::Wire::new(new_outer, true) else {
+            continue;
+        };
+        let new_outer_id = topo.add_wire(new_outer_wire);
+        let mut new_inner_ids = Vec::new();
+        for inner_oes in &inner_oes_list {
+            let kept = strip(inner_oes);
+            if kept.len() >= 2 {
+                if let Ok(w) = brepkit_topology::wire::Wire::new(kept, true) {
+                    new_inner_ids.push(topo.add_wire(w));
+                }
+            }
+        }
+        let mut new_face = Face::new(new_outer_id, new_inner_ids, surface);
+        if is_reversed {
+            new_face.set_reversed(true);
+        }
+        *fid = topo.add_face(new_face);
+    }
+    Ok(())
+}
+
+/// Whether a face's outer wire is an all-Line loop with fewer than 3
+/// distinct vertex positions (zero enclosed area).
+fn is_degenerate_line_sliver(topo: &Topology, fid: FaceId) -> bool {
+    use brepkit_topology::edge::EdgeCurve;
+
+    let Ok(face) = topo.face(fid) else {
+        return false;
+    };
+    let Ok(wire) = topo.wire(face.outer_wire()) else {
+        return false;
+    };
+    let mut positions: HashSet<QPos> = HashSet::new();
+    for oe in wire.edges() {
+        let Ok(edge) = topo.edge(oe.edge()) else {
+            return false;
+        };
+        if !matches!(edge.curve(), EdgeCurve::Line) {
+            return false;
+        }
+        for vid in [edge.start(), edge.end()] {
+            let Ok(v) = topo.vertex(vid) else {
+                return false;
+            };
+            positions.insert(quantize_point(v.point(), MERGE_TOL));
+            if positions.len() >= 3 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Split Line edges at intermediate collinear vertices from the global
+/// vertex set of the selected faces.
+///
+/// Splitting is driven purely by vertex position, so geometrically
+/// coincident edges on different faces always receive identical
+/// partitions; the sub-edge entities are created once per `EdgeId`, so
+/// faces sharing an edge keep sharing its sub-edges.
+#[allow(clippy::too_many_lines)]
+fn split_edges_at_collinear_vertices(
+    topo: &mut Topology,
+    face_ids: &mut [FaceId],
+) -> Result<(), AlgoError> {
+    use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
+    use brepkit_topology::vertex::VertexId;
+
+    let tol = MERGE_TOL;
+    let snap = tol * 10.0;
+
+    // Canonical vertex per quantized position, and unique Line edges.
+    let mut vert_at: HashMap<QPos, (VertexId, Point3)> = HashMap::new();
+    let mut line_edges: Vec<(EdgeId, VertexId, VertexId, Point3, Point3)> = Vec::new();
+    let mut seen_edges: HashSet<EdgeId> = HashSet::new();
+
+    for &fid in face_ids.iter() {
+        let face = topo.face(fid)?;
+        let wids: Vec<WireId> = std::iter::once(face.outer_wire())
+            .chain(face.inner_wires().iter().copied())
+            .collect();
+        for wid in wids {
+            let wire = topo.wire(wid)?;
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge())?;
+                let (sv, ev) = (edge.start(), edge.end());
+                let is_line = matches!(edge.curve(), EdgeCurve::Line);
+                let sp = topo.vertex(sv)?.point();
+                let ep = topo.vertex(ev)?.point();
+                vert_at.entry(quantize_point(sp, tol)).or_insert((sv, sp));
+                vert_at.entry(quantize_point(ep, tol)).or_insert((ev, ep));
+                if is_line && seen_edges.insert(oe.edge()) {
+                    line_edges.push((oe.edge(), sv, ev, sp, ep));
+                }
+            }
+        }
+    }
+
+    // Deterministic order for sub-edge allocation.
+    line_edges.sort_by_key(|(eid, ..)| eid.index());
+
+    let mut replacements: HashMap<EdgeId, Vec<OrientedEdge>> = HashMap::new();
+    for (eid, sv, ev, sp, ep) in line_edges {
+        let dir = ep - sp;
+        let len2 = dir.dot(dir);
+        if len2 < snap * snap {
+            continue;
+        }
+        let mut cuts: Vec<(f64, VertexId)> = Vec::new();
+        for &(vid, p) in vert_at.values() {
+            if (p - sp).length() < snap || (p - ep).length() < snap {
+                continue;
+            }
+            let t = (p - sp).dot(dir) / len2;
+            if !(0.0..=1.0).contains(&t) {
+                continue;
+            }
+            let foot = sp + dir * t;
+            if (p - foot).length() > snap {
+                continue;
+            }
+            cuts.push((t, vid));
+        }
+        if cuts.is_empty() {
+            continue;
+        }
+        cuts.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mut chain: Vec<VertexId> = Vec::with_capacity(cuts.len() + 2);
+        chain.push(sv);
+        chain.extend(cuts.iter().map(|&(_, vid)| vid));
+        chain.push(ev);
+        let mut subs = Vec::with_capacity(chain.len() - 1);
+        for w in chain.windows(2) {
+            let sub_eid = topo.add_edge(Edge::new(w[0], w[1], EdgeCurve::Line));
+            subs.push(OrientedEdge::new(sub_eid, true));
+        }
+        replacements.insert(eid, subs);
+    }
+
+    if replacements.is_empty() {
+        return Ok(());
+    }
+    let split_count = replacements.len();
+
+    // Rebuild faces whose wires reference a split edge.
+    for fid in face_ids.iter_mut() {
+        let (surface, is_reversed, outer_oes, inner_oes_list) = {
+            let face = topo.face(*fid)?;
+            let surface = face.surface().clone();
+            let is_reversed = face.is_reversed();
+            let outer_oes: Vec<(EdgeId, bool)> = topo
+                .wire(face.outer_wire())?
+                .edges()
+                .iter()
+                .map(|oe| (oe.edge(), oe.is_forward()))
+                .collect();
+            let mut inner_oes_list = Vec::new();
+            for &iw in face.inner_wires() {
+                inner_oes_list.push(
+                    topo.wire(iw)?
+                        .edges()
+                        .iter()
+                        .map(|oe| (oe.edge(), oe.is_forward()))
+                        .collect::<Vec<(EdgeId, bool)>>(),
+                );
+            }
+            (surface, is_reversed, outer_oes, inner_oes_list)
+        };
+
+        let touched = outer_oes
+            .iter()
+            .chain(inner_oes_list.iter().flatten())
+            .any(|(eid, _)| replacements.contains_key(eid));
+        if !touched {
+            continue;
+        }
+
+        let expand = |oes: &[(EdgeId, bool)]| -> Vec<OrientedEdge> {
+            let mut out = Vec::with_capacity(oes.len());
+            for &(eid, fwd) in oes {
+                if let Some(subs) = replacements.get(&eid) {
+                    if fwd {
+                        out.extend(subs.iter().copied());
+                    } else {
+                        out.extend(
+                            subs.iter()
+                                .rev()
+                                .map(|oe| OrientedEdge::new(oe.edge(), !oe.is_forward())),
+                        );
+                    }
+                } else {
+                    out.push(OrientedEdge::new(eid, fwd));
+                }
+            }
+            out
+        };
+
+        let Ok(new_outer) = brepkit_topology::wire::Wire::new(expand(&outer_oes), true) else {
+            continue;
+        };
+        let new_outer_id = topo.add_wire(new_outer);
+        let mut new_inner_ids = Vec::new();
+        for inner_oes in &inner_oes_list {
+            if let Ok(w) = brepkit_topology::wire::Wire::new(expand(inner_oes), true) {
+                new_inner_ids.push(topo.add_wire(w));
+            }
+        }
+
+        let mut new_face = Face::new(new_outer_id, new_inner_ids, surface);
+        if is_reversed {
+            new_face.set_reversed(true);
+        }
+        *fid = topo.add_face(new_face);
+    }
+
+    log::debug!("split_edges_at_collinear_vertices: split {split_count} edges");
+
+    Ok(())
 }
 
 /// Merge duplicate edges across selected faces by quantized endpoint position.

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -898,7 +898,7 @@ fn remove_zero_length_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Res
                 .collect()
         };
         let new_outer = strip(&outer_oes);
-        if new_outer.len() < 2 {
+        if !is_rebuildable_loop(topo, &new_outer) {
             continue;
         }
         let Ok(new_outer_wire) = brepkit_topology::wire::Wire::new(new_outer, true) else {
@@ -908,7 +908,7 @@ fn remove_zero_length_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Res
         let mut new_inner_ids = Vec::new();
         for inner_oes in &inner_oes_list {
             let kept = strip(inner_oes);
-            if kept.len() >= 2 {
+            if is_rebuildable_loop(topo, &kept) {
                 if let Ok(w) = brepkit_topology::wire::Wire::new(kept, true) {
                     new_inner_ids.push(topo.add_wire(w));
                 }
@@ -921,6 +921,26 @@ fn remove_zero_length_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Res
         *fid = topo.add_face(new_face);
     }
     Ok(())
+}
+
+/// Whether a stripped edge list can form a valid closed wire loop. Two or
+/// more edges always qualify. A single edge qualifies only when it is itself
+/// closed (e.g. a circular hole is one closed-circle edge) — start vertex
+/// equals end vertex, or the curve is inherently closed (Circle/Ellipse).
+/// Genuinely degenerate single-Line leftovers are rejected.
+fn is_rebuildable_loop(topo: &Topology, oes: &[OrientedEdge]) -> bool {
+    use brepkit_topology::edge::EdgeCurve;
+
+    match oes {
+        [] => false,
+        [single] => {
+            let Ok(edge) = topo.edge(single.edge()) else {
+                return false;
+            };
+            edge.is_closed() || matches!(edge.curve(), EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_))
+        }
+        _ => true,
+    }
 }
 
 /// Whether a face's outer wire is an all-Line loop with fewer than 3

--- a/crates/algo/src/builder/classify_2d.rs
+++ b/crates/algo/src/builder/classify_2d.rs
@@ -76,7 +76,10 @@ pub fn sample_interior_point(loop_pts: &[Point2]) -> Point2 {
     centroid
 }
 
-fn boundary_eps(loop_pts: &[Point2]) -> f64 {
+/// Scale-aware boundary tolerance for a 2D loop: a small fraction of the
+/// loop's bounding-box diagonal, floored to avoid collapsing to zero for
+/// degenerate inputs.
+pub fn boundary_eps(loop_pts: &[Point2]) -> f64 {
     let (mut min_x, mut min_y) = (f64::INFINITY, f64::INFINITY);
     let (mut max_x, mut max_y) = (f64::NEG_INFINITY, f64::NEG_INFINITY);
     for p in loop_pts {

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -183,16 +183,25 @@ pub fn split_face_2d(
     // boundary in UV space. Project each section endpoint to UV and test
     // if it lies on any boundary edge's UV segment (within tolerance).
     // This is surface-type agnostic and handles curved boundary edges.
+    let mut deduped_line_loops: Option<Vec<SectionEdge>> = None;
     let all_sections_internal = if sections.is_empty() {
         false
     } else if is_plane {
-        // Only for plane faces with exactly 1 closed section curve.
-        // Multiple circles on the same plane face need the wire builder
-        // for correct loop formation.
-        sections.len() == 1
+        // Plane faces: exactly 1 closed section curve, or all-Line
+        // sections forming closed loops strictly inside the boundary
+        // (nested coplanar footprints). Multiple circles on the same
+        // plane face still need the wire builder for loop formation.
+        let single_closed = sections.len() == 1
             && sections.iter().all(|s| {
                 (s.start - s.end).length() < tol.linear // closed curve
-            })
+            });
+        if single_closed {
+            true
+        } else {
+            deduped_line_loops =
+                plane_internal_line_loops(sections, frame, &boundary_edges, tol.linear);
+            deduped_line_loops.is_some()
+        }
     } else {
         // Non-plane faces: check if all section endpoints are off the
         // boundary in UV space.
@@ -206,11 +215,16 @@ pub fn split_face_2d(
     };
 
     if all_sections_internal {
+        let secs = deduped_line_loops.as_deref().unwrap_or(sections);
+        log::debug!(
+            "split_face_2d: face {face_id:?} routed to internal-loops path ({} sections)",
+            secs.len()
+        );
         return split_face_with_internal_loops(
             &surface,
             &boundary_edges,
             &original_inner_wires,
-            sections,
+            secs,
             rank,
             reversed,
             face_id,
@@ -707,4 +721,129 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
         });
     let n = sub_face.outer_wire.len() as f64;
     Point3::new(sum.x() / n, sum.y() / n, sum.z() / n)
+}
+
+/// Detect all-Line section edges forming closed loops strictly inside a
+/// plane face's boundary (nested coplanar footprints), and dedup repeated
+/// segments. Both the coplanar-contact pass and adjacent-face plane-plane
+/// intersections can emit the same footprint segment, so identical
+/// segments (by unordered quantized endpoints) collapse to one.
+///
+/// Returns the deduped sections when every quantized endpoint has degree
+/// exactly 2 (disjoint closed loops) and every endpoint lies strictly
+/// interior to the boundary polygon; `None` routes back to the generic
+/// wire-builder path.
+fn plane_internal_line_loops(
+    sections: &[SectionEdge],
+    frame: &PlaneFrame,
+    boundary_edges: &[OrientedPCurveEdge],
+    tol_linear: f64,
+) -> Option<Vec<SectionEdge>> {
+    use std::collections::{HashMap, HashSet};
+
+    type QPt = (i64, i64, i64);
+
+    if sections.len() < 3
+        || !sections
+            .iter()
+            .all(|s| matches!(s.curve_3d, EdgeCurve::Line))
+    {
+        return None;
+    }
+    let polygon: Vec<Point2> = boundary_edges.iter().map(|e| e.start_uv).collect();
+    if polygon.len() < 3 {
+        return None;
+    }
+
+    let quant = |p: Point3| -> QPt {
+        let s = 1.0 / (tol_linear * 100.0);
+        (
+            (p.x() * s).round() as i64,
+            (p.y() * s).round() as i64,
+            (p.z() * s).round() as i64,
+        )
+    };
+
+    let margin = tol_linear * 100.0;
+    let on_plane = |p: Point3| {
+        let uv = frame.project(p);
+        (frame.evaluate(uv.x(), uv.y()) - p).length() <= margin
+    };
+
+    let mut seen: HashSet<(QPt, QPt)> = HashSet::new();
+    let mut deduped: Vec<SectionEdge> = Vec::new();
+    for s in sections {
+        // A section can only bound a sub-face of this plane if it lies on
+        // the plane; off-plane segments (e.g. lateral edges grazing the
+        // face at one endpoint) are noise for this face.
+        if !on_plane(s.start) || !on_plane(s.end) {
+            continue;
+        }
+        let a = quant(s.start);
+        let b = quant(s.end);
+        if a == b {
+            return None;
+        }
+        let key = if a <= b { (a, b) } else { (b, a) };
+        if seen.insert(key) {
+            deduped.push(s.clone());
+        }
+    }
+    if deduped.len() < 3 {
+        return None;
+    }
+
+    // The same footprint side can arrive both whole and as sub-segments
+    // split at paves. Drop any segment that another section's endpoint
+    // subdivides (collinear, strictly interior) — the sub-segments carry
+    // the same geometry. If the sub-segments turn out incomplete, the
+    // degree check below rejects and the generic path takes over.
+    let endpoints: Vec<Point3> = deduped.iter().flat_map(|s| [s.start, s.end]).collect();
+    deduped.retain(|s| {
+        let dir = s.end - s.start;
+        let len2 = dir.dot(dir);
+        if len2 < margin * margin {
+            return true;
+        }
+        !endpoints.iter().any(|&p| {
+            if (p - s.start).length() < margin || (p - s.end).length() < margin {
+                return false;
+            }
+            let t = (p - s.start).dot(dir) / len2;
+            if !(0.0..=1.0).contains(&t) {
+                return false;
+            }
+            let foot = s.start + dir * t;
+            (p - foot).length() < margin
+        })
+    });
+
+    let mut degree: HashMap<QPt, u32> = HashMap::new();
+    for s in &deduped {
+        *degree.entry(quant(s.start)).or_insert(0) += 1;
+        *degree.entry(quant(s.end)).or_insert(0) += 1;
+        for p in [s.start, s.end] {
+            let uv = frame.project(p);
+            if !super::classify_2d::point_in_polygon_2d(uv, &polygon)
+                || super::classify_2d::distance_to_polygon_boundary(uv, &polygon) <= margin
+            {
+                log::debug!(
+                    "plane_internal_line_loops: endpoint {p:?} not strictly interior (dist {})",
+                    super::classify_2d::distance_to_polygon_boundary(uv, &polygon)
+                );
+                return None;
+            }
+        }
+    }
+    if degree.values().any(|&d| d != 2) {
+        let bad: Vec<_> = degree.iter().filter(|&(_, &d)| d != 2).collect();
+        log::debug!(
+            "plane_internal_line_loops: {} endpoints with degree != 2 (deduped {} of {}): {bad:?}",
+            bad.len(),
+            deduped.len(),
+            degree.len()
+        );
+        return None;
+    }
+    Some(deduped)
 }

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -449,15 +449,31 @@ pub(super) fn split_face_with_internal_loops(
                 break;
             }
 
-            // Find the next unused edge whose start matches last_end.
-            let next = forward_edges
-                .iter()
-                .enumerate()
-                .find(|(i, e)| !used[*i] && (e.start_3d - last_end).length() < tol_3d * 100.0);
+            // Find the next unused edge connecting to last_end. Section
+            // edges arrive with arbitrary orientation (each face-pair
+            // emits its own direction), so reversed matches are accepted
+            // and flipped into chain order.
+            let next = forward_edges.iter().enumerate().find_map(|(i, e)| {
+                if used[i] {
+                    None
+                } else if (e.start_3d - last_end).length() < tol_3d * 100.0 {
+                    Some((i, false))
+                } else if (e.end_3d - last_end).length() < tol_3d * 100.0 {
+                    Some((i, true))
+                } else {
+                    None
+                }
+            });
 
-            if let Some((idx, _)) = next {
+            if let Some((idx, rev)) = next {
                 used[idx] = true;
-                chain.push(forward_edges[idx].clone());
+                let mut e = forward_edges[idx].clone();
+                if rev {
+                    std::mem::swap(&mut e.start_uv, &mut e.end_uv);
+                    std::mem::swap(&mut e.start_3d, &mut e.end_3d);
+                    e.forward = !e.forward;
+                }
+                chain.push(e);
             } else {
                 break; // Can't continue -- open chain.
             }
@@ -470,6 +486,13 @@ pub(super) fn split_face_with_internal_loops(
             loops.push(chain);
         }
     }
+
+    log::debug!(
+        "split_face_with_internal_loops: face {face_id:?} {} sections -> {} loops (sizes {:?})",
+        sections.len(),
+        loops.len(),
+        loops.iter().map(Vec::len).collect::<Vec<_>>()
+    );
 
     // Build sub-faces.
     let mut result = Vec::new();
@@ -528,26 +551,31 @@ pub(super) fn split_face_with_internal_loops(
         // coplanar boundary face, causing ambiguous ray-cast classification.
         // Offset the point slightly along the face normal to break the tie.
         let disc_interior = {
-            // Sample 3D points along the circle to find its centroid.
-            let edge = &loop_edges[0];
-            let (t0, t1) = edge
-                .curve_3d
-                .domain_with_endpoints(edge.start_3d, edge.end_3d);
+            // Sample 3D points along every loop edge to find the loop's
+            // centroid (the circle center for single-circle loops, the
+            // polygon centroid for multi-Line footprint loops).
             let n_samples = 16;
             let mut sum = brepkit_math::vec::Vec3::new(0.0, 0.0, 0.0);
-            for k in 0..n_samples {
-                #[allow(clippy::cast_precision_loss)]
-                let t = t0 + (t1 - t0) * (k as f64 / n_samples as f64);
-                let pt = edge
+            let mut count = 0_usize;
+            for edge in loop_edges.iter() {
+                let (t0, t1) = edge
                     .curve_3d
-                    .evaluate_with_endpoints(t, edge.start_3d, edge.end_3d);
-                sum += brepkit_math::vec::Vec3::new(pt.x(), pt.y(), pt.z());
+                    .domain_with_endpoints(edge.start_3d, edge.end_3d);
+                for k in 0..n_samples {
+                    #[allow(clippy::cast_precision_loss)]
+                    let t = t0 + (t1 - t0) * (k as f64 / n_samples as f64);
+                    let pt = edge
+                        .curve_3d
+                        .evaluate_with_endpoints(t, edge.start_3d, edge.end_3d);
+                    sum += brepkit_math::vec::Vec3::new(pt.x(), pt.y(), pt.z());
+                    count += 1;
+                }
             }
             #[allow(clippy::cast_precision_loss)]
             let centroid = Point3::new(
-                sum.x() / n_samples as f64,
-                sum.y() / n_samples as f64,
-                sum.z() / n_samples as f64,
+                sum.x() / count as f64,
+                sum.y() / count as f64,
+                sum.z() / count as f64,
             );
             // Offset along the face normal by a small amount to ensure
             // the point is clearly inside the opposing solid (not on the
@@ -602,6 +630,50 @@ pub(super) fn split_face_with_internal_loops(
         }
     }
 
+    // For all-Line hole loops, compute the frame interior point in 3D:
+    // midway between the longest outer boundary edge's midpoint and its
+    // projection onto the hole polyline. The UV-based hole avoidance in
+    // `interior_point_3d` can miss multi-Line holes (sampled hole polygon
+    // in a mismatched frame), which classifies the frame as inside the
+    // opposing solid and silently drops the whole cap.
+    let all_line_holes = !all_holes.is_empty()
+        && all_holes
+            .iter()
+            .flatten()
+            .all(|e| matches!(e.curve_3d, EdgeCurve::Line));
+    let frame_interior = if all_line_holes {
+        boundary_edges
+            .iter()
+            .map(|e| {
+                let mid = e.start_3d + (e.end_3d - e.start_3d) * 0.5;
+                ((e.end_3d - e.start_3d).length(), mid)
+            })
+            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(_, outer_mid)| {
+                let mut nearest: Option<(f64, Point3)> = None;
+                for e in all_holes.iter().flatten() {
+                    let dir = e.end_3d - e.start_3d;
+                    let len2 = dir.dot(dir);
+                    let t = if len2 > 1e-18 {
+                        ((outer_mid - e.start_3d).dot(dir) / len2).clamp(0.0, 1.0)
+                    } else {
+                        0.0
+                    };
+                    let foot = e.start_3d + dir * t;
+                    let d = (foot - outer_mid).length();
+                    if nearest.is_none_or(|(dn, _)| d < dn) {
+                        nearest = Some((d, foot));
+                    }
+                }
+                match nearest {
+                    Some((_, hp)) => outer_mid + (hp - outer_mid) * 0.5,
+                    None => outer_mid,
+                }
+            })
+    } else {
+        None
+    };
+
     // The "outside" sub-face: original boundary with all loops as holes.
     // Pre-existing holes (from earlier boolean operations) stay with the
     // outside sub-face — dropping them would leave the faces ringing those
@@ -614,7 +686,7 @@ pub(super) fn split_face_with_internal_loops(
         reversed,
         parent: face_id,
         rank,
-        precomputed_interior: None,
+        precomputed_interior: frame_interior,
     });
 
     result

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -268,6 +268,12 @@ impl Builder {
                 Ok(point) => {
                     sf.classification =
                         classifier::classify_point(&self.topo, opposing_solid, point)?;
+                    log::trace!(
+                        "classify_sub_faces: idx={idx} face={:?} rank={:?} pt={point:?} class={:?}",
+                        sf.face_id,
+                        sf.rank,
+                        sf.classification
+                    );
                 }
                 Err(e) => {
                     return Err(AlgoError::ClassificationFailed(format!(
@@ -400,8 +406,22 @@ fn sample_face_interior(
     // Use 1e-4 of the diagonal, but at least the linear tolerance
     let offset_scale = (diag * 1e-4).max(tol.linear);
 
-    // Take the first boundary edge and evaluate at its midpoint
-    let first_oe = &edges[0];
+    // Take the longest boundary edge and evaluate at its midpoint. The
+    // longest edge gives the most room for the inward offset, and its
+    // midpoint is least likely to sit on a shared junction plane where
+    // the axis-aligned classification rays graze adjacent faces.
+    let mut first_oe = &edges[0];
+    let mut best_len = 0.0_f64;
+    for oe in edges {
+        let e = topo.edge(oe.edge())?;
+        let sp = topo.vertex(e.start())?.point();
+        let ep = topo.vertex(e.end())?.point();
+        let len = (ep - sp).length();
+        if len > best_len {
+            best_len = len;
+            first_oe = oe;
+        }
+    }
     let edge = topo.edge(first_oe.edge())?;
     let start_pos = topo.vertex(edge.start())?.point();
     let end_pos = topo.vertex(edge.end())?.point();
@@ -433,12 +453,33 @@ fn sample_face_interior(
     let inward = tangent.cross(face_normal);
     let inward_len = inward.length();
 
-    let offset = if inward_len > 1e-12 {
+    let mut offset = if inward_len > 1e-12 {
         inward * (offset_scale / inward_len)
     } else {
         // Degenerate — use a tiny offset along the face normal instead
         face_normal * offset_scale
     };
+
+    // The tangent-cross-normal direction assumes CCW winding; reversed or
+    // CW-wound faces flip it, sending the sample outside the face. Use the
+    // boundary vertex centroid to pick the side that points into the face.
+    let centroid = {
+        let mut sum = Vec3::new(0.0, 0.0, 0.0);
+        let mut n = 0_usize;
+        for oe in edges {
+            let e = topo.edge(oe.edge())?;
+            for vid in [e.start(), e.end()] {
+                let p = topo.vertex(vid)?.point();
+                sum += Vec3::new(p.x(), p.y(), p.z());
+                n += 1;
+            }
+        }
+        #[allow(clippy::cast_precision_loss)]
+        Point3::new(sum.x() / n as f64, sum.y() / n as f64, sum.z() / n as f64)
+    };
+    if offset.dot(centroid - mid_pt) < 0.0 {
+        offset = offset * -1.0;
+    }
 
     let interior_pt = mid_pt + offset;
 
@@ -447,6 +488,14 @@ fn sample_face_interior(
         if let Some(on_surface) = surface.evaluate(u, v) {
             return Ok(on_surface);
         }
+    }
+
+    // Planes have no UV projection, but the inward offset is already
+    // in-plane — the offset point itself is the on-surface sample.
+    // Falling back to `mid_pt` here would put the sample exactly on the
+    // face boundary, where junction-plane-grazing rays misclassify.
+    if matches!(surface, brepkit_topology::face::FaceSurface::Plane { .. }) && inward_len > 1e-12 {
+        return Ok(interior_pt);
     }
 
     // Fallback: use the midpoint itself (it's on the boundary, not ideal

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -198,13 +198,7 @@ pub fn detect_same_domain<S: BuildHasher>(
             }
         }
         for (mi, &i) in planar_indices.iter().enumerate() {
-            if sub_faces[i].interior_point.is_none() {
-                continue;
-            }
             for &j in &planar_indices[mi + 1..] {
-                if sub_faces[j].interior_point.is_none() {
-                    continue;
-                }
                 // Cheap surface-match guard first.
                 let same_dir = match (surfaces[i], surfaces[j]) {
                     (Some(si), Some(sj)) => surfaces_same_domain(si, sj, tol),
@@ -404,12 +398,6 @@ fn compute_edge_set_quantized(
 /// — typically a small "filling" face inside a larger face's outer
 /// boundary — without firing on legitimate adjacent face pairs.
 fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usize) -> bool {
-    let Some(p_i) = sub_faces[i].interior_point else {
-        return false;
-    };
-    let Some(p_j) = sub_faces[j].interior_point else {
-        return false;
-    };
     let Ok(face_i) = topo.face(sub_faces[i].face_id) else {
         return false;
     };
@@ -467,22 +455,31 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
     let poly_i: Vec<_> = pts_i.iter().map(|&p| frame.project(p)).collect();
     let poly_j: Vec<_> = pts_j.iter().map(|&p| frame.project(p)).collect();
 
-    // NOTE: `point_in_polygon_2d` uses a strict ray-cast with no boundary
-    // tolerance. Vertices that land exactly on the containing polygon's
-    // edge (e.g., two faces that share a boundary segment) may return false
-    // unpredictably and cause `all_inside` below to silently miss the pair.
-    // The edge-set pass above already handles identical-boundary cases, so
-    // Step 3b only reaches pairs with different outlines — contained-face
-    // vertices that lie exactly on the container's edge are rare in
-    // practice, but worth keeping in mind when extending this check.
-    let p_i_2d = frame.project(p_i);
-    let p_j_2d = frame.project(p_j);
+    // Passthrough faces arrive without a pre-computed interior point;
+    // derive one from the projected outer polygon so coincident-outline
+    // pairs (split disc vs. unsplit opposing cap) are still testable.
+    let p_i_2d = sub_faces[i].interior_point.map_or_else(
+        || super::classify_2d::sample_interior_point(&poly_i),
+        |p| frame.project(p),
+    );
+    let p_j_2d = sub_faces[j].interior_point.map_or_else(
+        || super::classify_2d::sample_interior_point(&poly_j),
+        |p| frame.project(p),
+    );
 
+    // Boundary-tolerant containment: a coincident-outline pair (e.g. a
+    // section-loop disc vs. the opposing solid's cap with differently split
+    // boundary edges) has every vertex exactly ON the container's polygon,
+    // where the strict ray-cast is unpredictable. The interior-point test
+    // below remains strict, so faces that merely touch along a shared
+    // boundary segment still don't pair.
+    let boundary_eps = 1e-6;
     let all_inside =
         |verts: &[brepkit_math::vec::Point2], poly: &[brepkit_math::vec::Point2]| -> bool {
-            verts
-                .iter()
-                .all(|&v| super::classify_2d::point_in_polygon_2d(v, poly))
+            verts.iter().all(|&v| {
+                super::classify_2d::point_in_polygon_2d(v, poly)
+                    || super::classify_2d::distance_to_polygon_boundary(v, poly) <= boundary_eps
+            })
         };
 
     // A point landing inside one of the container's inner wires sits in a

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -473,9 +473,9 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
     // where the strict ray-cast is unpredictable. The interior-point test
     // below remains strict, so faces that merely touch along a shared
     // boundary segment still don't pair.
-    let boundary_eps = 1e-6;
     let all_inside =
         |verts: &[brepkit_math::vec::Point2], poly: &[brepkit_math::vec::Point2]| -> bool {
+            let boundary_eps = super::classify_2d::boundary_eps(poly);
             verts.iter().all(|&v| {
                 super::classify_2d::point_in_polygon_2d(v, poly)
                     || super::classify_2d::distance_to_polygon_boundary(v, poly) <= boundary_eps

--- a/crates/algo/src/pave_filler/phase_ef.rs
+++ b/crates/algo/src/pave_filler/phase_ef.rs
@@ -269,6 +269,20 @@ fn check_edge_face_pairs(
             let face = topo.face(fid)?;
             let surface = face.surface();
 
+            // An edge lying entirely ON the face's surface is a coincidence
+            // handled by the FF/same-domain machinery, not a set of
+            // crossings; sampling it here would emit dozens of fake paves
+            // (e.g. a cap circle lying in the opposing cap's plane).
+            let n_chk = 16;
+            let edge_on_surface = (0..=n_chk).all(|i| {
+                let t = t0 + (t1 - t0) * (f64::from(i) / f64::from(n_chk));
+                let pt = curve.evaluate_with_endpoints(t, start_pos, end_pos);
+                distance_to_surface(pt, surface) < tol.linear
+            });
+            if edge_on_surface {
+                continue;
+            }
+
             let crossings = match surface {
                 FaceSurface::Plane { normal, d } => {
                     find_edge_plane_crossings(&curve, start_pos, end_pos, t0, t1, *normal, *d, tol)

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -149,6 +149,34 @@ pub fn perform(
                 raw_curves
             };
 
+            // Raw curves come from UNTRIMMED surface-surface intersection, so
+            // a curve can lie entirely beyond both faces' trimmed extents
+            // (e.g. tangency curvelets where a cone grazes a narrower
+            // cylinder, or a full cap circle paired with a smaller distant
+            // cap). Such curves fragment faces with spurious holes and bogus
+            // sub-faces downstream. Keep a curve only if at least one sample
+            // lies inside both faces' inflated AABBs.
+            let raw_curves: Vec<RawCurve> = raw_curves
+                .into_iter()
+                .filter(|raw| {
+                    let bb_a = bbox_a.expanded(tol.linear * 10.0);
+                    let bb_b = bbox_b.expanded(tol.linear * 10.0);
+                    let n = 16;
+                    (0..=n).any(|i| {
+                        let f = f64::from(i) / f64::from(n);
+                        // Line t_range is absolute arc length, not a
+                        // normalized [0,1] span — sample by endpoint lerp.
+                        let p = if matches!(raw.curve, EdgeCurve::Line) {
+                            raw.p_start + (raw.p_end - raw.p_start) * f
+                        } else {
+                            let t = raw.t_range.0 + (raw.t_range.1 - raw.t_range.0) * f;
+                            raw.curve.evaluate_with_endpoints(t, raw.p_start, raw.p_end)
+                        };
+                        bb_a.contains_point(p) && bb_b.contains_point(p)
+                    })
+                })
+                .collect();
+
             for raw in raw_curves {
                 let mut raw = raw;
                 // Closed Circle3D sections — produced by plane-sphere

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -156,11 +156,11 @@ pub fn perform(
             // cap). Such curves fragment faces with spurious holes and bogus
             // sub-faces downstream. Keep a curve only if at least one sample
             // lies inside both faces' inflated AABBs.
+            let bb_a = bbox_a.expanded(tol.linear * 10.0);
+            let bb_b = bbox_b.expanded(tol.linear * 10.0);
             let raw_curves: Vec<RawCurve> = raw_curves
                 .into_iter()
                 .filter(|raw| {
-                    let bb_a = bbox_a.expanded(tol.linear * 10.0);
-                    let bb_b = bbox_b.expanded(tol.linear * 10.0);
                     let n = 16;
                     (0..=n).any(|i| {
                         let f = f64::from(i) / f64::from(n);

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -2153,7 +2153,6 @@ fn fuse_ring_overlapping_shelled_box_height() {
 /// Reproduce Gridfinity lip volume bug: cut two lofted frustums, check
 /// that mesh volume is translation-invariant (proves consistent normals).
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn cut_lofted_frustums_consistent_normals() {
     use crate::copy::copy_solid;
     use crate::loft::loft;
@@ -2368,7 +2367,6 @@ fn cut_lofted_frustums_consistent_normals() {
 /// Reproduce the EXACT brepjs Gridfinity lip geometry: 8-vertex octagon
 /// profiles from drawRoundedRectangle → face_polygon.
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn cut_lofted_frustums_octagon_profiles() {
     use crate::copy::copy_solid;
     use crate::loft::loft;
@@ -2462,7 +2460,6 @@ fn cut_lofted_frustums_octagon_profiles() {
 
     let outer_vol = crate::measure::solid_volume(&topo, outer, 0.01).unwrap();
     let inner_vol = crate::measure::solid_volume(&topo, inner, 0.01).unwrap();
-
     // Cut outer - inner
     let lip = boolean(&mut topo, BooleanOp::Cut, outer, inner).unwrap();
     let lip_vol = crate::measure::solid_volume(&topo, lip, 0.01).unwrap();

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -652,7 +652,6 @@ fn vertex_blend_sphere_center_inside_solid() {
 /// Fillet on a boolean result: fuse(box, cylinder) → fillet should work
 /// on edges shared between two planar faces.
 #[test]
-#[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
 fn fillet_on_boolean_result() {
     let mut topo = Topology::new();
     let base = crate::primitives::make_box(&mut topo, 80.0, 60.0, 10.0).unwrap();

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -68,31 +68,17 @@ fn resample_closed_polygon(points: &[Point3], target_count: usize) -> Vec<Point3
     result
 }
 
-/// Extract the outward cap normal from a planar face, accounting for winding reversal.
+/// Outward cap normal from the corrected (CCW-relative-to-stack) profile
+/// vertices.
 ///
-/// `inward` controls the sign convention: `true` for the start cap (points into
-/// the loft interior, away from the profile direction), `false` for the end cap.
-fn cap_normal_from_face(
-    face: &brepkit_topology::face::Face,
-    winding_reversed: bool,
-    inward: bool,
-) -> Result<Vec3, crate::OperationsError> {
-    match face.surface() {
-        FaceSurface::Plane { normal, .. } => {
-            // The stored face normal comes from Newell on the original (pre-reversal)
-            // winding. When winding_reversed is true, that normal points the wrong way,
-            // so we negate it. The inward flag then flips the sign for the start cap.
-            let sign = if winding_reversed == inward {
-                1.0
-            } else {
-                -1.0
-            };
-            Ok(*normal * sign)
-        }
-        _ => Err(crate::OperationsError::InvalidInput {
-            reason: "unexpected non-planar face".into(),
-        }),
-    }
+/// The stored profile-face plane normal cannot be trusted: callers may build
+/// profiles with an arbitrary normal (e.g. always +Z) regardless of vertex
+/// winding. Newell on the post-correction vertices points along the stacking
+/// direction by construction, so the start cap (`inward = true`) is its
+/// negation and the end cap is the normal itself.
+fn cap_normal_from_verts(verts: &[Point3], inward: bool) -> Result<Vec3, crate::OperationsError> {
+    let unit = crate::winding::newell_normal(verts).normalize()?;
+    Ok(if inward { unit * -1.0 } else { unit })
 }
 
 /// Loft two or more planar profiles into a solid.
@@ -160,7 +146,7 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
     // Ensure profile vertex winding is CCW relative to the stacking direction.
     // The side normal formula `edge_dir.cross(connect_dir)` gives outward normals
     // only when vertices go CCW from the stacking direction.
-    let winding_reversed = ensure_ccw_profiles(&mut profile_verts);
+    let _ = ensure_ccw_profiles(&mut profile_verts);
 
     let num_profiles = profile_verts.len();
     let num_sections = num_profiles - 1;
@@ -208,8 +194,7 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
 
     // Start cap: reversed first profile (outward normal pointing away from loft).
     {
-        let face_data = topo.face(profiles[0])?;
-        let cap_normal = cap_normal_from_face(face_data, winding_reversed, true)?;
+        let cap_normal = cap_normal_from_verts(&profile_verts[0], true)?;
         let reversed_edges: Vec<OrientedEdge> = (0..n)
             .rev()
             .map(|i| OrientedEdge::new(ring_edges[0][i], false))
@@ -271,8 +256,7 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
 
     // End cap: last profile with forward orientation.
     {
-        let face_data = topo.face(profiles[num_profiles - 1])?;
-        let cap_normal = cap_normal_from_face(face_data, winding_reversed, false)?;
+        let cap_normal = cap_normal_from_verts(&profile_verts[num_profiles - 1], false)?;
         let edges: Vec<OrientedEdge> = (0..n)
             .map(|i| OrientedEdge::new(ring_edges[num_profiles - 1][i], true))
             .collect();
@@ -623,7 +607,7 @@ pub fn loft_smooth(
     }
 
     // Ensure profile vertex winding is CCW relative to the stacking direction.
-    let winding_reversed = ensure_ccw_profiles(&mut profile_verts);
+    let _ = ensure_ccw_profiles(&mut profile_verts);
 
     let num_profiles = profile_verts.len();
 
@@ -655,8 +639,7 @@ pub fn loft_smooth(
 
     // Start cap: reversed first profile.
     {
-        let face_data = topo.face(profiles[0])?;
-        let cap_normal = cap_normal_from_face(face_data, winding_reversed, true)?;
+        let cap_normal = cap_normal_from_verts(&profile_verts[0], true)?;
         let reversed_edges: Vec<OrientedEdge> = (0..n)
             .rev()
             .map(|i| OrientedEdge::new(ring_edges[0][i], false))
@@ -734,8 +717,7 @@ pub fn loft_smooth(
 
     // End cap: last profile with forward orientation.
     {
-        let face_data = topo.face(profiles[num_profiles - 1])?;
-        let cap_normal = cap_normal_from_face(face_data, winding_reversed, false)?;
+        let cap_normal = cap_normal_from_verts(&profile_verts[num_profiles - 1], false)?;
         let edges: Vec<OrientedEdge> = (0..n)
             .map(|i| OrientedEdge::new(ring_edges[num_profiles - 1][i], true))
             .collect();

--- a/crates/operations/tests/boolean_edge_cases.rs
+++ b/crates/operations/tests/boolean_edge_cases.rs
@@ -386,7 +386,6 @@ fn test_boolean_cone_box() {
 }
 
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn test_boolean_cone_cylinder() {
     // Cone r_bottom=2, r_top=1, height=3. Cylinder radius 0.5, height 3.
     let mut topo = Topology::new();

--- a/crates/operations/tests/coincident_planes.rs
+++ b/crates/operations/tests/coincident_planes.rs
@@ -115,10 +115,6 @@ fn partial_face_overlap_diagonal_offset_fuse() {
 // ── 3. Fully nested coplanar (small face inside larger) ────────────────
 
 #[test]
-#[ignore = "Gap: fully-nested coplanar fuse produces volume drift (~2% surplus). \
-            Tessellation-based volume reads ~17.33 instead of 17.0, suggesting either \
-            an internal-face leak in the result topology or winding inconsistency \
-            in the assembled shell."]
 fn fully_nested_coplanar_fuse() {
     // Small box stacked on the centre of a larger one, top face of A
     // strictly contains bottom face of B.

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -843,7 +843,6 @@ fn make_inner_sections(k: &mut BrepKernel) -> Vec<u32> {
 /// Reproduces `buildTopShapeLoft()` without the final fillet.
 /// Expected: valid solid, Euler=2, reasonable volume.
 #[test]
-#[ignore = "lip ring volume out of range — boolean coplanar face classification"]
 fn gridfinity_d1_lip_ring_loft_cut() {
     let mut k = BrepKernel::new();
 
@@ -1100,7 +1099,6 @@ fn gridfinity_d1a2_concentric_box_coplanar() {
 ///
 /// If D1 fails but D1b passes, the bug is in coplanar face handling.
 #[test]
-#[ignore = "GFA pipeline limitation"]
 fn gridfinity_d1b_lip_ring_no_coplanar() {
     let mut k = BrepKernel::new();
 


### PR DESCRIPTION
Fixes the coplanar cap-only-contact boolean cluster — cases where a tool touches the target only through coplanar cap faces (cone-cylinder cuts, lofted-frustum lip cuts, gridfinity lip rings).

## Changes
- `phase_ff`: raw section curves are rejected when no sample lies inside both faces' inflated AABBs — drops tangency curvelets from untrimmed-surface intersections and oversized cap circles that fragmented laterals with phantom holes.
- `phase_ef`: skips edge-face pairs where the edge lies entirely on the face surface.
- Plane face splitter: multi-Line internal footprint loops (nested coplanar contact) route to the internal-loops path — segment dedup, closed-loop detection, reversal-aware chaining, annulus interior points for frame sub-faces.
- Classification robustness: `sample_face_interior` keeps the in-plane offset for planes (`Plane::project_point` returns None, so planar samples silently degraded to boundary midpoints where axis rays graze junction planes); same-domain containment gained boundary-tolerant matching; assembly drops zero-area Line slivers and splits Line edges at intermediate collinear vertices.
- `loft()`: cap normals derived via Newell on the corrected profile winding — CW-wound octagon profiles produced inverted caps (measured 25560 vs 83254, not translation-invariant).

Un-ignores 7 tests: `test_boolean_cone_cylinder`, `cut_lofted_frustums_consistent_normals`, `cut_lofted_frustums_octagon_profiles`, `fillet_on_boolean_result`, `fully_nested_coplanar_fuse`, `gridfinity_d1_lip_ring_loft_cut`, `gridfinity_d1b_lip_ring_no_coplanar`. Gridfinity d4/d5 remain ignored (deeper residual defects, documented in their reason strings).

## Verification
algo 105, FULL operations (648 lib + 17 integration suites), wasm 212 — zero failures; fmt/clippy/boundaries clean; each un-ignored test 3×.