### PR TITLE
test(boolean): re-enable sequential column-cut volume/manifold test

### DIFF
--- a/crates/operations/tests/boolean_edge_cases.rs
+++ b/crates/operations/tests/boolean_edge_cases.rs
@@ -247,7 +247,6 @@ fn test_intersect_disjoint() {
 // ── Sequential booleans ─────────────────────────────────────────────
 
 #[test]
-#[ignore = "sequential column cuts produce a non-manifold result (an edge shared by 3 faces)"]
 fn test_sequential_cuts_volume() {
     // Start with 10x10x10 box. Cut 5 columns (1x1x10 each) at different positions.
     let mut topo = Topology::new();


### PR DESCRIPTION
## What

Re-enables `test_sequential_cuts_volume` in `boolean_edge_cases.rs`, which cuts five sequential 1×1×10 columns out of a 10×10×10 box and asserts both the resulting volume (≈950, within 2%) and manifoldness.

## Why now

The test was ignored because sequential column cuts used to leave a non-manifold edge shared by three faces. That case now produces a clean manifold solid with the correct volume after recent sequential-cut fixes — this PR simply removes the stale `#[ignore]`.

## Verification

- Target test reproducibly green **10/10** in fresh processes (guards against the known iteration-order nondeterminism in sequential booleans).
- Full `cargo test --workspace` passes with **no regression**.
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, and `scripts/check-boundaries.sh` all clean.