### PR TITLE
fix(algo): post-merge review follow-ups for rounded-rect booleans

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -605,7 +605,10 @@ pub fn split_face_2d(
             // forward then backward when a coplanar partner's boundary
             // coincides with the face's own corner arc. Classifying it as
             // outer creates a zero-area face; as hole, a spurious inner wire.
-            let perimeter: f64 = pts.windows(2).map(|w| (w[1] - w[0]).length()).sum();
+            let mut perimeter: f64 = pts.windows(2).map(|w| (w[1] - w[0]).length()).sum();
+            if let (Some(first), Some(last)) = (pts.first(), pts.last()) {
+                perimeter += (*last - *first).length();
+            }
             if area.abs() <= perimeter * tol.linear {
                 continue;
             }

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -72,7 +72,15 @@ pub fn build_wire_loops_with_winding(
 
     let turn_score = |incoming: f64, candidate: f64| -> f64 {
         let cw = clockwise_angle(incoming, candidate);
-        if cw_boundary { TAU - cw } else { cw }
+        // `clockwise_angle` returns TAU for exact continuation, which must rank
+        // as the worst (largest) score in both windings. The mirrored rule maps
+        // every other angle to `TAU - cw` but would map a continuation to 0
+        // (best), so keep it pinned at TAU.
+        if cw_boundary {
+            if cw >= TAU { TAU } else { TAU - cw }
+        } else {
+            cw
+        }
     };
 
     let u_period = if u_periodic { Some(TAU) } else { None };


### PR DESCRIPTION
Two review findings from #778 that landed after its auto-merge: (1) the mirrored wire-builder turn rule mapped clockwise_angle's TAU continuation sentinel to 0 (best) instead of TAU (worst) under cw_boundary, mis-ranking straight-through continuations; (2) the sliver-loop guard's perimeter omitted the closing segment, understating loop length relative to the closed-polygon area it gates. Full algo + operations suites green incl. the five rounded-rect regressions.