### PR TITLE
feat(wasm): add filletWithEvolution face-provenance tracking (#815)

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -829,8 +829,6 @@ pub fn boolean_with_evolution(
     a: SolidId,
     b: SolidId,
 ) -> Result<(SolidId, crate::evolution::EvolutionMap), crate::OperationsError> {
-    use crate::evolution::EvolutionMap;
-
     // Collect input face normals + centroids before the operation mutates topology.
     let input_faces_a = collect_face_signatures(topo, a)?;
     let input_faces_b = collect_face_signatures(topo, b)?;
@@ -846,98 +844,8 @@ pub fn boolean_with_evolution(
     // Collect output face normals + centroids.
     let output_faces = collect_face_signatures(topo, result)?;
 
-    // Build evolution map via heuristic matching.
-    let mut evo = EvolutionMap::new();
-    let mut matched_inputs: std::collections::HashSet<usize> = std::collections::HashSet::new();
-    let mut unmatched_outputs: Vec<(usize, Vec3, Point3)> = Vec::new();
-
-    // Normal dot threshold: cos(45deg) — relaxed to handle faces split by
-    // booleans where normals may shift slightly.
-    let normal_threshold = 0.707;
-    // Maximum centroid distance squared for a match (generous).
-    let centroid_dist_sq_max = 100.0;
-
-    for &(out_idx, out_normal, out_centroid) in &output_faces {
-        // Collect every input face whose normal+centroid is "close enough"
-        // to the output face. When fuse simplifies two coincident-plane
-        // inputs into one output (e.g. fuse of touching boxes via the
-        // box-pair shortcut: the top faces of A and B both collapse onto
-        // the result's top face), picking only the single best-scoring
-        // input drops the other input's metadata. Recording every
-        // qualifying input under the same output preserves both origins.
-        let mut best_score = f64::NEG_INFINITY;
-        let mut matches: Vec<(usize, f64)> = Vec::new();
-
-        for &(in_idx, in_normal, in_centroid) in &input_faces {
-            let dot = out_normal.dot(in_normal);
-            if dot < normal_threshold {
-                continue;
-            }
-
-            let dx = out_centroid.x() - in_centroid.x();
-            let dy = out_centroid.y() - in_centroid.y();
-            let dz = out_centroid.z() - in_centroid.z();
-            let dist_sq = dx.mul_add(dx, dy.mul_add(dy, dz * dz));
-
-            if dist_sq > centroid_dist_sq_max {
-                continue;
-            }
-
-            let score = dot - dist_sq / centroid_dist_sq_max;
-            if score > best_score {
-                best_score = score;
-            }
-            matches.push((in_idx, score));
-        }
-
-        if matches.is_empty() {
-            unmatched_outputs.push((out_idx, out_normal, out_centroid));
-            continue;
-        }
-
-        // Accept any match within a small tolerance of the best score —
-        // ties (or near-ties) usually indicate two input faces that
-        // legitimately contributed to the same output (e.g., the two
-        // halves of a face that merged across a same-domain boundary).
-        let score_tol = 0.05;
-        for &(in_idx, score) in &matches {
-            if score >= best_score - score_tol {
-                evo.add_modified(in_idx, out_idx);
-                matched_inputs.insert(in_idx);
-            }
-        }
-    }
-
-    // Unmatched output faces are "generated" — attribute them to the nearest
-    // input face (the face most likely responsible for generating them, e.g.
-    // intersection curves create new faces near the boundary).
-    for &(out_idx, _out_normal, out_centroid) in &unmatched_outputs {
-        let mut best_dist_sq = f64::MAX;
-        let mut best_input: Option<usize> = None;
-
-        for &(in_idx, _, in_centroid) in &input_faces {
-            let dx = out_centroid.x() - in_centroid.x();
-            let dy = out_centroid.y() - in_centroid.y();
-            let dz = out_centroid.z() - in_centroid.z();
-            let dist_sq = dx.mul_add(dx, dy.mul_add(dy, dz * dz));
-            if dist_sq < best_dist_sq {
-                best_dist_sq = dist_sq;
-                best_input = Some(in_idx);
-            }
-        }
-
-        if let Some(in_idx) = best_input {
-            evo.add_generated(in_idx, out_idx);
-            matched_inputs.insert(in_idx);
-        }
-    }
-
-    // Any input face not matched to any output is deleted.
-    for &(in_idx, _, _) in &input_faces {
-        if !matched_inputs.contains(&in_idx) {
-            evo.add_deleted(in_idx);
-        }
-    }
+    // Build the evolution map from geometric face-signature matching.
+    let evo = crate::evolution::build_evolution_by_geometry(&input_faces, &output_faces);
 
     Ok((result, evo))
 }
@@ -3299,7 +3207,9 @@ pub fn face_polygon(
 /// # Errors
 ///
 /// Returns an error if any face or wire cannot be resolved.
-fn collect_face_signatures(
+/// Snapshot each outer-shell face as `(index, outward normal, centroid)` — the
+/// signature [`crate::evolution::build_evolution_by_geometry`] matches on.
+pub fn collect_face_signatures(
     topo: &Topology,
     solid_id: SolidId,
 ) -> Result<Vec<(usize, Vec3, Point3)>, crate::OperationsError> {

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -3207,8 +3207,11 @@ pub fn face_polygon(
 /// # Errors
 ///
 /// Returns an error if any face or wire cannot be resolved.
-/// Snapshot each outer-shell face as `(index, outward normal, centroid)` — the
-/// signature [`crate::evolution::build_evolution_by_geometry`] matches on.
+/// Snapshot each outer-shell face as `(index, face normal, centroid)` — the
+/// signature [`crate::evolution::build_evolution_by_geometry`] matches on. The
+/// normal is the stored plane normal (or a polygon-derived normal for
+/// non-planar faces), not re-oriented by the face's `reversed` flag; matching
+/// stays consistent because input and output faces use the same convention.
 pub fn collect_face_signatures(
     topo: &Topology,
     solid_id: SolidId,

--- a/crates/operations/src/evolution.rs
+++ b/crates/operations/src/evolution.rs
@@ -6,6 +6,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use brepkit_math::vec::{Point3, Vec3};
+
 /// Tracks how faces evolve through a modeling operation.
 ///
 /// After a boolean, fillet, or other operation, this map records:
@@ -75,5 +77,166 @@ impl EvolutionMap {
             generated_entries.join(","),
             deleted_vals.join(",")
         )
+    }
+}
+
+/// Build an [`EvolutionMap`] by matching output faces to input faces purely
+/// from geometry (face normal + centroid signatures `(index, normal, centroid)`).
+///
+/// This is operation-agnostic — any op that can snapshot face signatures before
+/// and after (booleans, fillets, …) reuses it:
+/// - An output face whose normal+centroid is close to an input face is a
+///   **modified** version of it (every near-tied input is recorded, so a
+///   same-domain merge of two inputs into one output keeps both origins).
+/// - An output face matching no input is **generated**, attributed to the
+///   nearest input (e.g. a fillet blend face or a boolean intersection face).
+/// - An input face matched by no output is **deleted**.
+#[must_use]
+pub fn build_evolution_by_geometry(
+    input_faces: &[(usize, Vec3, Point3)],
+    output_faces: &[(usize, Vec3, Point3)],
+) -> EvolutionMap {
+    let mut evo = EvolutionMap::new();
+    let mut matched_inputs: HashSet<usize> = HashSet::new();
+    let mut unmatched_outputs: Vec<(usize, Vec3, Point3)> = Vec::new();
+
+    // Normal dot threshold cos(45°) — relaxed because faces split by an
+    // operation may shift slightly. Centroid distance² cap is generous.
+    let normal_threshold = 0.707;
+    let centroid_dist_sq_max = 100.0;
+
+    for &(out_idx, out_normal, out_centroid) in output_faces {
+        let mut best_score = f64::NEG_INFINITY;
+        let mut matches: Vec<(usize, f64)> = Vec::new();
+
+        for &(in_idx, in_normal, in_centroid) in input_faces {
+            let dot = out_normal.dot(in_normal);
+            if dot < normal_threshold {
+                continue;
+            }
+            let dx = out_centroid.x() - in_centroid.x();
+            let dy = out_centroid.y() - in_centroid.y();
+            let dz = out_centroid.z() - in_centroid.z();
+            let dist_sq = dx.mul_add(dx, dy.mul_add(dy, dz * dz));
+            if dist_sq > centroid_dist_sq_max {
+                continue;
+            }
+            let score = dot - dist_sq / centroid_dist_sq_max;
+            if score > best_score {
+                best_score = score;
+            }
+            matches.push((in_idx, score));
+        }
+
+        if matches.is_empty() {
+            unmatched_outputs.push((out_idx, out_normal, out_centroid));
+            continue;
+        }
+
+        // Accept any near-tied match: two inputs legitimately contributing to
+        // one output (e.g. the two halves of a same-domain-merged face).
+        let score_tol = 0.05;
+        for &(in_idx, score) in &matches {
+            if score >= best_score - score_tol {
+                evo.add_modified(in_idx, out_idx);
+                matched_inputs.insert(in_idx);
+            }
+        }
+    }
+
+    // Unmatched outputs are generated — attribute each to the nearest input.
+    for &(out_idx, _out_normal, out_centroid) in &unmatched_outputs {
+        let mut best_dist_sq = f64::MAX;
+        let mut best_input: Option<usize> = None;
+        for &(in_idx, _, in_centroid) in input_faces {
+            let dx = out_centroid.x() - in_centroid.x();
+            let dy = out_centroid.y() - in_centroid.y();
+            let dz = out_centroid.z() - in_centroid.z();
+            let dist_sq = dx.mul_add(dx, dy.mul_add(dy, dz * dz));
+            if dist_sq < best_dist_sq {
+                best_dist_sq = dist_sq;
+                best_input = Some(in_idx);
+            }
+        }
+        if let Some(in_idx) = best_input {
+            evo.add_generated(in_idx, out_idx);
+            matched_inputs.insert(in_idx);
+        }
+    }
+
+    // Any input matched by nothing was deleted.
+    for &(in_idx, _, _) in input_faces {
+        if !matched_inputs.contains(&in_idx) {
+            evo.add_deleted(in_idx);
+        }
+    }
+
+    evo
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use brepkit_math::vec::{Point3, Vec3};
+
+    use super::*;
+
+    #[test]
+    fn matcher_classifies_modified_generated_deleted() {
+        let pz = Vec3::new(0.0, 0.0, 1.0);
+        let nz = Vec3::new(0.0, 0.0, -1.0);
+        let px = Vec3::new(1.0, 0.0, 0.0);
+        let inputs = [
+            (0usize, pz, Point3::new(0.0, 0.0, 0.0)),
+            (1usize, nz, Point3::new(0.0, 0.0, -10.0)),
+        ];
+        let outputs = [
+            // Same normal+position as input 0 → modified.
+            (100usize, pz, Point3::new(0.0, 0.0, 0.0)),
+            // Orthogonal normal, matches nothing → generated, nearest input is 0.
+            (200usize, px, Point3::new(1.0, 0.0, 0.0)),
+        ];
+        let evo = build_evolution_by_geometry(&inputs, &outputs);
+        assert_eq!(evo.modified.get(&0), Some(&vec![100]));
+        assert_eq!(evo.generated.get(&0), Some(&vec![200]));
+        assert!(evo.deleted.contains(&1), "input 1 had no output → deleted");
+    }
+
+    #[test]
+    fn fillet_evolution_tracks_all_faces() {
+        use brepkit_topology::explorer::solid_edges;
+
+        let mut topo = brepkit_topology::Topology::new();
+        let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let inputs = crate::boolean::collect_face_signatures(&topo, cube).unwrap();
+        let edges = solid_edges(&topo, cube).unwrap();
+        let filleted = crate::blend_ops::fillet_v2(&mut topo, cube, &[edges[0]], 1.0)
+            .unwrap()
+            .solid;
+        let outputs = crate::boolean::collect_face_signatures(&topo, filleted).unwrap();
+
+        let evo = build_evolution_by_geometry(&inputs, &outputs);
+
+        // The fillet adds a blend face (6 → 7) yet removes no box face.
+        assert_eq!(inputs.len(), 6);
+        assert_eq!(outputs.len(), 7);
+        assert!(
+            evo.deleted.is_empty(),
+            "no box face is deleted by the fillet"
+        );
+        assert_eq!(evo.modified.len(), 6, "all six box faces are tracked");
+
+        // Every output face — including the new blend — is attributed to an
+        // input, so a downstream face reference always resolves.
+        let tracked: HashSet<usize> = evo
+            .modified
+            .values()
+            .chain(evo.generated.values())
+            .flatten()
+            .copied()
+            .collect();
+        let output_indices: HashSet<usize> = outputs.iter().map(|&(i, _, _)| i).collect();
+        assert_eq!(tracked, output_indices, "every output face is attributed");
     }
 }

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -300,6 +300,49 @@ impl BrepKernel {
         }
     }
 
+    /// Apply a constant-radius fillet and return face-evolution tracking data.
+    ///
+    /// Returns a JSON string `{"solid": <u32>, "evolution": {modified,
+    /// generated, deleted}}` — the same shape as `fuseWithEvolution`. Blend
+    /// faces appear under `generated` and surviving faces under `modified`.
+    /// Provenance is matched geometrically (face normal + centroid), so it is
+    /// unaffected by how the fillet renumbers faces.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a handle is invalid, the radius is non-positive, or
+    /// the fillet fails.
+    #[wasm_bindgen(js_name = "filletWithEvolution")]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn fillet_with_evolution(
+        &mut self,
+        solid: u32,
+        edge_handles: Vec<u32>,
+        radius: f64,
+    ) -> Result<JsValue, JsError> {
+        validate_positive(radius, "radius")?;
+        let solid_id = self.resolve_solid(solid)?;
+        let edge_ids: Vec<brepkit_topology::edge::EdgeId> = edge_handles
+            .iter()
+            .map(|&h| self.resolve_edge(h))
+            .collect::<Result<_, _>>()?;
+
+        let input_faces =
+            brepkit_operations::boolean::collect_face_signatures(&self.topo, solid_id)?;
+        let result = try_fillet(self.topo_mut(), solid_id, &edge_ids, radius)?;
+        let output_faces =
+            brepkit_operations::boolean::collect_face_signatures(&self.topo, result)?;
+        let evo =
+            brepkit_operations::evolution::build_evolution_by_geometry(&input_faces, &output_faces);
+
+        let json = format!(
+            "{{\"solid\":{},\"evolution\":{}}}",
+            solid_id_to_u32(result),
+            evo.to_json()
+        );
+        Ok(JsValue::from_str(&json))
+    }
+
     // ── Operations ─────────────────────────────────────────────────
 
     /// Extrude a planar face along a direction vector to create a solid.

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -327,20 +327,30 @@ impl BrepKernel {
             .map(|&h| self.resolve_edge(h))
             .collect::<Result<_, _>>()?;
 
-        let input_faces =
-            brepkit_operations::boolean::collect_face_signatures(&self.topo, solid_id)?;
-        let result = try_fillet(self.topo_mut(), solid_id, &edge_ids, radius)?;
-        let output_faces =
-            brepkit_operations::boolean::collect_face_signatures(&self.topo, result)?;
-        let evo =
-            brepkit_operations::evolution::build_evolution_by_geometry(&input_faces, &output_faces);
-
-        let json = format!(
-            "{{\"solid\":{},\"evolution\":{}}}",
-            solid_id_to_u32(result),
-            evo.to_json()
-        );
-        Ok(JsValue::from_str(&json))
+        // Wrap in catch_unwind like `fillet` does: a fillet panic must not
+        // abort the whole WASM instance.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+            || -> Result<String, JsError> {
+                let input_faces =
+                    brepkit_operations::boolean::collect_face_signatures(&self.topo, solid_id)?;
+                let result = try_fillet(self.topo_mut(), solid_id, &edge_ids, radius)?;
+                let output_faces =
+                    brepkit_operations::boolean::collect_face_signatures(&self.topo, result)?;
+                let evo = brepkit_operations::evolution::build_evolution_by_geometry(
+                    &input_faces,
+                    &output_faces,
+                );
+                Ok(format!(
+                    "{{\"solid\":{},\"evolution\":{}}}",
+                    solid_id_to_u32(result),
+                    evo.to_json()
+                ))
+            },
+        ));
+        match result {
+            Ok(inner) => inner.map(|json| JsValue::from_str(&json)),
+            Err(panic_info) => Err(JsError::new(&panic_message(&panic_info, "Fillet"))),
+        }
     }
 
     // ── Operations ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the one tractable gap from the #815 audit: **shape-evolution for fillets**. brepjs's `shapeRef` suite tracks face provenance through booleans (the existing `fuseWithEvolution`/`cutWithEvolution`/`intersectWithEvolution`) *and* fillets (`filletWithEvolution`) — but brepkit only exposed the boolean half. This adds the fillet half.

