### PR TITLE
fix(operations): build shell arc edges along wire traversal direction

### DIFF
--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -130,16 +130,13 @@ fn build_inner_wires(
             let vi = iw_vert_ids[i].index();
             let vj = iw_vert_ids[j].index();
             let (key_min, key_max) = if vi <= vj { (vi, vj) } else { (vj, vi) };
-            let is_forward = vi <= vj;
 
             let edge_id = *edge_map.entry((key_min, key_max)).or_insert_with(|| {
-                let (start, end) = if vi <= vj {
-                    (iw_vert_ids[i], iw_vert_ids[j])
-                } else {
-                    (iw_vert_ids[j], iw_vert_ids[i])
-                };
-                topo.add_edge(Edge::new(start, end, EdgeCurve::Line))
+                topo.add_edge(Edge::new(iw_vert_ids[i], iw_vert_ids[j], EdgeCurve::Line))
             });
+            // Shared edges may carry a geometric direction (circle arcs), so
+            // derive orientation from the stored start vertex.
+            let is_forward = topo.edge(edge_id)?.start() == iw_vert_ids[i];
 
             iw_oriented_edges.push(OrientedEdge::new(edge_id, is_forward));
         }
@@ -230,14 +227,10 @@ pub(crate) fn assemble_solid_mixed(
                         continue; // Skip degenerate zero-length edges.
                     }
                     let (key_min, key_max) = if vi <= vj { (vi, vj) } else { (vj, vi) };
