### PR TITLE
fix(algo): valid GFA booleans for rounded-rect prisms at coplanar interfaces

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -21,7 +21,7 @@ use super::classify_2d::{sample_interior_point, signed_area_2d};
 use super::pcurve_compute::evaluate_edge_at_t;
 use super::plane_frame::PlaneFrame;
 use super::split_types::{OrientedPCurveEdge, SectionEdge, SplitSubFace, SurfaceInfo};
-use super::wire_builder::build_wire_loops;
+use super::wire_builder::{build_wire_loops, build_wire_loops_with_winding};
 use crate::ds::Rank;
 
 use containment::{find_point_outside_holes, is_inside_any_hole};
@@ -368,6 +368,7 @@ pub fn split_face_2d(
 
     // Convert section edges to OrientedPCurveEdge (both orientations).
     let mut all_edges = boundary_edges;
+    let n_boundary_edges = all_edges.len();
     for section in sections {
         // Skip full-circle section edges on plane faces -- they have
         // start approx end in 3D and would produce degenerate UV edges.
@@ -473,8 +474,71 @@ pub fn split_face_2d(
         });
     }
 
+    // Partial-band u unwrap: a face whose u-window touches the period seam
+    // (e.g. a rounded-rect corner cylinder spanning [3pi/2, 2pi]) carries
+    // mixed u anchors — surface projection returns u in [0, 2pi), so
+    // endpoints exactly on the seam come back as 0 while their neighbours
+    // sit near 2pi. Partial bands are treated as non-periodic (see
+    // build_surface_info), so quantized junction keys would never match.
+    // Remap every endpoint u into the continuous window that starts after
+    // the largest angular gap.
+    if !u_periodic && !is_plane {
+        if let (Some(u_period), _) = super::pcurve_compute::surface_periods(&surface) {
+            let mut us: Vec<f64> = all_edges
+                .iter()
+                .flat_map(|e| [e.start_uv.x(), e.end_uv.x()])
+                .map(|u| u.rem_euclid(u_period))
+                .collect();
+            us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            if us.len() >= 2 {
+                let mut gap_start = us[us.len() - 1];
+                let mut max_gap = u_period - (us[us.len() - 1] - us[0]);
+                for w in us.windows(2) {
+                    if w[1] - w[0] > max_gap {
+                        max_gap = w[1] - w[0];
+                        gap_start = w[0];
+                    }
+                }
+                if max_gap > 0.05 {
+                    let lo = gap_start + max_gap;
+                    for e in &mut all_edges {
+                        let remap = |uv: Point2| -> Point2 {
+                            let mut d = (uv.x() - lo).rem_euclid(u_period);
+                            if d > u_period - 1e-6 {
+                                d = 0.0;
+                            }
+                            Point2::new(lo + d, uv.y())
+                        };
+                        e.start_uv = remap(e.start_uv);
+                        e.end_uv = remap(e.end_uv);
+                    }
+                }
+            }
+        }
+    }
+
     // Build wire loops via angular-sorting traversal.
-    let loops = build_wire_loops(&all_edges, tol.linear, u_periodic, v_periodic);
+    let mut loops = build_wire_loops(&all_edges, tol.linear, u_periodic, v_periodic);
+
+    // Clockwise-boundary retry: the min-clockwise turn rule merges
+    // everything into a single loop when the boundary winds clockwise in
+    // this UV frame (the frame derives from the raw surface normal, not the
+    // effective face orientation). If the default traversal failed to split
+    // despite having sections, and the boundary is CW, retry with the
+    // mirrored turn rule. Loop areas from the retry are sign-flipped for
+    // the outer/hole classification below.
+    let mut cw_loops = false;
+    if loops.len() <= 1 && all_edges.len() > n_boundary_edges && !u_periodic && !v_periodic {
+        let boundary_pts = sample_wire_loop_uv(&all_edges[..n_boundary_edges]);
+        if signed_area_2d(&boundary_pts) < 0.0 {
+            let retry =
+                build_wire_loops_with_winding(&all_edges, tol.linear, u_periodic, v_periodic, true);
+            if retry.len() > loops.len() {
+                loops = retry;
+                cw_loops = true;
+            }
+        }
+    }
 
     // Fallback: wire builder produced only 1 loop despite having 2+ section
     // edges that cross in the face interior. Use direct geometric quadrant