(Per the [#815 audit](https://github.com/andymai/brepkit/issues/815#issuecomment-4704000927), the other items — convex hull, interference, boolean evolution — already exist; Minkowski sum and HLR remain large separate features.)

## Approach

The boolean already builds its `EvolutionMap` by **geometric face-signature matching** (face normal + centroid), not builder provenance — so it's directly reusable:

1. Extract that matcher into `evolution::build_evolution_by_geometry(inputs, outputs) -> EvolutionMap` (operation-agnostic, no topology deps): near-tied input → `modified`, unmatched output → `generated`, unmatched input → `deleted`.
2. Make `boolean::collect_face_signatures` public and refactor `boolean_with_evolution` onto the shared matcher — **behavior-preserving** (the 97 boolean tests stay green; net −95 lines there).
3. Add the `filletWithEvolution` binding: snapshot signatures around `try_fillet`, return `{"solid":<u32>,"evolution":{modified,generated,deleted}}` — the exact JSON shape `fuseWithEvolution` returns — so brepjs's adapter wires without representation loss.

## Tests

- `matcher_classifies_modified_generated_deleted` — synthetic signatures exercise all three buckets.
- `fillet_evolution_tracks_all_faces` — a real box fillet: 6 → 7 faces, no box face deleted, and **every** output face (including the blend) is attributed to an input, so a downstream face reference always resolves. (The blend face is attributed to both edge-adjacent faces — sound provenance under the generous heuristic.)

Refs #815