### PR TITLE
fix(algo): sample concave face interiors via point-in-polygon (thin-shell fuse)

### DIFF
--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -447,16 +447,56 @@ fn sample_face_interior(
     let inward = tangent.cross(face_normal);
     let inward_len = inward.length();
 
-    let mut offset = if inward_len > 1e-12 {
+    let base_offset = if inward_len > 1e-12 {
         inward * (offset_scale / inward_len)
     } else {
         // Degenerate — use a tiny offset along the face normal instead
         face_normal * offset_scale
     };
 
-    // The tangent-cross-normal direction assumes CCW winding; reversed or
-    // CW-wound faces flip it, sending the sample outside the face. Use the
-    // boundary vertex centroid to pick the side that points into the face.
+    // For a planar face, verify the sample lands strictly inside the
+    // (possibly concave) boundary polygon. The tangent×normal sign is
+    // unreliable on inner/notch edges and reversed winding, and a
+    // boundary-vertex centroid can fall in a concavity — e.g. the notch of an
+    // L-shaped face left by a corner cut — so a centroid-based flip points the
+    // sample OUTSIDE the face and into the opposing solid, misclassifying a
+    // thin sliver. Project the boundary, then pick the offset sign (shrinking
+    // the magnitude for strips thinner than the offset) that lands inside.
+    if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = surface {
+        if inward_len > 1e-12 {
+            let mut poly = Vec::with_capacity(edges.len());
+            for oe in edges {
+                let e = topo.edge(oe.edge())?;
+                poly.push(topo.vertex(oe.oriented_start(e))?.point());
+            }
+            let frame = plane_frame::PlaneFrame::from_plane_face(*normal, &poly);
+            let poly2d: Vec<_> = poly.iter().map(|p| frame.project(*p)).collect();
+            let eps = classify_2d::boundary_eps(&poly2d);
+            let mut scale = 1.0_f64;
+            for _ in 0..24 {
+                for sign in [1.0_f64, -1.0] {
+                    let cand = mid_pt + base_offset * (sign * scale);
+                    let c2 = frame.project(cand);
+                    if classify_2d::point_in_polygon_2d(c2, &poly2d)
+                        && classify_2d::distance_to_polygon_boundary(c2, &poly2d) > eps
+                    {
+                        return Ok(cand);
+                    }
+                }
+                scale *= 0.5;
+            }
+            // Near-zero-area face: robust interior point of the projected
+            // boundary, mapped back to 3D.
+            let ip = classify_2d::sample_interior_point(&poly2d);
+            return Ok(frame.evaluate(ip.x(), ip.y()));
+        }
+    }
+
+    // Non-planar surfaces: the tangent×normal direction assumes CCW winding;
+    // reversed or CW-wound faces flip it, sending the sample outside the
+    // face. Use the boundary vertex centroid to pick the side that points
+    // into the face.
+    let mut offset = base_offset;
     let centroid = {
         let mut sum = Vec3::new(0.0, 0.0, 0.0);
         let mut n = 0_usize;
@@ -484,15 +524,42 @@ fn sample_face_interior(
         }
     }
 
-    // Planes have no UV projection, but the inward offset is already
-    // in-plane — the offset point itself is the on-surface sample.
-    // Falling back to `mid_pt` here would put the sample exactly on the
-    // face boundary, where junction-plane-grazing rays misclassify.
-    if matches!(surface, brepkit_topology::face::FaceSurface::Plane { .. }) && inward_len > 1e-12 {
-        return Ok(interior_pt);
-    }
-
     // Fallback: use the midpoint itself (it's on the boundary, not ideal
     // but better than a centroid that may be outside the face)
     Ok(mid_pt)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use brepkit_topology::builder::{make_face_from_wire, make_polygon_wire};
+
+    #[test]
+    fn sample_face_interior_thin_l_frame_lands_in_strip() {
+        // L-frame: a side-1.0001 square with a side-1.0 corner notch removed at
+        // the origin, leaving a 0.0001-thin strip. The boundary-vertex centroid
+        // (~0.667, ~0.667) falls inside the removed notch, so the old
+        // centroid-based flip placed the sample outside the face. The sample
+        // must instead land in the strip (one coordinate >= 1.0).
+        let mut topo = Topology::new();
+        let s = 1.0001;
+        let n = 1.0;
+        let pts = vec![
+            Point3::new(n, 0.0, 0.0),
+            Point3::new(s, 0.0, 0.0),
+            Point3::new(s, s, 0.0),
+            Point3::new(0.0, s, 0.0),
+            Point3::new(0.0, n, 0.0),
+            Point3::new(n, n, 0.0),
+        ];
+        let wire = make_polygon_wire(&mut topo, &pts, 1e-7).unwrap();
+        let face = make_face_from_wire(&mut topo, wire).unwrap();
+
+        let pt = sample_face_interior(&topo, face, Tolerance::default()).unwrap();
+        assert!(
+            pt.x() >= n - 1e-9 || pt.y() >= n - 1e-9,
+            "sample {pt:?} fell in the notch instead of the L-frame strip"
+        );
+    }
 }

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -463,15 +463,23 @@ fn sample_face_interior(
     // thin sliver. Project the boundary, then pick the offset sign (shrinking
     // the magnitude for strips thinner than the offset) that lands inside.
     if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = surface {
-        if inward_len > 1e-12 {
-            let mut poly = Vec::with_capacity(edges.len());
-            for oe in edges {
-                let e = topo.edge(oe.edge())?;
-                poly.push(topo.vertex(oe.oriented_start(e))?.point());
-            }
+        let mut poly = Vec::with_capacity(edges.len());
+        for oe in edges {
+            let e = topo.edge(oe.edge())?;
+            poly.push(topo.vertex(oe.oriented_start(e))?.point());
+        }
+        // A boundary with >= 3 vertices forms a real polygon to test against.
+        // A planar face bounded by a single closed curve (one circle/ellipse
+        // edge → <3 vertices) has no polygon; its centroid is the disc center
+        // (interior), so it falls through to the centroid heuristic below.
+        if inward_len > 1e-12 && poly.len() >= 3 {
             let frame = plane_frame::PlaneFrame::from_plane_face(*normal, &poly);
             let poly2d: Vec<_> = poly.iter().map(|p| frame.project(*p)).collect();
             let eps = classify_2d::boundary_eps(&poly2d);
+            // Halve the offset until a candidate lands strictly inside. 24
+            // halvings reach scale ~6e-8 (min offset ~diag·6e-12), below any
+            // physically meaningful strip width, so the loop only exits to the
+            // fallback for a near-zero-area (degenerate) face.
             let mut scale = 1.0_f64;
             for _ in 0..24 {
                 for sign in [1.0_f64, -1.0] {
@@ -485,10 +493,16 @@ fn sample_face_interior(
                 }
                 scale *= 0.5;
             }
-            // Near-zero-area face: robust interior point of the projected
-            // boundary, mapped back to 3D.
+            // Near-zero-area face: try a robust interior point of the projected
+            // boundary. Verify it before use — its last-resort path returns the
+            // vertex centroid, which can fall outside a concave boundary. If
+            // even that is exterior, fall back to the edge midpoint (on the
+            // boundary, never exterior) rather than a known-bad sample.
             let ip = classify_2d::sample_interior_point(&poly2d);
-            return Ok(frame.evaluate(ip.x(), ip.y()));
+            if classify_2d::point_in_polygon_2d(ip, &poly2d) {
+                return Ok(frame.evaluate(ip.x(), ip.y()));
+            }
+            return Ok(mid_pt);
         }
     }
 
@@ -524,6 +538,15 @@ fn sample_face_interior(
         }
     }
 
+    // Planes have no UV projection, but the inward offset is already in-plane,
+    // so the offset point itself is the on-surface sample. This reaches a
+    // planar face only when its boundary has < 3 vertices (a single closed
+    // circle/ellipse edge); the centroid above is the disc center, so the
+    // flipped offset points into the disc.
+    if matches!(surface, brepkit_topology::face::FaceSurface::Plane { .. }) && inward_len > 1e-12 {
+        return Ok(interior_pt);
+    }
+
     // Fallback: use the midpoint itself (it's on the boundary, not ideal
     // but better than a centroid that may be outside the face)
     Ok(mid_pt)
@@ -533,6 +556,7 @@ fn sample_face_interior(
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
+    use brepkit_math::vec::Vec3;
     use brepkit_topology::builder::{make_face_from_wire, make_polygon_wire};
 
     #[test]
@@ -557,9 +581,49 @@ mod tests {
         let face = make_face_from_wire(&mut topo, wire).unwrap();
 
         let pt = sample_face_interior(&topo, face, Tolerance::default()).unwrap();
+        // Strip check (not in the notch)...
         assert!(
             pt.x() >= n - 1e-9 || pt.y() >= n - 1e-9,
             "sample {pt:?} fell in the notch instead of the L-frame strip"
+        );
+        // ...and a direct interior-membership proof against the L-polygon.
+        let frame = plane_frame::PlaneFrame::from_plane_face(Vec3::new(0.0, 0.0, 1.0), &pts);
+        let poly2d: Vec<_> = pts.iter().map(|p| frame.project(*p)).collect();
+        assert!(
+            classify_2d::point_in_polygon_2d(frame.project(pt), &poly2d),
+            "sample {pt:?} is not inside the L-frame polygon"
+        );
+    }
+
+    #[test]
+    fn sample_face_interior_planar_disc_lands_inside() {
+        // A planar disc bounded by a single closed circle edge has < 3 boundary
+        // vertices, so the point-in-polygon path can't apply. The sample must
+        // still land inside the disc, not on the bounding circle (the
+        // degenerate-polygon failure mode).
+        use brepkit_topology::builder::make_circle_edge;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+
+        let mut topo = Topology::new();
+        let edge = make_circle_edge(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            1.0,
+            1e-7,
+        )
+        .unwrap();
+        let wire = topo.add_wire(Wire::new(vec![OrientedEdge::new(edge, true)], true).unwrap());
+        let face = make_face_from_wire(&mut topo, wire).unwrap();
+
+        let pt = sample_face_interior(&topo, face, Tolerance::default()).unwrap();
+        let r = pt.x().hypot(pt.y());
+        // Strictly inside the unit disc. The degenerate-polygon failure mode
+        // (point_in_polygon on a single projected vertex → boundary vertex)
+        // would return a point on the circle (r == 1.0).
+        assert!(
+            r < 1.0 - 1e-9,
+            "disc sample (r={r}) should be interior, not on the bounding circle"
         );
     }
 }

--- a/crates/operations/tests/boolean_invariants.rs
+++ b/crates/operations/tests/boolean_invariants.rs
@@ -571,10 +571,15 @@ fn cut_then_fuse_back_containment() {
 //   inter  = Intersect(A, B) // identical-shortcut: copy of A, vol ≈ 0.125000075
 //   fused  = Fuse(diff, inter)
 //   expect: vol(fused) ≈ vol(A) since diff ⊂ inter
-//   actual: vol(fused) ≈ 1.5×vol(A) — the overlap region is double-counted.
-
+//
+// Regression: diff's three d=0 origin faces are 0.0001-thin L-frames around
+// the inner cube. Sampling their interior for classification overshot the
+// strip into the concave notch (the removed cube corner), misclassifying two
+// of the three as Inside. They were dropped from the Fuse, leaving an open
+// shell that fell back to the mesh boolean, which double-counted the
+// coincident interface (+0.0625 = half the inner cube). Robust concave-face
+// sampling keeps all three, so the GFA result assembles directly.
 #[test]
-#[ignore = "Fuse(thin L-shell, containing solid) overshoots: vol_fused ≈ 1.5×vol(A) (0.18758 vs 0.12508, surplus 0.0625 = half the inner cube) instead of ≈ vol(A) — the overlap region is double-counted in the assembled result."]
 fn fuse_thin_shell_with_containing_solid_preserves_larger_volume() {
     // Uses 0.5001 (above tol.linear) so the identical-Cut shortcut doesn't
     // fire and Cut(A,B) actually goes through GFA, producing the L-shell.


### PR DESCRIPTION
## Summary

Fuse of a thin L-shell with the solid that contains it overshot its volume by exactly half the inner cube (`vol_fused ≈ 1.5×vol(A)`). Ground-truth per-face decomposition traced the surplus to a **concave face-interior sampling bug** in `sample_face_interior` (the boolean classification sample point), not to same-domain detection, selection, or the classifier truth table — all of which were verified correct for this case.

## Root cause (pinned with full per-face instrumentation)

`Fuse(diff, inter)` where `A=0.5001³`, `B=0.5³` corner-nested, `diff=Cut(A,B)` (thin L-shell), `inter=B` (cube):

1. `diff`'s three `d=0` origin faces are **0.0001-thin L-frames** wrapping the cube corner.
2. `sample_face_interior` offsets from a boundary-edge midpoint, then flips toward the **boundary-vertex centroid** to pick the inward side. For a concave L-frame the centroid lands **in the notch** (the removed cube corner — outside the face), so the flip pushed the sample *into the opposing cube*.
3. Two of the three symmetric L-frames (`x=0`, `z=0`) were sampled inside the cube → classified **Inside** → dropped by the Fuse truth table; `y=0` happened to land in the strip → Outside → kept. (Asymmetric purely by which edge/centroid geometry each face had.)
4. The two dropped faces left an **open shell** → GFA result rejected by the manifold/Euler gate → **mesh boolean fallback**.
5. The mesh fuse double-counted the coincident `d=0.5` interface → 3 diagonally-halved triangles → **+0.0625**.

The GFA result's *volume was already correct* (the dropped faces are at `d=0`, zero volume contribution); only its manifoldness was broken, which triggered the lossy fallback.

## Fix

For planar faces, replace the centroid flip with a **point-in-polygon verify**: project the boundary, then pick the offset sign — shrinking the magnitude for strips thinner than the offset — that lands strictly inside the polygon. 

- **Convex faces are unaffected**: the first candidate (current behavior's direction) is already interior, so it returns immediately with the same point.
- Only faces whose sample previously fell **outside their own boundary** (always a bug) change.
- Non-planar faces keep the existing centroid heuristic.

## Tests

- **Un-ignores** `fuse_thin_shell_with_containing_solid_preserves_larger_volume` (acceptance test; now `vol_fused = 0.1250750 = vol(A)`).
- Adds `sample_face_interior_thin_l_frame_lands_in_strip` unit test (asserts the sample lands in the strip, not the notch).

## Verification

- algo **114** ✓ · operations full suite (incl. 201s boolean suite) **0 failures** ✓ · io **156** ✓ · wasm **211** ✓
- clippy clean · fmt clean · `check-boundaries.sh` valid
- 10/10 deterministic (flake check on `boolean_invariants`)

## Risk

**HIGH** — `sample_face_interior` is on every boolean's classification path (core GFA). Mitigated by: convex-case behavior is identical, the change only affects samples that previously fell outside their face, and full algo/operations/io/wasm regression is green. Flagging for human review rather than auto-merge.