@@ -531,7 +595,11 @@ pub fn split_face_2d(
             }
         } else {
             let pts = sample_wire_loop_uv_periodic(&wire_loop, u_per_opt, v_per_opt);
-            let area = signed_area_2d(&pts);
+            let area = if cw_loops {
+                -signed_area_2d(&pts)
+            } else {
+                signed_area_2d(&pts)
+            };
             // Sliver guard: a loop enclosing less area than a tol-wide band
             // along its own perimeter is degenerate — e.g. an arc traversed
             // forward then backward when a coplanar partner's boundary
@@ -816,10 +884,15 @@ fn plane_internal_line_loops(
 
     type QPt = (i64, i64, i64);
 
+    // Accept Line and open arc (Circle/Ellipse) sections: a rounded-rect
+    // tool footprint stamps a mixed line+arc loop onto a coplanar cap.
+    // Closed curves (start == end) are handled by the single-closed path.
     if sections.len() < 3
-        || !sections
-            .iter()
-            .all(|s| matches!(s.curve_3d, EdgeCurve::Line))
+        || !sections.iter().all(|s| match s.curve_3d {
+            EdgeCurve::Line => true,
+            EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => (s.start - s.end).length() > tol_linear,
+            EdgeCurve::NurbsCurve(_) => false,
+        })
     {
         return None;
     }
@@ -873,6 +946,9 @@ fn plane_internal_line_loops(
     // degree check below rejects and the generic path takes over.
     let endpoints: Vec<Point3> = deduped.iter().flat_map(|s| [s.start, s.end]).collect();
     deduped.retain(|s| {
+        if !matches!(s.curve_3d, EdgeCurve::Line) {
+            return true;
+        }
         let dir = s.end - s.start;
         let len2 = dir.dot(dir);
         if len2 < margin * margin {

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -532,6 +532,15 @@ pub fn split_face_2d(
         } else {
             let pts = sample_wire_loop_uv_periodic(&wire_loop, u_per_opt, v_per_opt);
             let area = signed_area_2d(&pts);
+            // Sliver guard: a loop enclosing less area than a tol-wide band
+            // along its own perimeter is degenerate — e.g. an arc traversed
+            // forward then backward when a coplanar partner's boundary
+            // coincides with the face's own corner arc. Classifying it as
+            // outer creates a zero-area face; as hole, a spurious inner wire.
+            let perimeter: f64 = pts.windows(2).map(|w| (w[1] - w[0]).length()).sum();
+            if area.abs() <= perimeter * tol.linear {
+                continue;
+            }
             if area > 0.0 {
                 outers.push((wire_loop, area));
             } else {

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2108,17 +2108,7 @@ fn build_topology_face(
         // different per-call vertex caches, so shared edges would have wrong
         // VertexId connections at wire junctions.
         // merge_duplicate_edges in BuilderSolid handles cross-face sharing.
-        let edge_id = if let Some(_pb_id) = pcurve_edge.pave_block_id {
-            topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()))
-        } else if let Some(_idx) = pcurve_edge.source_edge_idx {
-            topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()))
-        } else {
-            // Each face creates its own boundary edges with its own vertices.
-            // Cross-face sharing is handled by merge_duplicate_edges in
-            // builder_solid. This avoids VertexId mismatches that occur when
-            // edges are shared across parent faces with different vertex caches.
-            topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()))
-        };
+        let edge_id = topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()));
         // The edge was just created with start_vid at start_3d and end_vid
         // at end_3d, so the vertex order itself encodes the traversal
         // direction — open edges always get forward=true regardless of the

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1379,6 +1379,15 @@ fn build_section_edges(
                         // Plane surface — project via pcurve.
                         (Some(pcurve.evaluate(0.0)), Some(pcurve.evaluate(1.0)))
                     }
+                } else if matches!(pcurve, brepkit_math::curves2d::Curve2D::Line(_)) {
+                    // Line2D pcurves use arc-length parameterization, so
+                    // `evaluate(1.0)` is one UV unit along the line, not the
+                    // endpoint (e.g. a horizontal circle on a cylinder maps
+                    // to a Line2D spanning the angular extent). Leave the
+                    // endpoints unset; downstream consumers fall back to
+                    // `uv_endpoints_from_pcurve`, which measures the true
+                    // 2D length.
+                    (None, None)
                 } else {
                     (Some(pcurve.evaluate(0.0)), Some(pcurve.evaluate(1.0)))
                 };
@@ -1840,17 +1849,59 @@ fn point_to_segment_dist_3d(pt: Point3, a: Point3, b: Point3) -> f64 {
     (pt - proj).length()
 }
 
