### PR TITLE
fix(tessellate): route grouped solid tessellation through the watertight shared-edge pipeline

### DIFF
--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -82,7 +82,10 @@ pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize {
 /// `tri_faces` is a parallel tri -> face attribution array (one entry per
 /// triangle); entries for removed triangles are filtered alongside so group
 /// offsets recomputed from it stay aligned.
-pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh, tri_faces: &mut Vec<u32>) {
+pub(super) fn dedupe_coincident_triangles(
+    mesh: &mut TriangleMesh,
+    tri_faces: Option<&mut Vec<u32>>,
+) {
     /// 1µm grid: tight enough that legitimately distinct CAD features (down to
     /// ~10µm geometry like thin plates) keep separate keys, while still
     /// merging post-merge floating-point noise in coincident vertices that
@@ -169,16 +172,18 @@ pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh, tri_faces: &m
     }
 
     let mut new_indices = Vec::with_capacity(mesh.indices.len());
-    let mut new_tri_faces = Vec::with_capacity(tri_faces.len());
+    let mut new_tri_faces = Vec::with_capacity(tri_faces.as_ref().map_or(0, |tf| tf.len()));
     for (t, &k) in keep.iter().enumerate().take(tri_count) {
         if k {
             new_indices.extend_from_slice(&mesh.indices[t * 3..t * 3 + 3]);
-            if let Some(&f) = tri_faces.get(t) {
+            if let Some(&f) = tri_faces.as_ref().and_then(|tf| tf.get(t)) {
                 new_tri_faces.push(f);
             }
         }
     }
-    *tri_faces = new_tri_faces;
+    if let Some(tf) = tri_faces {
+        *tf = new_tri_faces;
+    }
 
     // Compact the position/normal buffers: drop any vertex no longer
     // referenced by a surviving triangle. Downstream consumers that iterate
@@ -350,7 +355,7 @@ pub fn sample_solid_edges_filtered(
 pub(super) fn weld_boundary_vertices(
     mesh: &mut TriangleMesh,
     deflection: f64,
-    tri_faces: &mut Vec<u32>,
+    tri_faces: Option<&mut Vec<u32>>,
 ) {
     let n_verts = mesh.positions.len();
     if n_verts == 0 || mesh.indices.is_empty() {
@@ -458,19 +463,21 @@ pub(super) fn weld_boundary_vertices(
 
     if changed {
         let mut new_indices = Vec::with_capacity(mesh.indices.len());
-        let mut new_tri_faces = Vec::with_capacity(tri_faces.len());
+        let mut new_tri_faces = Vec::with_capacity(tri_faces.as_ref().map_or(0, |tf| tf.len()));
         for (t, tri) in mesh.indices.chunks_exact(3).enumerate() {
             let (i0, i1, i2) = (tri[0], tri[1], tri[2]);
             if i0 != i1 && i1 != i2 && i2 != i0 {
                 new_indices.push(i0);
                 new_indices.push(i1);
                 new_indices.push(i2);
-                if let Some(&f) = tri_faces.get(t) {
+                if let Some(&f) = tri_faces.as_ref().and_then(|tf| tf.get(t)) {
                     new_tri_faces.push(f);
                 }
             }
         }
         mesh.indices = new_indices;
-        *tri_faces = new_tri_faces;
+        if let Some(tf) = tri_faces {
+            *tf = new_tri_faces;
+        }
     }
 }

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -79,7 +79,10 @@ pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize {
 /// (sort-permutation parity equal) deduplicate to one triangle; pairs with
 /// opposite winding cancel (both removed) — that's the signature of two faces
 /// tessellated from opposite sides of the same plane.
-pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh) {
+/// `tri_faces` is a parallel tri -> face attribution array (one entry per
+/// triangle); entries for removed triangles are filtered alongside so group
+/// offsets recomputed from it stay aligned.
+pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh, tri_faces: &mut Vec<u32>) {
     /// 1µm grid: tight enough that legitimately distinct CAD features (down to
     /// ~10µm geometry like thin plates) keep separate keys, while still
     /// merging post-merge floating-point noise in coincident vertices that
@@ -166,11 +169,16 @@ pub(super) fn dedupe_coincident_triangles(mesh: &mut TriangleMesh) {
     }
 
     let mut new_indices = Vec::with_capacity(mesh.indices.len());
+    let mut new_tri_faces = Vec::with_capacity(tri_faces.len());
     for (t, &k) in keep.iter().enumerate().take(tri_count) {
         if k {
             new_indices.extend_from_slice(&mesh.indices[t * 3..t * 3 + 3]);
+            if let Some(&f) = tri_faces.get(t) {
+                new_tri_faces.push(f);
+            }
         }
     }
+    *tri_faces = new_tri_faces;
 
     // Compact the position/normal buffers: drop any vertex no longer
     // referenced by a surviving triangle. Downstream consumers that iterate
@@ -337,7 +345,13 @@ pub fn sample_solid_edges_filtered(
 /// Uses union-find over a spatial hash grid to merge boundary vertices that
 /// are within `weld_tol` of each other. Rewrites triangle indices and removes
 /// degenerate triangles (where merged indices create duplicate vertices).
-pub(super) fn weld_boundary_vertices(mesh: &mut TriangleMesh, deflection: f64) {
+/// `tri_faces` is the parallel tri -> face attribution array; entries for
+/// removed degenerate triangles are filtered alongside.
+pub(super) fn weld_boundary_vertices(
+    mesh: &mut TriangleMesh,
+    deflection: f64,
+    tri_faces: &mut Vec<u32>,
+) {
     let n_verts = mesh.positions.len();
     if n_verts == 0 || mesh.indices.is_empty() {
         return;
@@ -444,14 +458,19 @@ pub(super) fn weld_boundary_vertices(mesh: &mut TriangleMesh, deflection: f64) {
 
     if changed {
         let mut new_indices = Vec::with_capacity(mesh.indices.len());
-        for tri in mesh.indices.chunks_exact(3) {
+        let mut new_tri_faces = Vec::with_capacity(tri_faces.len());
+        for (t, tri) in mesh.indices.chunks_exact(3).enumerate() {
             let (i0, i1, i2) = (tri[0], tri[1], tri[2]);
             if i0 != i1 && i1 != i2 && i2 != i0 {
                 new_indices.push(i0);
                 new_indices.push(i1);
                 new_indices.push(i2);
+                if let Some(&f) = tri_faces.get(t) {
+                    new_tri_faces.push(f);
+                }
             }
         }
         mesh.indices = new_indices;
+        *tri_faces = new_tri_faces;
     }
 }

--- a/crates/operations/src/tessellate/mod.rs
+++ b/crates/operations/src/tessellate/mod.rs
@@ -39,7 +39,9 @@ pub use mesh_ops::{
     EdgeLines, boundary_edge_count, is_watertight, non_manifold_edge_count, sample_solid_edges,
     sample_solid_edges_filtered,
 };
-pub use solid::{tessellate_solid, tessellate_solid_with_tolerance};
+pub use solid::{
+    tessellate_solid, tessellate_solid_grouped_with_tolerance, tessellate_solid_with_tolerance,
+};
 
 /// Merge-grid cell size for tolerance-based vertex deduplication.
 ///

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -61,13 +61,83 @@ pub fn tessellate_solid(
 /// # Errors
 ///
 /// Returns an error if any topology lookup or face tessellation fails.
-#[allow(clippy::too_many_lines)]
 pub fn tessellate_solid_with_tolerance(
     topo: &Topology,
     solid: SolidId,
     deflection: f64,
     angular_tol: f64,
 ) -> Result<TriangleMesh, crate::OperationsError> {
+    tessellate_solid_core(topo, solid, deflection, angular_tol).map(|(mesh, _, _)| mesh)
+}
+
+/// Watertight solid tessellation with per-face triangle grouping.
+///
+/// Runs the same shared-edge-pool pipeline as [`tessellate_solid_with_tolerance`],
+/// then reorders triangles so each face's triangles are contiguous. Returns the
+/// mesh plus `face_offsets`: one entry per face of
+/// `explorer::solid_faces(topo, solid)` (in that order, including empty groups)
+/// where `face_offsets[i]` is the start offset into `mesh.indices` for face `i`,
+/// plus a final sentinel equal to `mesh.indices.len()`.
+///
+/// # Errors
+///
+/// Returns an error if any topology lookup or face tessellation fails.
+pub fn tessellate_solid_grouped_with_tolerance(
+    topo: &Topology,
+    solid: SolidId,
+    deflection: f64,
+    angular_tol: f64,
+) -> Result<(TriangleMesh, Vec<u32>), crate::OperationsError> {
+    let (mut mesh, tri_faces, n_faces) =
+        tessellate_solid_core(topo, solid, deflection, angular_tol)?;
+    debug_assert_eq!(tri_faces.len() * 3, mesh.indices.len());
+
+    let mut counts = vec![0_u32; n_faces];
+    for &f in &tri_faces {
+        if let Some(c) = counts.get_mut(f as usize) {
+            *c += 1;
+        }
+    }
+
+    let mut face_offsets = Vec::with_capacity(n_faces + 1);
+    let mut acc = 0_u32;
+    face_offsets.push(0_u32);
+    for &c in &counts {
+        acc += c * 3;
+        face_offsets.push(acc);
+    }
+
+    // Stable counting-sort scatter: per-face triangle order is preserved.
+    let mut cursors: Vec<usize> = face_offsets[..n_faces]
+        .iter()
+        .map(|&o| o as usize)
+        .collect();
+    let mut new_indices = vec![0_u32; mesh.indices.len()];
+    for (t, &f) in tri_faces.iter().enumerate() {
+        let Some(cursor) = cursors.get_mut(f as usize) else {
+            continue;
+        };
+        let dst = *cursor;
+        new_indices[dst..dst + 3].copy_from_slice(&mesh.indices[t * 3..t * 3 + 3]);
+        *cursor += 3;
+    }
+    mesh.indices = new_indices;
+
+    Ok((mesh, face_offsets))
+}
+
+/// Core watertight tessellation pipeline.
+///
+/// Returns the merged mesh, a parallel `tri -> face` array (one entry per
+/// triangle, holding the index of the owning face within
+/// `explorer::solid_faces` order), and the face count.
+#[allow(clippy::too_many_lines)]
+fn tessellate_solid_core(
+    topo: &Topology,
+    solid: SolidId,
+    deflection: f64,
+    angular_tol: f64,
+) -> Result<(TriangleMesh, Vec<u32>, usize), crate::OperationsError> {
     use brepkit_topology::explorer;
 
     // Phase 1: Collect all faces and build edge->face adjacency.
@@ -302,8 +372,12 @@ pub fn tessellate_solid_with_tolerance(
     }
 
     // Phase 4: Tessellate each face using its boundary edge vertices.
+    // `tri_faces` runs parallel to the mesh triangles: tri_faces[t] is the
+    // index (into `all_faces`) of the face that produced triangle t.
+    let mut tri_faces: Vec<u32> = Vec::new();
     #[allow(clippy::items_after_statements)]
     struct CdtJob {
+        face_index: u32,
         pts2d: Vec<brepkit_math::vec::Point2>,
         outer_count: usize,
         inner_wire_ranges: Vec<(usize, usize)>,
@@ -381,7 +455,9 @@ pub fn tessellate_solid_with_tolerance(
                     .map(|&p| project_by_normal(p, normal))
                     .collect();
 
+                #[allow(clippy::cast_possible_truncation)]
                 cdt_jobs.push(CdtJob {
+                    face_index: fi as u32,
                     pts2d,
                     outer_count,
                     inner_wire_ranges,
@@ -436,6 +512,7 @@ pub fn tessellate_solid_with_tolerance(
             let g0 = job.all_global_ids[i0].unwrap_or(0);
             let g1 = job.all_global_ids[i1].unwrap_or(0);
             let g2 = job.all_global_ids[i2].unwrap_or(0);
+            tri_faces.push(job.face_index);
             if needs_flip {
                 merged.indices.push(g0);
                 merged.indices.push(g2);
@@ -461,6 +538,10 @@ pub fn tessellate_solid_with_tolerance(
         ) {
             log::warn!("skipping face during tessellation: {e}");
         }
+        // Attribute every triangle appended by this face (even partial output
+        // before an error) so tri_faces stays parallel to the triangle list.
+        #[allow(clippy::cast_possible_truncation)]
+        tri_faces.resize(merged.indices.len() / 3, fi as u32);
     }
 
     // Phase 5: Surface-aware vertex normals.
@@ -550,15 +631,15 @@ pub fn tessellate_solid_with_tolerance(
     }
 
     // Phase 6: Weld boundary vertices.
-    weld_boundary_vertices(&mut merged, deflection);
+    weld_boundary_vertices(&mut merged, deflection, &mut tri_faces);
 
     // Phase 7: Drop coincident/cancelling triangles left by booleans that
     // produced overlapping coplanar faces (issue #696). Keyed on quantized
     // positions so position-coincident triangles with distinct vertex IDs
     // are still caught.
-    dedupe_coincident_triangles(&mut merged);
+    dedupe_coincident_triangles(&mut merged, &mut tri_faces);
 
-    Ok(merged)
+    Ok((merged, tri_faces, all_faces.len()))
 }
 
 /// Tessellate a single face, reusing shared edge vertices from the global mesh.

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -67,7 +67,7 @@ pub fn tessellate_solid_with_tolerance(
     deflection: f64,
     angular_tol: f64,
 ) -> Result<TriangleMesh, crate::OperationsError> {
-    tessellate_solid_core(topo, solid, deflection, angular_tol).map(|(mesh, _, _)| mesh)
+    tessellate_solid_core(topo, solid, deflection, angular_tol, false).map(|(mesh, _, _)| mesh)
 }
 
 /// Watertight solid tessellation with per-face triangle grouping.
@@ -89,7 +89,8 @@ pub fn tessellate_solid_grouped_with_tolerance(
     angular_tol: f64,
 ) -> Result<(TriangleMesh, Vec<u32>), crate::OperationsError> {
     let (mut mesh, tri_faces, n_faces) =
-        tessellate_solid_core(topo, solid, deflection, angular_tol)?;
+        tessellate_solid_core(topo, solid, deflection, angular_tol, true)?;
+    let tri_faces = tri_faces.unwrap_or_default();
     debug_assert_eq!(tri_faces.len() * 3, mesh.indices.len());
 
     let mut counts = vec![0_u32; n_faces];
@@ -128,16 +129,18 @@ pub fn tessellate_solid_grouped_with_tolerance(
 
 /// Core watertight tessellation pipeline.
 ///
-/// Returns the merged mesh, a parallel `tri -> face` array (one entry per
-/// triangle, holding the index of the owning face within
-/// `explorer::solid_faces` order), and the face count.
+/// When `track_faces` is set, also returns a parallel `tri -> face` array (one
+/// entry per triangle, holding the index of the owning face within
+/// `explorer::solid_faces` order); otherwise the attribution bookkeeping is
+/// skipped and `None` is returned. The face count is always returned.
 #[allow(clippy::too_many_lines)]
 fn tessellate_solid_core(
     topo: &Topology,
     solid: SolidId,
     deflection: f64,
     angular_tol: f64,
-) -> Result<(TriangleMesh, Vec<u32>, usize), crate::OperationsError> {
+    track_faces: bool,
+) -> Result<(TriangleMesh, Option<Vec<u32>>, usize), crate::OperationsError> {
     use brepkit_topology::explorer;
 
     // Phase 1: Collect all faces and build edge->face adjacency.
@@ -372,9 +375,10 @@ fn tessellate_solid_core(
     }
 
     // Phase 4: Tessellate each face using its boundary edge vertices.
-    // `tri_faces` runs parallel to the mesh triangles: tri_faces[t] is the
-    // index (into `all_faces`) of the face that produced triangle t.
-    let mut tri_faces: Vec<u32> = Vec::new();
+    // When tracking, `tri_faces` runs parallel to the mesh triangles:
+    // tri_faces[t] is the index (into `all_faces`) of the face that produced
+    // triangle t. The ungrouped caller skips this bookkeeping entirely.
+    let mut tri_faces: Option<Vec<u32>> = track_faces.then(Vec::new);
     #[allow(clippy::items_after_statements)]
     struct CdtJob {
         face_index: u32,
@@ -512,7 +516,9 @@ fn tessellate_solid_core(
             let g0 = job.all_global_ids[i0].unwrap_or(0);
             let g1 = job.all_global_ids[i1].unwrap_or(0);
             let g2 = job.all_global_ids[i2].unwrap_or(0);
-            tri_faces.push(job.face_index);
+            if let Some(tf) = tri_faces.as_mut() {
+                tf.push(job.face_index);
+            }
             if needs_flip {
                 merged.indices.push(g0);
                 merged.indices.push(g2);
@@ -540,8 +546,10 @@ fn tessellate_solid_core(
         }
         // Attribute every triangle appended by this face (even partial output
         // before an error) so tri_faces stays parallel to the triangle list.
-        #[allow(clippy::cast_possible_truncation)]
-        tri_faces.resize(merged.indices.len() / 3, fi as u32);
+        if let Some(tf) = tri_faces.as_mut() {
+            #[allow(clippy::cast_possible_truncation)]
+            tf.resize(merged.indices.len() / 3, fi as u32);
+        }
     }
 
     // Phase 5: Surface-aware vertex normals.
@@ -631,13 +639,13 @@ fn tessellate_solid_core(
     }
 
     // Phase 6: Weld boundary vertices.
-    weld_boundary_vertices(&mut merged, deflection, &mut tri_faces);
+    weld_boundary_vertices(&mut merged, deflection, tri_faces.as_mut());
 
     // Phase 7: Drop coincident/cancelling triangles left by booleans that
     // produced overlapping coplanar faces (issue #696). Keyed on quantized
     // positions so position-coincident triangles with distinct vertex IDs
     // are still caught.
-    dedupe_coincident_triangles(&mut merged, &mut tri_faces);
+    dedupe_coincident_triangles(&mut merged, tri_faces.as_mut());
 
     Ok((merged, tri_faces, all_faces.len()))
 }

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -429,7 +429,7 @@ fn dedupe_cancels_opposing_winding_pair() {
         indices: vec![0, 1, 2, 0, 2, 1],
     };
     let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, Some(&mut tri_faces));
     assert_eq!(
         mesh.indices.len(),
         0,
@@ -454,7 +454,7 @@ fn dedupe_collapses_same_winding_duplicate() {
         indices: vec![0, 1, 2, 0, 1, 2],
     };
     let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, Some(&mut tri_faces));
     assert_eq!(
         mesh.indices.len(),
         3,
@@ -479,7 +479,7 @@ fn dedupe_matches_position_coincidence_not_index() {
         indices: vec![0, 1, 2, 3, 4, 5],
     };
     let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, Some(&mut tri_faces));
     assert_eq!(
         mesh.indices.len(),
         3,
@@ -510,7 +510,7 @@ fn dedupe_preserves_thin_plate_geometry() {
         indices: vec![0, 1, 2, 3, 5, 4],
     };
     let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, Some(&mut tri_faces));
     assert_eq!(
         mesh.indices.len(),
         6,

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -428,7 +428,8 @@ fn dedupe_cancels_opposing_winding_pair() {
         normals: vec![Vec3::new(0.0, 0.0, 1.0); 3],
         indices: vec![0, 1, 2, 0, 2, 1],
     };
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
     assert_eq!(
         mesh.indices.len(),
         0,
@@ -452,7 +453,8 @@ fn dedupe_collapses_same_winding_duplicate() {
         normals: vec![Vec3::new(0.0, 0.0, 1.0); 3],
         indices: vec![0, 1, 2, 0, 1, 2],
     };
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
     assert_eq!(
         mesh.indices.len(),
         3,
@@ -476,7 +478,8 @@ fn dedupe_matches_position_coincidence_not_index() {
         normals: vec![Vec3::new(0.0, 0.0, 1.0); 6],
         indices: vec![0, 1, 2, 3, 4, 5],
     };
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
     assert_eq!(
         mesh.indices.len(),
         3,
@@ -506,7 +509,8 @@ fn dedupe_preserves_thin_plate_geometry() {
         normals: vec![Vec3::new(0.0, 0.0, 1.0); 6],
         indices: vec![0, 1, 2, 3, 5, 4],
     };
-    super::mesh_ops::dedupe_coincident_triangles(&mut mesh);
+    let mut tri_faces = vec![0_u32; mesh.indices.len() / 3];
+    super::mesh_ops::dedupe_coincident_triangles(&mut mesh, &mut tri_faces);
     assert_eq!(
         mesh.indices.len(),
         6,
@@ -1588,5 +1592,189 @@ fn circle_and_degenerate_ellipse_do_not_over_tessellate() {
     assert!(
         n_e < 5_000,
         "near-circular ellipse(5,5) over-tessellates: {n_e} mesh vertices"
+    );
+}
+
+// -- Grouped solid tessellation (wasm export path) --
+
+/// Count boundary and non-manifold edges with vertices unified by quantized
+/// (1e-4) position keys -- the same equivalence an STL export induces.
+fn quantized_edge_defects(mesh: &TriangleMesh) -> (usize, usize) {
+    const EXPORT_GRID: f64 = 1e-4;
+
+    let mut pos_to_canonical: DetHashMap<(i64, i64, i64), u32> = DetHashMap::default();
+    let mut canonical_ids: Vec<u32> = Vec::with_capacity(mesh.positions.len());
+    for pos in &mesh.positions {
+        let key = point_merge_key(*pos, EXPORT_GRID);
+        let next = pos_to_canonical.len() as u32;
+        canonical_ids.push(*pos_to_canonical.entry(key).or_insert(next));
+    }
+
+    let mut edge_count: DetHashMap<(u32, u32), (u32, u32)> = DetHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let i0 = canonical_ids[tri[0] as usize];
+        let i1 = canonical_ids[tri[1] as usize];
+        let i2 = canonical_ids[tri[2] as usize];
+        if i0 == i1 || i1 == i2 || i2 == i0 {
+            continue;
+        }
+        for (a, b) in [(i0, i1), (i1, i2), (i2, i0)] {
+            let entry = edge_count.entry((a.min(b), a.max(b))).or_default();
+            if a < b {
+                entry.0 += 1;
+            } else {
+                entry.1 += 1;
+            }
+        }
+    }
+
+    let boundary = edge_count
+        .values()
+        .filter(|&&(f, r)| f + r == 1 || (f + r == 2 && (f == 0 || r == 0)))
+        .count();
+    let non_manifold = edge_count.values().filter(|&&(f, r)| f + r > 2).count();
+    (boundary, non_manifold)
+}
+
+/// Box(21^3) cut by a through-cylinder(r=3.75) at (6,6): the canonical
+/// boolean-result solid that the wasm `tessellateSolidGrouped` path exported
+/// with T-junctions.
+fn make_box_with_through_hole(topo: &mut Topology) -> brepkit_topology::solid::SolidId {
+    use brepkit_math::mat::Mat4;
+    let bx = crate::primitives::make_box(topo, 21.0, 21.0, 21.0).unwrap();
+    let cyl = crate::primitives::make_cylinder(topo, 3.75, 30.0).unwrap();
+    crate::transform::transform_solid(topo, cyl, &Mat4::translation(6.0, 6.0, -5.0)).unwrap();
+    crate::boolean::boolean(topo, crate::boolean::BooleanOp::Cut, bx, cyl).unwrap()
+}
+
+/// Regression for the wasm `tessellateSolidGrouped` export path: the previous
+/// implementation merged standalone per-face tessellations, whose mismatched
+/// boundary vertices produced 156 boundary edges on this solid even under
+/// STL-export (1e-4) vertex quantization. The grouped output must now match
+/// the watertight shared-edge-pool invariant.
+#[test]
+fn grouped_tessellation_watertight_box_cut_cylinder() {
+    let mut topo = Topology::new();
+    let solid = make_box_with_through_hole(&mut topo);
+
+    // The watertight ungrouped path is the reference: it must pass.
+    let watertight = tessellate_solid_with_tolerance(
+        &topo,
+        solid,
+        0.1,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+    )
+    .unwrap();
+    let (wb, wn) = quantized_edge_defects(&watertight);
+    assert_eq!(
+        wb, 0,
+        "watertight path must have 0 boundary edges, got {wb}"
+    );
+    assert_eq!(
+        wn, 0,
+        "watertight path must have 0 non-manifold edges, got {wn}"
+    );
+
+    let (mesh, _offsets) = tessellate_solid_grouped_with_tolerance(
+        &topo,
+        solid,
+        0.1,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+    )
+    .unwrap();
+    let (gb, gn) = quantized_edge_defects(&mesh);
+    assert_eq!(
+        gb, 0,
+        "grouped tessellation must have 0 boundary edges, got {gb}"
+    );
+    assert_eq!(
+        gn, 0,
+        "grouped tessellation must have 0 non-manifold edges, got {gn}"
+    );
+
+    // Grouped output is a triangle-order permutation of the ungrouped mesh.
+    assert_eq!(mesh.indices.len(), watertight.indices.len());
+    assert_eq!(mesh.positions.len(), watertight.positions.len());
+}
+
+#[test]
+fn grouped_tessellation_offsets_invariants() {
+    let mut topo = Topology::new();
+    let solid = make_box_with_through_hole(&mut topo);
+    let faces = brepkit_topology::explorer::solid_faces(&topo, solid).unwrap();
+
+    let (mesh, offsets) = tessellate_solid_grouped_with_tolerance(
+        &topo,
+        solid,
+        0.1,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+    )
+    .unwrap();
+
+    assert_eq!(
+        offsets.len(),
+        faces.len() + 1,
+        "one offset per face plus sentinel (brepjs maps faceHash positionally)"
+    );
+    assert_eq!(offsets[0], 0);
+    assert_eq!(
+        *offsets.last().unwrap() as usize,
+        mesh.indices.len(),
+        "sentinel must equal indices.len()"
+    );
+    for w in offsets.windows(2) {
+        assert!(w[0] <= w[1], "offsets must be monotonic");
+        assert_eq!((w[1] - w[0]) % 3, 0, "group sizes must be whole triangles");
+    }
+}
+
+/// Group alignment check: every triangle in face i's group must lie on face
+/// i's surface. A silent offset misalignment (e.g. triangle deletion without
+/// filtering the attribution array) would put cylinder triangles in plane
+/// groups and fail here.
+#[test]
+fn grouped_tessellation_triangles_lie_on_their_face() {
+    let mut topo = Topology::new();
+    let solid = make_box_with_through_hole(&mut topo);
+    let faces = brepkit_topology::explorer::solid_faces(&topo, solid).unwrap();
+
+    let (mesh, offsets) = tessellate_solid_grouped_with_tolerance(
+        &topo,
+        solid,
+        0.1,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+    )
+    .unwrap();
+
+    let mut nonempty = 0;
+    for (fi, &face_id) in faces.iter().enumerate() {
+        let surf = topo.face(face_id).unwrap().surface().clone();
+        let group = &mesh.indices[offsets[fi] as usize..offsets[fi + 1] as usize];
+        if !group.is_empty() {
+            nonempty += 1;
+        }
+        for &vid in group {
+            let p = mesh.positions[vid as usize];
+            let dist = match &surf {
+                FaceSurface::Plane { normal, d } => {
+                    (normal.dot(p - Point3::new(0.0, 0.0, 0.0)) - d).abs()
+                }
+                FaceSurface::Cylinder(cyl) => {
+                    let to_p = p - cyl.origin();
+                    let axial = to_p.dot(cyl.axis());
+                    ((to_p - cyl.axis() * axial).length() - cyl.radius()).abs()
+                }
+                _ => 0.0,
+            };
+            assert!(
+                dist < 1e-6,
+                "face {fi} group contains a vertex {dist:.2e} off its surface"
+            );
+        }
+    }
+    assert!(
+        nonempty >= faces.len() - 1,
+        "expected nearly all groups nonempty, got {nonempty}/{}",
+        faces.len()
     );
 }

--- a/crates/wasm/src/bindings/tessellate.rs
+++ b/crates/wasm/src/bindings/tessellate.rs
@@ -81,6 +81,10 @@ impl BrepKernel {
     /// Returns a JSON string containing `{ positions, normals, indices, faceOffsets }`.
     /// `faceOffsets` is an array where `faceOffsets[i]` is the start index into
     /// `indices` for face `i`, and the last element is `indices.length`.
+    ///
+    /// Uses the watertight shared-edge-pool tessellation: adjacent faces share
+    /// identical boundary vertices, so the exported mesh has no T-junctions
+    /// regardless of how the solid was constructed (booleans included).
     #[wasm_bindgen(js_name = "tessellateSolidGrouped")]
     pub fn tessellate_solid_grouped(
         &self,
@@ -91,41 +95,27 @@ impl BrepKernel {
         validate_positive(deflection, "deflection")?;
         let angular_tol = resolve_angular_tol(angular_tolerance)?;
         let solid_id = self.resolve_solid(solid)?;
-        let faces = brepkit_topology::explorer::solid_faces(&self.topo, solid_id)?;
 
-        let mut all_positions: Vec<f64> = Vec::new();
-        let mut all_normals: Vec<f64> = Vec::new();
-        let mut all_indices: Vec<u32> = Vec::new();
-        let mut face_offsets: Vec<u32> = Vec::new();
+        let (mesh, face_offsets) = tessellate::tessellate_solid_grouped_with_tolerance(
+            &self.topo,
+            solid_id,
+            deflection,
+            angular_tol,
+        )?;
 
-        for &face_id in &faces {
-            #[allow(clippy::cast_possible_truncation)]
-            let idx_offset = (all_positions.len() / 3) as u32;
-            face_offsets.push(all_indices.len() as u32);
-
-            let mesh = tessellate::tessellate_with_tolerance(
-                &self.topo,
-                face_id,
-                deflection,
-                angular_tol,
-            )?;
-            for p in &mesh.positions {
-                all_positions.extend_from_slice(&[p.x(), p.y(), p.z()]);
-            }
-            for n in &mesh.normals {
-                all_normals.extend_from_slice(&[n.x(), n.y(), n.z()]);
-            }
-            for &idx in &mesh.indices {
-                all_indices.push(idx + idx_offset);
-            }
+        let mut all_positions: Vec<f64> = Vec::with_capacity(mesh.positions.len() * 3);
+        for p in &mesh.positions {
+            all_positions.extend_from_slice(&[p.x(), p.y(), p.z()]);
         }
-        #[allow(clippy::cast_possible_truncation)]
-        face_offsets.push(all_indices.len() as u32);
+        let mut all_normals: Vec<f64> = Vec::with_capacity(mesh.normals.len() * 3);
+        for n in &mesh.normals {
+            all_normals.extend_from_slice(&[n.x(), n.y(), n.z()]);
+        }
 
         let result = GroupedMeshResult {
             positions: all_positions,
             normals: all_normals,
-            indices: all_indices,
+            indices: mesh.indices,
             face_offsets,
         };
         Ok(serde_json::to_string(&result)
@@ -309,26 +299,30 @@ mod tests {
     fn tessellate_solid_grouped_via_operations() {
         let mut topo = brepkit_topology::topology::Topology::new();
         let solid = brepkit_operations::primitives::make_box(&mut topo, 2.0, 3.0, 4.0).unwrap();
-        let faces = brepkit_topology::explorer::solid_faces(&topo, solid).unwrap();
 
-        let mut all_positions = 0usize;
-        let mut all_indices = 0usize;
-        let mut face_offsets = Vec::new();
+        let (mesh, face_offsets) =
+            brepkit_operations::tessellate::tessellate_solid_grouped_with_tolerance(
+                &topo,
+                solid,
+                0.1,
+                brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+            )
+            .unwrap();
 
-        for &face_id in &faces {
-            face_offsets.push(all_indices);
-            if let Ok(mesh) = brepkit_operations::tessellate::tessellate(&topo, face_id, 0.1) {
-                all_positions += mesh.positions.len();
-                all_indices += mesh.indices.len();
-            }
-        }
-        face_offsets.push(all_indices);
-
-        assert!(all_positions > 0, "expected vertices");
-        assert!(all_indices > 0, "expected indices");
+        assert!(!mesh.positions.is_empty(), "expected vertices");
+        assert!(!mesh.indices.is_empty(), "expected indices");
         // Box has 6 faces, so faceOffsets has 7 entries (6 starts + 1 sentinel).
         assert_eq!(face_offsets.len(), 7, "expected 7 face offsets for a box");
-        assert_eq!(*face_offsets.last().unwrap(), all_indices);
+        assert_eq!(*face_offsets.last().unwrap() as usize, mesh.indices.len());
+        // Watertight grouped output: every group is a non-empty triangle run.
+        for w in face_offsets.windows(2) {
+            assert!(w[0] < w[1], "box face groups must be non-empty");
+            assert_eq!((w[1] - w[0]) % 3, 0);
+        }
+        assert!(
+            brepkit_operations::tessellate::is_watertight(&mesh),
+            "grouped box mesh must be watertight"
+        );
     }
 
     // ── mesh_edges_all ────────────────────────────────────────────


### PR DESCRIPTION
tessellateSolidGrouped (the wasm export path used for all solid meshing downstream) looped standalone per-face tessellation, so adjacent faces of boolean-result solids got mismatched boundary vertices → T-junctions → non-manifold STL exports regardless of boolean correctness. New tessellate_solid_grouped_with_tolerance carries a tri→face attribution array through weld and dedupe phases, emitting contiguous per-face groups preserving the GroupedMeshResult contract. Regression: box-minus-cylinder export went 156 boundary edges → 0. Note: boundary vertices are now shared with surface-averaged normals (same semantics as the ungrouped watertight path) — flagging for a downstream visual check on sharp-edge shading. Full gates + wasm target build green.