### PR TITLE
fix(boolean): don't drop a coincident-face operand from fuse (#801)

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -114,6 +114,41 @@ pub fn boolean(
                     .all(|(outer_d, inner_d)| *outer_d > *inner_d * 1.1)
             };
 
+        // AABB enclosure is necessary but NOT sufficient for solid
+        // containment: a non-convex container (notched or hollow) can
+        // AABB-enclose a solid that actually lies in its empty region.
+        // Issue #801: `(a − b) ∪ (a ∩ b)` dropped the `a ∩ b` operand
+        // because the unit cube's bbox fits inside the notched `a − b`'s
+        // bbox, yet the cube lives in the carved-out notch. Confirm the
+        // AABB-only fallback with a real point-in-solid test: reject when
+        // the inner solid's center is provably inside `inner` yet outside
+        // `outer`. By the containment lemma (inner ⊆ outer ⇒ every point
+        // of inner is in outer), that witness can only occur for genuine
+        // non-containment, so it never rejects a true containment.
+        let center_outside = |topo: &Topology,
+                              inner: SolidId,
+                              outer: SolidId,
+                              bb: &Option<(Point3, Point3)>|
+         -> bool {
+            let Some((lo, hi)) = *bb else { return false };
+            let c = Point3::new(
+                0.5 * (lo.x() + hi.x()),
+                0.5 * (lo.y() + hi.y()),
+                0.5 * (lo.z() + hi.z()),
+            );
+            let (dx, dy, dz) = (hi.x() - lo.x(), hi.y() - lo.y(), hi.z() - lo.z());
+            let defl = (dx.mul_add(dx, dy.mul_add(dy, dz * dz)).sqrt() * 0.01).max(1e-6);
+            let inside_inner = matches!(
+                crate::classify::classify_point(topo, inner, c, defl, tol.linear),
+                Ok(crate::classify::PointClassification::Inside)
+            );
+            let outside_outer = matches!(
+                crate::classify::classify_point(topo, outer, c, defl, tol.linear),
+                Ok(crate::classify::PointClassification::Outside)
+            );
+            inside_inner && outside_outer
+        };
+
         // Bidirectional vertex check via the analytic classifier — the
         // primary signal for identical/containment classification. A vertex
         // classifying as inside-or-on (None within tolerance band counts
