### PR TITLE
fix(boolean): strip out-and-back wire spurs from fused faces (#801)

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -546,6 +546,10 @@ pub fn boolean(
             }
             if result_faces > 0 {
                 let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
+                // Strip out-and-back wire spurs left by the GFA wire builder on
+                // U-shaped (single-opening-notch) faces — they over-connect the
+                // opening edge and inflate volume (issue #801 slot fuse).
+                let _ = crate::heal::remove_wire_spurs(topo, result)?;
                 // A coincident-junction fuse can leave duplicate junction-wire
                 // edges (one per argument) that differ by sub-micron loft noise
                 // → free edges. Merge those coincident duplicates. Gated on the

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4215,14 +4215,14 @@ fn issue_801_recombined_box_is_genus0_manifold() {
 }
 
 #[test]
-#[ignore = "deep: GFA + mesh coincident-coplanar handling over-counts the \
-            slot fuse by a tessellation-artifact pyramid (vol 1083⅓ vs 1000); \
-            same root cause as #696. Tracks the eventual full fix."]
 fn issue_801_slot_fuse_recovers_volume() {
-    // b touches a on only two faces (a floating edge groove). Unlike the
-    // corner cases, both GFA same-domain annihilation and the mesh-boolean
-    // fallback leave a phantom 250/3 ≈ 83.3 volume from mismatched coincident-
-    // coplanar triangulations. When the coincident-coplanar work lands this
-    // must recover vol(a) = 1000.
-    assert_cut_fuse_back_recovers(10.0, 5.0, 2.5);
+    // b touches a on only two faces (a floating edge groove). The notched faces
+    // are U-shaped (notch open on one edge), which GFA's wire builder emitted
+    // with an out-and-back spur across the opening — over-connecting that edge
+    // and inflating the volume (the reported case went to 1083⅓).
+    // `remove_wire_spurs` strips the spur so the fuse recovers vol(a) as a clean
+    // manifold, across several groove sizes/positions.
+    assert_cut_fuse_back_recovers(10.0, 5.0, 2.5); // the reported repro
+    assert_cut_fuse_back_recovers(12.0, 4.0, 4.0);
+    assert_cut_fuse_back_recovers(8.0, 3.0, 2.0);
 }

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -355,10 +355,17 @@ pub fn remove_wire_spurs(
             };
 
             let n_removed = strip_wire_spurs(&mut oes);
-            // Leave fully-collapsed wires (a face that was nothing but a spur)
-            // alone — that is a degenerate-face concern for a later pass, not
-            // something to silently drop here.
-            if n_removed == 0 || oes.len() < 3 {
+            if n_removed == 0 {
+                continue;
+            }
+            // Always write the stripped wire back when it still has an edge, so
+            // the over-connected spur edge is never left behind. If stripping
+            // takes the wire below three edges the face was already degenerate
+            // (a spur wrapping a bigon or self-loop); the residual bigon is then
+            // rejected by `validate_boolean_result` and the op drops to the mesh
+            // fallback — strictly better than letting the spur survive into the
+            // result. `Wire::new` only rejects an empty edge list.
+            if oes.is_empty() {
                 continue;
             }
 

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -314,6 +314,102 @@ pub fn remove_degenerate_edges(
     Ok(removed_count)
 }
 
+/// Remove out-and-back spurs from face wires.
+///
+/// A *spur* is a consecutive pair of oriented edges in a wire that reference the
+/// SAME edge with opposite orientations: the wire walks out along the edge and
+/// immediately walks back. It encloses zero area (it never changes the face's
+/// region) but it over-connects that edge — counting it twice for the face.
+///
+/// GFA's wire builder can emit a spur for a U-shaped face: when a notch opens
+/// onto a single boundary edge (e.g. `(a−b) ∪ (a∩b)` where `b` meets `a` on two
+/// faces, issue #801), the notched face's wire traverses the opening edge
+/// out-and-back instead of leaving it as the clean boundary shared with the
+/// filler face. The spur makes that edge non-manifold (3+ faces) and inflates
+/// the measured volume. Stripping it is always sound — the face region is
+/// unchanged and the edge drops to its correct neighbours.
+///
+/// Returns the number of oriented-edge occurrences removed (two per spur).
+///
+/// # Errors
+/// Returns an error if topology lookups fail.
+pub fn remove_wire_spurs(
+    topo: &mut Topology,
+    solid: SolidId,
+) -> Result<usize, crate::OperationsError> {
+    let face_ids = brepkit_topology::explorer::solid_faces(topo, solid)?;
+    let mut removed = 0;
+
+    for fid in face_ids {
+        let wire_ids: Vec<_> = {
+            let face = topo.face(fid)?;
+            std::iter::once(face.outer_wire())
+                .chain(face.inner_wires().iter().copied())
+                .collect()
+        };
+
+        for wid in wire_ids {
+            let (mut oes, closed) = {
+                let wire = topo.wire(wid)?;
+                (wire.edges().to_vec(), wire.is_closed())
+            };
+
+            let n_removed = strip_wire_spurs(&mut oes);
+            // Leave fully-collapsed wires (a face that was nothing but a spur)
+            // alone — that is a degenerate-face concern for a later pass, not
+            // something to silently drop here.
+            if n_removed == 0 || oes.len() < 3 {
+                continue;
+            }
+
+            let new_wire = Wire::new(oes, closed)?;
+            let new_wid = topo.add_wire(new_wire);
+            let face = topo.face_mut(fid)?;
+            if face.outer_wire() == wid {
+                face.set_outer_wire(new_wid);
+            } else {
+                let inner = face.inner_wires().to_vec();
+                for (i, &iwid) in inner.iter().enumerate() {
+                    if iwid == wid {
+                        face.inner_wires_mut()[i] = new_wid;
+                    }
+                }
+            }
+            removed += n_removed;
+        }
+    }
+
+    Ok(removed)
+}
+
+/// Strip consecutive same-edge opposite-orientation pairs (out-and-back spurs)
+/// from an oriented-edge loop, including the wrap-around pair. Iterates because
+/// removing one spur can expose another. Returns the count removed.
+fn strip_wire_spurs(oes: &mut Vec<OrientedEdge>) -> usize {
+    let mut removed = 0;
+    loop {
+        let n = oes.len();
+        if n < 2 {
+            break;
+        }
+        let spur = (0..n).find_map(|i| {
+            let j = (i + 1) % n;
+            (oes[i].edge() == oes[j].edge() && oes[i].is_forward() != oes[j].is_forward())
+                .then_some((i, j))
+        });
+        match spur {
+            Some((i, j)) => {
+                let (lo, hi) = if i < j { (i, j) } else { (j, i) };
+                oes.remove(hi);
+                oes.remove(lo);
+                removed += 2;
+            }
+            None => break,
+        }
+    }
+    removed
+}
+
 /// Fix face orientations so normals point outward from the solid.
 ///
 /// Uses the signed volume test: for each face, computes the signed volume


### PR DESCRIPTION
## Summary

Fixes the remaining floating-slot case of #801. `(a − b) ∪ (a ∩ b)` where `b` touches `a` on only **two** faces fused to a **non-manifold** solid with an inflated volume:

```
box(10) , box(5)@dx=2.5 :  fuse → was 1083⅓ (non-manifold) , now 1000 ✓ (manifold, 8 faces)
```

This un-ignores `issue_801_slot_fuse_recovers_volume`.

## Root cause

The notched faces in `a − b` are **U-shaped** — the notch opens onto a single boundary edge (unlike the corner case, where the notch opens onto two edges and forms a clean L). GFA's wire builder reconstructed each U-shaped face with an **out-and-back spur** across the opening: its wire walks the opening edge forward, then immediately backward.

```
face (z=0): … → (2.5,0,0)
            e67 fwd (2.5,0,0)→(7.5,0,0)     ← spur out
            e67 rev (7.5,0,0)→(2.5,0,0)     ← spur back
            → (0,0,0) → …
```

The spur encloses zero area but counts the opening edge twice for the face, so that edge ends up shared by **6 faces** (the two notched faces' spurs + the two filler quads) → non-manifold, and the groove volume is double-counted.

## Fix

Add `remove_wire_spurs` — a heal pass that strips consecutive same-edge opposite-orientation pairs (including the wrap-around pair) from face wires — and run it on the GFA result in the boolean pipeline.

`★` Stripping a spur is **provably sound**: a wire that walks an edge out-and-back is always a zero-area degenerate appendage, never a valid face boundary. So it can only remove artifacts, never valid topology — safe to run on every result, and faces without spurs (e.g. the corner cases) are untouched. After stripping, the opening edge drops to its correct two neighbours (the filler quads) → manifold, vol = 1000.

This is a heal-layer cleanup of a GFA wire-builder artifact, not a change to the boolean's region selection.

## Verification

- `issue_801_slot_fuse_recovers_volume` — un-ignored; passes across three groove sizes/positions, both operand orders.
- The corner-nested cases (`issue_801_fuse_recovers_volume_scaling`, `…_genus0_manifold`) unchanged.
- **Full `cargo test` operations (23 binaries) + wasm (213): all green, no regressions.**

## Review note

Touches the core boolean pipeline (one new sound heal pass + one call site on the GFA success path). The spur-removal logic and its wrap-around handling are the parts worth a close read.

Closes #801