### PR TITLE
fix(boolean): restrict analytic FF curves + merge coincident junction edges

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -185,6 +185,18 @@ pub fn perform(
                 })
                 .collect();
 
+            // Restrict surface-surface intersection curves to the region that
+            // lies inside BOTH faces. `compute_raw_curves` works on the
+            // unbounded surfaces; the analytic-analytic marcher already bounds
+            // its curves, but the plane-analytic and algebraic paths return
+            // the full surface-surface curve. A cylinder/cone or
+            // cylinder/tilted-plane ellipse that meets the other face only
+            // along a shared cap then reaches far past it and slits the
+            // partner face's wire. Keep only the in-both span (curves only).
+            let raw_curves = restrict_curves_to_faces(
+                topo, fa, fb, surf_a, surf_b, v_range_a, v_range_b, raw_curves, tol,
+            );
+
             for raw in raw_curves {
                 let mut raw = raw;
                 // Closed Circle3D sections — produced by plane-sphere
@@ -308,6 +320,215 @@ pub fn perform(
     }
 
     Ok(())
+}
+
+/// A face's trimmed extent, used to test whether a 3D point lies inside the
+/// face (so surface-surface intersection curves can be restricted to the
+/// region inside both faces — the reference's "true boundary" restriction).
+enum FaceExtent {
+    /// Planar face: 2D boundary polygon in a plane frame (arc edges sampled).
+    Plane {
+        frame: crate::builder::plane_frame::PlaneFrame,
+        poly: Vec<brepkit_math::vec::Point2>,
+        margin: f64,
+    },
+    /// Analytic lateral face (cylinder/cone/sphere/torus): bound by the
+    /// axial `v` parameter range of the face.
+    Analytic {
+        surface: FaceSurface,
+        v0: f64,
+        v1: f64,
+        margin: f64,
+    },
+}
+
+impl FaceExtent {
+    fn new(
+        topo: &Topology,
+        face_id: FaceId,
+        surface: &FaceSurface,
+        v_range: Option<(f64, f64)>,
+        tol: Tolerance,
+    ) -> Option<Self> {
+        if let FaceSurface::Plane { normal, .. } = surface {
+            let face = topo.face(face_id).ok()?;
+            let wire = topo.wire(face.outer_wire()).ok()?;
+            let first = wire.edges().first()?;
+            let origin = topo
+                .vertex(topo.edge(first.edge()).ok()?.start())
+                .ok()?
+                .point();
+            let frame =
+                crate::builder::plane_frame::PlaneFrame::from_normal_and_point(*normal, origin);
+            let mut poly = Vec::new();
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge()).ok()?;
+                let s3 = topo.vertex(edge.start()).ok()?.point();
+                let e3 = topo.vertex(edge.end()).ok()?.point();
+                let oriented_start = if oe.is_forward() { s3 } else { e3 };
+                match edge.curve() {
+                    EdgeCurve::Line => poly.push(frame.project(oriented_start)),
+                    curve => {
+                        let (t0, t1) = curve.domain_with_endpoints(s3, e3);
+                        for i in 0..16 {
+                            #[allow(clippy::cast_precision_loss)]
+                            let f = i as f64 / 16.0;
+                            let t = if oe.is_forward() {
+                                t0 + (t1 - t0) * f
+                            } else {
+                                t1 + (t0 - t1) * f
+                            };
+                            poly.push(frame.project(curve.evaluate_with_endpoints(t, s3, e3)));
+                        }
+                    }
+                }
+            }
+            if poly.len() < 3 {
+                return None;
+            }
+            // Margin keeps boundary-coincident points (the shared cap) inside;
+            // scaled to the footprint so it stays small vs the stray extent.
+            let bb = brepkit_math::aabb::Aabb3::from_points(
+                poly.iter()
+                    .map(|p| brepkit_math::vec::Point3::new(p.x(), p.y(), 0.0)),
+            );
+            let diag = (bb.max - bb.min).length();
+            Some(Self::Plane {
+                frame,
+                poly,
+                margin: (diag * 0.01).max(tol.linear),
+            })
+        } else {
+            let (v0, v1) = v_range?;
+            let margin = (v1 - v0).abs() * 0.01 + tol.linear;
+            Some(Self::Analytic {
+                surface: surface.clone(),
+                v0,
+                v1,
+                margin,
+            })
+        }
+    }
+
+    fn contains(&self, p: Point3) -> bool {
+        match self {
+            Self::Plane {
+                frame,
+                poly,
+                margin,
+            } => {
+                let uv = frame.project(p);
+                crate::builder::classify_2d::point_in_polygon_2d(uv, poly)
+                    || point_to_polygon_dist(uv, poly) <= *margin
+            }
+            Self::Analytic {
+                surface,
+                v0,
+                v1,
+                margin,
+            } => surface
+                .project_point(p)
+                .is_none_or(|(_, v)| v >= *v0 - *margin && v <= *v1 + *margin),
+        }
+    }
+}
+
+/// Minimum distance from a 2D point to a closed polygon's edges.
+fn point_to_polygon_dist(p: brepkit_math::vec::Point2, poly: &[brepkit_math::vec::Point2]) -> f64 {
+    let n = poly.len();
+    let mut best = f64::MAX;
+    for i in 0..n {
+        let (a, b) = (poly[i], poly[(i + 1) % n]);
+        let (abx, aby) = (b.x() - a.x(), b.y() - a.y());
+        let (apx, apy) = (p.x() - a.x(), p.y() - a.y());
+        let len2 = abx * abx + aby * aby;
+        let t = if len2 > 1e-20 {
+            ((apx * abx + apy * aby) / len2).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let (cx, cy) = (a.x() + abx * t, a.y() + aby * t);
+        best = best.min(((p.x() - cx).powi(2) + (p.y() - cy).powi(2)).sqrt());
+    }
+    best
+}
+
+/// Restrict surface-surface intersection curves to the region inside BOTH
+/// faces. `compute_raw_curves` works on the unbounded surfaces, so a
+/// plane-analytic or algebraic curve (e.g. a cylinder/tilted-plane ellipse)
+/// can reach far past the faces' shared region and slit the partner face's
+/// wire. A non-Line curve whose longest contiguous in-both sample run is under
+/// two samples only grazes the mutual extent at a tangency/point — it never
+/// splits either face, so it is dropped. Curves with a real in-both span are
+/// kept whole (the downstream splitter trims them to the boundary). Lines are
+/// left to the downstream `clip_line_to_face`. Conservative: if either face's
+/// extent cannot be built, the curves are returned unchanged.
+#[allow(clippy::too_many_arguments, clippy::items_after_statements)]
+fn restrict_curves_to_faces(
+    topo: &Topology,
+    fa: FaceId,
+    fb: FaceId,
+    surf_a: &FaceSurface,
+    surf_b: &FaceSurface,
+    v_range_a: Option<(f64, f64)>,
+    v_range_b: Option<(f64, f64)>,
+    raw_curves: Vec<RawCurve>,
+    tol: Tolerance,
+) -> Vec<RawCurve> {
+    let (Some(ext_a), Some(ext_b)) = (
+        FaceExtent::new(topo, fa, surf_a, v_range_a, tol),
+        FaceExtent::new(topo, fb, surf_b, v_range_b, tol),
+    ) else {
+        // Conservative: if either face's extent can't be built, don't restrict.
+        return raw_curves;
+    };
+
+    const N: usize = 24;
+    let mut out = Vec::with_capacity(raw_curves.len());
+    for raw in raw_curves {
+        // Lines are clipped downstream by `clip_line_to_face`; only the
+        // unbounded analytic curves (ellipse/circle/marched NURBS) need the
+        // mutual-extent test here.
+        if matches!(raw.curve, EdgeCurve::Line) {
+            out.push(raw);
+            continue;
+        }
+        let pt = |i: usize| -> Point3 {
+            #[allow(clippy::cast_precision_loss)]
+            let f = i as f64 / N as f64;
+            let t = raw.t_range.0 + (raw.t_range.1 - raw.t_range.0) * f;
+            raw.curve.evaluate_with_endpoints(t, raw.p_start, raw.p_end)
+        };
+        let inb: Vec<bool> = (0..=N)
+            .map(|i| {
+                let p = pt(i);
+                ext_a.contains(p) && ext_b.contains(p)
+            })
+            .collect();
+        // Longest contiguous in-both run.
+        let (mut b0, mut b1) = (0usize, 0usize);
+        let mut cur: Option<usize> = None;
+        for (i, &v) in inb.iter().enumerate() {
+            if v {
+                let c = *cur.get_or_insert(i);
+                if i - c > b1 - b0 {
+                    b0 = c;
+                    b1 = i;
+                }
+            } else {
+                cur = None;
+            }
+        }
+        // A contiguous in-both run of <2 samples is a tangency/grazing point
+        // (or no presence at all) — such a curve never splits either face, so
+        // drop it. Curves with a real in-both span are kept whole (the
+        // downstream splitter trims them to the face boundary).
+        if b1 - b0 < 2 {
+            continue;
+        }
+        out.push(raw);
+    }
+    out
 }
 
 /// Compute AABB for a face by sampling its boundary edges.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -326,10 +326,12 @@ pub fn perform(
 /// face (so surface-surface intersection curves can be restricted to the
 /// region inside both faces — the reference's "true boundary" restriction).
 enum FaceExtent {
-    /// Planar face: 2D boundary polygon in a plane frame (arc edges sampled).
+    /// Planar face: 2D outer boundary polygon in a plane frame (arc edges
+    /// sampled), plus any inner-wire (hole) polygons subtracted from it.
     Plane {
         frame: crate::builder::plane_frame::PlaneFrame,
         poly: Vec<brepkit_math::vec::Point2>,
+        holes: Vec<Vec<brepkit_math::vec::Point2>>,
         margin: f64,
     },
     /// Analytic lateral face (cylinder/cone/sphere/torus): bound by the
@@ -352,40 +354,54 @@ impl FaceExtent {
     ) -> Option<Self> {
         if let FaceSurface::Plane { normal, .. } = surface {
             let face = topo.face(face_id).ok()?;
-            let wire = topo.wire(face.outer_wire()).ok()?;
-            let first = wire.edges().first()?;
+            let outer = topo.wire(face.outer_wire()).ok()?;
+            let first = outer.edges().first()?;
             let origin = topo
                 .vertex(topo.edge(first.edge()).ok()?.start())
                 .ok()?
                 .point();
             let frame =
                 crate::builder::plane_frame::PlaneFrame::from_normal_and_point(*normal, origin);
-            let mut poly = Vec::new();
-            for oe in wire.edges() {
-                let edge = topo.edge(oe.edge()).ok()?;
-                let s3 = topo.vertex(edge.start()).ok()?.point();
-                let e3 = topo.vertex(edge.end()).ok()?.point();
-                let oriented_start = if oe.is_forward() { s3 } else { e3 };
-                match edge.curve() {
-                    EdgeCurve::Line => poly.push(frame.project(oriented_start)),
-                    curve => {
-                        let (t0, t1) = curve.domain_with_endpoints(s3, e3);
-                        for i in 0..16 {
-                            #[allow(clippy::cast_precision_loss)]
-                            let f = i as f64 / 16.0;
-                            let t = if oe.is_forward() {
-                                t0 + (t1 - t0) * f
-                            } else {
-                                t1 + (t0 - t1) * f
-                            };
-                            poly.push(frame.project(curve.evaluate_with_endpoints(t, s3, e3)));
+            // Project a wire's boundary into the plane frame, sampling each arc
+            // edge (endpoints included) so curved corners aren't chord-cut.
+            let wire_poly = |wid| -> Option<Vec<brepkit_math::vec::Point2>> {
+                let wire = topo.wire(wid).ok()?;
+                let mut poly = Vec::new();
+                for oe in wire.edges() {
+                    let edge = topo.edge(oe.edge()).ok()?;
+                    let s3 = topo.vertex(edge.start()).ok()?.point();
+                    let e3 = topo.vertex(edge.end()).ok()?.point();
+                    match edge.curve() {
+                        EdgeCurve::Line => {
+                            poly.push(frame.project(if oe.is_forward() { s3 } else { e3 }));
+                        }
+                        curve => {
+                            let (t0, t1) = curve.domain_with_endpoints(s3, e3);
+                            for i in 0..=16 {
+                                #[allow(clippy::cast_precision_loss)]
+                                let f = i as f64 / 16.0;
+                                let t = if oe.is_forward() {
+                                    t0 + (t1 - t0) * f
+                                } else {
+                                    t1 + (t0 - t1) * f
+                                };
+                                poly.push(frame.project(curve.evaluate_with_endpoints(t, s3, e3)));
+                            }
                         }
                     }
                 }
-            }
+                Some(poly)
+            };
+            let poly = wire_poly(face.outer_wire())?;
             if poly.len() < 3 {
                 return None;
             }
+            let holes: Vec<_> = face
+                .inner_wires()
+                .iter()
+                .filter_map(|&iw| wire_poly(iw))
+                .filter(|h| h.len() >= 3)
+                .collect();
             // Margin keeps boundary-coincident points (the shared cap) inside;
             // scaled to the footprint so it stays small vs the stray extent.
             let bb = brepkit_math::aabb::Aabb3::from_points(
@@ -396,6 +412,7 @@ impl FaceExtent {
             Some(Self::Plane {
                 frame,
                 poly,
+                holes,
                 margin: (diag * 0.01).max(tol.linear),
             })
         } else {
@@ -415,11 +432,21 @@ impl FaceExtent {
             Self::Plane {
                 frame,
                 poly,
+                holes,
                 margin,
             } => {
                 let uv = frame.project(p);
-                crate::builder::classify_2d::point_in_polygon_2d(uv, poly)
-                    || point_to_polygon_dist(uv, poly) <= *margin
+                let in_outer = crate::builder::classify_2d::point_in_polygon_2d(uv, poly)
+                    || point_to_polygon_dist(uv, poly) <= *margin;
+                if !in_outer {
+                    return false;
+                }
+                // A point strictly inside a hole (beyond the boundary margin)
+                // is not on the trimmed face.
+                !holes.iter().any(|h| {
+                    crate::builder::classify_2d::point_in_polygon_2d(uv, h)
+                        && point_to_polygon_dist(uv, h) > *margin
+                })
             }
             Self::Analytic {
                 surface,
@@ -457,12 +484,13 @@ fn point_to_polygon_dist(p: brepkit_math::vec::Point2, poly: &[brepkit_math::vec
 /// faces. `compute_raw_curves` works on the unbounded surfaces, so a
 /// plane-analytic or algebraic curve (e.g. a cylinder/tilted-plane ellipse)
 /// can reach far past the faces' shared region and slit the partner face's
-/// wire. A non-Line curve whose longest contiguous in-both sample run is under
-/// two samples only grazes the mutual extent at a tangency/point — it never
-/// splits either face, so it is dropped. Curves with a real in-both span are
-/// kept whole (the downstream splitter trims them to the boundary). Lines are
-/// left to the downstream `clip_line_to_face`. Conservative: if either face's
-/// extent cannot be built, the curves are returned unchanged.
+/// wire. A non-Line curve whose longest contiguous in-both run spans fewer than
+/// two sample segments (at most two consecutive in-both samples out of `N+1`)
+/// only grazes the mutual extent at a tangency/point — it never splits either
+/// face, so it is dropped. Curves with a real in-both span are kept whole (the
+/// downstream splitter trims them to the boundary). Lines are left to the
+/// downstream `clip_line_to_face`. Conservative: if either face's extent cannot
+/// be built, the curves are returned unchanged.
 #[allow(clippy::too_many_arguments, clippy::items_after_statements)]
 fn restrict_curves_to_faces(
     topo: &Topology,
@@ -519,10 +547,11 @@ fn restrict_curves_to_faces(
                 cur = None;
             }
         }
-        // A contiguous in-both run of <2 samples is a tangency/grazing point
-        // (or no presence at all) — such a curve never splits either face, so
-        // drop it. Curves with a real in-both span are kept whole (the
-        // downstream splitter trims them to the face boundary).
+        // An in-both run spanning fewer than two segments (b1-b0 < 2, i.e. at
+        // most two consecutive in-both samples) is a tangency/grazing point —
+        // such a curve never splits either face, so drop it. Curves with a real
+        // in-both span are kept whole (the downstream splitter trims them to the
+        // face boundary).
         if b1 - b0 < 2 {
             continue;
         }

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -2778,9 +2778,13 @@ fn unify_coincident_boundary_edges(
         let mut inner_ids = Vec::new();
         for (inner_oes, inner_closed) in &snap.inners {
             let oes = rebuild(topo, inner_oes, &mut ecanon, &mut changed)?;
-            if let Ok(w) = Wire::new(oes, *inner_closed) {
-                inner_ids.push(topo.add_wire(w));
-            }
+            let Ok(w) = Wire::new(oes, *inner_closed) else {
+                // A dropped hole silently changes topology (and removes free
+                // edges, so the downstream gate can't catch it). Bail like the
+                // outer-wire case, leaving the original solid untouched.
+                return Ok(false);
+            };
+            inner_ids.push(topo.add_wire(w));
         }
         let mut new_face =
             brepkit_topology::face::Face::new(outer_id, inner_ids, snap.surface.clone());

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -478,6 +478,17 @@ pub fn boolean(
             }
             if result_faces > 0 {
                 let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
+                // A coincident-junction fuse can leave duplicate junction-wire
+                // edges (one per argument) that differ by sub-micron loft noise
+                // → free edges. Merge those coincident duplicates. Gated on the
+                // shell actually being open so clean results keep exact topology.
+                if has_free_edges(topo, result).unwrap_or(false) {
+                    let _ = unify_coincident_boundary_edges(
+                        topo,
+                        result,
+                        (tol.linear * 10.0).max(1e-6),
+                    );
+                }
                 // Check Euler before unify_faces — if already valid, skip
                 // unify to avoid its face-merging bugs (non-manifold edges).
                 let (f_pre, e_pre, v_pre) =
@@ -2574,6 +2585,210 @@ fn merge_result_vertices(
     solid_mut.set_outer_shell(new_shell_id);
 
     Ok(())
+}
+
+/// Merge geometrically-coincident duplicate boundary edges on the outer shell.
+///
+/// A coincident-junction fuse (e.g. a box stacked on a tapered loft that share
+/// a cap face) annihilates the shared cap but leaves each argument's faces
+/// carrying their OWN copy of the junction-wire edges. Because the two copies
+/// come from independently-built solids their endpoints differ by sub-micron
+/// numerical noise (loft re-parameterization), so the tight-tolerance vertex
+/// merge above leaves them as distinct edges — each used once → free edges that
+/// open the shell.
+///
+/// This snaps vertices at `tol_merge` (looser than the default linear
+/// tolerance, to absorb that noise), then rebuilds every wire against a global
+/// canonical-edge map keyed by *unordered canonical endpoints + curve type +
+/// geometric midpoint* — so a straight line and a bulged arc between the same
+/// endpoints stay distinct, while true duplicates collapse to one shared edge.
+/// Edges whose endpoints merge to a single vertex (degenerate) are dropped.
+///
+/// Returns `true` if anything changed. Run only on already-broken results
+/// (free edges / non-manifold) so clean booleans keep their exact topology.
+#[allow(
+    clippy::too_many_lines,
+    clippy::type_complexity,
+    clippy::items_after_statements
+)]
+fn unify_coincident_boundary_edges(
+    topo: &mut Topology,
+    solid: SolidId,
+    tol_merge: f64,
+) -> Result<bool, crate::OperationsError> {
+    use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
+    use brepkit_topology::vertex::VertexId;
+    use brepkit_topology::wire::{OrientedEdge, Wire, WireId};
+    use std::collections::HashMap;
+
+    let shell_id = topo.solid(solid)?.outer_shell();
+    let face_ids: Vec<_> = topo.shell(shell_id)?.faces().to_vec();
+
+    let scale = 1.0 / tol_merge;
+    let q = |p: Point3| -> (i64, i64, i64) {
+        (
+            (p.x() * scale).round() as i64,
+            (p.y() * scale).round() as i64,
+            (p.z() * scale).round() as i64,
+        )
+    };
+
+    // 1. Canonical vertex per quantized position (first VertexId seen wins).
+    let mut vcanon: HashMap<(i64, i64, i64), VertexId> = HashMap::new();
+    for &fid in &face_ids {
+        let face = topo.face(fid)?;
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            let wire = topo.wire(wid)?;
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge())?;
+                for vid in [edge.start(), edge.end()] {
+                    let key = q(topo.vertex(vid)?.point());
+                    vcanon.entry(key).or_insert(vid);
+                }
+            }
+        }
+    }
+
+    // 2. Snapshot each face's wires (edge id, fwd, curve, endpoints, tol).
+    type OeSnap = (EdgeId, bool, EdgeCurve, VertexId, VertexId, Option<f64>);
+    struct FaceSnap {
+        surface: FaceSurface,
+        reversed: bool,
+        outer: Vec<OeSnap>,
+        outer_closed: bool,
+        inners: Vec<(Vec<OeSnap>, bool)>,
+    }
+    let snap_wire =
+        |topo: &Topology, wid: WireId| -> Result<(Vec<OeSnap>, bool), crate::OperationsError> {
+            let w = topo.wire(wid)?;
+            let closed = w.is_closed();
+            let oes = w
+                .edges()
+                .iter()
+                .map(|oe| -> Result<OeSnap, crate::OperationsError> {
+                    let e = topo.edge(oe.edge())?;
+                    Ok((
+                        oe.edge(),
+                        oe.is_forward(),
+                        e.curve().clone(),
+                        e.start(),
+                        e.end(),
+                        e.tolerance(),
+                    ))
+                })
+                .collect::<Result<_, _>>()?;
+            Ok((oes, closed))
+        };
+    let mut snaps = Vec::with_capacity(face_ids.len());
+    for &fid in &face_ids {
+        let face = topo.face(fid)?;
+        let surface = face.surface().clone();
+        let reversed = face.is_reversed();
+        let (outer, outer_closed) = snap_wire(topo, face.outer_wire())?;
+        let mut inners = Vec::new();
+        for iw in face.inner_wires() {
+            inners.push(snap_wire(topo, *iw)?);
+        }
+        snaps.push(FaceSnap {
+            surface,
+            reversed,
+            outer,
+            outer_closed,
+            inners,
+        });
+    }
+
+    // 3. Rebuild wires against a global canonical-edge map.
+    //    Key: (lo endpoint q, hi endpoint q, midpoint q, curve type tag).
+    type EdgeKey = (
+        (i64, i64, i64),
+        (i64, i64, i64),
+        (i64, i64, i64),
+        &'static str,
+    );
+    let mut ecanon: HashMap<EdgeKey, (EdgeId, VertexId, VertexId)> = HashMap::new();
+    let mut changed = false;
+
+    let canon_vid = |topo: &Topology, vid: VertexId| -> Result<VertexId, crate::OperationsError> {
+        Ok(*vcanon.get(&q(topo.vertex(vid)?.point())).unwrap_or(&vid))
+    };
+
+    let rebuild = |topo: &mut Topology,
+                   oes: &[OeSnap],
+                   ecanon: &mut HashMap<EdgeKey, (EdgeId, VertexId, VertexId)>,
+                   changed: &mut bool|
+     -> Result<Vec<OrientedEdge>, crate::OperationsError> {
+        let mut out = Vec::with_capacity(oes.len());
+        for (eid, fwd, curve, start, end, etol) in oes {
+            let cs = canon_vid(topo, *start)?;
+            let ce = canon_vid(topo, *end)?;
+            if cs == ce {
+                // Endpoints collapsed to a single vertex → degenerate, drop it.
+                *changed = true;
+                continue;
+            }
+            let sp = topo.vertex(*start)?.point();
+            let ep = topo.vertex(*end)?.point();
+            let (t0, t1) = curve.domain_with_endpoints(sp, ep);
+            let mid = curve.evaluate_with_endpoints((t0 + t1) * 0.5, sp, ep);
+            let (cs_q, ce_q) = (q(topo.vertex(cs)?.point()), q(topo.vertex(ce)?.point()));
+            let (lo, hi) = if cs_q <= ce_q {
+                (cs_q, ce_q)
+            } else {
+                (ce_q, cs_q)
+            };
+            let key = (lo, hi, q(mid), curve.type_tag());
+
+            // Physical traversal start vertex (after canonicalization).
+            let trav_start = if *fwd { cs } else { ce };
+            if let Some(&(c_eid, c_start, _c_end)) = ecanon.get(&key) {
+                if c_eid != *eid {
+                    *changed = true;
+                }
+                out.push(OrientedEdge::new(c_eid, c_start == trav_start));
+            } else {
+                let new_eid = topo.add_edge(Edge::with_tolerance(cs, ce, curve.clone(), *etol));
+                if new_eid != *eid {
+                    *changed = true;
+                }
+                ecanon.insert(key, (new_eid, cs, ce));
+                out.push(OrientedEdge::new(new_eid, cs == trav_start));
+            }
+        }
+        Ok(out)
+    };
+
+    let mut new_face_ids = Vec::with_capacity(snaps.len());
+    for snap in &snaps {
+        let outer_oes = rebuild(topo, &snap.outer, &mut ecanon, &mut changed)?;
+        let Ok(outer_wire) = Wire::new(outer_oes, snap.outer_closed) else {
+            // Keep original face if the rebuilt wire is invalid.
+            return Ok(false);
+        };
+        let outer_id = topo.add_wire(outer_wire);
+        let mut inner_ids = Vec::new();
+        for (inner_oes, inner_closed) in &snap.inners {
+            let oes = rebuild(topo, inner_oes, &mut ecanon, &mut changed)?;
+            if let Ok(w) = Wire::new(oes, *inner_closed) {
+                inner_ids.push(topo.add_wire(w));
+            }
+        }
+        let mut new_face =
+            brepkit_topology::face::Face::new(outer_id, inner_ids, snap.surface.clone());
+        if snap.reversed {
+            new_face.set_reversed(true);
+        }
+        new_face_ids.push(topo.add_face(new_face));
+    }
+
+    if !changed {
+        return Ok(false);
+    }
+
+    let new_shell = brepkit_topology::shell::Shell::new(new_face_ids)?;
+    let new_shell_id = topo.add_shell(new_shell);
+    topo.solid_mut(solid)?.set_outer_shell(new_shell_id);
+    Ok(true)
 }
 
 /// Post-process a solid to enforce manifold topology via greedy flood-fill.

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -483,11 +483,13 @@ pub fn boolean(
                 // → free edges. Merge those coincident duplicates. Gated on the
                 // shell actually being open so clean results keep exact topology.
                 if has_free_edges(topo, result).unwrap_or(false) {
-                    let _ = unify_coincident_boundary_edges(
-                        topo,
-                        result,
-                        (tol.linear * 10.0).max(1e-6),
-                    );
+                    // Best-effort: an error here shouldn't abort the boolean,
+                    // but it's useful signal on an already-broken shell.
+                    if let Err(e) =
+                        unify_coincident_boundary_edges(topo, result, (tol.linear * 10.0).max(1e-6))
+                    {
+                        log::debug!("unify_coincident_boundary_edges failed: {e}");
+                    }
                 }
                 // Check Euler before unify_faces — if already valid, skip
                 // unify to avoid its face-merging bugs (non-manifold edges).
@@ -2742,17 +2744,24 @@ fn unify_coincident_boundary_edges(
             // Physical traversal start vertex (after canonicalization).
             let trav_start = if *fwd { cs } else { ce };
             if let Some(&(c_eid, c_start, _c_end)) = ecanon.get(&key) {
-                if c_eid != *eid {
-                    *changed = true;
-                }
+                // A duplicate of an already-seen edge → merge onto the keeper.
+                *changed = true;
                 out.push(OrientedEdge::new(c_eid, c_start == trav_start));
             } else {
-                let new_eid = topo.add_edge(Edge::with_tolerance(cs, ce, curve.clone(), *etol));
-                if new_eid != *eid {
+                // First edge with this key. Reuse the original edge when its
+                // endpoints didn't move; only allocate (and flag a change) when
+                // a vertex was snapped — so an already-clean shell is a no-op.
+                let (eid_use, e_start) = if cs == *start && ce == *end {
+                    (*eid, *start)
+                } else {
                     *changed = true;
-                }
-                ecanon.insert(key, (new_eid, cs, ce));
-                out.push(OrientedEdge::new(new_eid, cs == trav_start));
+                    (
+                        topo.add_edge(Edge::with_tolerance(cs, ce, curve.clone(), *etol)),
+                        cs,
+                    )
+                };
+                ecanon.insert(key, (eid_use, e_start, ce));
+                out.push(OrientedEdge::new(eid_use, e_start == trav_start));
             }
         }
         Ok(out)

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -3049,6 +3049,112 @@ fn fuse_shelled_box_with_socket_loft() {
     assert!(is_manifold, "fused solid should be manifold");
 }
 
+/// Coincident rounded-rect cap fuse where one solid is a tapered frustum
+/// (loft). A well-posed isolation of the curved-loft socket family
+/// (`fuse_shelled_box_with_socket_loft`): box A and frustum B are built from
+/// the *same* rounded-rect arc profile at z=0, so their caps should annihilate
+/// and the corners join cleanly.
+///
+/// Blocked by a loft limitation, not the boolean: `loft` samples each profile
+/// to a polygon (`face_polygon`) and builds every ring edge as `EdgeCurve::Line`
+/// with planar side faces — so B is an *octagonal* frustum (straight chord
+/// corners), while A keeps its true arc corners. B's chord-cornered z=0 cap can
+/// never match A's arc-cornered cap, leaving the corners non-manifold. The fix
+/// is a curve-preserving loft (build arc-cornered caps + ruled side patches
+/// between corresponding curve segments), not anything in the fuse pipeline.
+/// The FF-curve restriction and coincident-edge merge added alongside this test
+/// remove the *other* defects this geometry exposes (phantom face holes from
+/// untrimmed analytic intersections; duplicate junction edges), shrinking the
+/// raw GFA failure from euler=-7/8-holes/30+ free edges to euler=-2 with only
+/// the 4 arc-vs-chord corner mismatches remaining.
+#[ignore = "blocked by loft faceting curved profiles (octagon vs rounded-rect cap); needs curve-preserving loft"]
+#[test]
+fn fuse_coincident_rrect_cap_with_frustum() {
+    use brepkit_math::curves::Circle3D;
+
+    fn make_rr_arcs(topo: &mut Topology, hw: f64, hd: f64, r: f64, z: f64) -> FaceId {
+        let r = r.min(hw.min(hd));
+        let cc = [
+            Point3::new(hw - r, -hd + r, z),
+            Point3::new(hw - r, hd - r, z),
+            Point3::new(-hw + r, hd - r, z),
+            Point3::new(-hw + r, -hd + r, z),
+        ];
+        let ap = [
+            (Point3::new(hw - r, -hd, z), Point3::new(hw, -hd + r, z)),
+            (Point3::new(hw, hd - r, z), Point3::new(hw - r, hd, z)),
+            (Point3::new(-hw + r, hd, z), Point3::new(-hw, hd - r, z)),
+            (Point3::new(-hw, -hd + r, z), Point3::new(-hw + r, -hd, z)),
+        ];
+        let axis = Vec3::new(0.0, 0.0, 1.0);
+        let mut v = Vec::new();
+        for p in &ap {
+            v.push(topo.add_vertex(Vertex::new(p.0, 1e-7)));
+            v.push(topo.add_vertex(Vertex::new(p.1, 1e-7)));
+        }
+        let mut e = Vec::new();
+        e.push(topo.add_edge(Edge::new(v[7], v[0], EdgeCurve::Line)));
+        for i in 0..4 {
+            e.push(topo.add_edge(Edge::new(
+                v[2 * i],
+                v[2 * i + 1],
+                EdgeCurve::Circle(Circle3D::new(cc[i], axis, r).unwrap()),
+            )));
+            if i < 3 {
+                e.push(topo.add_edge(Edge::new(v[2 * i + 1], v[2 * i + 2], EdgeCurve::Line)));
+            }
+        }
+        let wire = Wire::new(
+            e.iter().map(|&id| OrientedEdge::new(id, true)).collect(),
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+        topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane { normal: axis, d: z },
+        ))
+    }
+
+    let mut topo = Topology::new();
+    let (hw, hd, r) = (20.0, 20.0, 4.0);
+    let face_a = make_rr_arcs(&mut topo, hw, hd, r, 0.0);
+    let solid_a =
+        crate::extrude::extrude(&mut topo, face_a, Vec3::new(0.0, 0.0, 1.0), 10.0).unwrap();
+    let b_bot = make_rr_arcs(&mut topo, hw - 3.0, hd - 3.0, r - 1.0, -10.0);
+    let b_top = make_rr_arcs(&mut topo, hw, hd, r, 0.0);
+    let solid_b = crate::loft::loft(&mut topo, &[b_bot, b_top]).unwrap();
+
+    let vol_a = crate::measure::solid_volume(&topo, solid_a, 0.01).unwrap();
+    let vol_b = crate::measure::solid_volume(&topo, solid_b, 0.01).unwrap();
+    let fused = boolean(&mut topo, BooleanOp::Fuse, solid_a, solid_b).unwrap();
+    let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(&topo, fused).unwrap();
+    #[allow(clippy::cast_possible_wrap)]
+    let euler = (v as i64) - (e as i64) + (f as i64);
+    let fused_vol = crate::measure::solid_volume(&topo, fused, 0.01).unwrap();
+    let shell = topo
+        .shell(topo.solid(fused).unwrap().outer_shell())
+        .unwrap();
+    let manifold = brepkit_topology::validation::validate_shell_manifold(shell, &topo);
+    eprintln!(
+        "rrect+frustum cap fuse: F={f} E={e} V={v} euler={euler} vol={fused_vol:.1} (a+b={:.1}) manifold={}",
+        vol_a + vol_b,
+        manifold.is_ok()
+    );
+
+    assert!(
+        (fused_vol - (vol_a + vol_b)).abs() < 1.0,
+        "fused vol {fused_vol:.1} != a+b {:.1}",
+        vol_a + vol_b
+    );
+    assert!(
+        manifold.is_ok(),
+        "fused solid should be manifold: {manifold:?}"
+    );
+    assert_eq!(euler, 2, "should be genus-0");
+}
+
 // ── GFA integration tests for analytic surfaces ────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Two robustness improvements for **coincident curved-surface fuses**, surfaced while isolating the curved-loft socket family (`fuse_shelled_box_with_socket_loft`).

### 1. `algo/phase_ff` — restrict analytic FF curves to both faces' extent
`compute_raw_curves` intersects the **unbounded** surfaces, so a plane-analytic / algebraic ellipse (e.g. a cylinder vs a tilted wall) can reach far past the faces' shared region and **slit the partner face's wire**, leaving phantom inner wires. The new `restrict_curves_to_faces` builds a lightweight per-face extent (planar boundary polygon, or analytic `v`-range) and drops non-Line curves whose longest contiguous in-both sample run is under two samples — a tangency/point that never splits either face. Conservative: if either extent can't be built, curves pass through unchanged.

### 2. `boolean` — merge coincident duplicate junction edges
A coincident-junction fuse annihilates the shared cap but leaves each argument carrying its **own** copy of the junction-wire edges, differing by sub-micron numerical noise (independent construction). The tight-tolerance vertex merge leaves them distinct → each used once → **free edges** that open the shell. `unify_coincident_boundary_edges` snaps vertices at a looser tolerance and rebuilds every wire against a canonical-edge map keyed by *unordered endpoints + curve type + geometric midpoint* (so a line and an arc between the same endpoints stay distinct); degenerate edges are dropped. **Gated on free-edge results** so clean booleans keep exact topology.

## Effect
Together these take the rrect-cap + frustum reproducer's raw GFA output from **euler=−7 / 8 phantom holes / 30+ free edges** down to **euler=−2 with only the 4 arc-vs-chord corner mismatches** left.

## Known residual (not addressed here)
The 4 remaining corner mismatches are a **loft limitation**: `loft` samples each profile to a polygon and builds straight (`Line`) ring edges with planar side faces, so a rounded-rect loft becomes an *octagonal* frustum whose chord-cornered cap can't match a box's arc-cornered cap. Tracked by the new ignored `fuse_coincident_rrect_cap_with_frustum` test. Closing it needs a **curve-preserving loft**, not a change in the fuse pipeline.

## Testing
Zero regressions: **algo 113, operations 662, io 156, wasm 210**. Clippy + boundaries clean. 5× flake gate on the boolean suite stable.

## ⚠️ Review note
`phase_ff` is **core GFA (pave_filler)** and runs on every analytic FF pair → **HIGH-risk**. Not set to auto-merge; requesting human review before merge.