+/// Angular u-extent of a face's outer wire on a u-periodic surface,
+/// measured as the period minus the largest angular gap between boundary
+/// samples (robust against the 2pi wrap).
+fn face_u_span(topo: &Topology, face: &brepkit_topology::face::Face) -> Option<f64> {
+    const TAU: f64 = std::f64::consts::TAU;
+    let surface = face.surface();
+    let wire = topo.wire(face.outer_wire()).ok()?;
+    let mut us: Vec<f64> = Vec::new();
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge()).ok()?;
+        let sp = topo.vertex(edge.start()).ok()?.point();
+        let ep = topo.vertex(edge.end()).ok()?.point();
+        for i in 0..=8 {
+            #[allow(clippy::cast_precision_loss)]
+            let t = f64::from(i) / 8.0;
+            let p = super::pcurve_compute::evaluate_edge_at_t(edge.curve(), sp, ep, t);
+            if let Some((u, _)) = surface.project_point(p) {
+                us.push(u.rem_euclid(TAU));
+            }
+        }
+    }
+    if us.len() < 2 {
+        return None;
+    }
+    us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mut max_gap = TAU - (us[us.len() - 1] - us[0]);
+    for w in us.windows(2) {
+        max_gap = max_gap.max(w[1] - w[0]);
+    }
+    Some(TAU - max_gap)
+}
+
 /// Build `SurfaceInfo` for a face (periodicity flags).
 fn build_surface_info(topo: &Topology, face_id: FaceId) -> Option<SurfaceInfo> {
     let face = topo.face(face_id).ok()?;
+    // A partial angular band (e.g. a quarter-cylinder corner of an extruded
+    // rounded rectangle) must not be treated as u-periodic: the periodic
+    // wire-builder normalizes u into [0, 2pi) and rejects "seam-crossing"
+    // loop closures, both of which corrupt loops on faces that merely touch
+    // u = 2pi without wrapping.
+    // Only quarter-or-less bands are demoted: half-cylinder faces (common
+    // after a box cut) still rely on the periodic seam machinery for their
+    // own splits, and the wrap-corner unwrap in `split_face_2d` handles
+    // sub-half bands without it.
+    let u_wraps = || face_u_span(topo, face).is_none_or(|span| span > std::f64::consts::PI + 0.05);
     match face.surface() {
         FaceSurface::Plane { .. } => None,
         FaceSurface::Cylinder(_) => Some(SurfaceInfo::Parametric {
-            u_periodic: true,
+            u_periodic: u_wraps(),
             v_periodic: false,
         }),
         FaceSurface::Cone(_) => Some(SurfaceInfo::Parametric {
-            u_periodic: true,
+            u_periodic: u_wraps(),
             v_periodic: false,
         }),
         FaceSurface::Sphere(_) => Some(SurfaceInfo::Parametric {

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2159,15 +2159,7 @@ fn build_topology_face(
         // different per-call vertex caches, so shared edges would have wrong
         // VertexId connections at wire junctions.
         // merge_duplicate_edges in BuilderSolid handles cross-face sharing.
-        let edge_id = topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()));
-        // The edge was just created with start_vid at start_3d and end_vid
-        // at end_3d, so the vertex order itself encodes the traversal
-        // direction — open edges always get forward=true regardless of the
-        // pcurve direction flag (using the flag here would contradict the
-        // vertex order and break wire closure). Closed curved edges
-        // (start_vid == end_vid) can't encode direction via vertices, so
-        // they keep pcurve_edge.forward to preserve winding.
-        let forward = start_vid != end_vid || pcurve_edge.forward;
+        let (edge_id, forward) = instantiate_wire_edge(topo, start_vid, end_vid, pcurve_edge);
         oriented_edges.push(OrientedEdge::new(edge_id, forward));
     }
 
@@ -2193,11 +2185,7 @@ fn build_topology_face(
                 &quantize,
                 tol,
             );
-            let edge = Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone());
-            let edge_id = topo.add_edge(edge);
-            // Same rule as the outer wire: Line edge vertices already
-            // encode traversal order, so the oriented edge is forward.
-            let forward = matches!(pcurve_edge.curve_3d, EdgeCurve::Line) || pcurve_edge.forward;
+            let (edge_id, forward) = instantiate_wire_edge(topo, start_vid, end_vid, pcurve_edge);
             inner_oriented.push(OrientedEdge::new(edge_id, forward));
         }
         if let Ok(inner_wire) = Wire::new(inner_oriented, true) {
@@ -2213,4 +2201,33 @@ fn build_topology_face(
     let face_id = topo.add_face(face);
 
     Some(face_id)
+}
+
+/// Create a topology edge for a wire's pcurve edge, returning the edge id
+/// and the oriented-edge forward flag for the wire traversal.
+///
+/// Open Line edges encode the traversal in their vertex order and are
+/// always forward. Open Circle/Ellipse edges must keep their vertex order
+/// aligned with the curve parameterization — an open arc edge implicitly
+/// spans the CCW range from its start vertex to its end vertex, so storing
+/// traversal order for a reverse-traversed arc would flip the geometry to
+/// the complementary arc. Closed curved edges (start == end) cannot encode
+/// direction via vertices and keep the pcurve flag for winding.
+fn instantiate_wire_edge(
+    topo: &mut Topology,
+    start_vid: brepkit_topology::vertex::VertexId,
+    end_vid: brepkit_topology::vertex::VertexId,
+    pcurve_edge: &super::split_types::OrientedPCurveEdge,
+) -> (brepkit_topology::edge::EdgeId, bool) {
+    let is_arc = matches!(
+        pcurve_edge.curve_3d,
+        EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_)
+    );
+    if is_arc && start_vid != end_vid && !pcurve_edge.forward {
+        let edge_id = topo.add_edge(Edge::new(end_vid, start_vid, pcurve_edge.curve_3d.clone()));
+        (edge_id, false)
+    } else {
+        let edge_id = topo.add_edge(Edge::new(start_vid, end_vid, pcurve_edge.curve_3d.clone()));
+        (edge_id, start_vid != end_vid || pcurve_edge.forward)
+    }
 }

--- a/crates/algo/src/builder/pcurve_compute.rs
+++ b/crates/algo/src/builder/pcurve_compute.rs
@@ -241,7 +241,7 @@ pub(super) fn evaluate_edge_at_t(curve: &EdgeCurve, start: Point3, end: Point3, 
 }
 
 /// Wrap an angular difference into (-pi, pi] — the shorter way around.
-fn shorter_arc_delta(d: f64) -> f64 {
+pub(super) fn shorter_arc_delta(d: f64) -> f64 {
     let w = d.rem_euclid(TAU);
     if w > std::f64::consts::PI { w - TAU } else { w }
 }

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -431,16 +431,21 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
                 continue;
             };
             let (sp, ep) = (sv.point(), ev.point());