@@ -144,10 +179,18 @@ pub fn boolean(
         // three dims so that sparse multi-shell solids (e.g., a fuse
         // of two disjoint boxes) don't false-positive as "contains
         // another solid".
-        let b_in_a = (all_b_verts_in_a && aabb_encloses(&aabb_b, &aabb_a))
-            || (ca.is_none() && aabb_strictly_contains(&aabb_b, &aabb_a));
-        let a_in_b = (all_a_verts_in_b && aabb_encloses(&aabb_a, &aabb_b))
-            || (cb.is_none() && aabb_strictly_contains(&aabb_a, &aabb_b));
+        // Both the analytic-classifier term and the AABB-only fallback can
+        // false-positive when the container is non-convex: the analytic
+        // classifier may mis-report notch points as inside-or-on, and an
+        // AABB encloses a notch's empty volume. Guard the whole determination
+        // with the `center_outside` witness — sound for every path because it
+        // only fires on proven non-containment (see the lemma above).
+        let b_in_a = ((all_b_verts_in_a && aabb_encloses(&aabb_b, &aabb_a))
+            || (ca.is_none() && aabb_strictly_contains(&aabb_b, &aabb_a)))
+            && !center_outside(topo, b, a, &aabb_b);
+        let a_in_b = ((all_a_verts_in_b && aabb_encloses(&aabb_a, &aabb_b))
+            || (cb.is_none() && aabb_strictly_contains(&aabb_a, &aabb_b)))
+            && !center_outside(topo, a, b, &aabb_a);
 
         // Identical-solid shortcut: matching AABBs AND every boundary
         // vertex of each solid classifies as inside-or-on the other's

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -138,6 +138,11 @@ pub fn boolean(
             );
             let (dx, dy, dz) = (hi.x() - lo.x(), hi.y() - lo.y(), hi.z() - lo.z());
             let defl = (dx.mul_add(dx, dy.mul_add(dy, dz * dz)).sqrt() * 0.01).max(1e-6);
+            // Conservative by design: when the AABB center falls in `inner`'s own
+            // concavity (a C/U-shaped solid), `inside_inner` is false and the
+            // witness is disabled, so a false-positive containment could still
+            // slip through. That only ever fails to *reject* — it never rejects a
+            // true containment — so the shortcut stays sound, just not complete.
             let inside_inner = matches!(
                 crate::classify::classify_point(topo, inner, c, defl, tol.linear),
                 Ok(crate::classify::PointClassification::Inside)

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4151,7 +4151,7 @@ fn assert_cut_fuse_back_recovers(a_dim: f64, b_dim: f64, b_dx: f64) {
     let mut topo = Topology::new();
     let a = crate::primitives::make_box(&mut topo, a_dim, a_dim, a_dim).unwrap();
     let b = crate::primitives::make_box(&mut topo, b_dim, b_dim, b_dim).unwrap();
-    if b_dx != 0.0 {
+    if b_dx.abs() > 1e-9 {
         crate::transform::transform_solid(
             &mut topo,
             b,

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4140,3 +4140,89 @@ fn cut_concentric_rounded_rect_arc_prisms_cavity() {
         "expected 8 analytic cylinder faces (4 outer + 4 cavity), got {cyl}"
     );
 }
+
+// ── Issue #801: cut-then-fuse-back must recover original volume ──────
+
+/// Run `(a − b) ∪ (a ∩ b)` and assert it recovers `vol(a)`, regardless of
+/// fuse operand order. `a` and `b` are boxes placed at `(0,0,0)` and
+/// `(dx,0,0)`; `b` is nested in `a` so the union must equal `a`.
+fn assert_cut_fuse_back_recovers(a_dim: f64, b_dim: f64, b_dx: f64) {
+    let vol_a = a_dim * a_dim * a_dim;
+    let mut topo = Topology::new();
+    let a = crate::primitives::make_box(&mut topo, a_dim, a_dim, a_dim).unwrap();
+    let b = crate::primitives::make_box(&mut topo, b_dim, b_dim, b_dim).unwrap();
+    if b_dx != 0.0 {
+        crate::transform::transform_solid(
+            &mut topo,
+            b,
+            &brepkit_math::mat::Mat4::translation(b_dx, 0.0, 0.0),
+        )
+        .unwrap();
+    }
+
+    let a_minus_b = boolean(&mut topo, BooleanOp::Cut, a, b).unwrap();
+    let a_and_b = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+
+    // Fuse in both operand orders — neither operand may be silently dropped.
+    for (first, second, order) in [
+        (a_minus_b, a_and_b, "(a-b)∪(a∩b)"),
+        (a_and_b, a_minus_b, "(a∩b)∪(a-b)"),
+    ] {
+        let recombined = boolean(&mut topo, BooleanOp::Fuse, first, second).unwrap();
+        let vol = crate::measure::solid_volume(&topo, recombined, 0.05).unwrap();
+        assert!(
+            (vol - vol_a).abs() < vol_a * 1e-4 + 1e-9,
+            "{order} for box({a_dim})/box({b_dim})@dx={b_dx} must recover vol(a)={vol_a}, got {vol}"
+        );
+    }
+}
+
+#[test]
+fn issue_801_fuse_recovers_cut_intersect_volume() {
+    // The reported minimal repro: box(2) ∪-recombined with box(1) at the corner.
+    assert_cut_fuse_back_recovers(2.0, 1.0, 0.0);
+}
+
+#[test]
+fn issue_801_fuse_recovers_volume_scaling() {
+    // The corner-nested scaling rows from the issue — error was always exactly
+    // vol(a ∩ b), confirming the second operand was dropped wholesale. The
+    // operands share three coincident cut-plane faces (a corner notch).
+    assert_cut_fuse_back_recovers(3.0, 1.0, 0.0); // 26 → 27
+    assert_cut_fuse_back_recovers(10.0, 5.0, 0.0); // 875 → 1000
+    assert_cut_fuse_back_recovers(3.0, 2.0, 1.0); // 19 → 27
+    assert_cut_fuse_back_recovers(10.0, 5.0, 5.0); // 875 → 1000 (other corner)
+}
+
+#[test]
+fn issue_801_recombined_box_is_genus0_manifold() {
+    // The recombined corner-cube union must be a clean genus-0 manifold with
+    // the correct volume. (It carries 9 faces rather than 6 because the three
+    // coplanar filler faces are not yet merged with the L-shaped outer faces —
+    // a separate same-domain coplanar-merge concern, not a volume defect.)
+    let mut topo = Topology::new();
+    let a = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+    let b = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+    let a_minus_b = boolean(&mut topo, BooleanOp::Cut, a, b).unwrap();
+    let a_and_b = boolean(&mut topo, BooleanOp::Intersect, a, b).unwrap();
+    let recombined = boolean(&mut topo, BooleanOp::Fuse, a_minus_b, a_and_b).unwrap();
+
+    check_result(&topo, recombined); // asserts manifold
+    let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(&topo, recombined).unwrap();
+    let euler = v as i64 - e as i64 + f as i64;
+    assert_eq!(euler, 2, "recombined union must be genus-0 (V-E+F=2)");
+    assert_volume_near(&topo, recombined, 8.0, 1e-4);
+}
+
+#[test]
+#[ignore = "deep: GFA + mesh coincident-coplanar handling over-counts the \
+            slot fuse by a tessellation-artifact pyramid (vol 1083⅓ vs 1000); \
+            same root cause as #696. Tracks the eventual full fix."]
+fn issue_801_slot_fuse_recovers_volume() {
+    // b touches a on only two faces (a floating edge groove). Unlike the
+    // corner cases, both GFA same-domain annihilation and the mesh-boolean
+    // fallback leave a phantom 250/3 ≈ 83.3 volume from mismatched coincident-
+    // coplanar triangulations. When the coincident-coplanar work lands this
+    // must recover vol(a) = 1000.
+    assert_cut_fuse_back_recovers(10.0, 5.0, 2.5);
+}


### PR DESCRIPTION
## Summary

`fuse((a − b), (a ∩ b))` silently returned `a − b`, losing exactly `vol(a ∩ b)` — the CSG identity `(a − b) ∪ (a ∩ b) === a` failed for nested solids that share coincident boundary faces (#801).

## Root cause

The **containment shortcut** in `boolean()` treated AABB enclosure (and a too-loose analytic classifier) as proof of *solid* containment. AABB enclosure is necessary but **not sufficient** for a non-convex container: the notched `a − b` bounding-box-encloses the empty notch where `a ∩ b` actually lives, so `b_in_a` fired and `fuse` returned a copy of `a − b`, dropping the second operand.

```
a = box(2,2,2)            // vol 8
b = box(1,1,1)            // vol 1, nested at the corner
fuse(cut(a,b), intersect(a,b))  // was 7 ✗  → now 8 ✓
```

## Fix

Confirm any heuristic containment with a **real point-in-solid witness** (`center_outside`): reject the shortcut only when the inner solid's center is provably *inside* `inner` yet *outside* `outer`.

By the containment lemma — `inner ⊆ outer ⇒ every point of inner ∈ outer` — that witness can only occur for genuine **non**-containment. So it never rejects a true containment; it only strips false positives, and it guards **both** the analytic-classifier term and the AABB-fallback term.

## Coverage

Fixes the reported minimal repro and all four corner-nested scaling rows from the issue:

| a | b | was | now |
|---|---|----:|----:|
| box(2) | box(1) | 7 | **8** ✓ |
| box(3) | box(1) | 26 | **27** ✓ |
| box(10) | box(5) | 875 | **1000** ✓ |
| box(3) | box(2)@dx=1 | 19 | **27** ✓ |

### Known remaining limitation (tracked, not fixed here)

The fifth row — `box(10)/box(5)@dx=2.5`, where the operands touch on only **two** faces (a floating edge groove) — still over-counts (vol 1083⅓). Once the containment shortcut correctly steps aside, both GFA same-domain annihilation **and** the mesh fallback leave a tessellation-artifact phantom volume (`250/3`) from mismatched coincident-coplanar triangulations. This is the **same root cause as #696** and needs the deeper coincident-coplanar work. Captured by an `#[ignore]`d regression test (`issue_801_slot_fuse_recovers_volume`) so it's ready to flip green when that lands.

## Tests

- `issue_801_fuse_recovers_cut_intersect_volume` — the minimal repro, both operand orders.
- `issue_801_fuse_recovers_volume_scaling` — the four corner-nested rows.
- `issue_801_recombined_box_is_genus0_manifold` — result is a genus-0 manifold with the correct volume.
- `issue_801_slot_fuse_recovers_volume` — `#[ignore]`d, documents the deep slot-fuse limitation.

Full `cargo test -p brepkit-operations` suite: **all green, 0 regressions**.

Refs #801