### PR TITLE
feat(sweep): native multi-section sweep with RMF frame transport (#814)

### DIFF
--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -5,6 +5,7 @@
 //! point. Uses rotation-minimizing frames (double-reflection method) to avoid
 //! Frenet-frame singularities on straight segments and inflection points.
 
+use brepkit_math::mat::Mat4;
 use brepkit_math::nurbs::curve::NurbsCurve;
 use brepkit_math::nurbs::surface_fitting::interpolate_surface;
 use brepkit_math::tolerance::Tolerance;
@@ -1856,6 +1857,163 @@ fn sweep_miter(
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
 }
 
+/// Sweep through multiple section profiles along a `spine`, lofting the
+/// positioned profiles.
+///
+/// Each planar profile is placed rigidly at its parameter along the spine: its
+/// centroid maps to the spine point, its normal to the spine tangent, and its
+/// plane to the frame's right/up plane. Orientation uses a rotation-minimizing
+/// frame so profiles stay twist-free on curved spines (unlike a per-section
+/// swing rotation). The placed profiles are then lofted — ruled (planar bands)
+/// or smooth (NURBS).
+///
+/// `sections` pairs each profile face with its spine parameter in `[0, 1]`.
+///
+/// # Errors
+///
+/// Returns [`crate::OperationsError::InvalidInput`] for fewer than two
+/// sections, a parameter outside `[0, 1]`, a non-planar profile, or a spine
+/// with fewer than two control points; propagates loft errors otherwise.
+pub fn multi_section_sweep(
+    topo: &mut Topology,
+    spine: &NurbsCurve,
+    sections: &[(FaceId, f64)],
+    ruled: bool,
+) -> Result<SolidId, crate::OperationsError> {
+    if sections.len() < 2 {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: format!(
+                "multi-section sweep requires at least 2 sections, got {}",
+                sections.len()
+            ),
+        });
+    }
+    if spine.control_points().len() < 2 {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "multi-section sweep spine must have at least 2 control points".into(),
+        });
+    }
+    for &(_, p) in sections {
+        if !(0.0..=1.0).contains(&p) {
+            return Err(crate::OperationsError::InvalidInput {
+                reason: format!("section parameter {p} is outside [0, 1]"),
+            });
+        }
+    }
+
+    // Dense rotation-minimizing frame for twist-free orientation; the exact
+    // origin/tangent per section is taken directly from the spine.
+    let dense_segments: usize = 64;
+    let t_start = spine.tangent(0.0)?;
+    let initial_up = orthogonalize(pick_reference_axis(t_start), t_start);
+    let dense = compute_frames(spine, dense_segments, initial_up, false)?;
+
+    let mut placed: Vec<FaceId> = Vec::with_capacity(sections.len());
+    for &(face_id, p) in sections {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let idx = ((p * dense_segments as f64).round() as usize).min(dense_segments);
+        let tangent = spine.tangent(p)?;
+        let up = orthogonalize(dense[idx].up, tangent);
+        let frame = Frame {
+            origin: spine.evaluate(p),
+            tangent,
+            up,
+            right: tangent.cross(up),
+        };
+        let mat = profile_to_frame_matrix(topo, face_id, &frame)?;
+        let placed_face = crate::copy::copy_face(topo, face_id)?;
+        crate::transform::transform_face(topo, placed_face, &mat)?;
+        placed.push(placed_face);
+    }
+
+    if ruled {
+        crate::loft::loft(topo, &placed)
+    } else {
+        crate::loft::loft_smooth(topo, &placed)
+    }
+}
+
+/// Pick a world axis not nearly parallel to `dir`, for seeding a frame.
+fn pick_reference_axis(dir: Vec3) -> Vec3 {
+    if dir.x().abs() < 0.9 {
+        Vec3::new(1.0, 0.0, 0.0)
+    } else {
+        Vec3::new(0.0, 1.0, 0.0)
+    }
+}
+
+/// Rigid transform placing a planar profile face into `frame`: centroid →
+/// `frame.origin`, normal → tangent, in-plane axes → right/up.
+fn profile_to_frame_matrix(
+    topo: &Topology,
+    face_id: FaceId,
+    frame: &Frame,
+) -> Result<Mat4, crate::OperationsError> {
+    let face = topo.face(face_id)?;
+    let normal = match face.surface() {
+        FaceSurface::Plane { normal, .. } => *normal,
+        _ => {
+            return Err(crate::OperationsError::InvalidInput {
+                reason: "multi-section sweep profiles must be planar".into(),
+            });
+        }
+    };
+
+    // Centroid = average of the outer-wire vertices.
+    let wire = topo.wire(face.outer_wire())?;
+    let mut sum = Point3::new(0.0, 0.0, 0.0);
+    let mut count = 0.0_f64;
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge())?;
+        let v = topo.vertex(oe.oriented_start(edge))?.point();
+        sum = Point3::new(sum.x() + v.x(), sum.y() + v.y(), sum.z() + v.z());
+        count += 1.0;
+    }
+    if count == 0.0 {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "multi-section sweep profile has no vertices".into(),
+        });
+    }
+    let centroid = Point3::new(sum.x() / count, sum.y() / count, sum.z() / count);
+
+    // Profile in-plane basis from a consistent world reference, so all profiles
+    // share an orientation and the RMF alone controls twist along the spine.
+    let p_x = orthogonalize(pick_reference_axis(normal), normal);
+    let p_y = normal.cross(p_x);
+
+    // R maps the profile basis (p_x, p_y, normal) onto (right, up, tangent):
+    // R = right⊗p_x + up⊗p_y + tangent⊗normal.
+    let t_cols = [
+        [frame.right.x(), frame.up.x(), frame.tangent.x()],
+        [frame.right.y(), frame.up.y(), frame.tangent.y()],
+        [frame.right.z(), frame.up.z(), frame.tangent.z()],
+    ];
+    let l_cols = [
+        [p_x.x(), p_y.x(), normal.x()],
+        [p_x.y(), p_y.y(), normal.y()],
+        [p_x.z(), p_y.z(), normal.z()],
+    ];
+    let mut rot = [[0.0_f64; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            rot[i][j] = (0..3).map(|k| t_cols[i][k] * l_cols[j][k]).sum();
+        }
+    }
+
+    // translation = origin − R·centroid
+    let c = [centroid.x(), centroid.y(), centroid.z()];
+    let o = [frame.origin.x(), frame.origin.y(), frame.origin.z()];
+    let trans: [f64; 3] =
+        std::array::from_fn(|i| o[i] - (0..3).map(|k| rot[i][k] * c[k]).sum::<f64>());
+
+    Ok(Mat4([
+        [rot[0][0], rot[0][1], rot[0][2], trans[0]],
+        [rot[1][0], rot[1][1], rot[1][2], trans[1]],
+        [rot[2][0], rot[2][1], rot[2][2], trans[2]],
+        [0.0, 0.0, 0.0, 1.0],
+    ]))
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
@@ -1896,6 +2054,95 @@ mod tests {
             vec![1.0, w, 1.0],
         )
         .unwrap()