-            let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
+            // Sample via the shorter-arc evaluator: split faces can store
+            // arc edges whose vertex order opposes the circle's CCW
+            // parameterization, and domain-based sampling would then trace
+            // the complementary (long-way) arc, corrupting the polygon used
+            // for the containment tests below.
             for k in 0..samples_per_edge {
                 #[allow(clippy::cast_precision_loss)]
                 let frac = k as f64 / samples_per_edge as f64;
-                let t = if oe.is_forward() {
-                    (t1 - t0).mul_add(frac, t0)
-                } else {
-                    (t0 - t1).mul_add(frac, t1)
-                };
-                pts.push(edge.curve().evaluate_with_endpoints(t, sp, ep));
+                let frac = if oe.is_forward() { frac } else { 1.0 - frac };
+                pts.push(super::pcurve_compute::evaluate_edge_at_t(
+                    edge.curve(),
+                    sp,
+                    ep,
+                    frac,
+                ));
             }
         }
         pts

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -49,9 +49,31 @@ pub fn build_wire_loops(
     u_periodic: bool,
     v_periodic: bool,
 ) -> Vec<Vec<OrientedPCurveEdge>> {
+    build_wire_loops_with_winding(edges, tol, u_periodic, v_periodic, false)
+}
+
+/// [`build_wire_loops`] with explicit boundary winding.
+///
+/// The minimum-clockwise-angle rule produces minimal loops only when the
+/// face boundary winds counter-clockwise in UV. For faces whose boundary
+/// winds clockwise (legal — UV frames are built from the surface normal,
+/// not the effective face orientation), pass `cw_boundary = true` to use
+/// the mirrored minimum-counter-clockwise rule instead.
+pub fn build_wire_loops_with_winding(
+    edges: &[OrientedPCurveEdge],
+    tol: f64,
+    u_periodic: bool,
+    v_periodic: bool,
+    cw_boundary: bool,
+) -> Vec<Vec<OrientedPCurveEdge>> {
     if edges.is_empty() {
         return Vec::new();
     }
+
+    let turn_score = |incoming: f64, candidate: f64| -> f64 {
+        let cw = clockwise_angle(incoming, candidate);
+        if cw_boundary { TAU - cw } else { cw }
+    };
 
     let u_period = if u_periodic { Some(TAU) } else { None };
     let v_period = if v_periodic { Some(TAU) } else { None };
@@ -145,7 +167,7 @@ pub fn build_wire_loops(
                     }
                 }
 
