### PR TITLE
test(boolean): strengthen #747/#787 regression assertions per review

### DIFF
--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1642,8 +1642,12 @@ fn compound_cut_matches_sequential_2x2_grid() {
 
     // Compound cut.
     let result = compound_cut(&mut topo, target, &tools, BooleanOptions::default()).unwrap();
-    // #747: N>=2 tools must produce a manifold solid, not just the right volume.
-    check_result(&topo, result);
+    // #747: N>=2 tools must produce a CLOSED manifold solid (every shell, no free
+    // edges), not just the right volume.
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "compound_cut result must be a closed manifold solid"
+    );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
 
     // 4x4x2 box minus four full-height r=0.3 cylinders.
@@ -1700,8 +1704,12 @@ fn compound_cut_matches_sequential_3x3_grid() {
 
     // Compound cut.
     let result = compound_cut(&mut topo, target, &tools, BooleanOptions::default()).unwrap();
-    // #747: N>=2 tools must produce a manifold solid, not just the right volume.
-    check_result(&topo, result);
+    // #747: N>=2 tools must produce a CLOSED manifold solid (every shell, no free
+    // edges), not just the right volume.
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "compound_cut result must be a closed manifold solid"
+    );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
 
     // 10x10x2 box minus nine full-height r=0.5 cylinders.
@@ -1765,8 +1773,12 @@ fn compound_cut_matches_sequential_4x4_grid() {
 
     // Compound cut.
     let result = compound_cut(&mut topo, target, &tools, BooleanOptions::default()).unwrap();
-    // #747: N>=2 tools must produce a manifold solid, not just the right volume.
-    check_result(&topo, result);
+    // #747: N>=2 tools must produce a CLOSED manifold solid (every shell, no free
+    // edges), not just the right volume.
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "compound_cut result must be a closed manifold solid"
+    );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
 
     // 20x20x2 box minus sixteen full-height r=0.5 cylinders.
@@ -1848,8 +1860,12 @@ fn compound_cut_shelled_target_many_tools() {
     let t0 = std::time::Instant::now();
     let result = compound_cut(&mut topo, target, &tools, opts).unwrap();
     let dt_compound = t0.elapsed();
-    // #747: shelled target + many tools must produce a manifold solid.
-    check_result(&topo, result);
+    // #747: shelled target + many tools must produce a CLOSED manifold solid,
+    // including the inner cavity shell (outer-shell-only checks miss it).
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "compound_cut shelled result must be a closed manifold solid"
+    );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
 
     let rel = (compound_vol - seq_vol).abs() / seq_vol;