-                    let is_forward = vi <= vj;
 
                     let edge_id = *edge_map.entry((key_min, key_max)).or_insert_with(|| {
-                        let (start, end) = if vi <= vj {
-                            (vert_ids[i], vert_ids[j])
-                        } else {
-                            (vert_ids[j], vert_ids[i])
-                        };
+                        let start = vert_ids[i];
+                        let end = vert_ids[j];
 
                         // Determine if this edge is angular (arc) or axial (line)
                         // by projecting both endpoints onto the cylinder.
@@ -252,13 +245,28 @@ pub(crate) fn assemble_solid_mixed(
                             && u_diff < (std::f64::consts::TAU - tol.linear)
                             && v_diff < tol.linear * 100.0
                         {
+                            // A stored Circle arc runs CCW start→end around its
+                            // axis. Build the arc along the polygon traversal
+                            // i→j: when the wrapped u-step is negative the
+                            // traversal runs clockwise around cylinder.axis(),
+                            // so negate the axis — otherwise the stored arc
+                            // would be the complement of the intended span.
+                            let mut du = u2 - u1;
+                            if du > std::f64::consts::PI {
+                                du -= std::f64::consts::TAU;
+                            } else if du < -std::f64::consts::PI {
+                                du += std::f64::consts::TAU;
+                            }
+                            let axis = if du >= 0.0 {
+                                cylinder.axis()
+                            } else {
+                                -cylinder.axis()
+                            };
                             // Create a Circle3D at the v-level of this edge.
                             let center = cylinder.origin() + cylinder.axis() * ((v1 + v2) * 0.5);
-                            if let Ok(circle) = brepkit_math::curves::Circle3D::new(
-                                center,
-                                cylinder.axis(),
-                                cylinder.radius(),
-                            ) {
+                            if let Ok(circle) =
+                                brepkit_math::curves::Circle3D::new(center, axis, cylinder.radius())
+                            {
                                 topo.add_edge(Edge::new(start, end, EdgeCurve::Circle(circle)))
                             } else {
                                 topo.add_edge(Edge::new(start, end, EdgeCurve::Line))
@@ -268,6 +276,7 @@ pub(crate) fn assemble_solid_mixed(
                             topo.add_edge(Edge::new(start, end, EdgeCurve::Line))
                         }
                     });
+                    let is_forward = topo.edge(edge_id)?.start() == vert_ids[i];
 
                     if oriented_edges
                         .last()
@@ -350,16 +359,15 @@ pub(crate) fn assemble_solid_mixed(
                         continue;
                     }
                     let (key_min, key_max) = if vi <= vj { (vi, vj) } else { (vj, vi) };
-                    let is_forward = vi <= vj;
 
                     let edge_id = *edge_map.entry((key_min, key_max)).or_insert_with(|| {
-                        let (start, end) = if vi <= vj {
-                            (vert_ids[i], vert_ids[j])
-                        } else {
-                            (vert_ids[j], vert_ids[i])
-                        };
-                        topo.add_edge(Edge::new(start, end, EdgeCurve::Line))
+                        topo.add_edge(Edge::new(vert_ids[i], vert_ids[j], EdgeCurve::Line))
                     });
+                    // Shared edges (e.g. circle arcs created by an adjacent
+                    // cylindrical face) carry a geometric direction, so derive
+                    // orientation from the stored start vertex rather than
+                    // vertex-index order.
+                    let is_forward = topo.edge(edge_id)?.start() == vert_ids[i];
 
                     // Skip duplicate edges anywhere in the wire (not just consecutive).
                     // Duplicates arise when the polygon revisits a vertex pair due to
@@ -1026,11 +1034,16 @@ pub(super) fn refine_boundary_edges(
                     } else {
                         (vb_idx, va_idx)
                     };
-                    let fwd = va_idx <= vb_idx;
                     let sub_eid = *edge_map.entry((key_min, key_max)).or_insert_with(|| {
-                        let (s, e) = if fwd { (va, vb) } else { (vb, va) };
+                        // The chain runs in this wire's traversal order; a
+                        // stored Circle arc means CCW start→end around its
+                        // axis, so a sub-edge of a reversed traversal must be
+                        // stored with swapped endpoints to keep the sub-arc
+                        // on the parent arc's span.
+                        let (s, e) = if oe.is_forward() { (va, vb) } else { (vb, va) };
                         topo.add_edge(Edge::new(s, e, original_curve.clone()))
                     });
+                    let fwd = topo.edge(sub_eid)?.start() == va;
                     // Skip if edge already in wire (prevents duplicates from
                     // vertex merging creating overlapping segments).
                     if !new_oriented_edges

--- a/crates/operations/src/measure/area.rs
+++ b/crates/operations/src/measure/area.rs
@@ -48,28 +48,32 @@ pub fn face_area(
                 let v_min = v_vals.iter().copied().fold(f64::INFINITY, f64::min);
                 let v_max = v_vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
                 let height = (v_max - v_min).abs();
-                // Compute angular sweep from boundary points projected onto the
-                // circular cross-section. For full cylinders this gives 2pi; for
-                // partial cylinders it gives the actual angular extent.
-                let u_vals: Vec<f64> = positions
-                    .iter()
-                    .map(|p| {
-                        let rel = *p - origin;
-                        let along = axis.dot(rel);
-                        let radial = rel - axis * along;
-                        radial.y().atan2(radial.x())
-                    })
-                    .collect();
-                let u_min = u_vals.iter().copied().fold(f64::INFINITY, f64::min);
-                let u_max = u_vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-                let angular_span = u_max - u_min;
-                // If the angular span covers most of a full circle (> 350 deg),
-                // treat it as a full revolution -- boundary sampling may not
-                // reach exactly +/-pi.
-                let sweep = if angular_span > 330.0_f64.to_radians() {
-                    std::f64::consts::TAU
+                let sweep = if let Some(s) = cylinder_arc_sweep(topo, face_id, axis, origin)? {
+                    s
                 } else {
-                    angular_span
+                    // Compute angular sweep from boundary points projected onto the
+                    // circular cross-section. For full cylinders this gives 2pi; for
+                    // partial cylinders it gives the actual angular extent.
+                    let u_vals: Vec<f64> = positions
+                        .iter()
+                        .map(|p| {
+                            let rel = *p - origin;
+                            let along = axis.dot(rel);
+                            let radial = rel - axis * along;
+                            radial.y().atan2(radial.x())
+                        })
+                        .collect();
+                    let u_min = u_vals.iter().copied().fold(f64::INFINITY, f64::min);
+                    let u_max = u_vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                    let angular_span = u_max - u_min;
+                    // If the angular span covers most of a full circle (> 350 deg),
+                    // treat it as a full revolution -- boundary sampling may not
+                    // reach exactly +/-pi.
+                    if angular_span > 330.0_f64.to_radians() {
+                        std::f64::consts::TAU
+                    } else {
+                        angular_span
+                    }
                 };
                 Ok(sweep * r * height)
             } else {
@@ -104,6 +108,58 @@ pub fn face_area(
             Ok(triangle_mesh_area(&mesh))
         }
     }
+}
+
+/// Angular sweep of a cylindrical face derived from its boundary arc edges.
+///
+/// `face_polygon` only contributes endpoint vertices for partial arcs, so a
+/// point-based angular range misreads spans that cross the atan2 branch cut
+/// (e.g. a 90-degree corner arc straddling u=pi reads as 270 degrees). The
+/// stored `Circle` arcs carry the true span (CCW start→end around their own
+/// axis): sum the spans per axial level and take the widest level.
+///
+/// Returns `None` when the boundary has no circle arcs (chord-polygon faces),
+/// letting the caller fall back to point-based estimation.
+fn cylinder_arc_sweep(
+    topo: &Topology,
+    face_id: FaceId,
+    axis: Vec3,
+    origin: Point3,
+) -> Result<Option<f64>, crate::OperationsError> {
+    use brepkit_topology::edge::EdgeCurve;
+
+    let face = topo.face(face_id)?;
+    let wire = topo.wire(face.outer_wire())?;
+    let mut levels: Vec<(f64, f64)> = Vec::new();
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge())?;
+        let EdgeCurve::Circle(circle) = edge.curve() else {
+            continue;
+        };
+        if edge.start() == edge.end() {
+            return Ok(Some(std::f64::consts::TAU));
+        }
+        let sp = topo.vertex(edge.start())?.point();
+        let ep = topo.vertex(edge.end())?.point();
+        let ts = circle.project(sp);
+        let mut te = circle.project(ep);
+        if te <= ts {
+            te += std::f64::consts::TAU;
+        }
+        let span = te - ts;
+        let v = axis.dot(circle.center() - origin);
+        if let Some(entry) = levels.iter_mut().find(|(lv, _)| (*lv - v).abs() < 1e-6) {
+            entry.1 += span;
+        } else {
+            levels.push((v, span));
+        }
+    }
+    Ok(levels
+        .iter()
+        .map(|&(_, span)| span.min(std::f64::consts::TAU))
+        .fold(None, |acc: Option<f64>, span| {
+            Some(acc.map_or(span, |a| a.max(span)))
+        }))
 }
 
 /// Compute the area of a conical face analytically.

--- a/crates/operations/src/measure/area.rs
+++ b/crates/operations/src/measure/area.rs
@@ -128,6 +128,12 @@ fn cylinder_arc_sweep(
 ) -> Result<Option<f64>, crate::OperationsError> {
     use brepkit_topology::edge::EdgeCurve;
 
+    // Axial-level merge guard. `v` is `axis · (center − origin)`, which
+    // accumulates more rounding error than a single distance comparison, so
+    // this stays looser than the 1e-7 default linear tolerance to keep arcs at
+    // the same axial height from splitting into distinct levels.
+    const LEVEL_MERGE_TOL: f64 = 1e-6;
+
     let face = topo.face(face_id)?;
     let wire = topo.wire(face.outer_wire())?;
     let mut levels: Vec<(f64, f64)> = Vec::new();
@@ -148,7 +154,10 @@ fn cylinder_arc_sweep(
         }
         let span = te - ts;
         let v = axis.dot(circle.center() - origin);
-        if let Some(entry) = levels.iter_mut().find(|(lv, _)| (*lv - v).abs() < 1e-6) {
+        if let Some(entry) = levels
+            .iter_mut()
+            .find(|(lv, _)| (*lv - v).abs() < LEVEL_MERGE_TOL)
+        {
             entry.1 += span;
         } else {
             levels.push((v, span));

--- a/crates/operations/src/shell_op.rs
+++ b/crates/operations/src/shell_op.rs
@@ -1356,4 +1356,205 @@ mod tests {
             bbox_y - d
         );
     }
+
+    /// Regression oracle for arc-edge identity in shelled rounded rects.
+    ///
+    /// When wire traversal runs u-decreasing around a corner cylinder, the
+    /// stored `EdgeCurve::Circle` arc must still be the intended 90-degree
+    /// corner arc, not its 270-degree complement. The complement corrupts
+    /// face areas, the synthesized rim annulus, the floor trim, and makes
+    /// tessellation non-watertight.
+    #[test]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::too_many_lines,
+        clippy::items_after_statements
+    )]
+    fn shell_rounded_rect_watertight() {
+        use std::collections::HashMap;
+
+        use brepkit_math::curves::Circle3D;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::Face;
+        use brepkit_topology::vertex::Vertex;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+
+        let mut topo = Topology::new();
+        let tol = Tolerance::new();
+
+        // Gridfinity 1x1 bin body: 41.5 x 41.5, corner radius 3.75.
+        let w = 41.5_f64;
+        let d = 41.5_f64;
+        let h = 21.0_f64;
+        let r = 3.75_f64;
+        let thickness = 1.2_f64;
+
+        let hw = w / 2.0;
+        let hd = d / 2.0;
+
+        let pts = [
+            Point3::new(hw - r, -hd, 0.0),
+            Point3::new(hw, -hd + r, 0.0),
+            Point3::new(hw, hd - r, 0.0),
+            Point3::new(hw - r, hd, 0.0),
+            Point3::new(-hw + r, hd, 0.0),
+            Point3::new(-hw, hd - r, 0.0),
+            Point3::new(-hw, -hd + r, 0.0),
+            Point3::new(-hw + r, -hd, 0.0),
+        ];
+        let vids: Vec<_> = pts
+            .iter()
+            .map(|p| topo.add_vertex(Vertex::new(*p, tol.linear)))
+            .collect();
+
+        let c_br = Point3::new(hw - r, -hd + r, 0.0);
+        let c_tr = Point3::new(hw - r, hd - r, 0.0);
+        let c_tl = Point3::new(-hw + r, hd - r, 0.0);
+        let c_bl = Point3::new(-hw + r, -hd + r, 0.0);
+        let z_axis = Vec3::new(0.0, 0.0, 1.0);
+
+        let mk_line = |topo: &mut Topology, s, e| topo.add_edge(Edge::new(s, e, EdgeCurve::Line));
+        let mk_arc = |topo: &mut Topology, s, e, center: Point3| {
+            let circle = Circle3D::new(center, z_axis, r).unwrap();
+            topo.add_edge(Edge::new(s, e, EdgeCurve::Circle(circle)))
+        };
+
+        let e_bot = mk_line(&mut topo, vids[7], vids[0]);
+        let e_br = mk_arc(&mut topo, vids[0], vids[1], c_br);
+        let e_right = mk_line(&mut topo, vids[1], vids[2]);
+        let e_tr = mk_arc(&mut topo, vids[2], vids[3], c_tr);
+        let e_top = mk_line(&mut topo, vids[3], vids[4]);
+        let e_tl = mk_arc(&mut topo, vids[4], vids[5], c_tl);
+        let e_left = mk_line(&mut topo, vids[5], vids[6]);
+        let e_bl = mk_arc(&mut topo, vids[6], vids[7], c_bl);
+
+        let wire = Wire::new(
+            vec![
+                OrientedEdge::new(e_bot, true),
+                OrientedEdge::new(e_br, true),
+                OrientedEdge::new(e_right, true),
+                OrientedEdge::new(e_tr, true),
+                OrientedEdge::new(e_top, true),
+                OrientedEdge::new(e_tl, true),
+                OrientedEdge::new(e_left, true),
+                OrientedEdge::new(e_bl, true),
+            ],
+            true,
+        )
+        .unwrap();
+        let wire_id = topo.add_wire(wire);
+
+        let normal = Vec3::new(0.0, 0.0, 1.0);
+        let face = Face::new(wire_id, vec![], FaceSurface::Plane { normal, d: 0.0 });
+        let face_id = topo.add_face(face);
+
+        let solid =
+            crate::extrude::extrude(&mut topo, face_id, Vec3::new(0.0, 0.0, 1.0), h).unwrap();
+
+        let top = find_faces_by_normal(&topo, solid, Vec3::new(0.0, 0.0, 1.0));
+        assert_eq!(top.len(), 1, "one top face");
+
+        let shelled = shell(&mut topo, solid, thickness, &top).unwrap();
+
+        // Analytic reference values.
+        let r_in = r - thickness;
+        let h_in = h - thickness;
+        let outer_corner_area = std::f64::consts::FRAC_PI_2 * r * h; // 123.70
+        let inner_corner_area = std::f64::consts::FRAC_PI_2 * r_in * h_in; // 79.31
+        let outer_section = w * d - (4.0 - std::f64::consts::PI) * r * r;
+        let inner_section = (w - 2.0 * thickness) * (d - 2.0 * thickness)
+            - (4.0 - std::f64::consts::PI) * r_in * r_in;
+        let rim_area = outer_section - inner_section; // 186.95
+        let floor_area = inner_section; // 1523.23
+        let expected_volume = outer_section * h - inner_section * h_in; // 5753.8
+
+        let face_ids = brepkit_topology::explorer::solid_faces(&topo, shelled).unwrap();
+
+        let mut outer_corners = 0;
+        let mut inner_corners = 0;
+        let mut rim_total = 0.0;
+        let mut floor_total = 0.0;
+        for &fid in &face_ids {
+            let f = topo.face(fid).unwrap();
+            let area = crate::measure::face_area(&topo, fid, 0.01).unwrap();
+            match f.surface() {
+                FaceSurface::Cylinder(_) => {
+                    if (area - outer_corner_area).abs() < 0.1 {
+                        outer_corners += 1;
+                    } else if (area - inner_corner_area).abs() < 0.1 {
+                        inner_corners += 1;
+                    } else {
+                        unreachable!(
+                            "cylinder face {} area {area:.2} matches neither outer corner \
+                             {outer_corner_area:.2} nor inner corner {inner_corner_area:.2}",
+                            fid.index()
+                        );
+                    }
+                }
+                FaceSurface::Plane { normal, .. } if normal.z().abs() > 0.9 => {
+                    let ow = topo.wire(f.outer_wire()).unwrap();
+                    let oe0 = ow.edges()[0];
+                    let z0 = topo
+                        .vertex(topo.edge(oe0.edge()).unwrap().start())
+                        .unwrap()
+                        .point()
+                        .z();
+                    if (z0 - h).abs() < 1e-6 {
+                        rim_total += area;
+                    } else if (z0 - thickness).abs() < 1e-6 {
+                        floor_total += area;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(outer_corners, 4, "4 outer corner cylinder faces");
+        assert_eq!(inner_corners, 4, "4 inner corner cylinder faces");
+        assert!(
+            (rim_total - rim_area).abs() < 0.5,
+            "rim annulus area {rim_total:.2} != expected {rim_area:.2}"
+        );
+        assert!(
+            (floor_total - floor_area).abs() < 0.5,
+            "floor area {floor_total:.2} != expected {floor_area:.2}"
+        );
+
+        let vol = crate::measure::solid_volume(&topo, shelled, 0.01).unwrap();
+        assert!(
+            (vol - expected_volume).abs() < 1.0,
+            "shell volume {vol:.2} != expected {expected_volume:.2}"
+        );
+
+        // Watertightness: every quantized mesh edge must be shared by
+        // exactly two triangles at all deflections.
+        type QuantPoint = (i64, i64, i64);
+        for defl in [0.01_f64, 0.1, 0.5] {
+            let mesh = crate::tessellate::tessellate_solid(&topo, shelled, defl).unwrap();
+            let q = |x: f64| (x * 1e4).round() as i64;
+            let mut edge_counts: HashMap<(QuantPoint, QuantPoint), u32> = HashMap::new();
+            for tri in mesh.indices.chunks_exact(3) {
+                let keys: Vec<_> = tri
+                    .iter()
+                    .map(|&i| {
+                        let p = mesh.positions[i as usize];
+                        (q(p.x()), q(p.y()), q(p.z()))
+                    })
+                    .collect();
+                for i in 0..3 {
+                    let a = keys[i];
+                    let b = keys[(i + 1) % 3];
+                    let key = if a < b { (a, b) } else { (b, a) };
+                    *edge_counts.entry(key).or_insert(0) += 1;
+                }
+            }
+            let boundary = edge_counts.values().filter(|&&c| c == 1).count();
+            let nonmanifold = edge_counts.values().filter(|&&c| c > 2).count();
+            assert_eq!(
+                (boundary, nonmanifold),
+                (0, 0),
+                "mesh at deflection {defl} has {boundary} boundary and {nonmanifold} \
+                 non-manifold edges"
+            );
+        }
+    }
 }


### PR DESCRIPTION
assemble_solid_mixed canonicalized angular Circle edges by vertex index, so every arc whose wire traversal runs u-decreasing (top arcs of corner-cylinder faces, inner-ring floor arcs on shelled rounded-rect solids) was stored as its 270° complement — breaking watertightness of shelled solids. Edges are now built along traversal direction (negated axis when the wrapped u-step is negative) with is_forward derived from the stored start vertex; face_area partial-cylinder sweep reads boundary arcs instead of branch-cut-prone atan2. New watertight regression with analytic area/volume oracles, verified failing pre-fix. Full workspace green (shared with the boolean fallback assembly path).