### PR TITLE
fix(tessellate): build drilled-hole cylinder/cone bands from shared rim vertices (#696)

### DIFF
--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -66,7 +66,10 @@ pub(super) fn tessellate_revolution_band_shared(
         let e = topo.edge(oe.edge())?;
         let closed = e.start() == e.end();
         match e.curve() {
-            EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) if closed => {
+            // Only closed circles are rims here. The caller gates this path on
+            // `is_standard_rect` (Line | Circle edges only), so ellipse rims
+            // never reach it — they take the CDT path instead.
+            EdgeCurve::Circle(_) if closed => {
                 let idx = oe.edge().index();
                 if !rim_edge_ids.contains(&idx) {
                     rim_edge_ids.push(idx);

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -3,10 +3,150 @@
 use brepkit_math::det_hash::{DetHashMap, DetHashSet};
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::face::{FaceId, FaceSurface};
 
 use super::edge_sampling::{sample_edge, segments_for_chord_deviation_a};
 use super::{MERGE_GRID, TriangleMesh, point_merge_key};
+
+/// Maps a 3D point to its `(u, v)` surface parameters.
+type ProjectFn = Box<dyn Fn(Point3) -> (f64, f64)>;
+/// Maps `(u, v)` surface parameters to the outward surface normal.
+type NormalFn = Box<dyn Fn(f64, f64) -> Vec3>;
+
+/// Tessellate a cylinder/cone lateral "standard band" face directly from the
+/// shared rim edge vertices, bypassing the snap path's proximity reconciliation.
+///
+/// The snap path tessellates the cylinder independently and snaps its rim
+/// vertices to the shared edge pool by 1e-6 proximity; when the independent rim
+/// sampling and the shared-edge sampling diverge by one segment (a radius/
+/// deflection-dependent off-by-one) the rim vertices land at different angles,
+/// fail the snap, and become near-coincident duplicates that crack the mesh
+/// (issue #696: a drilled magnet hole). Reusing the shared rim vertices makes
+/// the band watertight by construction.
+///
+/// Returns `Ok(true)` when the face is a simple two-rim band that was handled
+/// here, `Ok(false)` when it is not (the caller then falls back to the snap or
+/// CDT path). A "simple band" has no inner wires, exactly two **closed**
+/// rim-circle edges (everything else a seam line), and matching shared-vertex
+/// counts on the two rims.
+pub(super) fn tessellate_revolution_band_shared(
+    topo: &Topology,
+    face_data: &brepkit_topology::face::Face,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
+    merged: &mut TriangleMesh,
+) -> Result<bool, crate::OperationsError> {
+    if !face_data.inner_wires().is_empty() {
+        return Ok(false);
+    }
+
+    // Angle (u) projection and outward-normal closures for the surface.
+    let (project, surf_normal): (ProjectFn, NormalFn) = match face_data.surface() {
+        FaceSurface::Cylinder(c) => {
+            let (c1, c2) = (c.clone(), c.clone());
+            (
+                Box::new(move |p| c1.project_point(p)),
+                Box::new(move |u, v| c2.normal(u, v)),
+            )
+        }
+        FaceSurface::Cone(c) => {
+            let (c1, c2) = (c.clone(), c.clone());
+            (
+                Box::new(move |p| c1.project_point(p)),
+                Box::new(move |u, v| c2.normal(u, v)),
+            )
+        }
+        _ => return Ok(false),
+    };
+
+    // Collect the two closed rim-circle edges; everything else must be a seam line.
+    let wire = topo.wire(face_data.outer_wire())?;
+    let mut rim_edge_ids: Vec<usize> = Vec::new();
+    for oe in wire.edges() {
+        let e = topo.edge(oe.edge())?;
+        let closed = e.start() == e.end();
+        match e.curve() {
+            EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) if closed => {
+                let idx = oe.edge().index();
+                if !rim_edge_ids.contains(&idx) {
+                    rim_edge_ids.push(idx);
+                }
+            }
+            EdgeCurve::Line => {}
+            // An open arc rim, a NURBS boundary, or an open circle is not a
+            // simple full-revolution band — let the caller handle it.
+            _ => return Ok(false),
+        }
+    }
+    if rim_edge_ids.len() != 2 {
+        return Ok(false);
+    }
+
+    // Pull each rim's shared global vertex IDs, drop the closing duplicate, and
+    // require matching counts so the rings connect index-for-index.
+    let mut rims: Vec<Vec<u32>> = Vec::with_capacity(2);
+    for &re in &rim_edge_ids {
+        let Some(ids) = edge_global_indices.get(&re) else {
+            return Ok(false);
+        };
+        let mut ids = ids.clone();
+        if ids.len() > 1 && ids.first() == ids.last() {
+            ids.pop();
+        }
+        if ids.len() < 3 {
+            return Ok(false);
+        }
+        rims.push(ids);
+    }
+    if rims[0].len() != rims[1].len() {
+        return Ok(false);
+    }
+    let n = rims[0].len();
+
+    // Sort each rim by angle around the axis so the two rings align by index.
+    let angle_of = |gid: u32, merged: &TriangleMesh| project(merged.positions[gid as usize]).0;
+    for rim in &mut rims {
+        rim.sort_by(|&a, &b| {
+            angle_of(a, merged)
+                .partial_cmp(&angle_of(b, merged))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+
+    // Emit default-oriented (non-reversed) triangles: the geometric normal
+    // matches the surface outward normal, the convention `tessellate_analytic`
+    // uses. The caller (`tessellate_face_with_shared_edges`) applies the global
+    // `is_reversed` winding flip afterward, so we must NOT apply it here.
+    let emit = |merged: &mut TriangleMesh, a: u32, b: u32, c: u32| {
+        let (pa, pb, pc) = (
+            merged.positions[a as usize],
+            merged.positions[b as usize],
+            merged.positions[c as usize],
+        );
+        // Skip degenerate triangles (two rim points at the same position).
+        let geo = (pb - pa).cross(pc - pa);
+        if geo.length() < 1e-20 {
+            return;
+        }
+        let (u, v) = project(pa);
+        let outward = surf_normal(u, v);
+        let mut tri = [a, b, c];
+        if geo.dot(outward) < 0.0 {
+            tri.swap(1, 2);
+        }
+        merged.indices.extend_from_slice(&tri);
+    };
+
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let (b0, b1) = (rims[0][i], rims[0][j]);
+        let (t0, t1) = (rims[1][i], rims[1][j]);
+        emit(merged, b0, b1, t1);
+        emit(merged, b0, t1, t0);
+    }
+
+    Ok(true)
+}
 
 /// CDT-based tessellation for non-planar faces with exact boundary constraints.
 ///

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -10,7 +10,9 @@ use brepkit_topology::solid::SolidId;
 use super::TriangleMesh;
 use super::edge_sampling::{circle_param_range, sample_edge, segments_for_chord_deviation_a};
 use super::mesh_ops::{dedupe_coincident_triangles, weld_boundary_vertices};
-use super::nonplanar::{tessellate_nonplanar_cdt, tessellate_nonplanar_snap};
+use super::nonplanar::{
+    tessellate_nonplanar_cdt, tessellate_nonplanar_snap, tessellate_revolution_band_shared,
+};
 use super::nurbs::{compute_angular_range, compute_v_param_range};
 use super::planar::{
     cdt_triangulate_simple, collect_wire_global_vertices, project_by_normal,
@@ -814,16 +816,25 @@ pub(super) fn tessellate_face_with_shared_edges(
         };
 
         if is_standard_rect {
-            tessellate_nonplanar_snap(
-                topo,
-                face_id,
-                face_data,
-                deflection,
-                angular_tol,
-                edge_global_indices,
-                merged,
-                point_to_global,
-            )?;
+            // Prefer a structured band built from the shared rim vertices — it
+            // is watertight by construction and avoids the snap path's proximity
+            // reconciliation, which cracks drilled holes at certain radius/
+            // deflection combos (issue #696). Falls back to snap for faces that
+            // aren't a simple two-rim full-revolution band.
+            let handled =
+                tessellate_revolution_band_shared(topo, face_data, edge_global_indices, merged)?;
+            if !handled {
+                tessellate_nonplanar_snap(
+                    topo,
+                    face_id,
+                    face_data,
+                    deflection,
+                    angular_tol,
+                    edge_global_indices,
+                    merged,
+                    point_to_global,
+                )?;
+            }
         } else {
             let pos_save = merged.positions.len();
             let nrm_save = merged.normals.len();

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -540,28 +540,17 @@ fn tessellate_boolean_cut_cylinder_watertight() {
 }
 
 /// Issue #696: a cylindrical hole drilled through a box must tessellate
-/// watertight across radii and deflections, but currently does not.
+/// watertight across radii and deflections.
 ///
-/// Root cause: a drilled-hole cylinder lateral face takes the `is_standard_rect`
-/// snap path in `tessellate_face_with_shared_edges`. That path tessellates the
-/// cylinder independently (grid `nu = segments_for_chord_deviation_a` over the
-/// `compute_angular_range` span) and then reconciles the rim vertices to the
-/// shared edge pool by 1e-6 proximity. The shared rim *edge* is sampled by
-/// `edge_sample_count` over a `TAU` span; at radius/deflection combinations
-/// where the two segment counts diverge by one (e.g. r=3.25, deflection=0.05)
-/// the independent rim vertices land at different angles than the shared ones,
-/// fail the proximity snap, and become near-coincident duplicates — cracking
-/// the mesh (204 boundary edges).
-///
-/// Two fixes were explored and rejected: (1) routing drilled holes through the
-/// CDT path is watertight for clean through-holes but over-tessellates ~24x
-/// (the `interior_grid_resolution` `n_v` uses curvature for the straight axial
-/// direction) and still cracks coincident-cap holes; (2) pinning the grid's
-/// angular span to TAU did not align the counts. The real fix must make the
-/// snap path's rim sampling identical to the shared edge sampling (count AND
-/// phase). Tracked here as a runnable repro.
-#[ignore = "issue #696: drilled-hole cylinder snap-path rim sampling cracks the \
-            mesh at certain radius/deflection combos; needs rim-sampling alignment"]
+/// Previously a drilled-hole cylinder lateral face took the snap path, which
+/// tessellated the cylinder independently and reconciled its rim vertices to
+/// the shared edge pool by 1e-6 proximity. At radius/deflection combinations
+/// where the independent rim sampling and the shared-edge sampling diverged by
+/// one segment (e.g. r=3.25, deflection=0.05), the rim vertices landed at
+/// different angles, failed the snap, and became near-coincident duplicates —
+/// cracking the mesh (up to 252 boundary edges). The fix tessellates such bands
+/// directly from the shared rim vertices (`tessellate_revolution_band_shared`),
+/// making them watertight by construction.
 #[test]
 fn tessellate_drilled_hole_watertight_across_radii() {
     use brepkit_math::mat::Mat4;
@@ -585,6 +574,38 @@ fn tessellate_drilled_hole_watertight_across_radii() {
                 "drilled hole r={r} defl={defl} must be watertight, got bd={boundary} nm={nm}"
             );
         }
+    }
+}
+
+/// Issue #696 end-to-end: a gridfinity-style tile (pocketed slab + four magnet
+/// holes drilled through the floor into the pocket cavity) must tessellate
+/// watertight. This is the multi-feature scenario the consumer hit; the magnet
+/// cylinders are drilled holes that exercise the shared-rim band path.
+#[test]
+fn tessellate_gridfinity_magnet_tile_watertight() {
+    use crate::boolean::{BooleanOp, boolean};
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let slab = crate::primitives::make_box(&mut topo, 42.0, 42.0, 8.0).unwrap();
+    crate::transform::transform_solid(&mut topo, slab, &Mat4::translation(0.0, 0.0, -8.0)).unwrap();
+    let pocket = crate::primitives::make_box(&mut topo, 35.0, 35.0, 6.5).unwrap();
+    crate::transform::transform_solid(&mut topo, pocket, &Mat4::translation(3.5, 3.5, -6.0))
+        .unwrap();
+    let mut tile = boolean(&mut topo, BooleanOp::Cut, slab, pocket).unwrap();
+    for (cx, cy) in [(7.0, 7.0), (35.0, 7.0), (7.0, 35.0), (35.0, 35.0)] {
+        let cyl = crate::primitives::make_cylinder(&mut topo, 3.25, 4.0).unwrap();
+        crate::transform::transform_solid(&mut topo, cyl, &Mat4::translation(cx, cy, -8.5))
+            .unwrap();
+        tile = boolean(&mut topo, BooleanOp::Cut, tile, cyl).unwrap();
+    }
+    for &defl in &[0.05_f64, 0.1] {
+        let mesh = tessellate_solid(&topo, tile, defl).unwrap();
+        assert_eq!(
+            (boundary_edge_count(&mesh), non_manifold_edge_count(&mesh)),
+            (0, 0),
+            "magnet tile must tessellate watertight at deflection {defl}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the drilled-hole tessellation crack that was the remaining part of #696. A cylindrical hole drilled through a face failed to tessellate watertight at certain radius/deflection combinations, breaking STL watertightness for features like gridfinity magnet holes.

```
box(20,20,10) − cylinder(r=3.25, h=20), deflection 0.05  → was 204 boundary edges, now 0
```

This **un-ignores** and makes pass the `tessellate_drilled_hole_watertight_across_radii` repro added in #807.

## Root cause

A drilled-hole cylinder lateral face took the **snap** path, which tessellates the cylinder *independently* (its own angular grid) then reconciles the rim vertices to the shared edge pool by **1e-6 proximity**. When the independent rim sampling and the shared-edge sampling diverged by one segment (a radius/deflection-dependent off-by-one), the rim vertices landed at different angles, failed the proximity snap, and became near-coincident **duplicates** that cracked the mesh.

## Fix

Tessellate a simple two-rim full-revolution cylinder/cone band **directly from the shared rim edge vertices** (`tessellate_revolution_band_shared`):

- Reuses the exact `edge_global_indices` rim vertices → **watertight by construction** (no proximity snap).
- `nv = 1` band (connect bottom rim to top rim) → no axial over-tessellation.
- Triangles oriented to the surface outward normal; the existing global `is_reversed` flip handles reversal (validated by the golden volume).

It's taken **only** for faces with no inner wires, exactly two closed rim circles, and matching rim counts. Everything else — open arcs, mismatched rim counts (e.g. some cones), NURBS boundaries — falls back to the existing snap path unchanged.

`★` Earlier rejected approaches (documented in the #696 history): routing drilled holes through the CDT path over-tessellated ~24× and cracked coincident-cap holes; pinning the grid angular span to TAU didn't align the sampling because the cylinder *surface* and the rim *circle edge* have independent parameterizations. Reusing the shared vertices sidesteps all of that.

## Verification

- `tessellate_drilled_hole_watertight_across_radii` (6 radii × 2 deflections) — now passes (un-ignored).
- New `tessellate_gridfinity_magnet_tile_watertight` — end-to-end pocket + 4 magnet holes, watertight at both deflections.
- 61/61 tessellate tests, incl. plain cylinder/cone watertightness and the box−cylinder golden (**volume unchanged**, so winding is correct).
- **Full `cargo test` on operations (23 binaries) + check + io + wasm (213): all green, no regressions.**

## Review note

This touches the **core tessellation dispatch** (curved-face meshing), so it's a higher-risk change despite the contained surface area and strong test coverage — flagging for a careful look at the band winding/orientation and the fall-back conditions.

Closes #696