### PR TITLE
fix(algo): deterministic iteration in GFA pipeline

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1011,7 +1011,14 @@ fn split_edges_at_collinear_vertices(
         if cuts.is_empty() {
             continue;
         }
-        cuts.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        // `cuts` is gathered by iterating `vert_at.values()` (a HashMap), so
+        // the `vid` tiebreak makes this a total order — without it, cuts at
+        // equal `t` keep nondeterministic hash order and sub-edge IDs drift.
+        cuts.sort_by(|a, b| {
+            a.0.partial_cmp(&b.0)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.1.index().cmp(&b.1.index()))
+        });
 
         let mut chain: Vec<VertexId> = Vec::with_capacity(cuts.len() + 2);
         chain.push(sv);


### PR DESCRIPTION
## Summary

Wave-3 determinism pass over the GFA pipeline (`crates/algo/src/{pave_filler,builder}`). Audited every `HashMap`/`HashSet` for iteration-order dependence and fixed the one site whose iteration order feeds geometry/ID allocation.

## The bug

`split_edges_at_collinear_vertices` (builder_solid.rs) gathers cut points by iterating `vert_at.values()` (a `HashMap`) and sorts them by parametric `t`. Cuts at **equal `t`** kept the nondeterministic hash iteration order, so the resulting sub-edge chain — and thus `add_edge` ID allocation — could differ across runs. Fixed by making the sort a total order with a `VertexId` tiebreak.

## Audit result

| Disposition | Sites |
|---|---|
| **Fixed** | `builder_solid::split_edges_at_collinear_vertices` — `cuts` sort tiebreak |
| **Left (lookup-only)** | `shape_store` maps, `fill_images_faces` cb/section/merge maps, `link_existing`/`force_interf_ee` indices, `phase_ef`/`phase_vf` boundary sets, `bop`/`builder::mod` sd_indices, `wire_builder` adjacency, `face_splitter` dedup/degree maps |
| **Left (order-stable destination)** | `fill_face_info` (feeds `FaceInfo` BTreeSets), `same_domain` (outputs explicitly sorted), `fill_images_faces` vertex pool (sorted-by-key before alloc) |
| **Left (dead code)** | `builder_solid::perform_shapes_to_avoid` (never called) |

Every "left" site was additionally verified order-independent by a temporary **probe-swap build** that forces 8 distinct hash iteration orders across all GFA maps/sets — byte-identical output for every seed (scaffolding reverted, not in this diff).

## Distributions (fresh processes, after fix)

- `test_sequential_boolean_vertex_drift` — **50/50 pass**, volume collapses to a single value (123.362456344003, faces=14 edges=26 verts=14) across 60 fresh-process runs with varying `RandomState` seeds.
- `compound_cut_matches_sequential_{2x2,3x3,4x4}_grid` — **20/20 pass** each (all already un-ignored on main; left un-ignored).

## Gates

`fmt --check` ✅ · `clippy -p brepkit-algo -D warnings` ✅ · `check-boundaries` ✅ · `cargo test -p brepkit-algo` (112) ✅ · `cargo test -p brepkit-operations` (0 failed) ✅ · `cargo test -p brepkit-wasm --lib` (210) ✅