+    }
+
+    /// Helper: a `size`×`size` square profile face centered at the origin in
+    /// the XY plane (normal +Z).
+    fn make_square(topo: &mut Topology, size: f64) -> FaceId {
+        let hs = size / 2.0;
+        let t = 1e-7;
+        let v0 = topo.add_vertex(Vertex::new(Point3::new(-hs, -hs, 0.0), t));
+        let v1 = topo.add_vertex(Vertex::new(Point3::new(hs, -hs, 0.0), t));
+        let v2 = topo.add_vertex(Vertex::new(Point3::new(hs, hs, 0.0), t));
+        let v3 = topo.add_vertex(Vertex::new(Point3::new(-hs, hs, 0.0), t));
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
+        let e2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
+        let e3 = topo.add_edge(Edge::new(v3, v0, EdgeCurve::Line));
+        let wire = Wire::new(
+            vec![
+                OrientedEdge::new(e0, true),
+                OrientedEdge::new(e1, true),
+                OrientedEdge::new(e2, true),
+                OrientedEdge::new(e3, true),
+            ],
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+        topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: 0.0,
+            },
+        ))
+    }
+
+    #[test]
+    fn multi_section_sweep_line_spine_tapered_volume() {
+        let mut topo = Topology::new();
+        let big = make_square(&mut topo, 10.0);
+        let small = make_square(&mut topo, 6.0);
+        let spine = straight_z_path(20.0);
+
+        let solid =
+            multi_section_sweep(&mut topo, &spine, &[(big, 0.0), (small, 1.0)], true).unwrap();
+        let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+
+        // Frustum between a 10×10 and 6×6 square over height 20 lies strictly
+        // between the two straight-prism volumes (6²·20 = 720 and 10²·20 = 2000).
+        assert!(
+            vol > 720.0 && vol < 2000.0,
+            "expected tapered volume, got {vol}"
+        );
+    }
+
+    #[test]
+    fn multi_section_sweep_curved_spine_positive_volume() {
+        let mut topo = Topology::new();
+        // Three sections so the loft follows the quarter-circle spine; the RMF
+        // keeps each profile perpendicular and twist-free.
+        let a = make_square(&mut topo, 4.0);
+        let b = make_square(&mut topo, 4.0);
+        let c = make_square(&mut topo, 4.0);
+        let spine = quarter_circle_xz_path(20.0);
+
+        let solid =
+            multi_section_sweep(&mut topo, &spine, &[(a, 0.0), (b, 0.5), (c, 1.0)], true).unwrap();
+        let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+        assert!(
+            vol > 0.0,
+            "curved-spine multi-section sweep volume, got {vol}"
+        );
+    }
+
+    #[test]
+    fn multi_section_sweep_rejects_single_section() {
+        let mut topo = Topology::new();
+        let only = make_square(&mut topo, 4.0);
+        let spine = straight_z_path(10.0);
+        assert!(multi_section_sweep(&mut topo, &spine, &[(only, 0.0)], true).is_err());
+    }
+
+    #[test]
+    fn multi_section_sweep_rejects_out_of_range_param() {
+        let mut topo = Topology::new();
+        let a = make_square(&mut topo, 4.0);
+        let b = make_square(&mut topo, 4.0);
+        let spine = straight_z_path(10.0);
+        assert!(multi_section_sweep(&mut topo, &spine, &[(a, 0.0), (b, 1.5)], true).is_err());
     }
 
     #[test]

