### PR TITLE
fix(algo): require mutual containment for boundary-tolerant same-domain merge

### DIFF
--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -467,19 +467,41 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
         |p| frame.project(p),
     );
 
+    // Strict containment: every vertex of `verts` lies inside `poly` by the
+    // ray-cast test, no boundary tolerance.
+    let all_inside_strict =
+        |verts: &[brepkit_math::vec::Point2], poly: &[brepkit_math::vec::Point2]| -> bool {
+            verts
+                .iter()
+                .all(|&v| super::classify_2d::point_in_polygon_2d(v, poly))
+        };
+
     // Boundary-tolerant containment: a coincident-outline pair (e.g. a
     // section-loop disc vs. the opposing solid's cap with differently split
     // boundary edges) has every vertex exactly ON the container's polygon,
-    // where the strict ray-cast is unpredictable. The interior-point test
-    // below remains strict, so faces that merely touch along a shared
-    // boundary segment still don't pair.
-    let all_inside =
+    // where the strict ray-cast is unpredictable.
+    let all_inside_tol =
         |verts: &[brepkit_math::vec::Point2], poly: &[brepkit_math::vec::Point2]| -> bool {
             let boundary_eps = super::classify_2d::boundary_eps(poly);
             verts.iter().all(|&v| {
                 super::classify_2d::point_in_polygon_2d(v, poly)
                     || super::classify_2d::distance_to_polygon_boundary(v, poly) <= boundary_eps
             })
+        };
+
+    // Two coplanar faces that tile disjoint side-by-side regions share a
+    // boundary segment, so every vertex of one lands ON the other's polygon
+    // and `all_inside_tol` reports a false containment in a single direction.
+    // A genuine coincident-outline pair (the case boundary tolerance exists
+    // for) instead has BOTH faces' interior points mutually inside, because
+    // the outlines coincide. Require that mutual containment before trusting
+    // a boundary-tolerant match; strict containment needs no such guard.
+    let ip_i_in_j = super::classify_2d::point_in_polygon_2d(p_i_2d, &poly_j);
+    let ip_j_in_i = super::classify_2d::point_in_polygon_2d(p_j_2d, &poly_i);
+    let outlines_coincide = ip_i_in_j && ip_j_in_i;
+    let all_inside =
+        |verts: &[brepkit_math::vec::Point2], poly: &[brepkit_math::vec::Point2]| -> bool {
+            all_inside_strict(verts, poly) || (outlines_coincide && all_inside_tol(verts, poly))
         };
 
     // A point landing inside one of the container's inner wires sits in a
@@ -520,7 +542,7 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
 
     // i fully contained in j: every vertex of i (plus its interior sample)
     // is inside j's polygon.
-    if super::classify_2d::point_in_polygon_2d(p_i_2d, &poly_j)
+    if ip_i_in_j
         && all_inside(&poly_i, &poly_j)
         && !in_hole(p_i_2d, face_j)
         && !footprint_in_holes(p_i_2d, &poly_i, &poly_j, face_j)
@@ -528,7 +550,7 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
         return true;
     }
     // j fully contained in i.
-    if super::classify_2d::point_in_polygon_2d(p_j_2d, &poly_i)
+    if ip_j_in_i
         && all_inside(&poly_j, &poly_i)
         && !in_hole(p_j_2d, face_i)
         && !footprint_in_holes(p_j_2d, &poly_j, &poly_i, face_i)

--- a/crates/operations/src/section.rs
+++ b/crates/operations/src/section.rs
@@ -681,7 +681,6 @@ mod tests {
     /// box at this plane. At minimum, we verify the section succeeds and
     /// produces a face with positive area less than the full 20×20 = 400.
     #[test]
-    #[ignore = "section through the cut region returns the full 400 box-face area — the cut cavity is missing from the section plane (#767 un-ignored this prematurely; still red on main)"]
     fn section_after_boolean_cut() {
         let mut topo = Topology::new();
         let b = crate::primitives::make_box(&mut topo, 20.0, 20.0, 20.0).unwrap();


### PR DESCRIPTION
The boundary-tolerant containment in `planar_faces_overlap` (added in #766) reported a false one-directional containment for two coplanar faces that tile **disjoint side-by-side regions**. Every vertex of one face lands ON the shared boundary segment of the other, so `all_inside` passed via the boundary epsilon even though the faces do not overlap.

## Root cause

In a box-minus-sphere cut, this wrongly merged two planar sub-faces as same-domain, corrupting the GFA result and forcing a mesh-boolean fallback. The fallback tessellates everything into planar triangles, so the spherical cavity face is lost. A `section` through the cut then iterates faces (no triangle straddles the cutting plane) and returns the full uncut box-face area (400) instead of `box − quarter-disc`.

This was an untested interaction: #767 un-ignored `section_after_boolean_cut`, but #767 CI ran against pre-#766 main; on the combination the test regressed.

## Fix

Boundary tolerance exists for genuine coincident-outline pairs (a section-loop disc vs. the opposing cap with differently split boundary edges), which always have **both** faces interior points mutually inside (the outlines coincide). Two disjoint side-by-side faces have only one direction inside.

Gate the boundary-tolerant relaxation on that mutual containment. Strict ray-cast containment still pairs without it, so #766 lofted-frustum and gridfinity lip-ring cases remain covered.

Also un-ignores `section_after_boolean_cut` (re-ignored as a stopgap in #769).

## Verification

- `section_after_boolean_cut`: now passes (cut solid: 7 faces, 6 planes + 1 sphere; section area ~287)
- box-sphere GFA suite (`cut_box_by_translated_sphere`)
- #766 un-ignored tests: `test_boolean_cone_cylinder`, `cut_lofted_frustums_consistent_normals`, `cut_lofted_frustums_octagon_profiles`, `fillet_on_boolean_result`, `fully_nested_coplanar_fuse`, `gridfinity_d1_lip_ring_loft_cut`, `gridfinity_d1b_lip_ring_no_coplanar`
- `cargo test -p brepkit-algo` (112), full `cargo test -p brepkit-operations` (0 failures), `cargo test -p brepkit-wasm --lib` (210)
- fmt/clippy/boundaries clean