@@ -1912,8 +1928,12 @@ fn compound_cut_shelled_target_9_tools() {
 
     // Compound.
     let result = compound_cut(&mut topo, target, &tools, opts).unwrap();
-    // #747: shelled target + many tools must produce a manifold solid.
-    check_result(&topo, result);
+    // #747: shelled target + many tools must produce a CLOSED manifold solid,
+    // including the inner cavity shell (outer-shell-only checks miss it).
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "compound_cut shelled result must be a closed manifold solid"
+    );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
 
     // Lower-bound guard: with the relaxed `rel < 2.0` bound below, a true

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1645,7 +1645,7 @@ fn compound_cut_matches_sequential_2x2_grid() {
     // #747: N>=2 tools must produce a CLOSED manifold solid (every shell, no free
     // edges), not just the right volume.
     assert!(
-        is_closed_manifold(&topo, result).unwrap(),
+        is_closed_manifold(&topo, result).expect("is_closed_manifold query failed"),
         "compound_cut result must be a closed manifold solid"
     );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
@@ -1707,7 +1707,7 @@ fn compound_cut_matches_sequential_3x3_grid() {
     // #747: N>=2 tools must produce a CLOSED manifold solid (every shell, no free
     // edges), not just the right volume.
     assert!(
-        is_closed_manifold(&topo, result).unwrap(),
+        is_closed_manifold(&topo, result).expect("is_closed_manifold query failed"),
         "compound_cut result must be a closed manifold solid"
     );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
@@ -1776,7 +1776,7 @@ fn compound_cut_matches_sequential_4x4_grid() {
     // #747: N>=2 tools must produce a CLOSED manifold solid (every shell, no free
     // edges), not just the right volume.
     assert!(
-        is_closed_manifold(&topo, result).unwrap(),
+        is_closed_manifold(&topo, result).expect("is_closed_manifold query failed"),
         "compound_cut result must be a closed manifold solid"
     );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
@@ -1863,7 +1863,7 @@ fn compound_cut_shelled_target_many_tools() {
     // #747: shelled target + many tools must produce a CLOSED manifold solid,
     // including the inner cavity shell (outer-shell-only checks miss it).
     assert!(
-        is_closed_manifold(&topo, result).unwrap(),
+        is_closed_manifold(&topo, result).expect("is_closed_manifold query failed"),
         "compound_cut shelled result must be a closed manifold solid"
     );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
@@ -1931,7 +1931,7 @@ fn compound_cut_shelled_target_9_tools() {
     // #747: shelled target + many tools must produce a CLOSED manifold solid,
     // including the inner cavity shell (outer-shell-only checks miss it).
     assert!(
-        is_closed_manifold(&topo, result).unwrap(),
+        is_closed_manifold(&topo, result).expect("is_closed_manifold query failed"),
         "compound_cut shelled result must be a closed manifold solid"
     );
     let compound_vol = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
@@ -3930,7 +3930,7 @@ fn fuse_stacked_rounded_rect_arc_prisms_same_footprint() {
         "fused volume {vol:.2} != expected {expected:.2}"
     );
     assert!(
-        is_closed_manifold(&topo, result).unwrap(),
+        is_closed_manifold(&topo, result).expect("is_closed_manifold query failed"),
         "fuse result must be closed-manifold"
     );
     assert!(!has_free_edges(&topo, result).unwrap());

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -807,9 +807,10 @@ fn sample_solid_edges_cylinder() {
 fn sample_solid_edges_boolean_filters_coplanar() {
     // Fuse two boxes flush along x=10 with the second narrower in y (0..6 vs 0..10).
     // The shared x=10 strip (y 0..6) becomes internal, but the top (z=10), bottom
-    // (z=0), and back (y=0) faces of the two boxes stay as coplanar adjacent
-    // fragments when unify_faces is off. The seams between those same-plane
-    // fragments are exactly the smooth edges sample_solid_edges should drop.
+    // (z=0), and front (y=0) faces of the two boxes stay as coplanar adjacent
+    // fragments when unify_faces is off (make_box puts y=0 at the front). The seams
+    // between those three same-plane fragment pairs are exactly the smooth edges
+    // sample_solid_edges should drop.
     use brepkit_math::mat::Mat4;
     let mut topo = Topology::new();
     let a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
@@ -831,9 +832,13 @@ fn sample_solid_edges_boolean_filters_coplanar() {
     let filtered = sample_solid_edges(&topo, fused, 0.1).unwrap();
     let all = sample_solid_edges_filtered(&topo, fused, 0.1, false).unwrap();
 
-    assert!(
-        filtered.offsets.len() < all.offsets.len(),
-        "coplanar seams should be filtered: filtered ({}) should be fewer than unfiltered ({})",
+    // Exactly the three coplanar seams (top, bottom, front) must be dropped — a bare
+    // `filtered < unfiltered` would still pass if the boolean output drifted to a
+    // single removed seam, defeating the point of the test.
+    assert_eq!(
+        all.offsets.len() - filtered.offsets.len(),
+        3,
+        "exactly 3 coplanar seams should be filtered: filtered={}, unfiltered={}",
         filtered.offsets.len(),
         all.offsets.len()
     );

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -836,8 +836,8 @@ fn sample_solid_edges_boolean_filters_coplanar() {
     // `filtered < unfiltered` would still pass if the boolean output drifted to a
     // single removed seam, defeating the point of the test.
     assert_eq!(
-        all.offsets.len() - filtered.offsets.len(),
-        3,
+        filtered.offsets.len() + 3,
+        all.offsets.len(),
         "exactly 3 coplanar seams should be filtered: filtered={}, unfiltered={}",
         filtered.offsets.len(),
         all.offsets.len()


### PR DESCRIPTION
Follow-up addressing Greptile + Copilot review comments on the recently-merged #787 and #788 (which auto-merged before the reviewers posted).

## #788 — manifold assertion was outer-shell-only
Copilot noted `check_result()` runs `validate_shell_manifold` on only the **outer** shell, so it can't catch free/boundary edges or problems on **inner cavity shells** — exactly what the *shelled-target* compound_cut tests produce.

Replaced `check_result()` with `is_closed_manifold()` in all five `compound_cut_*` grid/shelled tests. It walks every shell (outer + inner) and requires each edge used exactly twice (closed + manifold). **All five still pass** — verified the shelled cases' inner cavity shells are genuinely closed-manifold, so #747's resolution holds under the stronger check.

## #787 — assertion too weak + mislabeled comment
- Copilot: a bare `filtered < unfiltered` would pass even if the boolean drifted to a single removed seam. Tightened to `assert_eq!(unfiltered - filtered, 3)` — exactly the three coplanar seams (top, bottom, front). Stable 10/10 across fresh processes.
- Copilot: the comment called the y=0 plane "back"; `make_box` puts y=0 at the **front**. Fixed.
- Greptile P2 (Mat4 imported inside the function): **waived** — every test fn in this file imports `Mat4` locally; there is no module-level import, so the local `use` matches the established file convention.

## Verification
- Affected tests pass; 10/10 across fresh processes.
- `scripts/check-boundaries.sh` clean; pre-commit (fmt + clippy + machete) and pre-push (full workspace suite + cargo-deny) pass with no regression.