--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -1908,8 +1908,13 @@ pub fn multi_section_sweep(
     let initial_up = orthogonalize(pick_reference_axis(t_start), t_start);
     let dense = compute_frames(spine, dense_segments, initial_up, false)?;
 
-    let mut placed: Vec<FaceId> = Vec::with_capacity(sections.len());
-    for &(face_id, p) in sections {
+    // The loft joins profiles in order along the spine, so place them by
+    // ascending parameter regardless of the caller's ordering.
+    let mut ordered: Vec<(FaceId, f64)> = sections.to_vec();
+    ordered.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut placed: Vec<FaceId> = Vec::with_capacity(ordered.len());
+    for (face_id, p) in ordered {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let idx = ((p * dense_segments as f64).round() as usize).min(dense_segments);
         let tangent = spine.tangent(p)?;
@@ -1951,7 +1956,7 @@ fn profile_to_frame_matrix(
 ) -> Result<Mat4, crate::OperationsError> {
     let face = topo.face(face_id)?;
     let normal = match face.surface() {
-        FaceSurface::Plane { normal, .. } => *normal,
+        FaceSurface::Plane { normal, .. } => normal.normalize().unwrap_or(*normal),
         _ => {
             return Err(crate::OperationsError::InvalidInput {
                 reason: "multi-section sweep profiles must be planar".into(),
@@ -1959,27 +1964,24 @@ fn profile_to_frame_matrix(
         }
     };
 
-    // Centroid = average of the outer-wire vertices.
-    let wire = topo.wire(face.outer_wire())?;
-    let mut sum = Point3::new(0.0, 0.0, 0.0);
-    let mut count = 0.0_f64;
-    for oe in wire.edges() {
-        let edge = topo.edge(oe.edge())?;
-        let v = topo.vertex(oe.oriented_start(edge))?.point();
-        sum = Point3::new(sum.x() + v.x(), sum.y() + v.y(), sum.z() + v.z());
-        count += 1.0;
-    }
-    if count == 0.0 {
+    // Centroid of the sampled boundary — robust for a circle profile whose
+    // outer wire is a single closed edge (where averaging start vertices would
+    // collapse to the seam point).
+    let boundary = crate::boolean::face_polygon(topo, face_id)?;
+    if boundary.is_empty() {
         return Err(crate::OperationsError::InvalidInput {
-            reason: "multi-section sweep profile has no vertices".into(),
+            reason: "multi-section sweep profile has no boundary".into(),
         });
     }
-    let centroid = Point3::new(sum.x() / count, sum.y() / count, sum.z() / count);
+    let centroid = crate::winding::polygon_centroid(&boundary);
 
     // Profile in-plane basis from a consistent world reference, so all profiles
     // share an orientation and the RMF alone controls twist along the spine.
+    // `p_y = p_x × normal` makes (p_x, p_y, normal) left-handed to match the
+    // target frame (right, up, tangent) — so R is a proper rotation (det +1)
+    // and asymmetric profiles are not mirrored.
     let p_x = orthogonalize(pick_reference_axis(normal), normal);
-    let p_y = normal.cross(p_x);
+    let p_y = p_x.cross(normal);
 
     // R maps the profile basis (p_x, p_y, normal) onto (right, up, tangent):
     // R = right⊗p_x + up⊗p_y + tangent⊗normal.
@@ -2143,6 +2145,62 @@ mod tests {
         let b = make_square(&mut topo, 4.0);
         let spine = straight_z_path(10.0);
         assert!(multi_section_sweep(&mut topo, &spine, &[(a, 0.0), (b, 1.5)], true).is_err());
+    }
+
+    #[test]
+    fn multi_section_sweep_unsorted_params_match_sorted() {
+        // Placement sorts by parameter, so input order must not change the result.
+        let mut t1 = Topology::new();
+        let (a1, b1) = (make_square(&mut t1, 10.0), make_square(&mut t1, 4.0));
+        let s1 = multi_section_sweep(
+            &mut t1,
+            &straight_z_path(20.0),
+            &[(a1, 0.0), (b1, 1.0)],
+            true,
+        )
+        .unwrap();
+        let v_sorted = crate::measure::solid_volume(&t1, s1, 0.1).unwrap();
+
+        let mut t2 = Topology::new();
+        let (a2, b2) = (make_square(&mut t2, 10.0), make_square(&mut t2, 4.0));
+        let s2 = multi_section_sweep(
+            &mut t2,
+            &straight_z_path(20.0),
+            &[(b2, 1.0), (a2, 0.0)],
+            true,
+        )
+        .unwrap();
+        let v_unsorted = crate::measure::solid_volume(&t2, s2, 0.1).unwrap();
+
+        assert!(
+            (v_sorted - v_unsorted).abs() < 1e-6,
+            "{v_sorted} vs {v_unsorted}"
+        );
+    }
+
+    #[test]
+    fn profile_to_frame_matrix_is_proper_rotation() {
+        // The placement must be a proper rotation (det +1), never a reflection,
+        // or asymmetric profiles would be mirrored.
+        let mut topo = Topology::new();
+        let face = make_square(&mut topo, 4.0);
+        let tangent = Vec3::new(1.0, 1.0, 1.0).normalize().unwrap();
+        let up = orthogonalize(Vec3::new(0.0, 0.0, 1.0), tangent);
+        let frame = Frame {
+            origin: Point3::new(5.0, 6.0, 7.0),
+            tangent,
+            up,
+            right: tangent.cross(up),
+        };
+        let m = profile_to_frame_matrix(&topo, face, &frame).unwrap();
+        let r = &m.0;
+        let det = r[0][0] * (r[1][1] * r[2][2] - r[1][2] * r[2][1])
+            - r[0][1] * (r[1][0] * r[2][2] - r[1][2] * r[2][0])
+            + r[0][2] * (r[1][0] * r[2][1] - r[1][1] * r[2][0]);
+        assert!(
+            (det - 1.0).abs() < 1e-9,
+            "rotation det should be +1, got {det}"
+        );
     }
 
     #[test]

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -626,6 +626,50 @@ impl BrepKernel {
                 let solid = sweep(self.topo_mut(), face_id, &curve).map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
+            "multiSectionSweep" => {
+                let faces: Vec<u32> = args["faces"]
+                    .as_array()
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|v| v.as_u64().map(|n| n as u32))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let params: Vec<f64> = args["params"]
+                    .as_array()
+                    .map(|a| a.iter().filter_map(serde_json::Value::as_f64).collect())
+                    .unwrap_or_default();
+                if faces.len() != params.len() {
+                    return Err("multiSectionSweep: faces and params length mismatch".into());
+                }
+                let spine_edge = get_u32(args, "spineEdge")?;
+                let edge_id = self.resolve_edge(spine_edge).map_err(|e| e.to_string())?;
+                let edge_data = self.topo.edge(edge_id).map_err(|e| e.to_string())?;
+                let spine = match edge_data.curve() {
+                    EdgeCurve::NurbsCurve(c) => c.clone(),
+                    EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
+                        return Err("multiSectionSweep spine must be a NURBS edge".into());
+                    }
+                };
+                let ruled = args["ruled"].as_bool().unwrap_or(true);
+                let sections: Vec<(brepkit_topology::face::FaceId, f64)> = faces
+                    .iter()
+                    .zip(params.iter())
+                    .map(|(&h, &p)| {
+                        self.resolve_face(h)
+                            .map(|f| (f, p))
+                            .map_err(|e| e.to_string())
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let solid = brepkit_operations::sweep::multi_section_sweep(
+                    self.topo_mut(),
+                    &spine,
+                    &sections,
+                    ruled,
+                )
+                .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!(solid_id_to_u32(solid)))
+            }
             "chamfer" => {
                 let s = get_u32(args, "solid")?;
                 let dist = get_f64(args, "distance")?;

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -516,6 +516,102 @@ impl BrepKernel {
         Ok(solid_id_to_u32(solid_id))
     }
 
+    /// Sweep through multiple section profiles along a spine, lofting the
+    /// rotation-minimizing-frame-placed profiles.
+    ///
+    /// `face_handles` and `params` are parallel arrays: each planar profile and
+    /// its parameter in `[0, 1]` along the spine (given as raw NURBS data).
+    /// `ruled` selects ruled (planar bands) vs smooth (NURBS) lofted sides.
+    ///
+    /// Returns a solid handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for fewer than two sections, mismatched array lengths, a
+    /// non-finite or out-of-range value, a non-planar profile, or loft failure.
+    #[wasm_bindgen(js_name = "multiSectionSweep")]
+    #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+    pub fn multi_section_sweep(
+        &mut self,
+        face_handles: Vec<u32>,
+        params: Vec<f64>,
+        spine_degree: u32,
+        spine_knots: Vec<f64>,
+        spine_control_points: Vec<f64>,
+        spine_weights: Vec<f64>,
+        ruled: bool,
+    ) -> Result<u32, JsError> {
+        if face_handles.len() != params.len() {
+            return Err(WasmError::InvalidInput {
+                reason: format!(
+                    "face_handles ({}) and params ({}) must have equal length",
+                    face_handles.len(),
+                    params.len()
+                ),
+            }
+            .into());
+        }
+        if spine_control_points.len() % 3 != 0 {
+            return Err(WasmError::InvalidInput {
+                reason: format!(
+                    "spine_control_points length must be a multiple of 3, got {}",
+                    spine_control_points.len()
+                ),
+            }
+            .into());
+        }
+        let num_pts = spine_control_points.len() / 3;
+        if spine_weights.len() != num_pts {
+            return Err(WasmError::InvalidInput {
+                reason: format!(
+                    "spine_weights length ({}) must match control point count ({num_pts})",
+                    spine_weights.len()
+                ),
+            }
+            .into());
+        }
+        for p in &params {
+            validate_finite(*p, "param")?;
+        }
+        for (name, arr) in [
+            ("spine_knots", &spine_knots),
+            ("spine_control_points", &spine_control_points),
+            ("spine_weights", &spine_weights),
+        ] {
+            if let Some(pos) = arr.iter().position(|v| !v.is_finite()) {
+                return Err(WasmError::InvalidInput {
+                    reason: format!("{name}[{pos}] is not finite"),
+                }
+                .into());
+            }
+        }
+
+        let control_points: Vec<Point3> = spine_control_points
+            .chunks_exact(3)
+            .map(|c| Point3::new(c[0], c[1], c[2]))
+            .collect();
+        let spine = NurbsCurve::new(
+            spine_degree as usize,
+            spine_knots,
+            control_points,
+            spine_weights,
+        )?;
+
+        let sections: Vec<(brepkit_topology::face::FaceId, f64)> = face_handles
+            .iter()
+            .zip(params.iter())
+            .map(|(&h, &p)| self.resolve_face(h).map(|f| (f, p)))
+            .collect::<Result<_, _>>()?;
+
+        let solid_id = brepkit_operations::sweep::multi_section_sweep(
+            self.topo_mut(),
+            &spine,
+            &sections,
+            ruled,
+        )?;
+        Ok(solid_id_to_u32(solid_id))
+    }
+
     /// Sweep a face along a path with smooth NURBS side surfaces.
     ///
     /// Like `sweep()`, but produces a single NURBS surface per edge strip
@@ -1465,6 +1561,33 @@ mod tests {
     fn wire_perimeter(k: &BrepKernel, wire_handle: u32) -> f64 {
         let wid = k.resolve_wire(wire_handle).unwrap();
         brepkit_operations::measure::wire_length(&k.topo, wid).unwrap()
+    }
+
+    #[test]
+    fn multi_section_sweep_lofts_circles_along_line() {
+        let mut k = BrepKernel::new();
+        let big = k.make_circle_face(10.0, 24).unwrap();
+        let small = k.make_circle_face(5.0, 24).unwrap();
+        // Degree-1 line spine from the origin to (0, 0, 50).
+        let solid = k
+            .multi_section_sweep(
+                vec![big, small],
+                vec![0.0, 1.0],
+                1,
+                vec![0.0, 0.0, 1.0, 1.0],
+                vec![0.0, 0.0, 0.0, 0.0, 0.0, 50.0],
+                vec![1.0, 1.0],
+                true,
+            )
+            .unwrap();
+        let vol = k.volume(solid, 0.5).unwrap();
+        assert!(
+            vol > 0.0,
+            "tapered tube should have positive volume, got {vol}"
+        );
+        // (Validation paths — <2 sections, length mismatch, out-of-range param —
+        // are covered by the operations-layer tests; the error path can't be
+        // exercised here because JsError can't be constructed off-wasm.)
     }
 
     #[test]

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -1591,6 +1591,42 @@ mod tests {
     }
 
     #[test]
+    fn multi_section_sweep_batch_dispatch_lofts_circles() {
+        let mut k = BrepKernel::new();
+        let big = k.make_circle_face(10.0, 24).unwrap();
+        let small = k.make_circle_face(5.0, 24).unwrap();
+        // A degree-1 NURBS line spine edge (the batch op takes the spine by edge).
+        let spine = k
+            .make_nurbs_edge(
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                50.0,
+                1,
+                vec![0.0, 0.0, 1.0, 1.0],
+                vec![0.0, 0.0, 0.0, 0.0, 0.0, 50.0],
+                vec![1.0, 1.0],
+            )
+            .unwrap();
+        let out = dispatch(
+            &mut k,
+            "multiSectionSweep",
+            serde_json::json!({
+                "faces": [big, small],
+                "params": [0.0, 1.0],
+                "spineEdge": spine,
+                "ruled": true,
+            }),
+        );
+        assert!(
+            out.get("ok").and_then(serde_json::Value::as_u64).is_some(),
+            "expected an ok solid handle, got {out}"
+        );
+    }
+
+    #[test]
     fn offset_wire_2d_with_join_routes_arc_distinct_from_chamfer() {
         let mut k = BrepKernel::new();
         let w_int = square_wire(&mut k);


### PR DESCRIPTION
## Summary

Implements **multi-profile sweep** (#814, the `multiSweepFns` gap): sweep through multiple section profiles along a spine, interpolating between them — the lofted-pipe workflow.

### Context from the audit

brepjs already *composes* this in JS — `multiSectionSweep` = position each profile along the spine (`positionOnCurve`) + `loft`, both of which reduce to existing brepkit primitives (`transformWire`, `loftWithOptions`). So the basic case works today. **But** that JS `positionOnCurve` uses a single swing-rotation with no rotation-minimizing frame, so it **twists profiles on curved spines** (the tests only exercise line spines).

This PR adds a **first-class native operation** that's more robust and a single call.

### Approach

`operations::sweep::multi_section_sweep(spine, sections, ruled)`:
- Places each planar profile at its spine parameter using the sweep engine's existing **rotation-minimizing frame** (`compute_frames`, double-reflection) — twist-free on curved paths.
- The placement maps the profile's centroid → spine point, normal → tangent, and plane → the frame's right/up (a rigid `Mat4` via `copy_face` + `transform_face`).
- Lofts the placed profiles — `loft` (ruled) or `loft_smooth`.

Exposed as the `multiSectionSweep` WASM binding (spine as raw NURBS data, parallel `face_handles`/`params` arrays, `ruled` flag), mirroring the existing `sweep` binding's shape.

### Why native vs. leaving it to JS composition

- **RMF** — profiles stay perpendicular and twist-free on curved spines; the JS swing-rotation does not.
- One kernel call instead of N positioning calls + a loft.
- A foundation for guided sweep (#814's second half).

### Tests

- `multi_section_sweep_line_spine_tapered_volume` — frustum between 10×10 and 6×6 squares; volume strictly between the two prism bounds.
- `multi_section_sweep_curved_spine_positive_volume` — 3 sections on a quarter-circle spine; valid positive volume.
- `multi_section_sweep_rejects_single_section`, `…_rejects_out_of_range_param`.
- WASM contract test: lofts two circles along a line spine → positive volume.

(Validation error paths can't be exercised at the WASM boundary off-wasm because `JsError` can't be constructed there — they're covered at the operations layer.)

Refs #814 (multi-profile half). Guided sweep / auxiliary spine remains the second half.