### PR TITLE
fix(fillet): skip edges bordering NURBS blend faces instead of emitting garbage (#813)

### DIFF
--- a/crates/operations/src/query.rs
+++ b/crates/operations/src/query.rs
@@ -49,3 +49,100 @@ pub fn filter_planar_edges(
     }
     Ok(result)
 }
+
+/// Filter edges to only those the blend engines can fillet: manifold edges
+/// (shared by exactly two faces) whose **both** neighbor faces are analytic
+/// (plane/cylinder/cone/sphere/torus, not NURBS).
+///
+/// The walking and rolling-ball fillet engines build the blend section against
+/// analytic neighbor surfaces. An edge bordering a NURBS face (e.g. a previous
+/// fillet's blend face) is unsupported — attempting it yields a silent no-op or
+/// a self-intersecting solid — so callers should skip such edges rather than
+/// feed them to the engine.
+///
+/// # Errors
+///
+/// Returns `OperationsError::Topology` if any entity ID is invalid.
+pub fn filter_filletable_edges(
+    topo: &Topology,
+    solid_id: SolidId,
+    edge_ids: &[EdgeId],
+) -> Result<Vec<EdgeId>, OperationsError> {
+    let solid_data = topo.solid(solid_id)?;
+    let shell = topo.shell(solid_data.outer_shell())?;
+
+    let mut edge_faces: HashMap<usize, Vec<FaceId>> = HashMap::new();
+    for &fid in shell.faces() {
+        let face = topo.face(fid)?;
+        let wire = topo.wire(face.outer_wire())?;
+        for oe in wire.edges() {
+            edge_faces.entry(oe.edge().index()).or_default().push(fid);
+        }
+    }
+
+    let mut result = Vec::new();
+    for &eid in edge_ids {
+        let Some(adj_faces) = edge_faces.get(&eid.index()) else {
+            continue;
+        };
+        if adj_faces.len() != 2 {
+            continue;
+        }
+        let both_analytic = adj_faces.iter().all(|&fid| {
+            topo.face(fid)
+                .map(|f| f.surface().is_analytic())
+                .unwrap_or(false)
+        });
+        if both_analytic {
+            result.push(eid);
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use brepkit_topology::explorer::solid_edges;
+
+    use super::*;
+
+    #[test]
+    fn filletable_edges_all_planar_box() {
+        let mut topo = Topology::new();
+        let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edges(&topo, cube).unwrap();
+        let filletable = filter_filletable_edges(&topo, cube, &edges).unwrap();
+        assert_eq!(
+            filletable.len(),
+            edges.len(),
+            "every box edge is plane↔plane and filletable"
+        );
+        assert_eq!(edges.len(), 12);
+    }
+
+    #[test]
+    fn filletable_edges_exclude_nurbs_blend_neighbors() {
+        let mut topo = Topology::new();
+        let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edges(&topo, cube).unwrap();
+        // A single fillet introduces a NURBS blend face; its boundary edges
+        // border a NURBS neighbor and must be excluded.
+        let filleted = crate::blend_ops::fillet_v2(&mut topo, cube, &[edges[0]], 1.0)
+            .unwrap()
+            .solid;
+        let r_edges = solid_edges(&topo, filleted).unwrap();
+        let filletable = filter_filletable_edges(&topo, filleted, &r_edges).unwrap();
+        assert!(
+            filletable.len() < r_edges.len(),
+            "edges bordering the NURBS blend must be excluded: {} of {} kept",
+            filletable.len(),
+            r_edges.len()
+        );
+        assert!(
+            !filletable.is_empty(),
+            "the remaining plane↔plane edges stay filletable"
+        );
+    }
+}

--- a/crates/operations/src/query.rs
+++ b/crates/operations/src/query.rs
@@ -1,6 +1,6 @@
 //! Shape query utilities.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use brepkit_topology::Topology;
 use brepkit_topology::edge::EdgeId;
@@ -71,12 +71,18 @@ pub fn filter_filletable_edges(
     let solid_data = topo.solid(solid_id)?;
     let shell = topo.shell(solid_data.outer_shell())?;
 
-    let mut edge_faces: HashMap<usize, Vec<FaceId>> = HashMap::new();
+    // Map each edge to its set of *distinct* adjacent faces, walking both outer
+    // and inner (hole-boundary) wires — the same adjacency the fillet engine
+    // sees. The set dedups a seam edge that a single face's wire lists twice.
+    let mut edge_faces: HashMap<usize, HashSet<FaceId>> = HashMap::new();
     for &fid in shell.faces() {
         let face = topo.face(fid)?;
-        let wire = topo.wire(face.outer_wire())?;
-        for oe in wire.edges() {
-            edge_faces.entry(oe.edge().index()).or_default().push(fid);
+        let mut wires = vec![face.outer_wire()];
+        wires.extend(face.inner_wires().iter().copied());
+        for wid in wires {
+            for oe in topo.wire(wid)?.edges() {
+                edge_faces.entry(oe.edge().index()).or_default().insert(fid);
+            }
         }
     }
 

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -163,21 +163,32 @@ pub fn try_fillet(
     edge_ids: &[brepkit_topology::edge::EdgeId],
     radius: f64,
 ) -> Result<brepkit_topology::solid::SolidId, brepkit_operations::OperationsError> {
+    // Skip edges the blend engines can't handle — those bordering a NURBS face
+    // (e.g. a prior fillet's blend face). Attempting them silently no-ops
+    // (`fillet_v2`) or yields a self-intersecting solid (`fillet_rolling_ball`),
+    // so we fillet only the analytic-neighbor edges (#813). If none qualify the
+    // solid is returned unchanged, matching the binding's existing skip policy.
+    let edges = brepkit_operations::query::filter_filletable_edges(topo, solid_id, edge_ids)?;
+    if edges.is_empty() {
+        return Ok(solid_id);
+    }
+    let edges = edges.as_slice();
+
     let rolling_ball = |topo: &mut brepkit_topology::Topology| {
-        brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edge_ids, radius)
+        brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edges, radius)
     };
     let builder = |topo: &mut brepkit_topology::Topology| {
-        brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edge_ids, radius).map(|r| r.solid)
+        brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edges, radius).map(|r| r.solid)
     };
 
-    let result = if edge_ids.len() > 1 {
+    let result = if edges.len() > 1 {
         rolling_ball(topo).or_else(|_| builder(topo))
     } else {
         builder(topo).or_else(|_| rolling_ball(topo))
     };
 
     // Final fallback: flat bevel (simplest).
-    result.or_else(|_| brepkit_operations::fillet::fillet(topo, solid_id, edge_ids, radius))
+    result.or_else(|_| brepkit_operations::fillet::fillet(topo, solid_id, edges, radius))
 }
 
 /// Extract a human-readable message from a `catch_unwind` panic payload.
@@ -527,5 +538,33 @@ mod fillet_tests {
             vol > 970.0 && vol < 1000.0,
             "filleted box volume should be ≈975.6, got {vol}"
         );
+    }
+
+    #[test]
+    fn try_fillet_second_pass_does_not_break_solid() {
+        // #813: a second fillet whose target edges border the first fillet's
+        // NURBS blend faces must not produce a self-intersecting solid (vol grew
+        // past the base to 1000.30 before the fix). Such edges are skipped.
+        let mut topo = Topology::new();
+        let cube = brepkit_operations::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edge_ids(&topo, cube);
+        let first = try_fillet(&mut topo, cube, &[edges[0], edges[1]], 1.0).expect("first fillet");
+        let v1 = brepkit_operations::measure::solid_volume(&topo, first, 0.05).unwrap();
+
+        // The first two edges of the result border the new NURBS blend faces.
+        let r_edges = solid_edge_ids(&topo, first);
+        let second =
+            try_fillet(&mut topo, first, &[r_edges[0], r_edges[1]], 0.5).expect("second fillet");
+        let v2 = brepkit_operations::measure::solid_volume(&topo, second, 0.05).unwrap();
+
+        // A fillet on these convex edges can only remove material, never add it.
+        assert!(
+            v2 <= v1 + 1e-6,
+            "second fillet must not add material: first={v1:.2}, second={v2:.2}"
+        );
+        let sd = topo.solid(second).expect("result solid");
+        let sh = topo.shell(sd.outer_shell()).expect("shell");
+        brepkit_topology::validation::validate_shell_manifold(sh, &topo)
+            .expect("second fillet result must remain a manifold solid");
     }
 }

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -542,29 +542,45 @@ mod fillet_tests {
 
     #[test]
     fn try_fillet_second_pass_does_not_break_solid() {
-        // #813: a second fillet whose target edges border the first fillet's
-        // NURBS blend faces must not produce a self-intersecting solid (vol grew
-        // past the base to 1000.30 before the fix). Such edges are skipped.
+        use brepkit_topology::face::FaceSurface;
+
+        // #813: a second fillet whose target edge borders the first fillet's
+        // NURBS blend face must not produce a self-intersecting solid — the
+        // volume grew past the base to 1000.30 before the fix; such edges are
+        // now skipped. Checked over *every* result edge so the guard doesn't
+        // rely on a particular edge ordering.
         let mut topo = Topology::new();
         let cube = brepkit_operations::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
         let edges = solid_edge_ids(&topo, cube);
         let first = try_fillet(&mut topo, cube, &[edges[0], edges[1]], 1.0).expect("first fillet");
         let v1 = brepkit_operations::measure::solid_volume(&topo, first, 0.05).unwrap();
 
-        // The first two edges of the result border the new NURBS blend faces.
-        let r_edges = solid_edge_ids(&topo, first);
-        let second =
-            try_fillet(&mut topo, first, &[r_edges[0], r_edges[1]], 0.5).expect("second fillet");
-        let v2 = brepkit_operations::measure::solid_volume(&topo, second, 0.05).unwrap();
-
-        // A fillet on these convex edges can only remove material, never add it.
-        assert!(
-            v2 <= v1 + 1e-6,
-            "second fillet must not add material: first={v1:.2}, second={v2:.2}"
-        );
-        let sd = topo.solid(second).expect("result solid");
+        // The scenario under test only exists if the first fillet produced NURBS
+        // blend faces for the later edges to border.
+        let sd = topo.solid(first).expect("solid");
         let sh = topo.shell(sd.outer_shell()).expect("shell");
-        brepkit_topology::validation::validate_shell_manifold(sh, &topo)
-            .expect("second fillet result must remain a manifold solid");
+        let has_blend = sh.faces().iter().any(|&fid| {
+            topo.face(fid)
+                .is_ok_and(|f| matches!(f.surface(), FaceSurface::Nurbs(_)))
+        });
+        assert!(has_blend, "first fillet should create NURBS blend faces");
+
+        // Filleting any single result edge can only remove material from this
+        // convex solid (never add it), and must stay a manifold solid.
+        let r_edges = solid_edge_ids(&topo, first);
+        for &e in &r_edges {
+            let mut t = topo.clone();
+            let s = try_fillet(&mut t, first, &[e], 0.5).expect("second fillet");
+            let v2 = brepkit_operations::measure::solid_volume(&t, s, 0.05).unwrap();
+            assert!(
+                v2 <= v1 + 1e-6,
+                "second fillet on edge {} added material: first={v1:.2}, second={v2:.2}",
+                e.index()
+            );
+            let ssd = t.solid(s).expect("result solid");
+            let ssh = t.shell(ssd.outer_shell()).expect("shell");
+            brepkit_topology::validation::validate_shell_manifold(ssh, &t)
+                .expect("second fillet result must remain a manifold solid");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Addresses the **contained safety half of #813 Part 2** (double fillet across NURBS blend faces). Full diagnosis is in [the issue thread](https://github.com/andymai/brepkit/issues/813#issuecomment-4703904492).

### The bug

The walking (`fillet_v2`) and rolling-ball fillet engines build their blend section against *analytic* neighbor surfaces. An edge bordering a **NURBS face** — e.g. a previous fillet's blend face (the "fillet a fillet" workflow) — is unsupported, and **neither engine detects it**:

| second fillet on a plane↔NURBS-blend edge | before |
|---|---|
| `fillet_v2` | `Ok`, volume **unchanged** — silent **no-op** |
| `fillet_rolling_ball` | `Ok`, volume **grows to 1000.30 > 1000 base** — self-intersecting solid |

The garbage result is topologically *manifold*, so a watertightness post-condition can't catch it.

### The fix

Add `operations::query::filter_filletable_edges` — manifold edges (exactly 2 neighbors) whose **both** neighbors are analytic — and pre-filter in the wasm `try_fillet` best-effort path. We fillet only the analytic-neighbor edges and skip the rest (skip-and-continue, matching the binding's existing skip policy and brepjs's `fillet(allEdges)` expectation). If no edges qualify, the solid is returned unchanged.

Result: the double fillet returns a **valid material-removing (or no-op) manifold solid** instead of garbage.

### Scope

This stops the *silent wrong result*. Actually rounding an edge against a NURBS blend face ("fillet a fillet") is a separate, larger blend-engine feature (generalize the section solver to NURBS neighbor surfaces) — tracked in #813 Part 2.

Also confirmed in the same diagnosis: **#813 Part 1 (variable-radius fillet volume) does not reproduce** on current main (correct ~991–994 volumes) — likely a stale brepjs divergence key.

### Tests

- `query::filter_filletable_edges` unit tests: box → all 12 edges filletable; post-fillet → NURBS-blend-neighbor edges excluded, plane↔plane edges retained.
- `try_fillet_second_pass_does_not_break_solid`: a second fillet on blend-adjacent edges never adds material and stays manifold. **Confirmed to fail pre-fix** at `second=1000.30`, pass post-fix.

Refs #813