### PR TITLE
fix(algo): total-order float comparison in collinear cut sort

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1015,8 +1015,7 @@ fn split_edges_at_collinear_vertices(
         // the `vid` tiebreak makes this a total order — without it, cuts at
         // equal `t` keep nondeterministic hash order and sub-edge IDs drift.
         cuts.sort_by(|a, b| {
-            a.0.partial_cmp(&b.0)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            a.0.total_cmp(&b.0)
                 .then_with(|| a.1.index().cmp(&b.1.index()))
         });
 


### PR DESCRIPTION
Follow-up to #774 addressing the review note that landed after auto-merge: the cut sort used `partial_cmp` with an `Equal` fallback, which violates strict-weak-ordering if a NaN ever reaches it. `f64::total_cmp` gives a total order unconditionally (`t` comes from clamped projections, so NaN is theoretical — this is hardening, not a behavior change). One-line diff; algo suite green.