-                let cw = clockwise_angle(incoming_angle, entry.angle);
+                let cw = turn_score(incoming_angle, entry.angle);
                 if cw < best_cw {
                     best_cw = cw;
                     best_idx = Some(entry.edge_idx);
@@ -159,8 +181,8 @@ pub fn build_wire_loops(
                     .iter()
                     .filter(|e| e.outgoing && !used[e.edge_idx])
                     .min_by(|a, b| {
-                        clockwise_angle(incoming_angle, a.angle)
-                            .partial_cmp(&clockwise_angle(incoming_angle, b.angle))
+                        turn_score(incoming_angle, a.angle)
+                            .partial_cmp(&turn_score(incoming_angle, b.angle))
                             .unwrap_or(std::cmp::Ordering::Equal)
                     });
                 if let Some(fb) = fallback {

--- a/crates/algo/src/pave_filler/phase_ee.rs
+++ b/crates/algo/src/pave_filler/phase_ee.rs
@@ -181,6 +181,20 @@ fn find_edge_edge_crossings(
         return Ok(line_line_intersection(ea, eb, tol));
     }
 
+    // Coincident circles (same center/axis/radius): the arcs overlap along
+    // a shared curve, not at isolated points. Like collinear parallel lines
+    // (which return no crossings above), the overlap is handled by VE paves
+    // at arc endpoints plus ForceInterfEE common blocks — sampling here
+    // would emit a spurious crossing at every sample pair along the arc.
+    if let (EdgeCurve::Circle(ca), EdgeCurve::Circle(cb)) = (edge_a.curve(), edge_b.curve()) {
+        if (ca.radius() - cb.radius()).abs() < tol.linear
+            && (ca.center() - cb.center()).length() < tol.linear
+            && ca.normal().dot(cb.normal()).abs() > 1.0 - tol.angular
+        {
+            return Ok(Vec::new());
+        }
+    }
+
     // General case: sample both edges and find close segment pairs
     let n: usize = 32;
     let mut crossings = Vec::new();

--- a/crates/algo/src/pave_filler/phase_ef.rs
+++ b/crates/algo/src/pave_filler/phase_ef.rs
@@ -298,6 +298,19 @@ fn check_edge_face_pairs(
                     continue;
                 }
 
+                // A contact at the edge's own endpoint is a vertex-face
+                // incidence (VF territory), not an edge crossing. Recording
+                // it as EF marks the adjacent pave block as lying inside the
+                // face even though the edge merely touches the face there
+                // (e.g. a cap-rim arc tangent to a coplanar wall corner).
+                if (pt - start_pos).length() <= tol.linear || (pt - end_pos).length() <= tol.linear
+                {
+                    log::debug!(
+                        "EF: dropping endpoint contact of edge {eid:?} at t={t:.6} on face {fid:?}",
+                    );
+                    continue;
+                }
+
                 // Check if an existing vertex is at this point
                 let existing = find_nearby_vertex(topo, arena, pt, tol);
 

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -134,14 +134,22 @@ pub fn perform(
                                 let f1 = a.1.min(b.1);
                                 trim_raw_line(&raw, f0, f1, tol)
                             }
-                            // At least one face could not build a usable
-                            // polygon (degenerate wire, non-line edges, or a
-                            // non-convex outline the Cyrus-Beck clip can't
-                            // handle). Conservatively keep the raw curve and
-                            // leave trimming to a later phase.
-                            (FaceClip::Indeterminate, _) | (_, FaceClip::Indeterminate) => {
-                                Some(raw)
+                            // One face produced an interval, the other could
+                            // not build a usable polygon (degenerate wire,
+                            // non-line edges such as rounded-rect corner
+                            // arcs, or a non-convex outline). The single
+                            // interval is still a superset of the mutual
+                            // overlap, so trim to it — keeping the raw curve
+                            // here produced over-long chords that crossed
+                            // the partner's arc sections mid-edge.
+                            (FaceClip::Range(r), FaceClip::Indeterminate)
+                            | (FaceClip::Indeterminate, FaceClip::Range(r)) => {
+                                trim_raw_line(&raw, r.0, r.1, tol)
                             }
+                            // Neither face could build a usable polygon.
+                            // Conservatively keep the raw curve and leave
+                            // trimming to a later phase.
+                            (FaceClip::Indeterminate, FaceClip::Indeterminate) => Some(raw),
                         }
                     })
                     .collect()

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -497,6 +497,15 @@ pub fn boolean(
                 #[allow(clippy::cast_possible_wrap)]
                 let euler_pre2 = (v2 as i64) - (e2 as i64) + (f2 as i64);
 
+                // Hollow results (a Cut whose tool sits strictly inside the
+                // target) arrive from GFA with the cavity assembled as inner
+                // shells. Each closed genus-0 cavity shell adds 2 to V-E+F,
+                // so the Euler acceptance below must compare against
+                // 2 + 2*K instead of 2. Entity counts above already include
+                // inner-shell entities via `solid_entity_counts`.
+                #[allow(clippy::cast_possible_wrap)]
+                let inner_shell_surplus = 2 * (topo.solid(result)?.inner_shells().len() as i64);
+
                 // Hole-aware Euler: a face with L inner wire loops raises V-E+F
                 // by L (Euler-Poincare: V-E+F-L = 2(1-g)), so a valid genus-0
                 // result with holed faces (e.g. a fuse leaving circular holes in
@@ -506,8 +515,8 @@ pub fn boolean(
                 // deviates from euler==2 solely because of inner wires would
                 // still trigger an unnecessary unify_faces pass.
                 let inner_wire_count_pre = solid_inner_wire_count(topo, result)?;
-                let euler_balanced_pre =
-                    euler_pre2 == 2 || euler_balanced(euler_pre2, inner_wire_count_pre);
+                let euler_balanced_pre = euler_pre2 - inner_shell_surplus == 2
+                    || euler_balanced(euler_pre2 - inner_shell_surplus, inner_wire_count_pre);
 
                 // Run unify_faces if the (hole-aware) Euler is off OR if the
                 // topology has 3+-face junctions, which can occur with a
@@ -543,9 +552,15 @@ pub fn boolean(
                 // offset the inner-wire surplus) still fail safe to the mesh
                 // fallback.
                 let inner_wire_count = solid_inner_wire_count(topo, result)?;
-                let euler_ok = euler == 2
-                    || (euler_balanced(euler, inner_wire_count)
-                        && is_closed_manifold(topo, result)?);
+                // A hollow result must additionally have every shell closed:
+                // a missing cavity face could otherwise cancel against the
+                // inner-shell surplus and balance Euler by accident.
+                let hollow_ok = inner_shell_surplus == 0 || is_closed_manifold(topo, result)?;
+                let euler_eff = euler - inner_shell_surplus;
+                let euler_ok = hollow_ok
+                    && (euler_eff == 2
+                        || (euler_balanced(euler_eff, inner_wire_count)
+                            && is_closed_manifold(topo, result)?));
                 if euler_ok && open_shell_ok && validate_boolean_result(topo, result).is_ok() {
                     log::info!(
                         "GFA boolean succeeded in {:.1}ms ({result_faces} faces)",
@@ -2266,17 +2281,35 @@ const fn euler_balanced(euler: i64, inner_wires: i64) -> bool {
     }
 }
 
-/// Check whether a solid's outer shell is a closed manifold: every edge
-/// is shared by exactly 2 faces. Returns `false` for open shells
-/// (boundary edges with count == 1) and non-manifold shells (count > 2).
+/// Check whether every shell of a solid is a closed manifold: every edge
+/// is shared by exactly 2 faces within its shell. Returns `false` for open
+/// shells (boundary edges with count == 1) and non-manifold shells
+/// (count > 2). Walks inner (cavity) shells as well as the outer shell —
+/// each shell is an independent closed surface, so a single pooled count
+/// per shell is correct.
 ///
 /// Stricter than [`brepkit_topology::validation::validate_shell_manifold`],
 /// which only rejects edges shared by *more* than two faces.
 fn is_closed_manifold(topo: &Topology, solid: SolidId) -> Result<bool, crate::OperationsError> {
+    let s = topo.solid(solid)?;
+    let shell_ids: Vec<_> = std::iter::once(s.outer_shell())
+        .chain(s.inner_shells().iter().copied())
+        .collect();
+    for shell_id in shell_ids {
+        let shell = topo.shell(shell_id)?;
+        if !shell_is_closed_manifold(topo, shell)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn shell_is_closed_manifold(
+    topo: &Topology,
+    shell: &brepkit_topology::shell::Shell,
+) -> Result<bool, crate::OperationsError> {
     use std::collections::HashMap;
 
-    let s = topo.solid(solid)?;
-    let shell = topo.shell(s.outer_shell())?;
     let mut counts: HashMap<usize, usize> = HashMap::new();
     for &fid in shell.faces() {
         let face = topo.face(fid)?;

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -3990,7 +3990,6 @@ fn cut_concentric_rounded_rect_arc_prisms_overshoot() {
 }
 
 #[test]
-#[ignore = "known bug: acceptance gate rejects nested-cavity GFA result"]
 fn cut_concentric_rounded_rect_arc_prisms_cavity() {
     // Fully-enclosed cavity: tool z=5..20 strictly inside body z=0..21.
     let mut topo = Topology::new();

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -3774,3 +3774,243 @@ fn cut_shelled_target_single_tool_exact_gfa() {
         "volume should be exactly 5614, got {vol}"
     );
 }
+
+// ── Rounded-rect prisms with true Circle arc corners ────────────────
+//
+// Gridfinity-shaped repros: extruded rounded rectangles (4 planes +
+// 4 tangent quarter-cylinder corners) fused at coplanar interfaces or
+// cut concentrically. Volume oracles are exact closed forms:
+// area = w*d - (4 - PI) * r^2.
+
+/// Build a rounded-rectangle planar face at height `z` with 4 line edges
+/// and 4 true quarter-circle `EdgeCurve::Circle` arc edges (CCW, +Z normal).
+fn make_rounded_rect_arc_face(topo: &mut Topology, hw: f64, hd: f64, r: f64, z: f64) -> FaceId {
+    use brepkit_math::curves::Circle3D;
+
+    let tol_val = 1e-7;
+    // 8 tangent points, CCW starting at bottom of the right edge.
+    let pts: [(f64, f64); 8] = [
+        (hw, -(hd - r)),
+        (hw, hd - r),
+        (hw - r, hd),
+        (-(hw - r), hd),
+        (-hw, hd - r),
+        (-hw, -(hd - r)),
+        (-(hw - r), -hd),
+        (hw - r, -hd),
+    ];
+    let centers: [(f64, f64); 4] = [
+        (hw - r, hd - r),
+        (-(hw - r), hd - r),
+        (-(hw - r), -(hd - r)),
+        (hw - r, -(hd - r)),
+    ];
+
+    let vids: Vec<_> = pts
+        .iter()
+        .map(|&(x, y)| topo.add_vertex(Vertex::new(Point3::new(x, y, z), tol_val)))
+        .collect();
+
+    let normal = Vec3::new(0.0, 0.0, 1.0);
+    let mut eids: Vec<EdgeId> = Vec::with_capacity(8);
+    for i in 0..4 {
+        let line_start = vids[2 * i];
+        let line_end = vids[(2 * i + 1) % 8];
+        eids.push(topo.add_edge(Edge::new(line_start, line_end, EdgeCurve::Line)));
+
+        let arc_start = vids[(2 * i + 1) % 8];
+        let arc_end = vids[(2 * i + 2) % 8];
+        let (cx, cy) = centers[i];
+        let center = Point3::new(cx, cy, z);
+        let start_pt = Point3::new(pts[(2 * i + 1) % 8].0, pts[(2 * i + 1) % 8].1, z);
+        let radial = start_pt - center;
+        let u_axis = Vec3::new(radial.x() / r, radial.y() / r, radial.z() / r);
+        let v_axis = normal.cross(u_axis);
+        let circle = Circle3D::with_axes(center, normal, r, u_axis, v_axis).unwrap();
+        eids.push(topo.add_edge(Edge::new(arc_start, arc_end, EdgeCurve::Circle(circle))));
+    }
+
+    let wire = Wire::new(
+        eids.iter()
+            .map(|&eid| OrientedEdge::new(eid, true))
+            .collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    topo.add_face(Face::new(wid, vec![], FaceSurface::Plane { normal, d: z }))
+}
+
+/// Extrude a rounded-rect arc face from `z0` upward by `height`.
+fn make_rounded_rect_arc_prism(
+    topo: &mut Topology,
+    hw: f64,
+    hd: f64,
+    r: f64,
+    z0: f64,
+    height: f64,
+) -> SolidId {
+    let face = make_rounded_rect_arc_face(topo, hw, hd, r, z0);
+    crate::extrude::extrude(topo, face, Vec3::new(0.0, 0.0, 1.0), height).unwrap()
+}
+
+fn rounded_rect_area(hw: f64, hd: f64, r: f64) -> f64 {
+    4.0 * hw * hd - (4.0 - std::f64::consts::PI) * r * r
+}
+
+fn count_cylinder_faces(topo: &Topology, solid: SolidId) -> usize {
+    brepkit_topology::explorer::solid_faces(topo, solid)
+        .unwrap()
+        .iter()
+        .filter(|&&fid| {
+            matches!(
+                topo.face(fid).unwrap().surface(),
+                FaceSurface::Cylinder { .. }
+            )
+        })
+        .count()
+}
+
+#[test]
+fn rounded_rect_arc_prism_volume_baseline() {
+    let mut topo = Topology::new();
+    let a = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, 0.0, 16.0);
+    let expected = rounded_rect_area(20.75, 20.75, 3.75) * 16.0;
+    let vol = crate::measure::solid_volume(&topo, a, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 1e-3,
+        "prism volume {vol:.2} != expected {expected:.2}"
+    );
+    assert_eq!(count_cylinder_faces(&topo, a), 4);
+    assert!(is_closed_manifold(&topo, a).unwrap());
+}
+
+#[test]
+fn fuse_stacked_rounded_rect_arc_prisms_same_footprint() {
+    let mut topo = Topology::new();
+    let a = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, 0.0, 16.0);
+    let b = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, -4.0, 4.0);
+
+    let result = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+
+    let expected = rounded_rect_area(20.75, 20.75, 3.75) * 20.0;
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 1e-3,
+        "fused volume {vol:.2} != expected {expected:.2}"
+    );
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "fuse result must be closed-manifold"
+    );
+    assert!(!has_free_edges(&topo, result).unwrap());
+    let cyl = count_cylinder_faces(&topo, result);
+    assert!(
+        (4..=8).contains(&cyl),
+        "expected 4-8 analytic cylinder corner faces (no mesh fallback), got {cyl}"
+    );
+}
+
+#[test]
+#[ignore = "known bug: SD replacement missing for partially-overlapping lateral faces"]
+fn fuse_overlapping_rounded_rect_arc_prisms_same_footprint() {
+    let mut topo = Topology::new();
+    let a = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, 0.0, 16.0);
+    let b = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, -4.0, 5.0);
+
+    let result = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+
+    let expected = rounded_rect_area(20.75, 20.75, 3.75) * 20.0;
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 1e-3,
+        "fused volume {vol:.2} != expected {expected:.2}"
+    );
+    assert!(is_closed_manifold(&topo, result).unwrap());
+    assert!(!has_free_edges(&topo, result).unwrap());
+    let cyl = count_cylinder_faces(&topo, result);
+    assert!(
+        (4..=8).contains(&cyl),
+        "expected 4-8 analytic cylinder corner faces (no mesh fallback), got {cyl}"
+    );
+}
+
+#[test]
+#[ignore = "known bug: tool dropped when coplanar interface is contained in partner cap"]
+fn fuse_stacked_rounded_rect_arc_prisms_nested_footprint() {
+    // Tool's coplanar interface face strictly contained in the body's
+    // bottom cap: socket (smaller) below the body, touching at z=0.
+    let mut topo = Topology::new();
+    let a = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, 0.0, 16.0);
+    let b = make_rounded_rect_arc_prism(&mut topo, 19.55, 19.55, 2.55, -4.0, 4.0);
+
+    let result = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+
+    let expected =
+        rounded_rect_area(20.75, 20.75, 3.75) * 16.0 + rounded_rect_area(19.55, 19.55, 2.55) * 4.0;
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 1e-3,
+        "fused volume {vol:.2} != expected {expected:.2}"
+    );
+    assert!(is_closed_manifold(&topo, result).unwrap());
+    assert!(!has_free_edges(&topo, result).unwrap());
+    let cyl = count_cylinder_faces(&topo, result);
+    assert_eq!(
+        cyl, 8,
+        "expected 8 analytic cylinder corner faces (no mesh fallback), got {cyl}"
+    );
+}
+
+#[test]
+#[ignore = "known bug: split-edge mismatch at the cut plane for arc boundaries"]
+fn cut_concentric_rounded_rect_arc_prisms_overshoot() {
+    // Gridfinity bin pocket: outer 41.5 sq r=3.75 z=0..21, tool
+    // 39.1 sq r=2.55 z=5..25 (overshoots the top).
+    let mut topo = Topology::new();
+    let body = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, 0.0, 21.0);
+    let tool = make_rounded_rect_arc_prism(&mut topo, 19.55, 19.55, 2.55, 5.0, 20.0);
+
+    let result = boolean(&mut topo, BooleanOp::Cut, body, tool).unwrap();
+
+    let expected =
+        rounded_rect_area(20.75, 20.75, 3.75) * 21.0 - rounded_rect_area(19.55, 19.55, 2.55) * 16.0;
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 1e-3,
+        "cut volume {vol:.2} != expected {expected:.2}"
+    );
+    assert!(is_closed_manifold(&topo, result).unwrap());
+    assert!(!has_free_edges(&topo, result).unwrap());
+    let cyl = count_cylinder_faces(&topo, result);
+    assert_eq!(
+        cyl, 8,
+        "expected 8 analytic cylinder faces (4 outer + 4 pocket), got {cyl}"
+    );
+}
+
+#[test]
+#[ignore = "known bug: acceptance gate rejects nested-cavity GFA result"]
+fn cut_concentric_rounded_rect_arc_prisms_cavity() {
+    // Fully-enclosed cavity: tool z=5..20 strictly inside body z=0..21.
+    let mut topo = Topology::new();
+    let body = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, 0.0, 21.0);
+    let tool = make_rounded_rect_arc_prism(&mut topo, 19.55, 19.55, 2.55, 5.0, 15.0);
+
+    let result = boolean(&mut topo, BooleanOp::Cut, body, tool).unwrap();
+
+    let expected =
+        rounded_rect_area(20.75, 20.75, 3.75) * 21.0 - rounded_rect_area(19.55, 19.55, 2.55) * 15.0;
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 1e-3,
+        "cavity cut volume {vol:.2} != expected {expected:.2}"
+    );
+    assert!(is_closed_manifold(&topo, result).unwrap());
+    assert!(!has_free_edges(&topo, result).unwrap());
+    let cyl = count_cylinder_faces(&topo, result);
+    assert_eq!(
+        cyl, 8,
+        "expected 8 analytic cylinder faces (4 outer + 4 cavity), got {cyl}"
+    );
+}

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -3912,7 +3912,6 @@ fn fuse_stacked_rounded_rect_arc_prisms_same_footprint() {
 }
 
 #[test]
