### PR TITLE
fix(algo): trim coincident closed-circle sections per face

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -313,11 +313,6 @@ pub fn split_face_2d(
     // Convert section edges to OrientedPCurveEdge (both orientations).
     let mut all_edges = boundary_edges;
     for section in sections {
-        let pcurve_on_this_face = match rank {
-            Rank::A => &section.pcurve_a,
-            Rank::B => &section.pcurve_b,
-        };
-
         // Skip full-circle section edges on plane faces -- they have
         // start approx end in 3D and would produce degenerate UV edges.
         // The half-arc section edges handle the plane face correctly.
@@ -326,6 +321,30 @@ pub fn split_face_2d(
             continue;
         }
 
+        // Curved sections on plane faces must live in the same PlaneFrame
+        // as the boundary edges. The pcurve from build_section_edges was
+        // fitted in a frame anchored at the original (pre-split) wire, so
+        // its UV space — and its NURBS parameter domain — need not match
+        // `frame`; using it would disconnect the section from the boundary
+        // in UV. Refit it in this face's frame.
+        let owned_pcurve;
+        let pcurve_on_this_face = if is_plane && !matches!(section.curve_3d, EdgeCurve::Line) {
+            owned_pcurve = super::pcurve_compute::compute_pcurve_on_surface(
+                &section.curve_3d,
+                section.start,
+                section.end,
+                &surface,
+                &wire_pts,
+                Some(frame),
+            );
+            &owned_pcurve
+        } else {
+            match rank {
+                Rank::A => &section.pcurve_a,
+                Rank::B => &section.pcurve_b,
+            }
+        };
+
         // Project section endpoints to UV.
         // Use pre-computed UV endpoints when available (e.g. seam-split half-arcs
         // where the unwrapped UV was computed from the arc samples). Otherwise,
@@ -333,35 +352,38 @@ pub fn split_face_2d(
         // of independent surface projection -- this ensures UV endpoints are
         // consistent with the pcurve's unwrapped parameterization (e.g. arc
         // ending at u=2pi rather than u=0 after periodic unwrapping).
-        let (start_uv, end_uv) = match rank {
-            Rank::A => {
-                if let (Some(su), Some(eu)) = (section.start_uv_a, section.end_uv_a) {
-                    (su, eu)
-                } else if is_plane {
-                    (frame.project(section.start), frame.project(section.end))
-                } else {
-                    uv_endpoints_from_pcurve(
-                        pcurve_on_this_face,
-                        section.start,
-                        section.end,
-                        &surface,
-                        &wire_pts,
-                    )
+        let (start_uv, end_uv) = if is_plane {
+            // Plane faces: project in the boundary's frame. Precomputed UVs
+            // (when present) come from build_section_edges' own frame and
+            // would not connect to the boundary edges in UV.
+            (frame.project(section.start), frame.project(section.end))
+        } else {
+            match rank {
+                Rank::A => {
+                    if let (Some(su), Some(eu)) = (section.start_uv_a, section.end_uv_a) {
+                        (su, eu)
+                    } else {
+                        uv_endpoints_from_pcurve(
+                            pcurve_on_this_face,
+                            section.start,
+                            section.end,
+                            &surface,
+                            &wire_pts,
+                        )
+                    }
                 }
-            }
-            Rank::B => {
-                if let (Some(su), Some(eu)) = (section.start_uv_b, section.end_uv_b) {
-                    (su, eu)
-                } else if is_plane {
-                    (frame.project(section.start), frame.project(section.end))
-                } else {
-                    uv_endpoints_from_pcurve(
-                        pcurve_on_this_face,
-                        section.start,
-                        section.end,
-                        &surface,
-                        &wire_pts,
-                    )
+                Rank::B => {
+                    if let (Some(su), Some(eu)) = (section.start_uv_b, section.end_uv_b) {
+                        (su, eu)
+                    } else {
+                        uv_endpoints_from_pcurve(
+                            pcurve_on_this_face,
+                            section.start,
+                            section.end,
+                            &surface,
+                            &wire_pts,
+                        )
+                    }
                 }
             }
         };

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -153,6 +153,7 @@ pub fn split_face_2d(
             reversed,
             face_id,
             &wire_pts,
+            tol.linear,
         );
     }
 

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -10,16 +10,21 @@ use super::conversion::uv_endpoints_from_pcurve;
 use super::edge_splitting::split_boundary_edges_at_3d_points;
 use crate::ds::Rank;
 
-/// Split a face with no seam edges directly into cap + band sub-faces.
+/// Split a face with no seam edges directly into cap + remainder sub-faces.
 ///
 /// Faces whose boundary consists entirely of Line edges (no seam edges)
 /// can't be split by the wire builder (it needs vertical seam connections).
 /// This function bypasses the wire builder and constructs sub-faces
 /// geometrically from the section edges:
 ///
-/// - **Cap**: bounded by the section circle (2 half-arcs).
-/// - **Band**: bounded by the original boundary, with the section as hole.
-#[allow(clippy::too_many_arguments)]
+/// - **Cap**: bounded by the section arcs chained into one closed loop.
+/// - **Remainder**: when the cap loop stays interior, the original boundary
+///   with the reversed cap as a hole; when a cap arc runs along the face
+///   boundary (e.g. the in-region equator arc of a faceted sphere whose
+///   boundary polygon is inscribed in the same circle), the covered boundary
+///   edges are replaced by the arc, and the remainder is chained from the
+///   uncovered boundary edges plus the reversed non-coincident arcs.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(super) fn split_noseam_face_direct(
     surface: &FaceSurface,
     boundary_edges: &[OrientedPCurveEdge],
@@ -29,6 +34,9 @@ pub(super) fn split_noseam_face_direct(
     face_id: FaceId,
     wire_pts: &[Point3],
 ) -> Vec<SplitSubFace> {
+    let tol = brepkit_math::tolerance::Tolerance::new().linear;
+    let close_tol = tol * 100.0;
+
     // Helper: return the face unsplit (used in fallback paths).
     let unsplit = || {
         vec![SplitSubFace {
@@ -42,10 +50,8 @@ pub(super) fn split_noseam_face_direct(
         }]
     };
 
-    // Collect section forward/reverse edges on this face.
-    let mut cap_edges = Vec::new();
-    let mut hole_edges = Vec::new();
-
+    // Collect open section arcs on this face.
+    let mut open_sections: Vec<OrientedPCurveEdge> = Vec::new();
     for section in sections {
         let pcurve_on_this_face = match rank {
             Rank::A => &section.pcurve_a,
@@ -53,9 +59,8 @@ pub(super) fn split_noseam_face_direct(
         };
 
         // Skip full-circle section edges (start approx end in 3D) -- only use
-        // the half-arcs produced by build_seam_split_sections.
-        if (section.start - section.end).length() < brepkit_math::tolerance::Tolerance::new().linear
-        {
+        // the open arcs produced by the FF closed-circle split.
+        if (section.start - section.end).length() < tol {
             continue;
         }
 
@@ -73,8 +78,7 @@ pub(super) fn split_noseam_face_direct(
             )
         });
 
-        // Forward: for the cap outer wire.
-        cap_edges.push(OrientedPCurveEdge {
+        open_sections.push(OrientedPCurveEdge {
             curve_3d: section.curve_3d.clone(),
             pcurve: pcurve_on_this_face.clone(),
             start_uv,
@@ -85,42 +89,91 @@ pub(super) fn split_noseam_face_direct(
             source_edge_idx: None,
             pave_block_id: None,
         });
-
-        // Reverse: for the band's inner wire (hole).
-        hole_edges.push(OrientedPCurveEdge {
-            curve_3d: section.curve_3d.clone(),
-            pcurve: pcurve_on_this_face.clone(),
-            start_uv: end_uv,
-            end_uv: start_uv,
-            start_3d: section.end,
-            end_3d: section.start,
-            forward: false,
-            source_edge_idx: None,
-            pave_block_id: None,
-        });
     }
 
-    if cap_edges.is_empty() {
-        // No valid section edges -- return the face unsplit.
+    if open_sections.is_empty() {
         return unsplit();
     }
 
-    // Validate: cap edges must form a single closed loop (last end approx first start).
-    // If the topology is unexpected (multiple loops, open chain), fall back to unsplit.
-    let loop_gap = (cap_edges
-        .last()
-        .map_or(Point3::new(0.0, 0.0, 0.0), |e| e.end_3d)
-        - cap_edges
-            .first()
-            .map_or(Point3::new(0.0, 0.0, 0.0), |e| e.start_3d))
-    .length();
-    if loop_gap > brepkit_math::tolerance::Tolerance::new().linear * 100.0 {
+    // Chain the arcs into a single closed loop, greedily matching endpoints
+    // (with reversal). Disconnected or open chains fall back to unsplit.
+    let Some(cap_edges) = chain_closed_loop(open_sections, close_tol) else {
         return unsplit();
+    };
+
+    // Boundary edges covered by a cap arc: both segment endpoints lie on
+    // the arc's circle within its angular span. Those edges are replaced
+    // by the (exact) arc in the cap; the remainder must not reuse them.
+    let covered: Vec<bool> = boundary_edges
+        .iter()
+        .map(|be| cap_edges.iter().any(|arc| arc_covers_segment(arc, be, tol)))
+        .collect();
+    let coincident: Vec<bool> = cap_edges
+        .iter()
+        .map(|arc| {
+            boundary_edges
+                .iter()
+                .zip(&covered)
+                .any(|(be, &cov)| cov && arc_covers_segment(arc, be, tol))
+        })
+        .collect();
+
+    let reverse_of = |e: &OrientedPCurveEdge| OrientedPCurveEdge {
+        curve_3d: e.curve_3d.clone(),
+        pcurve: e.pcurve.clone(),
+        start_uv: e.end_uv,
+        end_uv: e.start_uv,
+        start_3d: e.end_3d,
+        end_3d: e.start_3d,
+        forward: !e.forward,
+        source_edge_idx: e.source_edge_idx,
+        pave_block_id: e.pave_block_id,
+    };
+
+    if covered.iter().any(|&c| c) {
+        // Cap loop runs along part of the boundary: remainder = uncovered
+        // boundary edges + reversed non-coincident arcs, chained closed.
+        let mut pool: Vec<OrientedPCurveEdge> = boundary_edges
+            .iter()
+            .zip(&covered)
+            .filter(|&(_, &cov)| !cov)
+            .map(|(be, _)| be.clone())
+            .collect();
+        for (arc, &coin) in cap_edges.iter().zip(&coincident) {
+            if !coin {
+                pool.push(reverse_of(arc));
+            }
+        }
+        let Some(remainder) = chain_closed_loop(pool, close_tol) else {
+            return unsplit();
+        };
+
+        let cap_interior = sphere_loop_interior(surface, &cap_edges);
+        let remainder_interior = sphere_loop_interior(surface, &remainder);
+        return vec![
+            SplitSubFace {
+                surface: surface.clone(),
+                outer_wire: cap_edges,
+                inner_wires: Vec::new(),
+                reversed,
+                parent: face_id,
+                rank,
+                precomputed_interior: cap_interior,
+            },
+            SplitSubFace {
+                surface: surface.clone(),
+                outer_wire: remainder,
+                inner_wires: Vec::new(),
+                reversed,
+                parent: face_id,
+                rank,
+                precomputed_interior: remainder_interior,
+            },
+        ];
     }
 
-    // Cap sub-face: outer wire = section forward half-arcs.
-    // The half-arcs connect end-to-end, forming a closed loop (the section circle).
-    // Band sub-face: outer wire = equatorial boundary, inner wire = section reversed.
+    // Cap loop is interior to the boundary: cap + band-with-hole.
+    let hole_edges: Vec<OrientedPCurveEdge> = cap_edges.iter().map(reverse_of).collect();
     vec![
         SplitSubFace {
             surface: surface.clone(),
@@ -141,6 +194,106 @@ pub(super) fn split_noseam_face_direct(
             precomputed_interior: None,
         },
     ]
+}
+
+/// Greedily chain edges into one closed loop by matching 3D endpoints,
+/// reversing edges as needed. Returns `None` when the edges are
+/// disconnected, leave leftovers, or do not close.
+fn chain_closed_loop(
+    mut pool: Vec<OrientedPCurveEdge>,
+    close_tol: f64,
+) -> Option<Vec<OrientedPCurveEdge>> {
+    if pool.is_empty() {
+        return None;
+    }
+    let mut chain = vec![pool.remove(0)];
+    while !pool.is_empty() {
+        let cur_end = chain.last()?.end_3d;
+        if let Some(pos) = pool
+            .iter()
+            .position(|e| (e.start_3d - cur_end).length() < close_tol)
+        {
+            chain.push(pool.remove(pos));
+        } else if let Some(pos) = pool
+            .iter()
+            .position(|e| (e.end_3d - cur_end).length() < close_tol)
+        {
+            let mut e = pool.remove(pos);
+            std::mem::swap(&mut e.start_uv, &mut e.end_uv);
+            std::mem::swap(&mut e.start_3d, &mut e.end_3d);
+            e.forward = !e.forward;
+            chain.push(e);
+        } else {
+            return None;
+        }
+    }
+    let gap = (chain.last()?.end_3d - chain.first()?.start_3d).length();
+    if gap > close_tol { None } else { Some(chain) }
+}
+
+/// Whether a straight boundary segment lies along (is a chord of) the
+/// arc: both endpoints on the arc's circle, within the arc's angular span.
+fn arc_covers_segment(arc: &OrientedPCurveEdge, segment: &OrientedPCurveEdge, tol: f64) -> bool {
+    use brepkit_topology::edge::EdgeCurve;
+    let EdgeCurve::Circle(c) = &arc.curve_3d else {
+        return false;
+    };
+    if !matches!(segment.curve_3d, EdgeCurve::Line) {
+        return false;
+    }
+    let on_circle = |p: Point3| -> bool {
+        let r = p - c.center();
+        let axial = c.normal().dot(r);
+        let radial = (r - c.normal() * axial).length();
+        axial.abs() < tol * 100.0 && (radial - c.radius()).abs() < tol * 100.0
+    };
+    if !on_circle(segment.start_3d) || !on_circle(segment.end_3d) {
+        return false;
+    }
+    let t0 = c.project(arc.start_3d);
+    let span = wrap_to_half_turn(c.project(arc.end_3d) - t0);
+    let eps = 1e-6;
+    let within = |p: Point3| -> bool {
+        let d = wrap_to_half_turn(c.project(p) - t0);
+        if span >= 0.0 {
+            (-eps..=span + eps).contains(&d)
+        } else {
+            (span - eps..=eps).contains(&d)
+        }
+    };
+    within(segment.start_3d) && within(segment.end_3d)
+}
+
+/// Wrap an angular difference into (-pi, pi].
+fn wrap_to_half_turn(d: f64) -> f64 {
+    let tau = std::f64::consts::TAU;
+    let w = d.rem_euclid(tau);
+    if w > std::f64::consts::PI { w - tau } else { w }
+}
+
+/// Interior point for a loop on a sphere face: the spherical centroid of
+/// the loop edges' midpoints, projected back onto the sphere. `None` for
+/// non-sphere surfaces (callers fall back to UV-based interior sampling).
+fn sphere_loop_interior(surface: &FaceSurface, edges: &[OrientedPCurveEdge]) -> Option<Point3> {
+    use brepkit_math::vec::Vec3;
+    let FaceSurface::Sphere(s) = surface else {
+        return None;
+    };
+    let center = s.center();
+    let mut dir = Vec3::new(0.0, 0.0, 0.0);
+    for e in edges {
+        let mid = super::super::pcurve_compute::evaluate_edge_at_t(
+            &e.curve_3d,
+            e.start_3d,
+            e.end_3d,
+            0.5,
+        );
+        if let Ok(d) = (mid - center).normalize() {
+            dir += d;
+        }
+    }
+    let d = dir.normalize().ok()?;
+    Some(center + d * s.radius())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -33,8 +33,8 @@ pub(super) fn split_noseam_face_direct(
     reversed: bool,
     face_id: FaceId,
     wire_pts: &[Point3],
+    tol: f64,
 ) -> Vec<SplitSubFace> {
-    let tol = brepkit_math::tolerance::Tolerance::new().linear;
     let close_tol = tol * 100.0;
 
     // Helper: return the face unsplit (used in fallback paths).
@@ -250,25 +250,34 @@ fn arc_covers_segment(arc: &OrientedPCurveEdge, segment: &OrientedPCurveEdge, to
     if !on_circle(segment.start_3d) || !on_circle(segment.end_3d) {
         return false;
     }
+    // The arc's traversal direction comes from `forward` relative to the
+    // circle's native (CCW) parameterization — not from the endpoint angles
+    // alone, which are direction-ambiguous. Measuring membership as the
+    // forward-progress delta from the start handles spans across the full
+    // (0, 2pi) range, including arcs longer than pi (a 270° arc no longer
+    // collapses to its complementary 90° short arc).
+    let tau = std::f64::consts::TAU;
     let t0 = c.project(arc.start_3d);
-    let span = wrap_to_half_turn(c.project(arc.end_3d) - t0);
-    let eps = 1e-6;
-    let within = |p: Point3| -> bool {
-        let d = wrap_to_half_turn(c.project(p) - t0);
-        if span >= 0.0 {
-            (-eps..=span + eps).contains(&d)
+    // Forward progress (always in [0, 2pi)) of `p` from the arc start in the
+    // arc's traversal direction.
+    let progress = |p: Point3| -> f64 {
+        let delta = c.project(p) - t0;
+        if arc.forward {
+            delta.rem_euclid(tau)
         } else {
-            (span - eps..=eps).contains(&d)
+            (-delta).rem_euclid(tau)
         }
     };
+    let span = progress(arc.end_3d);
+    let eps = 1e-6;
+    let within = |p: Point3| -> bool {
+        let d = progress(p);
+        // A point at the arc start wraps to ~2pi under rem_euclid; treat it
+        // as 0 so segment endpoints coincident with the start still match.
+        let d = if d > tau - eps { 0.0 } else { d };
+        d <= span + eps
+    };
     within(segment.start_3d) && within(segment.end_3d)
-}
-
-/// Wrap an angular difference into (-pi, pi].
-fn wrap_to_half_turn(d: f64) -> f64 {
-    let tau = std::f64::consts::TAU;
-    let w = d.rem_euclid(tau);
-    if w > std::f64::consts::PI { w - tau } else { w }
 }
 
 /// Interior point for a loop on a sphere face: the spherical centroid of
@@ -1047,10 +1056,87 @@ pub(super) fn try_split_crossing_plane_face(
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
+    use super::{OrientedPCurveEdge, arc_covers_segment};
+    use brepkit_math::curves::Circle3D;
+    use brepkit_math::curves2d::{Curve2D, Line2D};
     use brepkit_math::surfaces::CylindricalSurface;
-    use brepkit_math::vec::{Point3, Vec3};
+    use brepkit_math::vec::{Point2, Point3, Vec2, Vec3};
+    use brepkit_topology::edge::EdgeCurve;
     use brepkit_topology::face::FaceSurface;
     use std::f64::consts::{PI, TAU};
+
+    fn dummy_pcurve() -> Curve2D {
+        Curve2D::Line(Line2D::new(Point2::new(0.0, 0.0), Vec2::new(1.0, 0.0)).unwrap())
+    }
+
+    fn arc_edge(
+        circle: &Circle3D,
+        start_angle: f64,
+        end_angle: f64,
+        forward: bool,
+    ) -> OrientedPCurveEdge {
+        OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Circle(circle.clone()),
+            pcurve: dummy_pcurve(),
+            start_uv: Point2::new(0.0, 0.0),
+            end_uv: Point2::new(0.0, 0.0),
+            start_3d: circle.evaluate(start_angle),
+            end_3d: circle.evaluate(end_angle),
+            forward,
+            source_edge_idx: None,
+            pave_block_id: None,
+        }
+    }
+
+    fn line_chord(start: Point3, end: Point3) -> OrientedPCurveEdge {
+        OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Line,
+            pcurve: dummy_pcurve(),
+            start_uv: Point2::new(0.0, 0.0),
+            end_uv: Point2::new(0.0, 0.0),
+            start_3d: start,
+            end_3d: end,
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: None,
+        }
+    }
+
+    #[test]
+    fn arc_covers_chord_within_270_degree_span() {
+        // A 270° arc (0 → 3π/2, CCW). A chord whose endpoints lie within
+        // that span is covered; a chord in the complementary 90° gap is not.
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let arc = arc_edge(&circle, 0.0, 1.5 * PI, true);
+        let tol = 1e-7;
+
+        // Chord between angles 0.5π and π — inside the 270° sweep.
+        let inside = line_chord(circle.evaluate(0.5 * PI), circle.evaluate(PI));
+        assert!(arc_covers_segment(&arc, &inside, tol));
+
+        // Chord between angles 1.6π and 1.9π — inside the complementary
+        // 90° gap, which the arc does NOT cover. The old half-turn wrap
+        // mistook this complementary short arc for the real one.
+        let outside = line_chord(circle.evaluate(1.6 * PI), circle.evaluate(1.9 * PI));
+        assert!(!arc_covers_segment(&arc, &outside, tol));
+    }
+
+    #[test]
+    fn arc_covers_chord_on_reversed_arc() {
+        // Same geometry traversed CW (forward = false): the swept region is
+        // the complementary 90° arc, so the membership flips.
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let arc = arc_edge(&circle, 0.0, 1.5 * PI, false);
+        let tol = 1e-7;
+
+        let in_gap = line_chord(circle.evaluate(1.6 * PI), circle.evaluate(1.9 * PI));
+        assert!(arc_covers_segment(&arc, &in_gap, tol));
+
+        let in_long = line_chord(circle.evaluate(0.5 * PI), circle.evaluate(PI));
+        assert!(!arc_covers_segment(&arc, &in_long, tol));
+    }
 
     #[test]
     fn band_interior_antipode_wraps_into_domain() {

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2119,12 +2119,14 @@ fn build_topology_face(
             // edges are shared across parent faces with different vertex caches.
             topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()))
         };
-        // For Line edges: start_vid at start_3d, end_vid at end_3d encode
-        // the traversal direction directly — always use forward=true.
-        // For curved edges (Circle, Ellipse, etc.): the curve has its own
-        // parameterization that may differ from start_3d→end_3d order.
-        // Use pcurve_edge.forward to preserve the intended traversal.
-        let forward = matches!(pcurve_edge.curve_3d, EdgeCurve::Line) || pcurve_edge.forward;
+        // The edge was just created with start_vid at start_3d and end_vid
+        // at end_3d, so the vertex order itself encodes the traversal
+        // direction — open edges always get forward=true regardless of the
+        // pcurve direction flag (using the flag here would contradict the
+        // vertex order and break wire closure). Closed curved edges
+        // (start_vid == end_vid) can't encode direction via vertices, so
+        // they keep pcurve_edge.forward to preserve winding.
+        let forward = start_vid != end_vid || pcurve_edge.forward;
         oriented_edges.push(OrientedEdge::new(edge_id, forward));
     }
 

--- a/crates/algo/src/builder/pcurve_compute.rs
+++ b/crates/algo/src/builder/pcurve_compute.rs
@@ -8,6 +8,7 @@
 use std::f64::consts::TAU;
 
 use brepkit_math::curves2d::{Curve2D, Line2D, NurbsCurve2D};
+use brepkit_math::traits::ParametricCurve;
 use brepkit_math::vec::{Point2, Point3, Vec2, Vec3};
 use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::face::FaceSurface;
@@ -206,20 +207,43 @@ pub(super) fn sample_edge_to_uv(
 /// Evaluate a 3D edge curve at parameter t in [0, 1].
 ///
 /// For `Line`, linearly interpolates between start and end.
-/// For `Circle`/`Ellipse`/`NurbsCurve`, uses `evaluate_with_endpoints`.
+/// For open `Circle`/`Ellipse` edges, traces the shorter arc between the
+/// endpoints. For closed edges and `NurbsCurve`, uses the curve domain.
 pub(super) fn evaluate_edge_at_t(curve: &EdgeCurve, start: Point3, end: Point3, t: f64) -> Point3 {
-    if matches!(curve, EdgeCurve::Line) {
-        Point3::new(
+    match curve {
+        EdgeCurve::Line => Point3::new(
             start.x() + (end.x() - start.x()) * t,
             start.y() + (end.y() - start.y()) * t,
             start.z() + (end.z() - start.z()) * t,
-        )
-    } else {
-        // Delegate to EdgeCurve's parametric evaluation.
-        let (t0, t1) = curve.domain_with_endpoints(start, end);
-        let param = t0 + (t1 - t0) * t;
-        curve.evaluate_with_endpoints(param, start, end)
+        ),
+        // Open circle/ellipse edges follow the shorter-arc convention shared
+        // with tessellation and topology wire sampling: `domain_with_endpoints`
+        // returns the full [0, 2pi] regardless of endpoints, which is only
+        // right for closed edges — sampling an open arc over it would trace
+        // the whole circle.
+        EdgeCurve::Circle(c) if (start - end).length() > 1e-12 => {
+            let t0 = c.project(start);
+            let d = shorter_arc_delta(c.project(end) - t0);
+            ParametricCurve::evaluate(c, t0 + d * t)
+        }
+        EdgeCurve::Ellipse(e) if (start - end).length() > 1e-12 => {
+            let t0 = e.project(start);
+            let d = shorter_arc_delta(e.project(end) - t0);
+            ParametricCurve::evaluate(e, t0 + d * t)
+        }
+        _ => {
+            // Closed curves and NURBS: parametric evaluation over the domain.
+            let (t0, t1) = curve.domain_with_endpoints(start, end);
+            let param = t0 + (t1 - t0) * t;
+            curve.evaluate_with_endpoints(param, start, end)
+        }
     }
+}
+
+/// Wrap an angular difference into (-pi, pi] — the shorter way around.
+fn shorter_arc_delta(d: f64) -> f64 {
+    let w = d.rem_euclid(TAU);
+    if w > std::f64::consts::PI { w - TAU } else { w }
 }
 
 /// Sample points along a 3D edge curve and project each to UV via `PlaneFrame`.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -848,21 +848,27 @@ fn closed_circle_crosses_face_boundaries(
 }
 
 /// Find where a closed `Circle3D` section crosses the outer-wire
-/// boundary of the analytic-surface face in the pair (the non-plane
-/// face, which holds the boundary the curve actually exits at).
+/// boundaries of the face pair.
 ///
 /// Returns crossings as `(t_on_circle, point_3d)` sorted by `t`, with
 /// duplicates removed. Only `Line`-curve boundary edges are considered.
 ///
-/// Rationale: for plane-sphere intersections, the closed curve lies on
-/// both the plane face and the sphere hemisphere, but the *meaningful*
-/// boundary crossings are on the sphere hemisphere's equator polygon
-/// — those are the points where the section enters/leaves the
-/// hemisphere region. Using those crossings as split points gives
-/// half-arcs that cleanly bound a spherical cap sub-face. The plane
-/// face's boundary crossings can introduce points interior to the
-/// sphere hemisphere, producing arcs that don't form closed loops on
-/// the hemisphere.
+/// Hits are collected per face. A face whose boundary yields more than
+/// 4 hits is treated as circle-coincident (a chord polygon inscribed in
+/// the circle — every chord endpoint lies on the circle, e.g. the
+/// equator polygon of a faceted sphere whose great circle IS the
+/// section): its hits describe the boundary itself rather than
+/// entry/exit points, so they are excluded and only the other face's
+/// crossings are used.
+///
+/// When the pair contains a sphere face, the surviving hits from BOTH
+/// faces are unioned so the arcs are trimmed to the mutual overlap of
+/// the two face regions (a sphere face has no seam structure, so its
+/// noseam splitter needs arcs whose endpoints all land on the mutual
+/// region boundary). For other analytic pairs (cylinder/cone laterals)
+/// only the non-plane face's crossings are used — those surfaces keep
+/// full closed section circles for the periodic band splitter, and
+/// their seam-line hit must not combine with plane-boundary hits.
 fn closed_circle_boundary_crossings(
     topo: &Topology,
     face_a: FaceId,
@@ -870,32 +876,13 @@ fn closed_circle_boundary_crossings(
     circle: &brepkit_math::curves::Circle3D,
     tol: Tolerance,
 ) -> Vec<(f64, Point3)> {
-    let mut hits: Vec<(f64, Point3)> = Vec::new();
-
-    // Pick the non-plane face for boundary crossings. If both are planes
-    // or both are non-plane, fall back to using both (existing behavior).
-    let analytic_face = |fid: FaceId| -> Option<FaceId> {
-        let face = topo.face(fid).ok()?;
-        if matches!(face.surface(), FaceSurface::Plane { .. }) {
-            None
-        } else {
-            Some(fid)
-        }
-    };
-    let analytic_a = analytic_face(face_a);
-    let analytic_b = analytic_face(face_b);
-    let faces_to_check: Vec<FaceId> = match (analytic_a, analytic_b) {
-        (None, Some(b)) => vec![b],
-        (Some(a), None) => vec![a],
-        _ => vec![face_a, face_b],
-    };
-
-    for &fid in &faces_to_check {
+    let face_hits = |fid: FaceId| -> Vec<(f64, Point3)> {
+        let mut hits: Vec<(f64, Point3)> = Vec::new();
         let Ok(face) = topo.face(fid) else {
-            continue;
+            return hits;
         };
         let Ok(wire) = topo.wire(face.outer_wire()) else {
-            continue;
+            return hits;
         };
         for oe in wire.edges() {
             let Ok(edge) = topo.edge(oe.edge()) else {
@@ -913,13 +900,51 @@ fn closed_circle_boundary_crossings(
                 continue;
             };
             for (p, t) in circle.intersect_segment(sv.point(), ev.point(), tol.linear) {
-                // Dedup against existing hits by 3D distance.
                 let dup = hits
                     .iter()
                     .any(|(_, q)| (*q - p).length() < tol.linear * 10.0);
                 if !dup {
                     hits.push((t, p));
                 }
+            }
+        }
+        hits
+    };
+
+    let surface_of = |fid: FaceId| topo.face(fid).ok().map(|f| f.surface().clone());
+    let surf_a = surface_of(face_a);
+    let surf_b = surface_of(face_b);
+    let is_plane = |s: &Option<FaceSurface>| matches!(s, Some(FaceSurface::Plane { .. }));
+    let is_sphere = |s: &Option<FaceSurface>| matches!(s, Some(FaceSurface::Sphere(_)));
+
+    let pair_has_sphere = is_sphere(&surf_a) || is_sphere(&surf_b);
+    let faces_to_check: Vec<FaceId> = if pair_has_sphere {
+        vec![face_a, face_b]
+    } else {
+        match (is_plane(&surf_a), is_plane(&surf_b)) {
+            (true, false) => vec![face_b],
+            (false, true) => vec![face_a],
+            _ => vec![face_a, face_b],
+        }
+    };
+
+    let mut hits: Vec<(f64, Point3)> = Vec::new();
+    for &fid in &faces_to_check {
+        let fh = face_hits(fid);
+        if fh.len() > 4 {
+            log::debug!(
+                "closed_circle_boundary_crossings: {fid:?} has {} hits — boundary coincident \
+                 with circle, excluding its hits",
+                fh.len()
+            );
+            continue;
+        }
+        for (t, p) in fh {
+            let dup = hits
+                .iter()
+                .any(|(_, q)| (*q - p).length() < tol.linear * 10.0);
+            if !dup {
+                hits.push((t, p));
             }
         }
     }
@@ -930,20 +955,6 @@ fn closed_circle_boundary_crossings(
         "closed_circle_boundary_crossings: face_a={face_a:?} face_b={face_b:?} hits={}",
         hits.len()
     );
-
-    // If we found more than 4 crossings, the circle is almost certainly
-    // coincident with one of the face boundaries (e.g. the equator polygon
-    // approximating a great circle on a sphere). In that case the curve
-    // is the boundary itself, not an interior section — fall back to the
-    // existing closed-curve handling instead of splitting.
-    if hits.len() > 4 {
-        log::debug!(
-            "closed_circle_boundary_crossings: {} hits — assuming coincident with boundary, \
-             skipping split",
-            hits.len()
-        );
-        return Vec::new();
-    }
 
     hits
 }
@@ -1022,10 +1033,55 @@ fn emit_split_circle_arcs(
     };
     let bbox_a = face_aabb(face_a);
     let bbox_b = face_aabb(face_b);
+
+    // A sphere face's wire+surface AABB covers the whole ball, so the AABB
+    // filter alone cannot tell its hemisphere from its twin's. Derive the
+    // hemisphere axis from the boundary wire orientation (region lies to
+    // the left of the wire under the outward surface normal): the sum of
+    // normal x edge-direction over the wire points into the face's region.
+    let sphere_side = |fid: FaceId| -> Option<(Point3, Vec3)> {
+        let face = topo.face(fid).ok()?;
+        let FaceSurface::Sphere(s) = face.surface() else {
+            return None;
+        };
+        let center = s.center();
+        let wire = topo.wire(face.outer_wire()).ok()?;
+        let mut axis = Vec3::new(0.0, 0.0, 0.0);
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+                continue;
+            };
+            let (sp, ep) = if oe.is_forward() {
+                (sv.point(), ev.point())
+            } else {
+                (ev.point(), sv.point())
+            };
+            let mid = sp + (ep - sp) * 0.5;
+            axis += (mid - center).cross(ep - sp);
+        }
+        if face.is_reversed() {
+            axis = axis * -1.0;
+        }
+        let len = axis.length();
+        if len < tol.linear {
+            return None;
+        }
+        Some((center, axis * (1.0 / len)))
+    };
+    let side_a = sphere_side(face_a);
+    let side_b = sphere_side(face_b);
+    let side_eps = tol.linear * 10.0;
     let in_both = |p: Point3| -> bool {
         let a_ok = bbox_a.as_ref().is_none_or(|b| b.contains_point(p));
         let b_ok = bbox_b.as_ref().is_none_or(|b| b.contains_point(p));
-        a_ok && b_ok
+        let side_ok = |side: &Option<(Point3, Vec3)>| {
+            side.as_ref()
+                .is_none_or(|(c, axis)| (p - *c).dot(*axis) >= -side_eps)
+        };
+        a_ok && b_ok && side_ok(&side_a) && side_ok(&side_b)
     };
 
     // Pass 1: determine which arcs survive the AABB filter, *before*
@@ -1098,6 +1154,37 @@ fn emit_split_circle_arcs(
                 .unwrap_or_else(|| topo.add_vertex(Vertex::new(p, tol.linear)))
         };
 
+    // A geometrically identical arc may already exist from an earlier pair
+    // sharing a face (e.g. both hemispheres of a faceted sphere paired with
+    // the same coplanar box face yield the same equator arc). Re-emitting it
+    // would hand the shared face two coincident sections and corrupt its
+    // split. First pair wins; the later pair contributes nothing new to the
+    // shared face anyway (the circle lies along its twin's region boundary).
+    let close_pts = |a: Point3, b: Point3| (a - b).length() < tol.linear * 10.0;
+    let arc_exists = |arena: &GfaArena, p_s: Point3, p_e: Point3, p_m: Point3| -> bool {
+        arena.curves.iter().any(|c| {
+            let EdgeCurve::Circle(existing) = &c.curve else {
+                return false;
+            };
+            let shares_face = c.face_a == face_a
+                || c.face_a == face_b
+                || c.face_b == face_a
+                || c.face_b == face_b;
+            if !shares_face
+                || (existing.center() - circle.center()).length() > tol.linear * 10.0
+                || (existing.radius() - circle.radius()).abs() > tol.linear * 10.0
+            {
+                return false;
+            }
+            let s = existing.evaluate(c.t_range.0);
+            let e = existing.evaluate(c.t_range.1);
+            let m = existing.evaluate(0.5 * (c.t_range.0 + c.t_range.1));
+            close_pts(m, p_m)
+                && ((close_pts(s, p_s) && close_pts(e, p_e))
+                    || (close_pts(s, p_e) && close_pts(e, p_s)))
+        })
+    };
+
     let mut emitted = 0_usize;
     let num_survivors = survivors.len();
     for (a_idx, arc_points) in survivors.into_iter().enumerate() {
@@ -1105,6 +1192,15 @@ fn emit_split_circle_arcs(
         for w in arc_points.windows(2) {
             let (t_s, p_s, idx_s) = w[0];
             let (t_e, p_e, idx_e) = w[1];
+
+            let p_m = circle.evaluate(0.5 * (t_s + t_e));
+            if arc_exists(arena, p_s, p_e, p_m) {
+                log::debug!(
+                    "FF: skip duplicate closed-circle arc t=[{t_s:.4},{t_e:.4}] \
+                     for {face_a:?}/{face_b:?}"
+                );
+                continue;
+            }
 
             let start_vid = match idx_s {
                 Some(ci) => {

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -931,10 +931,16 @@ fn closed_circle_boundary_crossings(
     let mut hits: Vec<(f64, Point3)> = Vec::new();
     for &fid in &faces_to_check {
         let fh = face_hits(fid);
-        if fh.len() > 4 {
+        // The boundary is coincident with the section circle when its
+        // segments are chords of an *inscribed* polygon: every vertex lands
+        // on the circle, so the hits are the polygon's vertices, evenly
+        // distributed around the full turn. A bare `len > 4` count misses a
+        // 4-segment inscribed polygon (square equator → exactly 4 hits), so
+        // test even angular distribution instead of relying on the count.
+        if hits_are_inscribed_polygon(&fh) {
             log::debug!(
-                "closed_circle_boundary_crossings: {fid:?} has {} hits — boundary coincident \
-                 with circle, excluding its hits",
+                "closed_circle_boundary_crossings: {fid:?} has {} hits evenly distributed on \
+                 the circle — boundary coincident with circle, excluding its hits",
                 fh.len()
             );
             continue;
@@ -957,6 +963,41 @@ fn closed_circle_boundary_crossings(
     );
 
     hits
+}
+
+/// Whether boundary/circle hits describe an inscribed polygon (the boundary
+/// is coincident with the section circle) rather than a small set of
+/// entry/exit crossings.
+///
+/// Hits store the circle parameter `t` (an angle). An inscribed polygon's
+/// vertices spread evenly around the full circle, so the sorted angular gaps
+/// between consecutive hits (including the wrap-around gap) are all
+/// approximately equal and there are at least three of them. Two entry/exit
+/// crossings, or a few unevenly clustered hits, fail this test.
+fn hits_are_inscribed_polygon(hits: &[(f64, Point3)]) -> bool {
+    use std::f64::consts::TAU;
+    if hits.len() < 3 {
+        return false;
+    }
+    let mut angles: Vec<f64> = hits.iter().map(|(t, _)| t.rem_euclid(TAU)).collect();
+    angles.sort_by(f64::total_cmp);
+    #[allow(clippy::cast_precision_loss)]
+    let expected = TAU / angles.len() as f64;
+    // Relative slack so coarse polygons (few segments) and fine ones (many)
+    // are both accepted; a clustered entry/exit pattern has a dominant gap
+    // far from `expected` and fails.
+    let slack = expected * 0.25;
+    for i in 0..angles.len() {
+        let next = if i + 1 == angles.len() {
+            angles[0] + TAU
+        } else {
+            angles[i + 1]
+        };
+        if (next - angles[i] - expected).abs() > slack {
+            return false;
+        }
+    }
+    true
 }
 
 /// Emit N arc edges + `IntersectionCurveDS` entries for a closed-circle
@@ -1047,6 +1088,13 @@ fn emit_split_circle_arcs(
         let center = s.center();
         let wire = topo.wire(face.outer_wire()).ok()?;
         let mut axis = Vec3::new(0.0, 0.0, 0.0);
+        // The accumulated cross products have units of length^2, so the
+        // degeneracy threshold must be derived from the input magnitudes
+        // rather than compared against a bare linear tolerance. `scale`
+        // sums each term's magnitude bound (|mid - center| * |ep - sp|);
+        // a true near-parallel/cancelling wire leaves `axis` small
+        // relative to it.
+        let mut scale = 0.0;
         for oe in wire.edges() {
             let Ok(edge) = topo.edge(oe.edge()) else {
                 continue;
@@ -1060,13 +1108,16 @@ fn emit_split_circle_arcs(
                 (ev.point(), sv.point())
             };
             let mid = sp + (ep - sp) * 0.5;
-            axis += (mid - center).cross(ep - sp);
+            let radial = mid - center;
+            let chord = ep - sp;
+            scale += radial.length() * chord.length();
+            axis += radial.cross(chord);
         }
         if face.is_reversed() {
             axis = axis * -1.0;
         }
         let len = axis.length();
-        if len < tol.linear {
+        if scale < tol.linear * tol.linear || len < scale * tol.linear {
             return None;
         }
         Some((center, axis * (1.0 / len)))
@@ -1538,5 +1589,42 @@ mod tests {
         // A concave "arrowhead": the reflex vertex flips the turn sign.
         let poly = vec![(0.0, 0.0), (2.0, 1.0), (0.0, 2.0), (1.0, 1.0)];
         assert!(!polygon_is_convex(&poly));
+    }
+
+    fn hit_at(angle: f64) -> (f64, Point3) {
+        (angle, Point3::new(angle.cos(), angle.sin(), 0.0))
+    }
+
+    #[test]
+    fn inscribed_square_equator_is_coincident() {
+        // A 4-segment polygon inscribed in the circle (square equator)
+        // yields exactly 4 evenly distributed hits — the bare `len > 4`
+        // count missed this, treating the boundary as entry/exit crossings.
+        use std::f64::consts::FRAC_PI_2;
+        let hits: Vec<_> = (0..4).map(|k| hit_at(k as f64 * FRAC_PI_2)).collect();
+        assert!(hits_are_inscribed_polygon(&hits));
+    }
+
+    #[test]
+    fn inscribed_hexagon_is_coincident() {
+        use std::f64::consts::FRAC_PI_3;
+        let hits: Vec<_> = (0..6).map(|k| hit_at(k as f64 * FRAC_PI_3)).collect();
+        assert!(hits_are_inscribed_polygon(&hits));
+    }
+
+    #[test]
+    fn entry_exit_pair_is_not_coincident() {
+        // Two crossings (genuine entry/exit) must not be mistaken for an
+        // inscribed boundary.
+        let hits = vec![hit_at(0.3), hit_at(2.9)];
+        assert!(!hits_are_inscribed_polygon(&hits));
+    }
+
+    #[test]
+    fn clustered_hits_are_not_coincident() {
+        // Four hits clustered on one side leave a dominant wrap-around gap,
+        // far from the even spacing of an inscribed polygon.
+        let hits = vec![hit_at(0.1), hit_at(0.2), hit_at(0.3), hit_at(0.4)];
+        assert!(!hits_are_inscribed_polygon(&hits));
     }
 }

--- a/crates/operations/src/section.rs
+++ b/crates/operations/src/section.rs
@@ -681,7 +681,6 @@ mod tests {
     /// box at this plane. At minimum, we verify the section succeeds and
     /// produces a face with positive area less than the full 20×20 = 400.
     #[test]
-    #[ignore = "GFA pipeline limitation — old boolean pipeline removed"]
     fn section_after_boolean_cut() {
         let mut topo = Topology::new();
         let b = crate::primitives::make_box(&mut topo, 20.0, 20.0, 20.0).unwrap();


### PR DESCRIPTION
Box-sphere booleans now go through GFA end-to-end: Cut(box [0,20]³, sphere r=12 at corner) yields a closed manifold (7 faces, Euler 2, exact volume 7095.22) instead of falling back to the broken mesh path.

## Changes
- `closed_circle_boundary_crossings` collects boundary hits per face and excludes only a circle-coincident face's hits (>4 hits = inscribed chord polygon, e.g. the 16-segment sphere equator) instead of bailing entirely; for sphere pairs, surviving hits from BOTH faces are unioned so section arcs trim to the mutual overlap (equator → in-box quarter arc). Cylinder/cone pairs keep the previous analytic-only preference.
- `evaluate_edge_at_t` samples open Circle/Ellipse edges along the shorter arc between endpoints.

Un-ignores `section_after_boolean_cut` (the section now sees the spherical cavity instead of an uncut face).

Known remaining (documented, ignored): half-embedded sphere with the section circle fully interior to a coplanar face still produces an open shell — separate gap.

## Verification
algo + FULL operations + wasm suites green, zero regressions; fmt/clippy/boundaries clean.