### PR TITLE
fix: cone/torus curved-boolean bugs (volume integration + contained-cut) + parity corpus

### DIFF
--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -231,9 +231,10 @@ fn face_uv_bounds<S: ParametricSurface>(
     }
 
     if u_min >= u_max || v_min >= v_max {
-        return Err(CheckError::IntegrationFailed(
-            "degenerate UV domain for face".into(),
-        ));
+        // A degenerate projection (e.g. all boundary vertices on a sphere's
+        // pole seam) does not mean an empty face — it means the boundary failed
+        // to bound a sub-region, so the face spans the full analytic domain.
+        return Ok(full_domain);
     }
 
     Ok(((u_min, u_max), (v_min, v_max)))
@@ -382,10 +383,17 @@ fn integrate_parametric<S: ParametricSurface>(
 ) -> FaceContribution {
     let gauss_pts = gauss_legendre_points(gauss_order);
 
-    let u_scale = (u_range.1 - u_range.0) / 2.0;
-    let u_mid = f64::midpoint(u_range.0, u_range.1);
-    let v_scale = (v_range.1 - v_range.0) / 2.0;
-    let v_mid = f64::midpoint(v_range.0, v_range.1);
+    // Composite quadrature: tile the domain into patches no larger than ~PI/4
+    // so one Gauss rule resolves curved and periodic integrands. A single patch
+    // over a torus's full 2*PI period in both u and v under-resolves it (~0.5%
+    // error); several patches per period converge to machine precision.
+    let patch = std::f64::consts::FRAC_PI_4;
+    let nu = (((u_range.1 - u_range.0).abs() / patch).ceil() as usize).max(1);
+    let nv = (((v_range.1 - v_range.0).abs() / patch).ceil() as usize).max(1);
+    let du_patch = (u_range.1 - u_range.0) / nu as f64;
+    let dv_patch = (v_range.1 - v_range.0) / nv as f64;
+    let u_scale = du_patch / 2.0;
+    let v_scale = dv_patch / 2.0;
 
     let mut area = 0.0;
     let mut vol = 0.0;
@@ -396,40 +404,46 @@ fn integrate_parametric<S: ParametricSurface>(
     let mut cy = 0.0;
     let mut cz = 0.0;
 
-    for gpu in gauss_pts {
-        let u = u_scale.mul_add(gpu.x, u_mid);
-        for gpv in gauss_pts {
-            let v = v_scale.mul_add(gpv.x, v_mid);
-            let w = gpu.w * gpv.w * u_scale * v_scale;
+    for iu in 0..nu {
+        let u_mid = du_patch.mul_add(iu as f64, u_range.0) + u_scale;
+        for iv in 0..nv {
+            let v_mid = dv_patch.mul_add(iv as f64, v_range.0) + v_scale;
+            for gpu in gauss_pts {
+                let u = u_scale.mul_add(gpu.x, u_mid);
+                for gpv in gauss_pts {
+                    let v = v_scale.mul_add(gpv.x, v_mid);
+                    let w = gpu.w * gpv.w * u_scale * v_scale;
 
-            let p = surface.evaluate(u, v);
-            let du = surface.partial_u(u, v);
-            let dv = surface.partial_v(u, v);
+                    let p = surface.evaluate(u, v);
+                    let du = surface.partial_u(u, v);
+                    let dv = surface.partial_v(u, v);
 
-            // Normal = du x dv (unnormalized, includes Jacobian)
-            let n = Vec3::new(
-                du.y() * dv.z() - du.z() * dv.y(),
-                du.z() * dv.x() - du.x() * dv.z(),
-                du.x() * dv.y() - du.y() * dv.x(),
-            );
-            let n_len = n.length();
+                    // Normal = du x dv (unnormalized, includes Jacobian)
+                    let n = Vec3::new(
+                        du.y() * dv.z() - du.z() * dv.y(),
+                        du.z() * dv.x() - du.x() * dv.z(),
+                        du.x() * dv.y() - du.y() * dv.x(),
+                    );
+                    let n_len = n.length();
 
-            area += w * n_len;
+                    area += w * n_len;
 
-            // Volume: (1/3) P dot N (unnormalized N includes Jacobian)
-            let pv = Vec3::new(p.x(), p.y(), p.z());
-            vol += w * pv.dot(n) / 3.0;
+                    // Volume: (1/3) P dot N (unnormalized N includes Jacobian)
+                    let pv = Vec3::new(p.x(), p.y(), p.z());
+                    vol += w * pv.dot(n) / 3.0;
 
-            // Volume moments via divergence theorem:
-            // CoM_x = (1/2V) surface_integral(x^2 * n_x dA)
-            // n already includes Jacobian, so n.x() = N_x * |J|
-            mx += w * 0.5 * p.x() * p.x() * n.x();
-            my += w * 0.5 * p.y() * p.y() * n.y();
-            mz += w * 0.5 * p.z() * p.z() * n.z();
+                    // Volume moments via divergence theorem:
+                    // CoM_x = (1/2V) surface_integral(x^2 * n_x dA)
+                    // n already includes Jacobian, so n.x() = N_x * |J|
+                    mx += w * 0.5 * p.x() * p.x() * n.x();
+                    my += w * 0.5 * p.y() * p.y() * n.y();
+                    mz += w * 0.5 * p.z() * p.z() * n.z();
 
-            cx += w * p.x() * n_len;
-            cy += w * p.y() * n_len;
-            cz += w * p.z() * n_len;
+                    cx += w * p.x() * n_len;
+                    cy += w * p.y() * n_len;
+                    cz += w * p.z() * n_len;
+                }
+            }
         }
     }
 
@@ -445,6 +459,22 @@ fn integrate_parametric<S: ParametricSurface>(
     }
 }
 
+/// Absolute shoelace area of a UV polygon. Near-zero means the boundary has
+/// collapsed onto a line or point (a degenerate seam/pole projection).
+fn polygon_area(poly: &[(f64, f64)]) -> f64 {
+    let n = poly.len();
+    if n < 3 {
+        return 0.0;
+    }
+    let mut a = 0.0;
+    for i in 0..n {
+        let (x0, y0) = poly[i];
+        let (x1, y1) = poly[(i + 1) % n];
+        a += x0 * y1 - x1 * y0;
+    }
+    (a * 0.5).abs()
+}
+
 /// Dispatch to trimmed or untrimmed parametric integration based on whether
 /// a UV boundary polygon is available.
 fn integrate_with_trimming<S: ParametricSurface>(
@@ -456,7 +486,68 @@ fn integrate_with_trimming<S: ParametricSurface>(
     uv_boundary: &[(f64, f64)],
     u_periodic: bool,
 ) -> FaceContribution {
-    if uv_boundary.len() >= 3 {
+    if uv_boundary.len() < 3 {
+        return integrate_parametric(surface, u_range, v_range, gauss_order, sign);
+    }
+
+    // The dense boundary polygon is the reliable signal for a face's true
+    // parametric extent: `face_uv_bounds` samples only sparse edge endpoints and
+    // under-spans full-revolution faces (a cone's lateral face reports a narrow
+    // u-range though its boundary wraps the full 2pi). A face that wraps the
+    // full period in u, or whose boundary collapses onto a seam or pole, cannot
+    // be trimmed by a UV polygon — the apex/pole/seam folds the polygon and the
+    // point-in-polygon test rejects valid interior samples. Integrate the
+    // analytic surface untrimmed over its true domain in those cases.
+    let u_min = uv_boundary
+        .iter()
+        .map(|p| p.0)
+        .fold(f64::INFINITY, f64::min);
+    let v_min = uv_boundary
+        .iter()
+        .map(|p| p.1)
+        .fold(f64::INFINITY, f64::min);
+    let v_max = uv_boundary
+        .iter()
+        .map(|p| p.1)
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    // Winding number of the boundary around the periodic u-axis: ±TAU for a
+    // face that wraps a full revolution, ~0 for a partially-trimmed face.
+    // Computed from shortest signed steps so it is independent of the
+    // boundary's discretization (segment count).
+    let tau = std::f64::consts::TAU;
+    let winding: f64 = (0..uv_boundary.len())
+        .map(|i| {
+            let d = uv_boundary[(i + 1) % uv_boundary.len()].0 - uv_boundary[i].0;
+            d - tau * ((d + std::f64::consts::PI) / tau).floor()
+        })
+        .sum();
+    let full_revolution = u_periodic && winding.abs() >= tau - 1e-3;
+    let v_degenerate = (v_max - v_min) <= 1e-9;
+
+    if full_revolution && v_degenerate {
+        // Polar cap (e.g. a sphere hemisphere bounded only by one latitude
+        // circle): the cap runs from that latitude to a pole. The winding sign
+        // (CCW vs CW boundary) selects which pole — the boundary's interior
+        // side — so the two hemispheres do not both integrate the whole sphere.
+        let v_pole = if winding >= 0.0 { v_range.1 } else { v_range.0 };
+        let v_dom = (v_min.min(v_pole), v_min.max(v_pole));
+        integrate_parametric(surface, (u_min, u_min + tau), v_dom, gauss_order, sign)
+    } else if full_revolution {
+        // Full-revolution band (cone/cylinder): integrate the whole revolution
+        // over the band's v-extent.
+        integrate_parametric(
+            surface,
+            (u_min, u_min + tau),
+            (v_min, v_max),
+            gauss_order,
+            sign,
+        )
+    } else if polygon_area(uv_boundary) <= 1e-12 {
+        // Collapsed polygon (e.g. a closed torus whose seam projects to a
+        // point): trust the analytic full-domain range from `face_uv_bounds`.
+        integrate_parametric(surface, u_range, v_range, gauss_order, sign)
+    } else {
         integrate_parametric_trimmed(
             surface,
             u_range,
@@ -466,8 +557,6 @@ fn integrate_with_trimming<S: ParametricSurface>(
             uv_boundary,
             u_periodic,
         )
-    } else {
-        integrate_parametric(surface, u_range, v_range, gauss_order, sign)
     }
 }
 

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -381,15 +381,20 @@ fn integrate_parametric<S: ParametricSurface>(
     gauss_order: usize,
     sign: f64,
 ) -> FaceContribution {
-    let gauss_pts = gauss_legendre_points(gauss_order);
-
     // Composite quadrature: tile the domain into patches no larger than ~PI/4
     // so one Gauss rule resolves curved and periodic integrands. A single patch
     // over a torus's full 2*PI period in both u and v under-resolves it (~0.5%
-    // error); several patches per period converge to machine precision.
+    // error); several patches per period converge to machine precision. The
+    // patch count is capped so a long *linear* axis (e.g. a tall cylinder/cone
+    // whose v is axial distance) cannot make integration cost scale with model
+    // size — its integrand is low-degree, so a bounded number of patches stays
+    // exact. Angular axes never exceed 2*PI (= 8 patches), well under the cap.
+    const MAX_PATCHES: usize = 16;
+
+    let gauss_pts = gauss_legendre_points(gauss_order);
     let patch = std::f64::consts::FRAC_PI_4;
-    let nu = (((u_range.1 - u_range.0).abs() / patch).ceil() as usize).max(1);
-    let nv = (((v_range.1 - v_range.0).abs() / patch).ceil() as usize).max(1);
+    let nu = (((u_range.1 - u_range.0).abs() / patch).ceil() as usize).clamp(1, MAX_PATCHES);
+    let nv = (((v_range.1 - v_range.0).abs() / patch).ceil() as usize).clamp(1, MAX_PATCHES);
     let du_patch = (u_range.1 - u_range.0) / nu as f64;
     let dv_patch = (v_range.1 - v_range.0) / nv as f64;
     let u_scale = du_patch / 2.0;

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -1835,21 +1835,28 @@ fn solid_strictly_inside(
     let mut saw_vertex = false;
     for &fid in sh.faces() {
         let Ok(f) = topo.face(fid) else { return false };
-        let Ok(w) = topo.wire(f.outer_wire()) else {
-            return false;
-        };
-        for oe in w.edges() {
-            let Ok(e) = topo.edge(oe.edge()) else {
+        // Check the outer wire and any inner (hole) wires — a hole boundary on
+        // a simple solid's face can also reach the blank's surface.
+        let mut wires = vec![f.outer_wire()];
+        wires.extend_from_slice(f.inner_wires());
+        for wid in wires {
+            let Ok(w) = topo.wire(wid) else {
                 return false;
             };
-            for vid in [e.start(), e.end()] {
-                let Ok(v) = topo.vertex(vid) else {
+            for oe in w.edges() {
+                let Ok(e) = topo.edge(oe.edge()) else {
                     return false;
                 };
-                if classifier.classify(v.point(), tol) != Some(brepkit_algo::FaceClass::Inside) {
-                    return false;
+                for vid in [e.start(), e.end()] {
+                    let Ok(v) = topo.vertex(vid) else {
+                        return false;
+                    };
+                    if classifier.classify(v.point(), tol) != Some(brepkit_algo::FaceClass::Inside)
+                    {
+                        return false;
+                    }
+                    saw_vertex = true;
                 }
-                saw_vertex = true;
             }
         }
     }
@@ -1857,58 +1864,34 @@ fn solid_strictly_inside(
 }
 
 /// Build `Cut(blank, tool)` for a tool strictly contained in the blank: the
-/// result is the blank with a tool-shaped internal cavity. Copies the blank,
-/// then attaches a reversed deep-copy of the tool's outer shell as an inner
-/// (cavity) shell whose normals face into the void. Bypasses GFA, whose
-/// no-intersection assembly drops fully-contained cone/torus tools.
+/// result is the blank with a tool-shaped internal cavity. Deep-copies the
+/// blank and the tool, reverses every copied tool face in place so the cavity
+/// boundary faces into the void, and attaches the reversed tool shell to the
+/// copied blank as an inner shell. Bypasses GFA, whose no-intersection assembly
+/// drops fully-contained cone/torus tools.
 fn build_contained_cut_hollow(
     topo: &mut Topology,
     blank: SolidId,
     tool: SolidId,
 ) -> Result<SolidId, crate::OperationsError> {
-    use brepkit_topology::face::Face;
-    use brepkit_topology::shell::Shell;
-    use brepkit_topology::solid::Solid;
-
     let result = crate::copy::copy_solid(topo, blank)?;
 
-    let tool_faces: Vec<_> = {
-        let ts = topo.solid(tool)?;
-        let osh = ts.outer_shell();
-        topo.shell(osh)?.faces().to_vec()
-    };
-
-    let mut cavity_faces = Vec::with_capacity(tool_faces.len());
-    for fid in tool_faces {
-        let copied = crate::copy::copy_face(topo, fid)?;
-        let (ow, iw, surf, was_reversed) = {
-            let f = topo.face(copied)?;
-            (
-                f.outer_wire(),
-                f.inner_wires().to_vec(),
-                f.surface().clone(),
-                f.is_reversed(),
-            )
-        };
-        // Flip orientation relative to the tool so the cavity boundary faces
-        // inward (away from the remaining solid material).
-        let cavity = if was_reversed {
-            Face::new(ow, iw, surf)
-        } else {
-            Face::new_reversed(ow, iw, surf)
-        };
-        cavity_faces.push(topo.add_face(cavity));
+    // Deep-copy the tool as a whole solid so the cavity shell shares edges and
+    // vertices between adjacent faces (a per-face copy would duplicate shared
+    // boundary edges and leave the cavity non-manifold — wrong Euler, though
+    // per-face volume is unaffected). Reverse each copied face in place and
+    // reuse the copied outer shell directly as the cavity inner shell, so no
+    // duplicate faces or extra result solid are created.
+    let tool_copy = crate::copy::copy_solid(topo, tool)?;
+    let cavity_shell = topo.solid(tool_copy)?.outer_shell();
+    let cavity_faces = topo.shell(cavity_shell)?.faces().to_vec();
+    for fid in cavity_faces {
+        let face = topo.face_mut(fid)?;
+        let flipped = !face.is_reversed();
+        face.set_reversed(flipped);
     }
-
-    let cavity_shell = Shell::new(cavity_faces).map_err(crate::OperationsError::Topology)?;
-    let cavity_shell_id = topo.add_shell(cavity_shell);
-
-    let (outer, mut inners) = {
-        let rs = topo.solid(result)?;
-        (rs.outer_shell(), rs.inner_shells().to_vec())
-    };
-    inners.push(cavity_shell_id);
-    Ok(topo.add_solid(Solid::new(outer, inners)))
+    topo.solid_mut(result)?.add_inner_shell(cavity_shell);
+    Ok(result)
 }
 
 /// Best-effort mesh boolean fallback for high face-count solids.

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -176,6 +176,26 @@ pub fn boolean(
                 reason: "Cut with target fully contained in tool".into(),
             });
         }
+        // Cut with the tool strictly inside the blank: build the hollow result
+        // (blank + a reversed copy of the tool as a cavity shell) directly.
+        // GFA's no-intersection assembly drops fully-contained cone/torus
+        // tools; the cavity is exactly the tool's reversed shell, so construct
+        // it here for any simple tool whose vertices are all strictly inside.
+        if op == BooleanOp::Cut && b_in_a && !a_in_b {
+            if let Some(classifier) = ca.as_ref() {
+                let tool_simple = topo
+                    .solid(b)
+                    .map(|s| s.inner_shells().is_empty())
+                    .unwrap_or(false);
+                if tool_simple && solid_strictly_inside(topo, b, classifier, tol) {
+                    if let Ok(result) = build_contained_cut_hollow(topo, a, b) {
+                        if validate_boolean_result(topo, result).is_ok() {
+                            return Ok(result);
+                        }
+                    }
+                }
+            }
+        }
         if (b_in_a || a_in_b) && op != BooleanOp::Cut {
             return match (op, b_in_a, a_in_b) {
                 (BooleanOp::Fuse, true, _) => Ok(crate::copy::copy_solid(topo, a)?),
@@ -1794,6 +1814,101 @@ fn all_vertices_inside_or_on(
         }
     }
     true
+}
+
+/// True when every outer-shell vertex of `inner` classifies as *strictly*
+/// `Inside` (not on the boundary) of `classifier`. A strictly-contained tool
+/// has no surface contact with the blank, so `Cut(blank, tool)` is a clean
+/// internal cavity rather than a notch through the boundary.
+fn solid_strictly_inside(
+    topo: &Topology,
+    inner: SolidId,
+    classifier: &brepkit_algo::classifier::AnalyticClassifier,
+    tol: brepkit_math::tolerance::Tolerance,
+) -> bool {
+    let Ok(s) = topo.solid(inner) else {
+        return false;
+    };
+    let Ok(sh) = topo.shell(s.outer_shell()) else {
+        return false;
+    };
+    let mut saw_vertex = false;
+    for &fid in sh.faces() {
+        let Ok(f) = topo.face(fid) else { return false };
+        let Ok(w) = topo.wire(f.outer_wire()) else {
+            return false;
+        };
+        for oe in w.edges() {
+            let Ok(e) = topo.edge(oe.edge()) else {
+                return false;
+            };
+            for vid in [e.start(), e.end()] {
+                let Ok(v) = topo.vertex(vid) else {
+                    return false;
+                };
+                if classifier.classify(v.point(), tol) != Some(brepkit_algo::FaceClass::Inside) {
+                    return false;
+                }
+                saw_vertex = true;
+            }
+        }
+    }
+    saw_vertex
+}
+
+/// Build `Cut(blank, tool)` for a tool strictly contained in the blank: the
+/// result is the blank with a tool-shaped internal cavity. Copies the blank,
+/// then attaches a reversed deep-copy of the tool's outer shell as an inner
+/// (cavity) shell whose normals face into the void. Bypasses GFA, whose
+/// no-intersection assembly drops fully-contained cone/torus tools.
+fn build_contained_cut_hollow(
+    topo: &mut Topology,
+    blank: SolidId,
+    tool: SolidId,
+) -> Result<SolidId, crate::OperationsError> {
+    use brepkit_topology::face::Face;
+    use brepkit_topology::shell::Shell;
+    use brepkit_topology::solid::Solid;
+
+    let result = crate::copy::copy_solid(topo, blank)?;
+
+    let tool_faces: Vec<_> = {
+        let ts = topo.solid(tool)?;
+        let osh = ts.outer_shell();
+        topo.shell(osh)?.faces().to_vec()
+    };
+
+    let mut cavity_faces = Vec::with_capacity(tool_faces.len());
+    for fid in tool_faces {
+        let copied = crate::copy::copy_face(topo, fid)?;
+        let (ow, iw, surf, was_reversed) = {
+            let f = topo.face(copied)?;
+            (
+                f.outer_wire(),
+                f.inner_wires().to_vec(),
+                f.surface().clone(),
+                f.is_reversed(),
+            )
+        };
+        // Flip orientation relative to the tool so the cavity boundary faces
+        // inward (away from the remaining solid material).
+        let cavity = if was_reversed {
+            Face::new(ow, iw, surf)
+        } else {
+            Face::new_reversed(ow, iw, surf)
+        };
+        cavity_faces.push(topo.add_face(cavity));
+    }
+
+    let cavity_shell = Shell::new(cavity_faces).map_err(crate::OperationsError::Topology)?;
+    let cavity_shell_id = topo.add_shell(cavity_shell);
+
+    let (outer, mut inners) = {
+        let rs = topo.solid(result)?;
+        (rs.outer_shell(), rs.inner_shells().to_vec())
+    };
+    inners.push(cavity_shell_id);
+    Ok(topo.add_solid(Solid::new(outer, inners)))
 }
 
 /// Best-effort mesh boolean fallback for high face-count solids.

--- a/crates/operations/tests/curved_properties.rs
+++ b/crates/operations/tests/curved_properties.rs
@@ -15,8 +15,9 @@
 use std::f64::consts::PI;
 
 use brepkit_check::properties::{PropertiesOptions, solid_area, solid_volume};
-use brepkit_operations::primitives::{make_cone, make_cylinder, make_sphere, make_torus};
+use brepkit_operations::primitives::{make_box, make_cone, make_cylinder, make_sphere, make_torus};
 use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
 
 fn assert_close(got: f64, expected: f64, rel_tol: f64, what: &str) {
     let rel = (got - expected).abs() / expected.abs().max(1.0);
@@ -91,4 +92,73 @@ fn curved_primitive_areas_match_analytic() {
         2e-3,
         "torus area",
     );
+}
+
+/// Cutting a strictly-contained tool from a blank yields a hollow solid whose
+/// cavity is a topologically-faithful copy of the tool: exactly one inner
+/// shell, and `Euler(result) == Euler(blank) + Euler(tool)`. A per-face cavity
+/// copy duplicates shared boundary edges and breaks this (the box case gave
+/// Euler 8 instead of 4) while leaving the per-face volume correct — so this
+/// guards the topology that the metric oracles in the parity corpus cannot.
+#[test]
+fn contained_cut_cavity_topology_is_faithful() {
+    use brepkit_math::mat::Mat4;
+    use brepkit_operations::boolean::{BooleanOp, boolean};
+    use brepkit_operations::transform::transform_solid;
+    use brepkit_operations::validate::euler_characteristic;
+
+    type ToolBuilder = fn(&mut Topology) -> SolidId;
+    let cases: [(&str, ToolBuilder); 5] = [
+        ("cone", |t| {
+            let c = make_cone(t, 0.5, 0.0, 2.0).unwrap();
+            transform_solid(t, c, &Mat4::translation(1.5, 1.5, 0.5)).unwrap();
+            c
+        }),
+        ("cylinder", |t| {
+            let c = make_cylinder(t, 0.5, 2.0).unwrap();
+            transform_solid(t, c, &Mat4::translation(1.5, 1.5, 0.5)).unwrap();
+            c
+        }),
+        ("sphere", |t| {
+            let c = make_sphere(t, 0.5, 32).unwrap();
+            transform_solid(t, c, &Mat4::translation(1.5, 1.5, 1.5)).unwrap();
+            c
+        }),
+        ("box", |t| {
+            let c = make_box(t, 1.0, 1.0, 1.0).unwrap();
+            transform_solid(t, c, &Mat4::translation(1.0, 1.0, 1.0)).unwrap();
+            c
+        }),
+        ("torus", |t| {
+            let c = make_torus(t, 0.6, 0.2, 32).unwrap();
+            transform_solid(t, c, &Mat4::translation(1.5, 1.5, 1.5)).unwrap();
+            c
+        }),
+    ];
+
+    for (label, build_tool) in cases {
+        // Standalone Euler of the tool (genus-agnostic expected value).
+        let mut tt = Topology::new();
+        let standalone_tool = build_tool(&mut tt);
+        let tool_euler = euler_characteristic(&tt, standalone_tool).unwrap();
+
+        let mut topo = Topology::new();
+        let blank = make_box(&mut topo, 3.0, 3.0, 3.0).unwrap();
+        let blank_euler = euler_characteristic(&topo, blank).unwrap();
+        let tool = build_tool(&mut topo);
+        let result = boolean(&mut topo, BooleanOp::Cut, blank, tool).unwrap();
+
+        let inner = topo.solid(result).unwrap().inner_shells().len();
+        assert_eq!(
+            inner, 1,
+            "{label}: expected exactly one cavity shell, got {inner}"
+        );
+
+        let euler = euler_characteristic(&topo, result).unwrap();
+        assert_eq!(
+            euler,
+            blank_euler + tool_euler,
+            "{label}: cavity Euler {euler} != blank {blank_euler} + tool {tool_euler}"
+        );
+    }
 }

--- a/crates/operations/tests/curved_properties.rs
+++ b/crates/operations/tests/curved_properties.rs
@@ -1,0 +1,94 @@
+//! Regression guard for `brepkit_check` property integration on curved
+//! analytic surfaces.
+//!
+//! `solid_volume` / `solid_area` integrate each face numerically via
+//! `integrate_face`. Full-revolution and closed/pole faces (cone, sphere,
+//! torus) previously broke the polygon-trimmed quadrature — a cone integrated
+//! ~5x low, a torus to zero, a sphere errored on its poles — because the
+//! projected UV boundary collapses on the apex/pole/seam. These tests build the
+//! actual primitives and assert the numerical result against the analytic
+//! closed form, so a regression in the integrator is caught directly (the
+//! existing `check` unit tests only exercise the closed-form formulas).
+
+#![allow(clippy::unwrap_used, clippy::panic)]
+
+use std::f64::consts::PI;
+
+use brepkit_check::properties::{PropertiesOptions, solid_area, solid_volume};
+use brepkit_operations::primitives::{make_cone, make_cylinder, make_sphere, make_torus};
+use brepkit_topology::Topology;
+
+fn assert_close(got: f64, expected: f64, rel_tol: f64, what: &str) {
+    let rel = (got - expected).abs() / expected.abs().max(1.0);
+    assert!(
+        rel <= rel_tol,
+        "{what}: got {got:.6}, expected {expected:.6} (rel {rel:.2e} > {rel_tol:.0e})"
+    );
+}
+
+#[test]
+fn curved_primitive_volumes_match_analytic() {
+    let opt = PropertiesOptions::default();
+    let mut t = Topology::new();
+
+    // Cone (r=0.5, h=2): V = pi r^2 h / 3 = pi/6. Fully analytic.
+    let cone = make_cone(&mut t, 0.5, 0.0, 2.0).unwrap();
+    assert_close(
+        solid_volume(&t, cone, &opt).unwrap(),
+        PI / 6.0,
+        1e-3,
+        "cone volume",
+    );
+
+    // Sphere (r=0.5): V = 4/3 pi r^3 = pi/6. Two hemisphere faces.
+    let sphere = make_sphere(&mut t, 0.5, 64).unwrap();
+    assert_close(
+        solid_volume(&t, sphere, &opt).unwrap(),
+        PI / 6.0,
+        1e-3,
+        "sphere volume",
+    );
+
+    // Torus (R=1, r=0.3): V = 2 pi^2 R r^2. Single doubly-periodic face.
+    let torus = make_torus(&mut t, 1.0, 0.3, 64).unwrap();
+    assert_close(
+        solid_volume(&t, torus, &opt).unwrap(),
+        2.0 * PI * PI * 1.0 * 0.09,
+        2e-3,
+        "torus volume",
+    );
+
+    // Cylinder (r=0.5, h=2): V = pi r^2 h. Lateral is exact; the faceted caps
+    // leave a small (<1%) deficit, so the tolerance is looser here.
+    let cyl = make_cylinder(&mut t, 0.5, 2.0).unwrap();
+    assert_close(
+        solid_volume(&t, cyl, &opt).unwrap(),
+        PI * 0.25 * 2.0,
+        1e-2,
+        "cylinder volume",
+    );
+}
+
+#[test]
+fn curved_primitive_areas_match_analytic() {
+    let opt = PropertiesOptions::default();
+    let mut t = Topology::new();
+
+    // Sphere surface area = 4 pi r^2.
+    let sphere = make_sphere(&mut t, 0.5, 64).unwrap();
+    assert_close(
+        solid_area(&t, sphere, &opt).unwrap(),
+        4.0 * PI * 0.25,
+        2e-3,
+        "sphere area",
+    );
+
+    // Torus surface area = 4 pi^2 R r.
+    let torus = make_torus(&mut t, 1.0, 0.3, 64).unwrap();
+    assert_close(
+        solid_area(&t, torus, &opt).unwrap(),
+        4.0 * PI * PI * 1.0 * 0.3,
+        2e-3,
+        "torus area",
+    );
+}

--- a/crates/operations/tests/parity_boolean_curved.rs
+++ b/crates/operations/tests/parity_boolean_curved.rs
@@ -43,18 +43,18 @@ fn curved_boolean_corpus() {
         Case { name: "cyl_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Cyl(0.5,2.0), C_AXIS), op: Op::Cut,    oracle: Oracle::Volume(27.0 - 0.5 * PI), tol: CTOL, expect: Expect::Pass },
 
         // ── Sphere (r=0.5, V=π/6) fully inside a 3-cube ─────────────────
-        Case { name: "sphere_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Sphere(0.5), C_CTR), op: Op::Common, oracle: Oracle::Volume(PI / 6.0),  tol: CTOL, expect: Expect::Gap("sphere interior intersect: result sphere has pole UV degeneracy") },
+        Case { name: "sphere_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Sphere(0.5), C_CTR), op: Op::Common, oracle: Oracle::Volume(PI / 6.0),  tol: CTOL, expect: Expect::Pass },
         Case { name: "sphere_in_box_fuse_vol",   a: (BOX3, NONE), b: (Prim::Sphere(0.5), C_CTR), op: Op::Fuse,   oracle: Oracle::Volume(27.0),         tol: CTOL, expect: Expect::Pass },
         Case { name: "sphere_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Sphere(0.5), C_CTR), op: Op::Cut,    oracle: Oracle::Volume(27.0 - PI / 6.0), tol: CTOL, expect: Expect::Pass },
 
         // ── Cone (rb=0.5,rt=0,h=2, V=π/6) fully inside a 3-cube ─────────
-        Case { name: "cone_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Common, oracle: Oracle::Volume(PI / 6.0),  tol: CTOL, expect: Expect::Gap("cone intersect: negative volume (inverted face orientation)") },
+        Case { name: "cone_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Common, oracle: Oracle::Volume(PI / 6.0),  tol: CTOL, expect: Expect::Pass },
         Case { name: "cone_in_box_fuse_vol",   a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Fuse,   oracle: Oracle::Volume(27.0),         tol: CTOL, expect: Expect::Pass },
         Case { name: "cone_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Cut,    oracle: Oracle::Volume(27.0 - PI / 6.0), tol: CTOL, expect: Expect::Gap("cone cut: tool not subtracted (full box remains)") },
 
         // ── Torus (R=1,r=0.3, V=0.18π²) fully inside a flat 3×3×1 box ───
         // Cut yields a box with a toroidal (genus-1) cavity.
-        Case { name: "torus_in_box_common_vol", a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Common, oracle: Oracle::Volume(0.18 * PI * PI), tol: CTOL, expect: Expect::Gap("torus intersect: empty result") },
+        Case { name: "torus_in_box_common_vol", a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Common, oracle: Oracle::Volume(0.18 * PI * PI), tol: CTOL, expect: Expect::Pass },
         Case { name: "torus_in_box_fuse_vol",   a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Fuse,   oracle: Oracle::Volume(9.0),         tol: CTOL, expect: Expect::Pass },
         Case { name: "torus_in_box_cut_vol",    a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Cut,    oracle: Oracle::Volume(9.0 - 0.18 * PI * PI), tol: CTOL, expect: Expect::Gap("torus cut: tool not subtracted (full box remains)") },
 

--- a/crates/operations/tests/parity_boolean_curved.rs
+++ b/crates/operations/tests/parity_boolean_curved.rs
@@ -50,13 +50,13 @@ fn curved_boolean_corpus() {
         // ── Cone (rb=0.5,rt=0,h=2, V=π/6) fully inside a 3-cube ─────────
         Case { name: "cone_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Common, oracle: Oracle::Volume(PI / 6.0),  tol: CTOL, expect: Expect::Pass },
         Case { name: "cone_in_box_fuse_vol",   a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Fuse,   oracle: Oracle::Volume(27.0),         tol: CTOL, expect: Expect::Pass },
-        Case { name: "cone_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Cut,    oracle: Oracle::Volume(27.0 - PI / 6.0), tol: CTOL, expect: Expect::Gap("cone cut: tool not subtracted (full box remains)") },
+        Case { name: "cone_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Cut,    oracle: Oracle::Volume(27.0 - PI / 6.0), tol: CTOL, expect: Expect::Pass },
 
         // ── Torus (R=1,r=0.3, V=0.18π²) fully inside a flat 3×3×1 box ───
         // Cut yields a box with a toroidal (genus-1) cavity.
         Case { name: "torus_in_box_common_vol", a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Common, oracle: Oracle::Volume(0.18 * PI * PI), tol: CTOL, expect: Expect::Pass },
         Case { name: "torus_in_box_fuse_vol",   a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Fuse,   oracle: Oracle::Volume(9.0),         tol: CTOL, expect: Expect::Pass },
-        Case { name: "torus_in_box_cut_vol",    a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Cut,    oracle: Oracle::Volume(9.0 - 0.18 * PI * PI), tol: CTOL, expect: Expect::Gap("torus cut: tool not subtracted (full box remains)") },
+        Case { name: "torus_in_box_cut_vol",    a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Cut,    oracle: Oracle::Volume(9.0 - 0.18 * PI * PI), tol: CTOL, expect: Expect::Pass },
 
         // ── Interpenetration probes (same-domain machinery) ────────────
         // Coaxial cylinders overlapping along the axis: a z∈[0,2], b z∈[1,3].

--- a/crates/operations/tests/parity_boolean_curved.rs
+++ b/crates/operations/tests/parity_boolean_curved.rs
@@ -1,0 +1,73 @@
+//! Parity robustness corpus — curved-primitive booleans (cylinder, cone,
+//! sphere, torus against boxes and each other).
+//!
+//! Oracles are exact analytic volumes (πr²h, ⁴⁄₃πr³, ⅓πr²h, 2π²Rr²). Most
+//! cases use *containment* configurations: a curved primitive fully inside a
+//! box, so the intersection is the primitive's volume, the union is the box's,
+//! and the subtraction is a box with a curved cavity (an inner shell). These
+//! isolate the curved boolean + curved-cavity paths from intersection-curve
+//! noise. A few interpenetration probes (coaxial cylinders, sphere∩box) target
+//! the same-domain machinery prior work flagged as fragile.
+//!
+//! Tolerance is looser than the planar corpus because curved area/volume go
+//! through quadrature; it is still tight enough that a mangled boolean misses.
+//! `Gap` rows are calibrated from observed behavior — see the scoreboard.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![allow(clippy::missing_panics_doc)]
+
+mod parity_support;
+
+use std::f64::consts::PI;
+
+use parity_support::{Case, Expect, Op, Oracle, Prim, Xf, run_corpus};
+
+const NONE: &[Xf] = &[];
+const BOX3: Prim = Prim::Box(3.0, 3.0, 3.0);
+/// Relative tolerance for curved volumes. Covers quadrature error and primitive
+/// faceting (a built cylinder's volume runs ~0.2% under πr²h). Real boolean
+/// failures here miss by 2%–100%, so this stays well clear of them.
+const CTOL: f64 = 5e-3;
+
+// Centering transforms that place a primitive fully inside BOX3 ([0,3]³).
+const C_AXIS: &[Xf] = &[Xf::Translate(1.5, 1.5, 0.5)]; // base-at-z0 primitives (cyl/cone)
+const C_CTR: &[Xf] = &[Xf::Translate(1.5, 1.5, 1.5)]; // centered primitives (sphere)
+
+#[test]
+fn curved_boolean_corpus() {
+    #[rustfmt::skip]
+    let cases: &[Case] = &[
+        // ── Cylinder (r=0.5,h=2, V=0.5π) fully inside a 3-cube ──────────
+        Case { name: "cyl_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Cyl(0.5,2.0), C_AXIS), op: Op::Common, oracle: Oracle::Volume(0.5 * PI),  tol: CTOL, expect: Expect::Pass },
+        Case { name: "cyl_in_box_fuse_vol",   a: (BOX3, NONE), b: (Prim::Cyl(0.5,2.0), C_AXIS), op: Op::Fuse,   oracle: Oracle::Volume(27.0),         tol: CTOL, expect: Expect::Pass },
+        Case { name: "cyl_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Cyl(0.5,2.0), C_AXIS), op: Op::Cut,    oracle: Oracle::Volume(27.0 - 0.5 * PI), tol: CTOL, expect: Expect::Pass },
+
+        // ── Sphere (r=0.5, V=π/6) fully inside a 3-cube ─────────────────
+        Case { name: "sphere_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Sphere(0.5), C_CTR), op: Op::Common, oracle: Oracle::Volume(PI / 6.0),  tol: CTOL, expect: Expect::Gap("sphere interior intersect: result sphere has pole UV degeneracy") },
+        Case { name: "sphere_in_box_fuse_vol",   a: (BOX3, NONE), b: (Prim::Sphere(0.5), C_CTR), op: Op::Fuse,   oracle: Oracle::Volume(27.0),         tol: CTOL, expect: Expect::Pass },
+        Case { name: "sphere_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Sphere(0.5), C_CTR), op: Op::Cut,    oracle: Oracle::Volume(27.0 - PI / 6.0), tol: CTOL, expect: Expect::Pass },
+
+        // ── Cone (rb=0.5,rt=0,h=2, V=π/6) fully inside a 3-cube ─────────
+        Case { name: "cone_in_box_common_vol", a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Common, oracle: Oracle::Volume(PI / 6.0),  tol: CTOL, expect: Expect::Gap("cone intersect: negative volume (inverted face orientation)") },
+        Case { name: "cone_in_box_fuse_vol",   a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Fuse,   oracle: Oracle::Volume(27.0),         tol: CTOL, expect: Expect::Pass },
+        Case { name: "cone_in_box_cut_vol",    a: (BOX3, NONE), b: (Prim::Cone(0.5,0.0,2.0), C_AXIS), op: Op::Cut,    oracle: Oracle::Volume(27.0 - PI / 6.0), tol: CTOL, expect: Expect::Gap("cone cut: tool not subtracted (full box remains)") },
+
+        // ── Torus (R=1,r=0.3, V=0.18π²) fully inside a flat 3×3×1 box ───
+        // Cut yields a box with a toroidal (genus-1) cavity.
+        Case { name: "torus_in_box_common_vol", a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Common, oracle: Oracle::Volume(0.18 * PI * PI), tol: CTOL, expect: Expect::Gap("torus intersect: empty result") },
+        Case { name: "torus_in_box_fuse_vol",   a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Fuse,   oracle: Oracle::Volume(9.0),         tol: CTOL, expect: Expect::Pass },
+        Case { name: "torus_in_box_cut_vol",    a: (Prim::Box(3.0,3.0,1.0), &[Xf::Translate(-1.5,-1.5,-0.5)]), b: (Prim::Torus(1.0,0.3), NONE), op: Op::Cut,    oracle: Oracle::Volume(9.0 - 0.18 * PI * PI), tol: CTOL, expect: Expect::Gap("torus cut: tool not subtracted (full box remains)") },
+
+        // ── Interpenetration probes (same-domain machinery) ────────────
+        // Coaxial cylinders overlapping along the axis: a z∈[0,2], b z∈[1,3].
+        // Union is a cyl r1 h3 (V=3π); intersection a cyl r1 h1 (V=π).
+        Case { name: "coaxial_cyl_fuse_vol",   a: (Prim::Cyl(1.0,2.0), NONE), b: (Prim::Cyl(1.0,2.0), &[Xf::Translate(0.0,0.0,1.0)]), op: Op::Fuse,   oracle: Oracle::Volume(3.0 * PI), tol: CTOL, expect: Expect::Pass },
+        Case { name: "coaxial_cyl_common_vol", a: (Prim::Cyl(1.0,2.0), NONE), b: (Prim::Cyl(1.0,2.0), &[Xf::Translate(0.0,0.0,1.0)]), op: Op::Common, oracle: Oracle::Volume(PI), tol: CTOL, expect: Expect::Pass },
+        // Unit sphere (centered) partially overlapping a unit cube at +octant.
+        // Overlap is ⅛ of the ball (V=π/6); union V = ⁴⁄₃π + 1 − π/6.
+        Case { name: "sphere_box_partial_common_vol", a: (Prim::Sphere(1.0), NONE), b: (Prim::Box(1.0,1.0,1.0), NONE), op: Op::Common, oracle: Oracle::Volume(PI / 6.0), tol: CTOL, expect: Expect::Gap("sphere/box partial intersect: volume ~46% low") },
+        Case { name: "sphere_box_partial_fuse_vol",   a: (Prim::Sphere(1.0), NONE), b: (Prim::Box(1.0,1.0,1.0), NONE), op: Op::Fuse,   oracle: Oracle::Volume(4.0 / 3.0 * PI + 1.0 - PI / 6.0), tol: CTOL, expect: Expect::Gap("sphere/box partial fuse: volume ~2.2% low") },
+    ];
+
+    run_corpus(cases);
+}

--- a/crates/operations/tests/parity_boolean_empty.rs
+++ b/crates/operations/tests/parity_boolean_empty.rs
@@ -1,0 +1,56 @@
+//! Parity robustness corpus — operations that must yield an *empty* result.
+//!
+//! Empty results are a notorious robustness cliff: a kernel must recognize that
+//! a subtraction cancels, a tool misses, or two solids meet only on a shared
+//! boundary (zero volume), and return a clean empty shape rather than a sliver,
+//! a panic, or a malformed solid. The harness accepts either convention brepkit
+//! uses (an `EmptyResult` error or an `Ok` empty solid).
+//!
+//! Cases tagged `Pass` are asserted; `Gap` documents a known miss. See
+//! `parity_support` for the harness and scoreboard semantics.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![allow(clippy::missing_panics_doc)]
+
+mod parity_support;
+
+use parity_support::{Case, Expect, Op, Oracle, Prim, Xf, run_corpus};
+
+const NONE: &[Xf] = &[];
+const CUBE: Prim = Prim::Box(1.0, 1.0, 1.0);
+const EMPTY: Oracle = Oracle::Empty;
+
+#[test]
+fn empty_result_corpus() {
+    #[rustfmt::skip]
+    let cases: &[Case] = &[
+        // ── Self-cancelling subtraction (identical solids) ──────────────
+        Case { name: "identical_box_cut",        a: (Prim::Box(2.0,3.0,4.0), NONE), b: (Prim::Box(2.0,3.0,4.0), NONE), op: Op::Cut,    oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "identical_box_cutrev",     a: (Prim::Box(2.0,3.0,4.0), NONE), b: (Prim::Box(2.0,3.0,4.0), NONE), op: Op::CutRev, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "identical_sphere_cut",     a: (Prim::Sphere(1.0), NONE),      b: (Prim::Sphere(1.0), NONE),      op: Op::Cut,    oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "identical_cyl_cut",        a: (Prim::Cyl(0.7,2.0), NONE),     b: (Prim::Cyl(0.7,2.0), NONE),     op: Op::Cut,    oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+
+        // ── Subset subtraction (A ⊆ B  ⇒  A − B = ∅) ────────────────────
+        // small cube fully inside a 3-cube
+        Case { name: "subset_box_cut",           a: (CUBE, &[Xf::Translate(1.0,1.0,1.0)]), b: (Prim::Box(3.0,3.0,3.0), NONE), op: Op::Cut, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        // small box fully inside a sphere
+        Case { name: "subset_box_in_sphere_cut", a: (Prim::Box(0.2,0.2,0.2), &[Xf::Translate(-0.1,-0.1,-0.1)]), b: (Prim::Sphere(1.0), NONE), op: Op::Cut, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        // small sphere fully inside a 3-cube (sphere centered at the box center)
+        Case { name: "subset_sphere_in_box_cut", a: (Prim::Sphere(0.5), &[Xf::Translate(1.5,1.5,1.5)]), b: (Prim::Box(3.0,3.0,3.0), NONE), op: Op::Cut, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+
+        // ── Disjoint intersection (no shared volume) ────────────────────
+        Case { name: "disjoint_box_common_near", a: (CUBE, NONE), b: (CUBE, &[Xf::Translate(2.0,0.0,0.0)]), op: Op::Common, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "disjoint_box_common_far",  a: (CUBE, NONE), b: (CUBE, &[Xf::Translate(5.0,5.0,5.0)]), op: Op::Common, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "disjoint_cyl_common",      a: (Prim::Cyl(0.5,1.0), NONE), b: (Prim::Cyl(0.5,1.0), &[Xf::Translate(3.0,0.0,0.0)]), op: Op::Common, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "disjoint_sphere_common",   a: (Prim::Sphere(1.0), NONE), b: (Prim::Sphere(1.0), &[Xf::Translate(3.0,0.0,0.0)]), op: Op::Common, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+
+        // ── Boundary-only contact: intersection has zero volume ─────────
+        // Two cubes meeting on a shared face / edge / vertex only. The common
+        // is geometrically a face / edge / point — i.e. empty as a solid.
+        Case { name: "facetouch_box_common",     a: (CUBE, NONE), b: (CUBE, &[Xf::Translate(1.0,0.0,0.0)]), op: Op::Common, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "edgetouch_box_common",     a: (CUBE, NONE), b: (CUBE, &[Xf::Translate(1.0,1.0,0.0)]), op: Op::Common, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+        Case { name: "vertextouch_box_common",   a: (CUBE, NONE), b: (CUBE, &[Xf::Translate(1.0,1.0,1.0)]), op: Op::Common, oracle: EMPTY, tol: 0.0, expect: Expect::Pass },
+    ];
+
+    run_corpus(cases);
+}

--- a/crates/operations/tests/parity_boolean_planar.rs
+++ b/crates/operations/tests/parity_boolean_planar.rs
@@ -1,0 +1,99 @@
+//! Parity robustness corpus — all-planar boolean cases (box/box, box/prism).
+//!
+//! Every case carries an exact analytic oracle (surface area or volume), so
+//! these assert to near-machine precision and form a tight regression net for
+//! the configurations where boolean engines historically break: coincident
+//! faces, full containment (hollow results), and edge/corner contact producing
+//! non-convex solids.
+//!
+//! Oracle values are derived purely from the geometry (a box's area is the sum
+//! of its face areas; a hollow cut's volume is outer minus cavity). Each case
+//! is tagged `Pass` (asserted) or `Gap` (a documented robustness gap, allowed
+//! to miss). See `parity_support` for the harness and scoreboard semantics.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![allow(clippy::missing_panics_doc)]
+
+mod parity_support;
+
+use parity_support::{Case, Expect, Op, Oracle, Prim, Xf, run_corpus};
+
+const NONE: &[Xf] = &[];
+const HALF_X: &[Xf] = &[Xf::Translate(0.5, 0.0, 0.0)];
+const STACK_Z: &[Xf] = &[Xf::Translate(0.0, 0.0, 1.0)];
+const INSET: &[Xf] = &[Xf::Translate(0.5, 0.5, 0.5)];
+const CORNER: &[Xf] = &[Xf::Translate(0.5, 0.5, 0.0)];
+/// Unit square in XY, wound counter-clockwise (outward normal +Z).
+const UNIT_SQUARE: &[(f64, f64)] = &[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)];
+
+const CUBE: Prim = Prim::Box(1.0, 1.0, 1.0);
+
+#[test]
+fn planar_boolean_corpus() {
+    #[rustfmt::skip]
+    let cases: &[Case] = &[
+        // ── Family A: two identical unit cubes ──────────────────────────
+        // Union/intersection collapse to the same cube; either subtraction
+        // is empty. The canonical coincident-everything degenerate.
+        Case { name: "identical_cubes_fuse_area", a: (CUBE, NONE), b: (CUBE, NONE), op: Op::Fuse, oracle: Oracle::Area(6.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "identical_cubes_fuse_volume", a: (CUBE, NONE), b: (CUBE, NONE), op: Op::Fuse, oracle: Oracle::Volume(1.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "identical_cubes_common_area", a: (CUBE, NONE), b: (CUBE, NONE), op: Op::Common, oracle: Oracle::Area(6.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "identical_cubes_cut_empty", a: (CUBE, NONE), b: (CUBE, NONE), op: Op::Cut, oracle: Oracle::Empty, tol: 0.0, expect: Expect::Pass },
+        Case { name: "identical_cubes_cutrev_empty", a: (CUBE, NONE), b: (CUBE, NONE), op: Op::CutRev, oracle: Oracle::Empty, tol: 0.0, expect: Expect::Pass },
+
+        // ── Family B: 50% overlap along X (b shifted +0.5x) ─────────────
+        // Result solids are all axis-aligned boxes with exact dimensions.
+        Case { name: "halfx_fuse_area", a: (CUBE, NONE), b: (CUBE, HALF_X), op: Op::Fuse, oracle: Oracle::Area(8.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "halfx_fuse_volume", a: (CUBE, NONE), b: (CUBE, HALF_X), op: Op::Fuse, oracle: Oracle::Volume(1.5), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "halfx_cut_area", a: (CUBE, NONE), b: (CUBE, HALF_X), op: Op::Cut, oracle: Oracle::Area(4.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "halfx_common_area", a: (CUBE, NONE), b: (CUBE, HALF_X), op: Op::Common, oracle: Oracle::Area(4.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "halfx_common_volume", a: (CUBE, NONE), b: (CUBE, HALF_X), op: Op::Common, oracle: Oracle::Volume(0.5), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "halfx_cutrev_area", a: (CUBE, NONE), b: (CUBE, HALF_X), op: Op::CutRev, oracle: Oracle::Area(4.0), tol: 1e-6, expect: Expect::Pass },
+
+        // ── Family C: face-coincident stack along Z (b shifted +1z) ─────
+        // The two cubes share the z=1 face exactly — a coincident-face fuse.
+        Case { name: "facez_fuse_area", a: (CUBE, NONE), b: (CUBE, STACK_Z), op: Op::Fuse, oracle: Oracle::Area(10.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "facez_fuse_volume", a: (CUBE, NONE), b: (CUBE, STACK_Z), op: Op::Fuse, oracle: Oracle::Volume(2.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "facez_cut_unchanged_area", a: (CUBE, NONE), b: (CUBE, STACK_Z), op: Op::Cut, oracle: Oracle::Area(6.0), tol: 1e-6, expect: Expect::Pass },
+        // Common of face-touching cubes has zero volume → empty solid.
+        Case { name: "facez_common_empty", a: (CUBE, NONE), b: (CUBE, STACK_Z), op: Op::Common, oracle: Oracle::Empty, tol: 0.0, expect: Expect::Pass },
+
+        // ── Family D: full containment (small cube inside a 2-cube) ─────
+        // Cut produces a hollow solid (cavity in an inner shell) — exercises
+        // the all-faces measure. Outer area 24 + cavity area 6 = 30;
+        // volume 8 − 1 = 7.
+        Case { name: "contain_fuse_area", a: (Prim::Box(2.0, 2.0, 2.0), NONE), b: (CUBE, INSET), op: Op::Fuse, oracle: Oracle::Area(24.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "contain_common_area", a: (Prim::Box(2.0, 2.0, 2.0), NONE), b: (CUBE, INSET), op: Op::Common, oracle: Oracle::Area(6.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "contain_cut_hollow_area", a: (Prim::Box(2.0, 2.0, 2.0), NONE), b: (CUBE, INSET), op: Op::Cut, oracle: Oracle::Area(30.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "contain_cut_hollow_volume", a: (Prim::Box(2.0, 2.0, 2.0), NONE), b: (CUBE, INSET), op: Op::Cut, oracle: Oracle::Volume(7.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "contain_cutrev_empty", a: (Prim::Box(2.0, 2.0, 2.0), NONE), b: (CUBE, INSET), op: Op::CutRev, oracle: Oracle::Empty, tol: 0.0, expect: Expect::Pass },
+
+        // ── Family E: corner overlap (b shifted +0.5x +0.5y) ────────────
+        // Two cubes interpenetrating in a 0.5×0.5×1 column — non-convex
+        // (L-shaped) fuse and notched cut. GAP: fuse under-removes the
+        // overlap (volume 11/6 ≈ 1.833 vs true 1.75) and the notched cut
+        // carries a spurious 0.25 of face area (5.75 vs 5.5), although its
+        // volume (0.75) and the intersection (area 2.5) are correct. The
+        // disagreement between Fuse and Common over the same overlap points
+        // at the fuse/cut assembly, not the intersection.
+        Case { name: "corner_fuse_area", a: (CUBE, NONE), b: (CUBE, CORNER), op: Op::Fuse, oracle: Oracle::Area(9.5), tol: 1e-6, expect: Expect::Gap("corner interpenetration: fuse over-counts overlap") },
+        Case { name: "corner_fuse_volume", a: (CUBE, NONE), b: (CUBE, CORNER), op: Op::Fuse, oracle: Oracle::Volume(1.75), tol: 1e-6, expect: Expect::Gap("corner interpenetration: fuse volume 11/6 vs 7/4") },
+        Case { name: "corner_common_area", a: (CUBE, NONE), b: (CUBE, CORNER), op: Op::Common, oracle: Oracle::Area(2.5), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "corner_cut_notch_area", a: (CUBE, NONE), b: (CUBE, CORNER), op: Op::Cut, oracle: Oracle::Area(5.5), tol: 1e-6, expect: Expect::Gap("corner interpenetration: notched cut has a spurious face (+0.25 area)") },
+        Case { name: "corner_cut_notch_volume", a: (CUBE, NONE), b: (CUBE, CORNER), op: Op::Cut, oracle: Oracle::Volume(0.75), tol: 1e-6, expect: Expect::Pass },
+
+        // ── Family F: prism input path (extruded unit square == cube) ───
+        // Validates the PrismZ builder against the same oracles as box/box.
+        Case { name: "prism_box_halfx_fuse_area", a: (Prim::PrismZ(UNIT_SQUARE, 1.0), NONE), b: (CUBE, HALF_X), op: Op::Fuse, oracle: Oracle::Area(8.0), tol: 1e-6, expect: Expect::Pass },
+        Case { name: "prism_box_identical_common_area", a: (Prim::PrismZ(UNIT_SQUARE, 1.0), NONE), b: (CUBE, NONE), op: Op::Common, oracle: Oracle::Area(6.0), tol: 1e-6, expect: Expect::Pass },
+
+        // ── Family G: curved calibration probe ──────────────────────────
+        // Unit sphere (centered) fused with a unit cube at the +octant.
+        // Reference whole-boundary area ≈ 14.6394. Tagged Gap so it never
+        // fails CI; the scoreboard reports whether brepkit matches it and
+        // at what tolerance — used to set the curved-family default.
+        Case { name: "sphere_unit_box_fuse_area", a: (Prim::Sphere(1.0), NONE), b: (CUBE, NONE), op: Op::Fuse, oracle: Oracle::Area(14.6394), tol: 2e-2, expect: Expect::Gap("curved calibration probe") },
+    ];
+
+    run_corpus(cases);
+}

--- a/crates/operations/tests/parity_support/mod.rs
+++ b/crates/operations/tests/parity_support/mod.rs
@@ -1,0 +1,312 @@
+//! Shared harness for the boolean/blend robustness parity corpus.
+//!
+//! Each case (`Case`) is pure data: two input solids built from primitives plus
+//! transforms, a boolean operation, and an expected invariant (surface area,
+//! volume, or empty result). The expected value is an independent analytic
+//! oracle — for all-planar inputs it is exact, so the corpus doubles as a tight
+//! regression net; for curved inputs it is a calibrated reference value.
+//!
+//! `run_corpus` executes a slice of cases and asserts each oracle, but fails the
+//! test only on *unexpected* outcomes: a case tagged `Expect::Pass` that misses
+//! its oracle is a regression, while a case tagged `Expect::Gap` documents a
+//! known robustness gap and is allowed to miss. A `Gap` that starts passing is
+//! reported (so it can be promoted) without failing CI. The printed scoreboard
+//! makes parity a tracked number.
+//!
+//! This module is compiled into each corpus test binary; only a subset of its
+//! API is used by any single file, hence `#![allow(dead_code)]`.
+
+#![allow(dead_code)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// The scoreboard is intentional test diagnostics, printed via `--nocapture`.
+#![allow(clippy::print_stderr)]
+#![allow(
+    missing_docs,
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate
+)]
+
+use brepkit_check::properties::face_integrator::integrate_face;
+use brepkit_math::mat::Mat4;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::OperationsError;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::extrude::extrude;
+use brepkit_operations::primitives::{make_box, make_cone, make_cylinder, make_sphere, make_torus};
+use brepkit_operations::transform::transform_solid;
+use brepkit_operations::validate::validate_solid_relaxed;
+use brepkit_topology::Topology;
+use brepkit_topology::builder::make_planar_face;
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::solid::SolidId;
+
+/// Equatorial segment count for sphere inputs. High enough that the analytic
+/// surface area is essentially exact and boolean intersection curves are well
+/// resolved.
+const SPHERE_SEGMENTS: usize = 64;
+/// Segment count for torus inputs.
+const TORUS_SEGMENTS: usize = 64;
+/// Vertex-merge tolerance for prism (extruded-polygon) faces.
+const FACE_TOL: f64 = 1e-7;
+/// Gauss-Legendre quadrature order for area/volume integration.
+const GAUSS_ORDER: usize = 5;
+
+#[derive(Clone, Copy)]
+pub enum Axis {
+    X,
+    Y,
+    Z,
+}
+
+impl Axis {
+    fn rotation(self, radians: f64) -> Mat4 {
+        match self {
+            Self::X => Mat4::rotation_x(radians),
+            Self::Y => Mat4::rotation_y(radians),
+            Self::Z => Mat4::rotation_z(radians),
+        }
+    }
+}
+
+/// A placement transform applied to a freshly-built primitive, in list order.
+#[derive(Clone, Copy)]
+pub enum Xf {
+    Translate(f64, f64, f64),
+    /// Rotate about a principal axis through the origin (degrees).
+    Rotate {
+        axis: Axis,
+        degrees: f64,
+    },
+    /// Rotate about a principal axis through an arbitrary point (degrees).
+    RotateAbout {
+        axis: Axis,
+        point: (f64, f64, f64),
+        degrees: f64,
+    },
+}
+
+/// A primitive constructor with the kernel's placement conventions: box corner
+/// at the origin; cylinder/cone base at z=0; sphere/torus centered at origin.
+#[derive(Clone, Copy)]
+pub enum Prim {
+    Box(f64, f64, f64),
+    Sphere(f64),
+    Cyl(f64, f64),
+    Cone(f64, f64, f64),
+    Torus(f64, f64),
+    /// Extrude an XY polygon (wound CCW) by a height along +Z.
+    PrismZ(&'static [(f64, f64)], f64),
+}
+
+#[derive(Clone, Copy)]
+pub enum Op {
+    Fuse,
+    Cut,
+    Common,
+    /// Reverse cut: `b - a`.
+    CutRev,
+}
+
+#[derive(Clone, Copy)]
+pub enum Oracle {
+    Area(f64),
+    Volume(f64),
+    /// The operation must yield an empty result (no volume).
+    Empty,
+}
+
+#[derive(Clone, Copy)]
+pub enum Expect {
+    Pass,
+    /// Known robustness gap; carries a short reason. Allowed to miss its oracle.
+    Gap(&'static str),
+}
+
+#[derive(Clone, Copy)]
+pub struct Case {
+    pub name: &'static str,
+    pub a: (Prim, &'static [Xf]),
+    pub b: (Prim, &'static [Xf]),
+    pub op: Op,
+    pub oracle: Oracle,
+    /// Relative tolerance for the oracle comparison.
+    pub tol: f64,
+    pub expect: Expect,
+}
+
+fn build_err(e: OperationsError) -> String {
+    format!("build: {e:?}")
+}
+
+fn apply_xf(topo: &mut Topology, s: SolidId, xf: Xf) -> Result<(), String> {
+    let go = |topo: &mut Topology, m: &Mat4| {
+        transform_solid(topo, s, m).map_err(|e| format!("transform: {e:?}"))
+    };
+    match xf {
+        Xf::Translate(x, y, z) => go(topo, &Mat4::translation(x, y, z)),
+        Xf::Rotate { axis, degrees } => go(topo, &axis.rotation(degrees.to_radians())),
+        Xf::RotateAbout {
+            axis,
+            point: (px, py, pz),
+            degrees,
+        } => {
+            // Rotation about an axis through `point`: translate the point to the
+            // origin, rotate, translate back. Applied as successive in-place
+            // transforms so no Mat4 multiplication is required.
+            go(topo, &Mat4::translation(-px, -py, -pz))?;
+            go(topo, &axis.rotation(degrees.to_radians()))?;
+            go(topo, &Mat4::translation(px, py, pz))
+        }
+    }
+}
+
+fn build(topo: &mut Topology, &(prim, xforms): &(Prim, &'static [Xf])) -> Result<SolidId, String> {
+    let s = match prim {
+        Prim::Box(x, y, z) => make_box(topo, x, y, z).map_err(build_err)?,
+        Prim::Sphere(r) => make_sphere(topo, r, SPHERE_SEGMENTS).map_err(build_err)?,
+        Prim::Cyl(r, h) => make_cylinder(topo, r, h).map_err(build_err)?,
+        Prim::Cone(rb, rt, h) => make_cone(topo, rb, rt, h).map_err(build_err)?,
+        Prim::Torus(maj, min) => make_torus(topo, maj, min, TORUS_SEGMENTS).map_err(build_err)?,
+        Prim::PrismZ(poly, h) => {
+            let pts: Vec<Point3> = poly.iter().map(|&(x, y)| Point3::new(x, y, 0.0)).collect();
+            let face = make_planar_face(topo, &pts, FACE_TOL)
+                .map_err(|e| format!("planar face: {e:?}"))?;
+            extrude(topo, face, Vec3::new(0.0, 0.0, 1.0), h).map_err(build_err)?
+        }
+    };
+    for &xf in xforms {
+        apply_xf(topo, s, xf)?;
+    }
+    Ok(s)
+}
+
+fn run_op(topo: &mut Topology, op: Op, a: SolidId, b: SolidId) -> Result<SolidId, OperationsError> {
+    match op {
+        Op::Fuse => boolean(topo, BooleanOp::Fuse, a, b),
+        Op::Cut => boolean(topo, BooleanOp::Cut, a, b),
+        Op::Common => boolean(topo, BooleanOp::Intersect, a, b),
+        Op::CutRev => boolean(topo, BooleanOp::Cut, b, a),
+    }
+}
+
+/// Total boundary area over *all* faces (outer shell + any cavity shells), so
+/// hollow results measure their full surface, matching whole-boundary oracles.
+fn area(topo: &Topology, s: SolidId) -> Result<f64, String> {
+    let faces = solid_faces(topo, s).map_err(|e| format!("solid_faces: {e:?}"))?;
+    let mut total = 0.0;
+    for fid in faces {
+        total += integrate_face(topo, fid, GAUSS_ORDER)
+            .map_err(|e| format!("area: {e:?}"))?
+            .area;
+    }
+    Ok(total)
+}
+
+/// Net volume via the divergence theorem over *all* faces. Cavity-shell faces
+/// carry inward orientation, so their contributions subtract — a box with a
+/// cubic cavity nets (outer − cavity) volume automatically.
+fn volume(topo: &Topology, s: SolidId) -> Result<f64, String> {
+    let faces = solid_faces(topo, s).map_err(|e| format!("solid_faces: {e:?}"))?;
+    let mut total = 0.0;
+    for fid in faces {
+        total += integrate_face(topo, fid, GAUSS_ORDER)
+            .map_err(|e| format!("volume: {e:?}"))?
+            .volume;
+    }
+    Ok(total)
+}
+
+fn ensure_nonempty_valid(topo: &Topology, s: SolidId) -> Result<(), String> {
+    if topo.is_empty_solid(s) {
+        return Err("result is empty (expected a solid)".to_string());
+    }
+    let report = validate_solid_relaxed(topo, s).map_err(|e| format!("validate: {e:?}"))?;
+    if !report.is_valid() {
+        return Err(format!("invalid result ({} errors)", report.error_count()));
+    }
+    Ok(())
+}
+
+fn check_rel(got: f64, expected: f64, tol: f64, what: &str) -> Result<(), String> {
+    let denom = got.abs().max(expected.abs()).max(1.0);
+    let rel = (got - expected).abs() / denom;
+    if rel <= tol {
+        Ok(())
+    } else {
+        Err(format!(
+            "{what} {got:.6} vs expected {expected:.6} (rel {rel:.2e} > tol {tol:.0e})"
+        ))
+    }
+}
+
+/// Build both inputs, run the operation, and check the oracle. `Ok(())` means
+/// the case matched its oracle (and, for non-empty results, validated).
+fn evaluate(topo: &mut Topology, c: &Case) -> Result<(), String> {
+    let a = build(topo, &c.a)?;
+    let b = build(topo, &c.b)?;
+    let res = run_op(topo, c.op, a, b);
+    match c.oracle {
+        Oracle::Empty => match res {
+            Err(OperationsError::EmptyResult { .. }) => Ok(()),
+            Ok(s) if topo.is_empty_solid(s) => Ok(()),
+            Ok(s) => Err(format!(
+                "expected empty, got non-empty (area {:.6})",
+                area(topo, s)?
+            )),
+            Err(e) => Err(format!("expected empty, got error: {e:?}")),
+        },
+        Oracle::Area(expected) => {
+            let s = res.map_err(|e| format!("op failed: {e:?}"))?;
+            ensure_nonempty_valid(topo, s)?;
+            check_rel(area(topo, s)?, expected, c.tol, "area")
+        }
+        Oracle::Volume(expected) => {
+            let s = res.map_err(|e| format!("op failed: {e:?}"))?;
+            ensure_nonempty_valid(topo, s)?;
+            check_rel(volume(topo, s)?, expected, c.tol, "volume")
+        }
+    }
+}
+
+/// Execute a corpus and assert it. Fails only on unexpected regressions
+/// (`Expect::Pass` cases that miss their oracle). Prints a parity scoreboard.
+pub fn run_corpus(cases: &[Case]) {
+    let mut pass = 0usize;
+    let mut newly_passing: Vec<&str> = Vec::new();
+    let mut gaps: Vec<String> = Vec::new();
+    let mut regressions: Vec<String> = Vec::new();
+
+    for c in cases {
+        let mut topo = Topology::new();
+        let outcome = evaluate(&mut topo, c);
+        match (&outcome, c.expect) {
+            (Ok(()), Expect::Pass) => pass += 1,
+            (Ok(()), Expect::Gap(_)) => newly_passing.push(c.name),
+            (Err(why), Expect::Pass) => regressions.push(format!("[FAIL] {}: {}", c.name, why)),
+            (Err(why), Expect::Gap(reason)) => {
+                gaps.push(format!("{} — {why}  [{reason}]", c.name));
+            }
+        }
+    }
+
+    eprintln!(
+        "── parity scoreboard ──  {pass} pass · {} known-gap · {} newly-passing · {} unexpected-fail",
+        gaps.len(),
+        newly_passing.len(),
+        regressions.len()
+    );
+    for detail in &gaps {
+        eprintln!("   • known gap: {detail}");
+    }
+    for name in &newly_passing {
+        eprintln!("   ↑ newly passing — promote Gap→Pass: {name}");
+    }
+
+    assert!(
+        regressions.is_empty(),
+        "unexpected parity regressions ({}):\n{}",
+        regressions.len(),
+        regressions.join("\n")
+    );
+}

--- a/crates/topology/src/solid.rs
+++ b/crates/topology/src/solid.rs
@@ -44,4 +44,9 @@ impl Solid {
     pub fn inner_shells(&self) -> &[ShellId] {
         &self.inner_shells
     }
+
+    /// Adds an inner shell (void/cavity) to this solid.
+    pub fn add_inner_shell(&mut self, shell_id: ShellId) {
+        self.inner_shells.push(shell_id);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a table-driven boolean **robustness parity corpus** with a gap-tracking scoreboard, and fixes the **two bugs the corpus immediately surfaced** in cone/torus curved booleans. The reference kernel used to derive oracle values is never named in code, comments, or commits — it is used purely as an oracle.

Three independent commits (please **rebase-merge** or merge-commit rather than squash, so release-please sees the `fix(check)` and `fix(boolean)` entries separately):

1. `test(boolean)` — the parity corpus + harness
2. `fix(check)` — cone/torus/sphere volume & area integration
3. `fix(boolean)` — contained cone/torus cut tool-drop

**Parity scoreboard: 52 pass · 6 gap · 0 unexpected failures** (the corpus started at 47/11; 5 cases were promoted by the two fixes).

## The corpus (`crates/operations/tests/parity_*`)

Each case is pure data — two primitives + transforms, an operation, and an exact analytic oracle (area / volume / empty). A **known-gaps allowlist scoreboard** means CI fails only on *unexpected* regressions, while every tracked gap reports its live deviation and a gap that starts passing is flagged for promotion. Run any file with `-- --nocapture` to see the scoreboard. Covers planar box/box (incl. hollow-cavity cut), empty/degenerate results, and curved cyl/cone/sphere/torus booleans.

## Bug fixes

### `fix(check)` — curved-surface property integration
`integrate_face` mis-integrated full-revolution and closed/pole analytic faces because the projected UV boundary collapses on the apex/pole/seam, so polygon trimming rejected valid quadrature points: a cone integrated ~5.5× low, a torus to zero, a sphere errored on its poles. `check::{solid_volume, solid_area, center_of_mass}` were silently wrong for any solid with such a face.

- Winding-number full-revolution detection (robust to boundary discretization); the winding **sign** selects the pole for a hemisphere cap so the two halves don't both integrate the whole sphere
- Degenerate boundary polygon → integrate the analytic full domain (torus)
- `face_uv_bounds` falls back to the full domain instead of erroring on a degenerate projection (sphere poles)
- Composite Gauss quadrature (≤π/4 patches) so doubly-periodic surfaces converge

Adds `curved_properties` regression tests — the existing `check` tests only exercised the closed-form formulas, never the numerical integrator. This fix also promoted 3 corpus cases (cone/torus/sphere containment-intersect were correct all along, only mis-measured).

### `fix(boolean)` — contained cut tool-drop ⚠️ core engine
`Cut(blank, tool)` with the tool strictly inside the blank should return the blank with a tool-shaped cavity, but GFA's no-intersection assembly placed the tool faces in the *outer* shell (malformed) and the wrapper stripped them — so a contained cone or torus tool was silently dropped and the result was the unchanged blank. (Cylinder/sphere only survived via the mesh fallback.)

Fix: in the containment shortcut, detect a strictly-contained simple tool (blank has an analytic classifier; every tool vertex classifies strictly `Inside`) and assemble the hollow directly — copy the blank, attach a reversed deep-copy of the tool's outer shell as an inner cavity shell. Geometrically exact for any tool shape; also replaces the cylinder/sphere mesh fallback with a clean analytic hollow. Falls through to GFA when the tool touches the boundary or the assembled result fails validation.

## Validation

No regressions. Green: operations lib (664), every boolean integration suite (`boolean_invariants` 22, `boolean_edge_cases` 18, `boolean_stress` 57, `concentric_spheres`, `coaxial_*`, `coincident_planes`, `regress_hexwall_cuts`, `scale_dependent`, `golden_regression`, proptest), `check` (44), `algo` (115). `cargo fmt`, `cargo clippy --all-targets -D warnings`, and `scripts/check-boundaries.sh` all clean.

## Remaining gaps (separate bugs, not addressed here)
- sphere/box **partial overlap** — intersect ~46% low, fuse ~2.2% low (sphere-plane intersection accuracy)
- corner-interpenetrating box **fuse** over-counts (11/6 vs 7/4)
- sphere∪box area calibration probe

## Review note
The `fix(boolean)` commit touches the core boolean engine — flagging for human review; please do not auto-merge.
