### PR TITLE
test(tessellate): exercise coplanar-edge filtering with a real co-surface split

### DIFF
--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -804,30 +804,36 @@ fn sample_solid_edges_cylinder() {
 }
 
 #[test]
-#[ignore = "coplanar-edge filtering removes nothing on the fused result (filtered 18 == unfiltered 18)"]
 fn sample_solid_edges_boolean_filters_coplanar() {
+    // Fuse two boxes flush along x=10 with the second narrower in y (0..6 vs 0..10).
+    // The shared x=10 strip (y 0..6) becomes internal, but the top (z=10), bottom
+    // (z=0), and back (y=0) faces of the two boxes stay as coplanar adjacent
+    // fragments when unify_faces is off. The seams between those same-plane
+    // fragments are exactly the smooth edges sample_solid_edges should drop.
+    use brepkit_math::mat::Mat4;
     let mut topo = Topology::new();
-    let big = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
-    let small = crate::primitives::make_box(&mut topo, 3.0, 3.0, 15.0).unwrap();
+    let a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let b = crate::primitives::make_box(&mut topo, 10.0, 6.0, 10.0).unwrap();
+    crate::transform::transform_solid(&mut topo, b, &Mat4::translation(10.0, 0.0, 0.0)).unwrap();
     let opts = crate::boolean::BooleanOptions {
         unify_faces: false,
         ..Default::default()
     };
-    let cut = crate::boolean::boolean_with_options(
+    let fused = crate::boolean::boolean_with_options(
         &mut topo,
-        crate::boolean::BooleanOp::Cut,
-        big,
-        small,
+        crate::boolean::BooleanOp::Fuse,
+        a,
+        b,
         opts,
     )
     .unwrap();
 
-    let filtered = sample_solid_edges(&topo, cut, 0.1).unwrap();
-    let all = sample_solid_edges_filtered(&topo, cut, 0.1, false).unwrap();
+    let filtered = sample_solid_edges(&topo, fused, 0.1).unwrap();
+    let all = sample_solid_edges_filtered(&topo, fused, 0.1, false).unwrap();
 
     assert!(
         filtered.offsets.len() < all.offsets.len(),
-        "filtered ({}) should be fewer than unfiltered ({})",
+        "coplanar seams should be filtered: filtered ({}) should be fewer than unfiltered ({})",
         filtered.offsets.len(),
         all.offsets.len()
     );


### PR DESCRIPTION
## What

Re-enables `sample_solid_edges_boolean_filters_coplanar` (in `tessellate/tests.rs`) with corrected geometry.

## Why the old test could never pass

It cut a 3×3×15 box out of the origin corner of a 10×10×10 box and asserted `filtered < unfiltered`. But that cut produces a **clean 8-face L-prism** — bottom, top, and six *distinct* side planes — with no two adjacent faces coplanar. Instrumentation confirmed all 18 edges are 2-face plane/plane pairs with `surfaces_equivalent == false`, so the smooth-edge filter correctly removes nothing (`filtered == unfiltered == 18`). The assertion could only hold if the boolean emitted **redundant** coplanar fragments — i.e. the test was asserting a defect, not correct behavior.

## The fix

Retarget to a flush-partial box fuse: A = 10×10×10, B = 10×6×10 placed flush at x=10 (narrower in y), fused with `unify_faces = false`. The shared x=10 strip becomes internal, but the top (z=10), bottom (z=0), and back (y=0) faces stay as **coplanar adjacent fragments**, so `sample_solid_edges` drops three same-plane seams: **filtered 20 vs unfiltered 23**. The test now genuinely verifies coplanar smooth-edge filtering on a boolean result, which is its stated intent.

## Verification

- Target test reproducibly green **10/10** in fresh processes.
- `scripts/check-boundaries.sh` clean; pre-commit (fmt + clippy + machete) and pre-push (full workspace suite + cargo-deny) both pass with no regression.