### PR TITLE
test(gridfinity): shell the actual top face in D4 1×1 bin reproducer

### DIFF
--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -1571,26 +1571,20 @@ fn gridfinity_d4_full_1x1_bin() {
     // is unreliable here — it lands on the base face, not the top.
     let faces = k.get_solid_faces(box_solid).unwrap();
     assert!(!faces.is_empty(), "box should have faces");
-    let top_face = {
-        use brepkit_topology::face::FaceSurface;
-        faces
-            .iter()
-            .copied()
-            .find(|&fh| {
-                k.resolve_face(fh)
-                    .ok()
-                    .and_then(|fid| k.topo.face(fid).ok())
-                    .and_then(|f| match f.surface() {
-                        FaceSurface::Plane { normal, .. } => {
-                            let n = if f.is_reversed() { -*normal } else { *normal };
-                            Some(n.z() > 0.5)
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or(false)
-            })
-            .expect("extruded box should have a +Z top face")
-    };
+    let top_face = faces
+        .iter()
+        .copied()
+        .find(|&fh| {
+            k.resolve_face(fh)
+                .ok()
+                .and_then(|fid| k.topo.face(fid).ok())
+                .and_then(brepkit_topology::face::Face::effective_plane_normal)
+                // Top face points predominantly +Z. Compare against the
+                // normal's own magnitude rather than assuming unit length,
+                // since `FaceSurface::Plane` normals are not normalized.
+                .is_some_and(|n| n.z() > 0.5 * n.length())
+        })
+        .expect("extruded box should have a +Z top face");
     let r3 = k.execute_batch(&format!(
         r#"[{{"op": "shell", "args": {{"solid": {box_solid}, "thickness": {WALL_THICKNESS}, "faces": [{top_face}]}}}}]"#
     ));

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -1550,13 +1550,8 @@ fn gridfinity_d5_box_with_filleted_lip() {
 ///
 /// Builds the complete bin pipeline matching gridfinity-layout-tool's
 /// `generateBin()` for a 1×1 standard bin with stacking lip.
-/// Expected: Euler=2, faces < 200, volume ±5% of analytical.
-///
-/// Known failure: fuse step produces non-manifold topology (adjusted_euler=-13).
-/// The fuse issue is independent of fillet inner wire support — needs
-/// separate investigation of the boolean fuse path.
+/// Expected: genus-0 manifold (adjusted Euler == 2), faces < 200, volume.
 #[test]
-#[ignore = "D4 fuse produces non-manifold topology — separate investigation needed"]
 fn gridfinity_d4_full_1x1_bin() {
     let mut k = BrepKernel::new();
 
@@ -1570,11 +1565,32 @@ fn gridfinity_d4_full_1x1_bin() {
     assert_ok(&p1, 0);
     let box_solid = p1[0]["ok"].as_u64().unwrap() as u32;
 
-    // Step 2: Shell the box (remove top face)
+    // Step 2: Shell the box (remove top face).
+    // Select the top face by its outward normal (+Z). A rounded-rect extrude
+    // interleaves cylindrical corner faces, so positional indexing (faces[1])
+    // is unreliable here — it lands on the base face, not the top.
     let faces = k.get_solid_faces(box_solid).unwrap();
     assert!(!faces.is_empty(), "box should have faces");
-    // Top face is typically face[1] for extrude-based solids
-    let top_face = faces[1];
+    let top_face = {
+        use brepkit_topology::face::FaceSurface;
+        faces
+            .iter()
+            .copied()
+            .find(|&fh| {
+                k.resolve_face(fh)
+                    .ok()
+                    .and_then(|fid| k.topo.face(fid).ok())
+                    .and_then(|f| match f.surface() {
+                        FaceSurface::Plane { normal, .. } => {
+                            let n = if f.is_reversed() { -*normal } else { *normal };
+                            Some(n.z() > 0.5)
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or(false)
+            })
+            .expect("extruded box should have a +Z top face")
+    };
     let r3 = k.execute_batch(&format!(
         r#"[{{"op": "shell", "args": {{"solid": {box_solid}, "thickness": {WALL_THICKNESS}, "faces": [{top_face}]}}}}]"#
     ));


### PR DESCRIPTION
## Summary

Un-ignores `gridfinity_d4_full_1x1_bin`, which was marked as a "fuse produces
non-manifold topology" engine bug. The real cause was a **provably-wrong test
setup**, not the engine.

## Root cause (traced end-to-end)

The test builds the box by extruding a **rounded** rectangle, then shells it to
make a cup via `faces[1]` — assuming index 1 is the top face. For a rounded
extrude, cylindrical corner faces shift the ordering, so:

- `faces[1]` has outward normal **−Z** — it is the **base** face, not the top.
- The actual top face (normal +Z) is found by scanning normals.

Shelling the base instead of the top kept a cavity ceiling and forced
`shell_op`'s open-rim builder to merge the +X **outer** wall (x=20.75) and +X
**inner cavity** wall (x=19.15) into a single annular face with an *averaged*
plane (`d=19.95`, boundary vertices 0.8 off-plane). That one malformed face
propagates a spurious **genus-1 handle** through the downstream fuse:

```
before fix:  clean closed manifold, but V−E+(F−holes) = 0  → genus-1 (adj_euler 0)
```

## Fix

Select the top face by its outward normal (+Z) — exactly the test's stated
intent (`// Shell the box (remove top face)`) and the convention the other
shelling reproducers already use. With the intended top removed, the full bin
pipeline fuses to a genus-0 manifold:

```
after fix:   adjusted_euler == 2, 149 faces (<200), volume/bbox correct
```

## Integrity

- **Engine code untouched** — test-only change.
- **Oracle preserved**: every original assertion (`adjusted_euler == 2`,
  `faces < 200`, `vol > 5000`, z-extent) is unchanged and now met.
- The other two shelling reproducers keep `faces[1]`: they shell a plain
  `makeBox`, where index 1 genuinely is the top.
- 10/10 deterministic; full `brepkit-wasm` suite green (211 passed).

## Follow-up (out of scope)

`shell` producing a geometrically-invalid averaged-plane face when a *non-top*
face is removed on a rounded box is a real (separate) robustness gap worth
hardening later. This PR does not change that behavior; it makes the reproducer
exercise its intended top-removal scenario.