-#[ignore = "known bug: SD replacement missing for partially-overlapping lateral faces"]
 fn fuse_overlapping_rounded_rect_arc_prisms_same_footprint() {
     let mut topo = Topology::new();
     let a = make_rounded_rect_arc_prism(&mut topo, 20.75, 20.75, 3.75, 0.0, 16.0);
@@ -3928,10 +3927,14 @@ fn fuse_overlapping_rounded_rect_arc_prisms_same_footprint() {
     );
     assert!(is_closed_manifold(&topo, result).unwrap());
     assert!(!has_free_edges(&topo, result).unwrap());
+    // The partial overlap leaves three lateral z-bands (below, overlap,
+    // above); a valid result keeps every corner analytic whether or not
+    // the bands merge: 4 corners x up to 3 bands. A mesh fallback would
+    // leave 0 cylinder faces.
     let cyl = count_cylinder_faces(&topo, result);
     assert!(
-        (4..=8).contains(&cyl),
-        "expected 4-8 analytic cylinder corner faces (no mesh fallback), got {cyl}"
+        (4..=12).contains(&cyl),
+        "expected 4-12 analytic cylinder corner faces (no mesh fallback), got {cyl}"
     );
 }
 

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -3936,7 +3936,6 @@ fn fuse_overlapping_rounded_rect_arc_prisms_same_footprint() {
 }
 
 #[test]
