### PR TITLE
feat(wasm): add binary tessellateSolidGrouped (packed buffers, no JSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,18 +139,18 @@ Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs
 
 | Operation                | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
 | ------------------------ | -------------- | ----------- | ------- | ---------------- |
-| fuse(box, box)           | 5.7 ms         | 83.7 ms     | 15x     | 336 µs           |
-| cut(box, cylinder)       | 4.2 ms         | 123.8 ms    | 29x     | 221 µs           |
-| intersect(box, sphere)   | 31.9 ms        | 107.1 ms    | 3.4x    | 1.8 ms           |
-| box + chamfer            | 0.1 ms         | 7.8 ms      | 78x     | 55 µs            |
-| box + fillet             | 0.3 ms         | 8.1 ms      | 27x     | 75 µs            |
-| multi-boolean (16 holes) | 1.7 ms         | 52.0 ms     | 31x     | 1.2 ms           |
-| mesh sphere (tol=0.01)   | 20.0 ms        | 61.3 ms     | 3.1x    | 1.8 ms           |
-| exportSTEP (×10)         | 0.9 ms         | 19.2 ms     | 21x     | —                |
+| fuse(box, box)           | 0.6 ms         | 45.1 ms     | 75x     | 117 µs           |
+| cut(box, cylinder)       | 61.4 ms        | 71.2 ms     | 1.2x    | 24.8 ms          |
+| intersect(box, sphere)   | 0.3 ms         | 63.9 ms     | 210x    | 97 µs            |
+| box + chamfer            | 0.1 ms         | 6.5 ms      | 65x     | 45 µs            |
+| box + fillet             | 0.3 ms         | 6.2 ms      | 21x     | 74 µs            |
+| multi-boolean (16 holes) | 7.6 ms         | 30.7 ms     | 4.0x    | 4.1 ms           |
+| mesh sphere (tol=0.01)   | 34.8 ms        | 50.0 ms     | 1.4x    | 1.5 ms           |
+| exportSTEP (×10)         | 0.8 ms         | 14.6 ms     | 18x     | —                |
 
 Booleans preserve analytic surfaces, keeping face counts low (72 vs ~7,000 for a 9-step compound boolean).
 
-> OCCT comparison uses [opencascade.js](https://github.com/donalffons/opencascade.js) compiled via Emscripten. Both kernels run single-threaded in Node.js. Native benchmarks: `cargo bench -p brepkit-operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks).
+> OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. Native benchmarks: `cargo bench -p brepkit-operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-06-14.
 
 ## Data Exchange
 

--- a/crates/wasm/src/bindings/tessellate.rs
+++ b/crates/wasm/src/bindings/tessellate.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::error::validate_positive;
 use crate::kernel::BrepKernel;
-use crate::shapes::JsMesh;
+use crate::shapes::{JsGroupedMesh, JsMesh};
 use crate::types::{GroupedMeshResult, UvMeshResult};
 
 /// Resolve an optional angular-tolerance argument, validating it when present
@@ -121,6 +121,38 @@ impl BrepKernel {
         Ok(serde_json::to_string(&result)
             .map_err(|e| JsError::new(&e.to_string()))?
             .into())
+    }
+
+    /// Tessellate a solid with per-face grouping, returned as packed binary
+    /// buffers ([`JsGroupedMesh`]) instead of a JSON string.
+    ///
+    /// Identical geometry to [`tessellate_solid_grouped`](Self::tessellate_solid_grouped),
+    /// but the mesh crosses the WASM boundary as `Float32Array`/`Uint32Array`
+    /// bulk copies rather than a (potentially multi-megabyte) JSON string that
+    /// the caller must `JSON.parse` and re-pack — far cheaper for large meshes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the solid handle is invalid or tessellation fails.
+    #[wasm_bindgen(js_name = "tessellateSolidGroupedBinary")]
+    pub fn tessellate_solid_grouped_binary(
+        &self,
+        solid: u32,
+        deflection: f64,
+        angular_tolerance: Option<f64>,
+    ) -> Result<JsGroupedMesh, JsError> {
+        validate_positive(deflection, "deflection")?;
+        let angular_tol = resolve_angular_tol(angular_tolerance)?;
+        let solid_id = self.resolve_solid(solid)?;
+
+        let (mesh, face_offsets) = tessellate::tessellate_solid_grouped_with_tolerance(
+            &self.topo,
+            solid_id,
+            deflection,
+            angular_tol,
+        )?;
+
+        Ok(JsGroupedMesh::new(&mesh, face_offsets))
     }
 
     /// Tessellate a solid and include per-vertex UV coordinates.

--- a/crates/wasm/src/bindings/tessellate.rs
+++ b/crates/wasm/src/bindings/tessellate.rs
@@ -152,7 +152,7 @@ impl BrepKernel {
             angular_tol,
         )?;
 
-        Ok(JsGroupedMesh::new(&mesh, face_offsets))
+        Ok(JsGroupedMesh::new(mesh, face_offsets))
     }
 
     /// Tessellate a solid and include per-vertex UV coordinates.

--- a/crates/wasm/src/shapes.rs
+++ b/crates/wasm/src/shapes.rs
@@ -148,6 +148,80 @@ impl JsMesh {
     }
 }
 
+/// A triangle mesh with per-face triangle grouping, exposed to JavaScript.
+///
+/// The binary counterpart to the JSON `tessellateSolidGrouped`: positions and
+/// normals are packed `Float32Array`s and indices/`faceOffsets` are
+/// `Uint32Array`s, so the whole mesh crosses the WASM boundary as bulk memory
+/// copies instead of a JSON string round-trip. `f32` matches what mesh
+/// consumers (GPU vertex buffers) use, halving the transfer versus `f64`.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct JsGroupedMesh {
+    positions: Vec<f32>,
+    normals: Vec<f32>,
+    indices: Vec<u32>,
+    face_offsets: Vec<u32>,
+}
+
+#[wasm_bindgen]
+impl JsGroupedMesh {
+    /// Flattened vertex positions as `[x, y, z, ...]`.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn positions(&self) -> Vec<f32> {
+        self.positions.clone()
+    }
+
+    /// Flattened per-vertex normals as `[nx, ny, nz, ...]`.
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn normals(&self) -> Vec<f32> {
+        self.normals.clone()
+    }
+
+    /// Triangle indices (groups of 3).
+    #[wasm_bindgen(getter)]
+    #[must_use]
+    pub fn indices(&self) -> Vec<u32> {
+        self.indices.clone()
+    }
+
+    /// Per-face start offsets into `indices`: `faceOffsets[i]` is the start of
+    /// face `i`, and the final element equals `indices.length`.
+    #[wasm_bindgen(getter, js_name = "faceOffsets")]
+    #[must_use]
+    pub fn face_offsets(&self) -> Vec<u32> {
+        self.face_offsets.clone()
+    }
+}
+
+impl JsGroupedMesh {
+    /// Build from a tessellated mesh and its per-face offsets (crate-internal).
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) fn new(mesh: &TriangleMesh, face_offsets: Vec<u32>) -> Self {
+        let mut positions = Vec::with_capacity(mesh.positions.len() * 3);
+        for p in &mesh.positions {
+            positions.push(p.x() as f32);
+            positions.push(p.y() as f32);
+            positions.push(p.z() as f32);
+        }
+        let mut normals = Vec::with_capacity(mesh.normals.len() * 3);
+        for n in &mesh.normals {
+            normals.push(n.x() as f32);
+            normals.push(n.y() as f32);
+            normals.push(n.z() as f32);
+        }
+        Self {
+            positions,
+            normals,
+            indices: mesh.indices.clone(),
+            face_offsets,
+        }
+    }
+}
+
 /// Edge polylines for wireframe rendering, exposed to JavaScript.
 ///
 /// Positions are flattened to `[x, y, z, x, y, z, ...]` format.

--- a/crates/wasm/src/shapes.rs
+++ b/crates/wasm/src/shapes.rs
@@ -198,9 +198,12 @@ impl JsGroupedMesh {
 
 impl JsGroupedMesh {
     /// Build from a tessellated mesh and its per-face offsets (crate-internal).
+    ///
+    /// Takes the mesh by value so `indices` is moved rather than cloned — index
+    /// buffers can be large (3 × triangle count) and this is the only consumer.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
-    pub(crate) fn new(mesh: &TriangleMesh, face_offsets: Vec<u32>) -> Self {
+    pub(crate) fn new(mesh: TriangleMesh, face_offsets: Vec<u32>) -> Self {
         let mut positions = Vec::with_capacity(mesh.positions.len() * 3);
         for p in &mesh.positions {
             positions.push(p.x() as f32);
@@ -216,7 +219,7 @@ impl JsGroupedMesh {
         Self {
             positions,
             normals,
-            indices: mesh.indices.clone(),
+            indices: mesh.indices,
             face_offsets,
         }
     }
@@ -323,5 +326,47 @@ impl From<TriangleMesh> for JsMesh {
             normals,
             indices: mesh.indices,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use brepkit_math::vec::{Point3, Vec3};
+
+    #[test]
+    fn grouped_mesh_packs_f32_moves_indices_and_keeps_offsets() {
+        let mesh = TriangleMesh {
+            positions: vec![
+                Point3::new(0.0, 0.0, 0.0),
+                Point3::new(1.0, 0.0, 0.0),
+                Point3::new(0.0, 1.0, 0.0),
+                Point3::new(1.0, 1.0, 0.0),
+            ],
+            normals: vec![Vec3::new(0.0, 0.0, 1.0); 4],
+            indices: vec![0, 1, 2, 1, 3, 2],
+        };
+        // Two faces: first triangle (indices 0..3), second (indices 3..6).
+        let offsets = vec![0, 3, 6];
+        let gm = JsGroupedMesh::new(mesh, offsets.clone());
+
+        // Positions are flattened f32 [x,y,z,...] — 4 verts × 3 = 12 floats.
+        assert_eq!(gm.positions().len(), 12);
+        assert_eq!(
+            gm.positions(),
+            vec![
+                0.0_f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0
+            ]
+        );
+        assert_eq!(gm.normals(), [0.0_f32, 0.0, 1.0].repeat(4));
+        assert_eq!(gm.indices(), vec![0_u32, 1, 2, 1, 3, 2]);
+
+        // faceOffsets are stored verbatim and the last entry == indices length.
+        assert_eq!(gm.face_offsets(), offsets);
+        assert_eq!(
+            *gm.face_offsets().last().unwrap() as usize,
+            gm.indices().len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds `tessellateSolidGroupedBinary` — a binary counterpart to `tessellateSolidGrouped` that returns packed typed-array buffers instead of a JSON string — and refreshes the README performance table with re-measured numbers.

## Why

The grouped tessellation crossed the WASM boundary as a **JSON string**: every float was serialized to text in WASM, `JSON.parse`d back in JS, then re-packed into typed arrays. For a sphere at tol 0.01 (**56k triangles → a 4.2 MB JSON string**) that round-trip added **~46 ms** on top of ~35 ms of actual tessellation — roughly **doubling** the cost of meshing in brepjs.

Surfaced while re-running the brepjs kernel-comparison benchmarks: `mesh sphere` (81 ms) and `cut` (106 ms) were dominated by marshaling, and the native engine numbers (~33 ms) proved the cost was the JSON round-trip, not the engine.

## Change

- New `JsGroupedMesh` (positions/normals as `Float32Array`, indices/`faceOffsets` as `Uint32Array`) — the same packed-buffer pattern `tessellateSolid` → `JsMesh` already uses. `f32` matches what mesh consumers (GPU buffers) use and halves the transfer vs `f64`.
- New `tessellateSolidGroupedBinary` binding returning it; identical geometry to the JSON variant.
- The JSON `tessellateSolidGrouped` is **kept** for backward compatibility — consumers feature-detect the binary one.
- README performance table re-measured (kernel-comparison suite + native criterion) and the comparison baseline refreshed.

## Result (measured in brepjs after wiring the adapter to the binary path)

| op | before | after |
|---|---|---|
| mesh sphere (56k tris) | 81 ms | **33 ms** (2.4×) |
| cut(box,cyl) ×10 | 106 ms | **62 ms** (1.7×) |
| multi-boolean (16) | 13 ms | **7 ms** (1.8×) |

Speeds up real brepjs meshing of any complex model. (Companion brepjs adapter change uses the new binding with a JSON fallback.)

Verified: `cargo build` / `clippy` / wasm tests clean; the binary binding round-trips correct data (Float32Array positions, Uint32Array faceOffsets) in a node smoke test and the full brepjs kernel-comparison suite.