### PR TITLE
fix(algo): resolve d4 shelled-box + lip fuse (holed-face & section-arrangement splitting)

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -40,6 +40,193 @@ use special_cases::{
 /// section edge when testing whether it lies entirely inside an existing hole.
 const HOLE_PROBE_SAMPLES: usize = 8;
 
+/// Parameter `t` in `(0,1)` along segment `a0->a1` where it crosses segment
+/// `b0->b1` in 2D, for a crossing strictly interior to `a` and within (or at
+/// the ends of) `b`. `None` if parallel or out of range.
+fn seg_cross_param(a0: Point2, a1: Point2, b0: Point2, b1: Point2) -> Option<f64> {
+    let (rx, ry) = (a1.x() - a0.x(), a1.y() - a0.y());
+    let (sx, sy) = (b1.x() - b0.x(), b1.y() - b0.y());
+    let denom = rx.mul_add(sy, -(ry * sx));
+    if denom.abs() < 1e-12 {
+        return None;
+    }
+    let (qx, qy) = (b0.x() - a0.x(), b0.y() - a0.y());
+    let t = qx.mul_add(sy, -(qy * sx)) / denom;
+    let u = qx.mul_add(ry, -(qy * rx)) / denom;
+    (t > 1e-6 && t < 1.0 - 1e-6 && u > -1e-6 && u < 1.0 + 1e-6).then_some(t)
+}
+
+/// Weave hole boundaries into the section arrangement of a planar face.
+///
+/// When a holed planar face is cut by sections (e.g. a shelled box top with a
+/// cavity opening, fused with a lip whose walls cross that opening), the
+/// section runs partly through the cavity. Splitting only the outer boundary
+/// leaves the hole un-split, so a sub-face ends up as a square carrying the
+/// whole over-sized cavity hole instead of the true L-shaped rim. Trim each
+/// section at the points where it crosses a hole edge — dropping the
+/// sub-segment that lies inside the hole — and split the hole edges at those
+/// crossings. The wire builder then traces the real material region.
+///
+/// Returns the section + hole edges to append to the boundary, or `None` to
+/// fall back to the attach-whole-hole path (curved holes/sections, or no
+/// crossing — nothing to integrate).
+fn integrate_holes_plane(
+    sections: &[SectionEdge],
+    inner_wires: &[Vec<OrientedPCurveEdge>],
+    frame: &PlaneFrame,
+    base_src: usize,
+) -> Option<Vec<OrientedPCurveEdge>> {
+    // All-Line geometry only.
+    let line = |e: &OrientedPCurveEdge| matches!(e.curve_3d, EdgeCurve::Line);
+    if inner_wires.iter().flatten().any(|e| !line(e))
+        || sections
+            .iter()
+            .any(|s| !matches!(s.curve_3d, EdgeCurve::Line))
+    {
+        return None;
+    }
+
+    let hole_polys: Vec<Vec<Point2>> = inner_wires
+        .iter()
+        .map(|w| w.iter().map(|e| frame.project(e.start_3d)).collect())
+        .collect();
+    let hole_segs: Vec<(Point2, Point2, Point3, Point3)> = inner_wires
+        .iter()
+        .flatten()
+        .map(|e| {
+            (
+                frame.project(e.start_3d),
+                frame.project(e.end_3d),
+                e.start_3d,
+                e.end_3d,
+            )
+        })
+        .collect();
+
+    let mk_line =
+        |s_uv: Point2, e_uv: Point2, s3: Point3, e3: Point3, fwd: bool, src: Option<usize>| {
+            use brepkit_math::curves2d::{Curve2D, Line2D};
+            use brepkit_math::vec::Vec2;
+            let d = Vec2::new(e_uv.x() - s_uv.x(), e_uv.y() - s_uv.y());
+            let len = (d.x() * d.x() + d.y() * d.y()).sqrt();
+            let dir = if len > 1e-12 {
+                Vec2::new(d.x() / len, d.y() / len)
+            } else {
+                Vec2::new(1.0, 0.0)
+            };
+            let pcurve = Curve2D::Line(
+                Line2D::new(s_uv, dir)
+                    .or_else(|_| Line2D::new(s_uv, Vec2::new(1.0, 0.0)))
+                    .ok()?,
+            );
+            Some(OrientedPCurveEdge {
+                curve_3d: EdgeCurve::Line,
+                pcurve,
+                start_uv: s_uv,
+                end_uv: e_uv,
+                start_3d: s3,
+                end_3d: e3,
+                forward: fwd,
+                source_edge_idx: src,
+                pave_block_id: None,
+            })
+        };
+
+    let mut out: Vec<OrientedPCurveEdge> = Vec::new();
+    let mut any_crossing = false;
+    let mut next_src = base_src;
+
+    // Sections: split at hole crossings, drop the in-hole sub-segments.
+    for s in sections {
+        let s0 = frame.project(s.start);
+        let s1 = frame.project(s.end);
+        let mut ts: Vec<f64> = vec![0.0, 1.0];
+        for (b0, b1, _, _) in &hole_segs {
+            if let Some(t) = seg_cross_param(s0, s1, *b0, *b1) {
+                ts.push(t);
+                any_crossing = true;
+            }
+        }
+        ts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        ts.dedup_by(|a, b| (*a - *b).abs() < 1e-6);
+        for w in ts.windows(2) {
+            let (ta, tb) = (w[0], w[1]);
+            let tm = 0.5 * (ta + tb);
+            let mid = Point2::new(
+                s0.x() + (s1.x() - s0.x()) * tm,
+                s0.y() + (s1.y() - s0.y()) * tm,
+            );
+            if hole_polys
+                .iter()
+                .any(|poly| super::classify_2d::point_in_polygon_2d(mid, poly))
+            {
+                continue; // sub-segment runs through the cavity — not material
+            }
+            let lerp2 = |t: f64| {
+                Point2::new(
+                    s0.x() + (s1.x() - s0.x()) * t,
+                    s0.y() + (s1.y() - s0.y()) * t,
+                )
+            };
+            let lerp3 = |t: f64| {
+                Point3::new(
+                    s.start.x() + (s.end.x() - s.start.x()) * t,
+                    s.start.y() + (s.end.y() - s.start.y()) * t,
+                    s.start.z() + (s.end.z() - s.start.z()) * t,
+                )
+            };
+            let src = next_src;
+            next_src += 1;
+            let (ua, ub, pa, pb) = (lerp2(ta), lerp2(tb), lerp3(ta), lerp3(tb));
+            out.push(mk_line(ua, ub, pa, pb, true, Some(src))?);
+            out.push(mk_line(ub, ua, pb, pa, false, Some(src))?);
+        }
+    }
+
+    // Hole edges: split at section crossings, keep their stored orientation.
+    let sec_uv: Vec<(Point2, Point2)> = sections
+        .iter()
+        .map(|s| (frame.project(s.start), frame.project(s.end)))
+        .collect();
+    for (h0, h1, p0, p1) in &hole_segs {
+        let mut ts: Vec<f64> = vec![0.0, 1.0];
+        for (a0, a1) in &sec_uv {
+            if let Some(t) = seg_cross_param(*h0, *h1, *a0, *a1) {
+                ts.push(t);
+                any_crossing = true;
+            }
+        }
+        ts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        ts.dedup_by(|a, b| (*a - *b).abs() < 1e-6);
+        for w in ts.windows(2) {
+            let (ta, tb) = (w[0], w[1]);
+            let lerp2 = |t: f64| {
+                Point2::new(
+                    h0.x() + (h1.x() - h0.x()) * t,
+                    h0.y() + (h1.y() - h0.y()) * t,
+                )
+            };
+            let lerp3 = |t: f64| {
+                Point3::new(
+                    p0.x() + (p1.x() - p0.x()) * t,
+                    p0.y() + (p1.y() - p0.y()) * t,
+                    p0.z() + (p1.z() - p0.z()) * t,
+                )
+            };
+            out.push(mk_line(
+                lerp2(ta),
+                lerp2(tb),
+                lerp3(ta),
+                lerp3(tb),
+                true,
+                None,
+            )?);
+        }
+    }
+
+    any_crossing.then_some(out)
+}
+
 /// Split a face by its section edges, producing sub-faces.
 ///
 /// If there are no section edges, returns a single sub-face covering
@@ -369,7 +556,23 @@ pub fn split_face_2d(
     // Convert section edges to OrientedPCurveEdge (both orientations).
     let mut all_edges = boundary_edges;
     let n_boundary_edges = all_edges.len();
+
+    // Holed planar face cut by sections: weave the hole boundaries into the
+    // arrangement (trim sections at hole crossings, split hole edges) so the
+    // wire builder traces the true material region. When this applies, the
+    // original holes are consumed here and not attached whole below.
+    let holes_integrated = if is_plane && !original_inner_wires.is_empty() {
+        integrate_holes_plane(sections, &original_inner_wires, frame, 1_000_000)
+            .map(|extra| all_edges.extend(extra))
+            .is_some()
+    } else {
+        false
+    };
+
     for section in sections {
+        if holes_integrated {
+            break;
+        }
         // Skip full-circle section edges on plane faces -- they have
         // start approx end in 3D and would produce degenerate UV edges.
         // The half-arc section edges handle the plane face correctly.
@@ -553,7 +756,7 @@ pub fn split_face_2d(
     // section's endpoint mid-way on the other, 3 regions): it merges everything
     // into one loop, or splits on only one section. Prefer the direct geometric
     // construction whenever it yields more regions than the wire builder did.
-    if sections.len() >= 2 && is_plane {
+    if sections.len() >= 2 && is_plane && !holes_integrated {
         if let Some(ref boundary) = boundary_edges_backup {
             if let Some(result) = try_split_crossing_plane_face(
                 &surface, boundary, sections, rank, reversed, face_id, frame, tol,
@@ -692,7 +895,7 @@ pub fn split_face_2d(
     // sub-faces, etc. — fall back to the largest-area sub-face. A warning
     // fires for the fallback so the case stays visible; what we never do is
     // silently drop the hole as the earlier code did.
-    if !original_inner_wires.is_empty() {
+    if !original_inner_wires.is_empty() && !holes_integrated {
         let largest_sub_face_idx = |sub_faces: &[SplitSubFace]| -> Option<usize> {
             sub_faces
                 .iter()

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -548,16 +548,19 @@ pub fn split_face_2d(
         }
     }
 
-    // Fallback: wire builder produced only 1 loop despite having 2+ section
-    // edges that cross in the face interior. Use direct geometric quadrant
-    // construction. The wire builder struggles with 4-way junctions when
-    // boundary edges have inconsistent winding.
-    if loops.len() <= 1 && sections.len() >= 2 && is_plane {
+    // Geometric crossing/T-junction split. The wire builder under-partitions
+    // a plane face whose two sections cross (X, 4 regions) or meet in a T (one
+    // section's endpoint mid-way on the other, 3 regions): it merges everything
+    // into one loop, or splits on only one section. Prefer the direct geometric
+    // construction whenever it yields more regions than the wire builder did.
+    if sections.len() >= 2 && is_plane {
         if let Some(ref boundary) = boundary_edges_backup {
             if let Some(result) = try_split_crossing_plane_face(
                 &surface, boundary, sections, rank, reversed, face_id, frame, tol,
             ) {
-                return result;
+                if result.len() > loops.len() {
+                    return result;
+                }
             }
         }
     }

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -47,12 +47,17 @@ fn seg_cross_param(a0: Point2, a1: Point2, b0: Point2, b1: Point2) -> Option<f64
     let (rx, ry) = (a1.x() - a0.x(), a1.y() - a0.y());
     let (sx, sy) = (b1.x() - b0.x(), b1.y() - b0.y());
     let denom = rx.mul_add(sy, -(ry * sx));
-    if denom.abs() < 1e-12 {
+    // `denom = |r x s| = |r||s| sin(theta)`; test it relative to the segment
+    // lengths so near-parallel rejection is independent of model scale.
+    let scale = (rx.hypot(ry) * sx.hypot(sy)).max(f64::MIN_POSITIVE);
+    if denom.abs() <= 1e-9 * scale {
         return None;
     }
     let (qx, qy) = (b0.x() - a0.x(), b0.y() - a0.y());
     let t = qx.mul_add(sy, -(qy * sx)) / denom;
     let u = qx.mul_add(ry, -(qy * rx)) / denom;
+    // `t`/`u` are normalized [0,1] parameters, so these epsilons are already
+    // scale-invariant fractions of each segment.
     (t > 1e-6 && t < 1.0 - 1e-6 && u > -1e-6 && u < 1.0 + 1e-6).then_some(t)
 }
 
@@ -355,11 +360,15 @@ pub fn split_face_2d(
     // genus-1 handle in the assembled solid.
     let deduped_sections: Vec<SectionEdge>;
     let sections = {
+        // Quantize at the kernel's linear tolerance so dedup only collapses
+        // genuinely-coincident sections (a doubly-recorded interference) and
+        // never distinct splitters that happen to be close on a small model.
+        let scale = 1.0 / tol.linear.max(1e-12);
         let q = |p: Point3| -> (i64, i64, i64) {
             (
-                (p.x() * 1e4).round() as i64,
-                (p.y() * 1e4).round() as i64,
-                (p.z() * 1e4).round() as i64,
+                (p.x() * scale).round() as i64,
+                (p.y() * scale).round() as i64,
+                (p.z() * scale).round() as i64,
             )
         };
         let mut seen = std::collections::HashSet::new();

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -517,6 +517,14 @@ pub fn split_face_2d(
         }
     }
 
+    // Drop pendant section edges that dangle into the face interior — left
+    // in, the traversal walks out and back along them, spuriously
+    // over-splitting the face (boundary edges are never removed, so the
+    // boundary prefix and `n_boundary_edges` stay valid).
+    let all_edges = super::wire_builder::remove_pendant_sections(
+        &all_edges, tol.linear, u_periodic, v_periodic,
+    );
+
     // Build wire loops via angular-sorting traversal.
     let mut loops = build_wire_loops(&all_edges, tol.linear, u_periodic, v_periodic);
 

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -348,6 +348,36 @@ pub fn split_face_2d(
         &filtered_sections
     };
 
+    // Deduplicate sections sharing endpoints: a face-face interference can be
+    // recorded more than once (e.g. the same wall reached via two adjacent
+    // tool faces). A duplicated dividing section makes the wire builder weave
+    // a zero-area slit instead of splitting the face, which reads as a spurious
+    // genus-1 handle in the assembled solid.
+    let deduped_sections: Vec<SectionEdge>;
+    let sections = {
+        let q = |p: Point3| -> (i64, i64, i64) {
+            (
+                (p.x() * 1e4).round() as i64,
+                (p.y() * 1e4).round() as i64,
+                (p.z() * 1e4).round() as i64,
+            )
+        };
+        let mut seen = std::collections::HashSet::new();
+        deduped_sections = sections
+            .iter()
+            .filter(|s| {
+                // Key on the endpoints plus a midpoint sample so two distinct
+                // arcs sharing endpoints (e.g. the two halves of a split
+                // circle) are not collapsed into one.
+                let (a, b) = (q(s.start), q(s.end));
+                let mid = q(evaluate_edge_at_t(&s.curve_3d, s.start, s.end, 0.5));
+                seen.insert((if a <= b { (a, b) } else { (b, a) }, mid))
+            })
+            .cloned()
+            .collect();
+        &deduped_sections[..]
+    };
+
     // If no section edges, the face is unsplit -- return as-is with original holes.
     if sections.is_empty() {
         return vec![SplitSubFace {

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -956,11 +956,28 @@ pub(super) fn try_split_crossing_plane_face(
             }
             d.y().mul_add(d1.z(), -(d.z() * d1.y())) / det
         };
-        if !(0.01..=0.99).contains(&t0) {
+        cross_3d = s0.start + d0 * t0;
+        let t1 = (cross_3d - s1.start).dot(d1) / d1.dot(d1);
+        // The infinite lines must meet within both segments (endpoints allowed).
+        if !(-0.01..=1.01).contains(&t0) || !(-0.01..=1.01).contains(&t1) {
             return None;
         }
-        cross_3d = s0.start + d0 * t0;
-        section_endpoints = vec![s0.start, s0.end, s1.start, s1.end];
+        let mid = |t: f64| (0.01..=0.99).contains(&t);
+        section_endpoints = if mid(t0) && mid(t1) {
+            // X-crossing: both sections split mid-way → 4 regions.
+            vec![s0.start, s0.end, s1.start, s1.end]
+        } else if mid(t1) {
+            // T-junction: s0's endpoint lands mid-way on s1 → 3 regions.
+            // `cross_3d` is that endpoint; keep s0's far end + s1's two ends.
+            let s0_far = if t0 < 0.5 { s0.end } else { s0.start };
+            vec![s0_far, s1.start, s1.end]
+        } else if mid(t0) {
+            let s1_far = if t1 < 0.5 { s1.end } else { s1.start };
+            vec![s1_far, s0.start, s0.end]
+        } else {
+            // L-junction (shared endpoint) or no interior crossing — no split.
+            return None;
+        };
     } else if sections.len() == 4 {
         let all_pts: Vec<Point3> = sections.iter().flat_map(|s| [s.start, s.end]).collect();
         let mut common = None;
@@ -1057,7 +1074,7 @@ pub(super) fn try_split_crossing_plane_face(
     }
     section_indices.sort_unstable();
     section_indices.dedup();
-    if section_indices.len() != 4 {
+    if section_indices.len() != section_endpoints.len() || section_indices.len() < 3 {
         return None;
     }
 
@@ -1093,10 +1110,11 @@ pub(super) fn try_split_crossing_plane_face(
         }
     };
 
+    let n_regions = section_indices.len();
     let mut result = Vec::new();
-    for qi in 0..4 {
+    for qi in 0..n_regions {
         let arc_start = section_indices[qi];
-        let arc_end = section_indices[(qi + 1) % 4];
+        let arc_end = section_indices[(qi + 1) % n_regions];
         let mut wire = Vec::new();
         let mut idx = arc_start;
         loop {

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -212,6 +212,80 @@ pub fn build_wire_loops_with_winding(
     loops
 }
 
+/// Drop pendant section edges before loop building.
+///
+/// Mirrors the reference kernel's "shapes to avoid" pass: a section edge that
+/// fails to connect two parts of the face boundary dangles into the interior.
+/// Left in, the angular traversal is forced to walk out and back along it,
+/// producing a zero-area spur and over-splitting the face into spurious
+/// coplanar pieces.
+///
+/// A vertex is a free end if every alive edge touching it belongs to the same
+/// section (same `source_edge_idx`). Each section appears as a forward+reverse
+/// pair, so a genuine free end carries exactly that pair and nothing else.
+/// Boundary edges (`source_edge_idx == None`) never dangle — the outer wire is
+/// closed — so they anchor their vertices and are never removed. Peeling is
+/// iterative: removing one pendant can expose the next along a chain.
+pub fn remove_pendant_sections(
+    edges: &[OrientedPCurveEdge],
+    tol: f64,
+    u_periodic: bool,
+    v_periodic: bool,
+) -> Vec<OrientedPCurveEdge> {
+    let u_period = if u_periodic { Some(TAU) } else { None };
+    let v_period = if v_periodic { Some(TAU) } else { None };
+    let mut alive = vec![true; edges.len()];
+
+    loop {
+        let mut vmap: HashMap<(i64, i64), Vec<usize>> = HashMap::new();
+        for (i, e) in edges.iter().enumerate() {
+            if !alive[i] {
+                continue;
+            }
+            let sk = quantize_uv_periodic(e.start_uv, tol, u_period, v_period);
+            let ek = quantize_uv_periodic(e.end_uv, tol, u_period, v_period);
+            vmap.entry(sk).or_default().push(i);
+            if ek != sk {
+                vmap.entry(ek).or_default().push(i);
+            }
+        }
+
+        let mut pendant_src: Option<usize> = None;
+        for incident in vmap.values() {
+            let mut srcs = incident.iter().map(|&i| edges[i].source_edge_idx);
+            let first = srcs.next().flatten();
+            if let Some(src) = first {
+                if incident
+                    .iter()
+                    .all(|&i| edges[i].source_edge_idx == Some(src))
+                {
+                    pendant_src = Some(src);
+                    break;
+                }
+            }
+        }
+
+        match pendant_src {
+            Some(src) => {
+                for (i, e) in edges.iter().enumerate() {
+                    if e.source_edge_idx == Some(src) {
+                        alive[i] = false;
+                    }
+                }
+            }
+            None => break,
+        }
+    }
+
+    let mut kept = Vec::with_capacity(edges.len());
+    for (i, e) in edges.iter().enumerate() {
+        if alive[i] {
+            kept.push(e.clone());
+        }
+    }
+    kept
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -397,6 +471,68 @@ mod tests {
             source_edge_idx: None,
             pave_block_id: None,
         }
+    }
+
+    fn make_section_edge(start: Point2, end: Point2, src: usize) -> OrientedPCurveEdge {
+        let mut e = make_line_edge(start, end);
+        e.source_edge_idx = Some(src);
+        e
+    }
+
+    #[test]
+    fn remove_pendant_sections_drops_dangling_keeps_dividing() {
+        // Square boundary, bottom + top split at x=5 so a divider lands on
+        // existing vertices.
+        let mut edges = vec![
+            make_line_edge(Point2::new(0.0, 0.0), Point2::new(5.0, 0.0)),
+            make_line_edge(Point2::new(5.0, 0.0), Point2::new(10.0, 0.0)),
+            make_line_edge(Point2::new(10.0, 0.0), Point2::new(10.0, 10.0)),
+            make_line_edge(Point2::new(10.0, 10.0), Point2::new(5.0, 10.0)),
+            make_line_edge(Point2::new(5.0, 10.0), Point2::new(0.0, 10.0)),
+            make_line_edge(Point2::new(0.0, 10.0), Point2::new(0.0, 0.0)),
+        ];
+        let n_boundary = edges.len();
+        // Dividing section (both ends on the boundary) — kept.
+        edges.push(make_section_edge(
+            Point2::new(5.0, 0.0),
+            Point2::new(5.0, 10.0),
+            100,
+        ));
+        edges.push(make_section_edge(
+            Point2::new(5.0, 10.0),
+            Point2::new(5.0, 0.0),
+            100,
+        ));
+        // Pendant section (free end at (7,5) inside the face) — removed.
+        edges.push(make_section_edge(
+            Point2::new(5.0, 0.0),
+            Point2::new(7.0, 5.0),
+            200,
+        ));
+        edges.push(make_section_edge(
+            Point2::new(7.0, 5.0),
+            Point2::new(5.0, 0.0),
+            200,
+        ));
+
+        let kept = remove_pendant_sections(&edges, 1e-7, false, false);
+
+        assert_eq!(
+            kept.len(),
+            n_boundary + 2,
+            "pendant pair removed, dividing pair kept"
+        );
+        assert!(
+            kept.iter().all(|e| e.source_edge_idx != Some(200)),
+            "pendant section must be dropped"
+        );
+        assert_eq!(
+            kept.iter()
+                .filter(|e| e.source_edge_idx == Some(100))
+                .count(),
+            2,
+            "dividing section must survive"
+        );
     }
 
     #[test]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -3149,7 +3149,6 @@ fn gfa_box_cone_intersect() {
 /// - Lip solid (from boolean cut of nested boxes)
 /// - Fuse operation (merging coplanar boundary at z≈5)
 #[test]
-#[ignore = "known bug: non-manifold edge at shelled-box + socket fuse boundary"]
 fn d4_shelled_box_fuse_lip() {
     // Simplified D4: shell a box, build a lip (outer-inner cut), fuse
     let mut topo = Topology::default();


### PR DESCRIPTION
## Summary

Un-ignores `boolean::tests::d4_shelled_box_fuse_lip` — the long-standing "D4 gridfinity" shelled-box + lip fuse that produced non-manifold, wrong-genus topology. The result is now a genus-0 closed manifold (adjusted Euler == 2), verified 10× deterministic.

Four independent face-splitter fixes, each regression-clean on its own, were needed — the bug was a stack of distinct defects in how a planar face is partitioned by section edges. They generalize well beyond d4 (any boolean where tool walls cross a holed/rim face).

## The four fixes

1. **`c1d9046` — drop pendant section edges** (reference `PerformShapesToAvoid`). A section that doesn't connect two parts of the face boundary dangles into the interior; the angular wire traversal walks out and back along it, spuriously over-splitting the face. (nm 10→8)

2. **`91b55b0` — T-junction plane-face split.** The geometric fallback handled an X-crossing of two sections (4 quadrants) but not a **T-junction** (one section's endpoint mid-way on another → 3 regions). Generalized `try_split_crossing_plane_face` to N regions and made the caller prefer the geometric split when it yields more regions than the wire builder. (nm 8→2)

3. **`d50caee` — split hole boundaries when a holed plane face is cut by sections.** A face carrying an inner-wire hole (the shelled box top with its cavity opening) was split only on its outer boundary; the hole was attached whole. When the lip walls cross the opening, the sub-face ended up as a square carrying the over-sized cavity hole instead of the true L-shaped rim. Now the hole boundaries are woven into the section arrangement (sections trimmed at hole crossings, hole edges split), so the wire builder traces the real material region. (nm 2→0, free 6→0 — closed manifold)

4. **`da0d7dc` — deduplicate coincident section edges.** A face-face interference can be recorded twice for one face (the box outer walls each carried a duplicated y=8/x=8 section). A duplicated *dividing* section makes the wire builder weave a zero-area **slit** instead of splitting — and a slit gives a face the Euler of an annulus (0) rather than a disk (1), so each slit reads as one unit of spurious genus. Two slit walls → apparent genus-1 (Euler 0 vs 2) even on an otherwise-clean closed manifold. Dedup by endpoints + a midpoint sample (so split-circle half-arcs aren't collapsed), and the surviving single section forms a clean T-junction that fix #2 resolves.

## Verification

- `d4_shelled_box_fuse_lip` passes, 10/10 in fresh processes (no HashMap nondeterminism).
- Full suite green after each commit: `brepkit-algo`, `brepkit-operations`, `brepkit-io`, `brepkit-wasm` — 0 regressions.
- `./scripts/check-boundaries.sh` clean (all changes contained to `brepkit-algo`).

## Notes

- The sibling `fuse_shelled_box_with_socket_loft` (curved loft socket) is a separate, deeper case and stays ignored.
- ⚠️ These touch the GFA face splitter (a core boolean path). Flagging for human review rather than auto-merge.