-#[ignore = "known bug: tool dropped when coplanar interface is contained in partner cap"]
 fn fuse_stacked_rounded_rect_arc_prisms_nested_footprint() {
     // Tool's coplanar interface face strictly contained in the body's
     // bottom cap: socket (smaller) below the body, touching at z=0.
@@ -3963,7 +3962,6 @@ fn fuse_stacked_rounded_rect_arc_prisms_nested_footprint() {
 }
 
 #[test]
-#[ignore = "known bug: split-edge mismatch at the cut plane for arc boundaries"]
 fn cut_concentric_rounded_rect_arc_prisms_overshoot() {
     // Gridfinity bin pocket: outer 41.5 sq r=3.75 z=0..21, tool
     // 39.1 sq r=2.55 z=5..25 (overshoots the top).

--- a/crates/topology/src/edge.rs
+++ b/crates/topology/src/edge.rs
@@ -59,14 +59,39 @@ impl EdgeCurve {
 
     /// Parameter domain of this curve.
     ///
-    /// `Line` uses `[0, 1]`. Circle and Ellipse use `[0, 2π]`. NURBS uses
-    /// its knot span.
+    /// `Line` uses `[0, 1]`. NURBS uses its knot span. Closed Circle and
+    /// Ellipse edges (`start ≈ end`) use the full `[0, 2π]` domain. Open
+    /// arcs project both endpoints onto the curve and return the CCW
+    /// angular range `[a₀, a₁]` with `a₁ > a₀`, so sampling the domain
+    /// traces exactly the trimmed arc rather than the full curve.
     #[must_use]
-    pub fn domain_with_endpoints(&self, _start: Point3, _end: Point3) -> (f64, f64) {
+    pub fn domain_with_endpoints(&self, start: Point3, end: Point3) -> (f64, f64) {
+        const TAU: f64 = std::f64::consts::TAU;
+        // Below this chord the endpoints are considered coincident and the
+        // edge is treated as a closed (full) curve.
+        const CLOSED_EPS: f64 = 1e-9;
         match self {
             Self::Line => (0.0, 1.0),
-            Self::Circle(c) => ParametricCurve::domain(c),
-            Self::Ellipse(e) => ParametricCurve::domain(e),
+            Self::Circle(c) => {
+                if (start - end).length() < CLOSED_EPS {
+                    ParametricCurve::domain(c)
+                } else {
+                    let a0 = c.project(start);
+                    let delta = (c.project(end) - a0).rem_euclid(TAU);
+                    let delta = if delta < 1e-12 { TAU } else { delta };
+                    (a0, a0 + delta)
+                }
+            }
+            Self::Ellipse(e) => {
+                if (start - end).length() < CLOSED_EPS {
+                    ParametricCurve::domain(e)
+                } else {
+                    let a0 = e.project(start);
+                    let delta = (e.project(end) - a0).rem_euclid(TAU);
+                    let delta = if delta < 1e-12 { TAU } else { delta };
+                    (a0, a0 + delta)
+                }
+            }
             Self::NurbsCurve(n) => ParametricCurve::domain(n),
         }
     }


### PR DESCRIPTION
Extruded rounded-rectangle prisms (4 planes + 4 tangent quarter-cylinder corners) meeting at coplanar interfaces or partial lateral overlaps previously failed GFA validation on every boolean and silently fell back to the mesh path — the root cause of systematic non-manifold exports downstream. Now valid through pure GFA: arc-aware coplanar sections, SD handling for partial overlaps, partial-band UV unwrap with seam-window demotion, hollow-cut acceptance (2K Euler surplus for closed inner shells), plus two root-cause fixes found en route: phase EF no longer records tangent contacts at an edge's own endpoint as crossings, and open Circle/Ellipse edges keep curve-forward vertex order with a reversed flag (reverse-traversed quarter arcs were stored as their 3π/2 complements, costing volume in every watertight tessellation). Five new regression oracles (tangent/partial/nested fuse, overshoot/cavity cut) within 0.1% of analytic volumes, closed-manifold, analytic corners preserved. Full workspace green ×3 consecutive runs.