### PR TITLE
feat(sweep): guided (two-rail) sweep via auxiliary spine (#814)

### DIFF
--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -1116,21 +1116,32 @@ pub fn sweep_with_options(
         // Guided (two-rail) sweep: orient the profile so its up-vector points
         // toward the auxiliary spine at each path parameter. The tangent still
         // follows the main path, so this overrides `contact_mode`.
-        (0..=num_segments)
-            .map(|k| {
-                #[allow(clippy::cast_precision_loss)]
-                let t = k as f64 / num_segments as f64;
-                let origin = path.evaluate(t);
-                let tangent = path.tangent(t).unwrap_or(path_tangent_0);
-                let up = orthogonalize(aux.evaluate(t) - origin, tangent);
-                Frame {
-                    origin,
-                    tangent,
-                    up,
-                    right: tangent.cross(up),
-                }
-            })
-            .collect()
+        let mut out = Vec::with_capacity(num_segments + 1);
+        let mut prev_up: Option<Vec3> = None;
+        for k in 0..=num_segments {
+            #[allow(clippy::cast_precision_loss)]
+            let t = k as f64 / num_segments as f64;
+            let origin = path.evaluate(t);
+            let tangent = path.tangent(t).unwrap_or(path_tangent_0);
+            let guide_dir = aux.evaluate(t) - origin;
+            // Where the guide momentarily coincides with the spine the up-vector
+            // is undefined; carry the previous frame's up (re-orthogonalized) so
+            // orientation stays continuous instead of snapping to a world axis.
+            let up = if guide_dir.length() < 1e-9 {
+                let seed = prev_up.unwrap_or_else(|| pick_reference_axis(tangent));
+                orthogonalize(seed, tangent)
+            } else {
+                orthogonalize(guide_dir, tangent)
+            };
+            prev_up = Some(up);
+            out.push(Frame {
+                origin,
+                tangent,
+                up,
+                right: tangent.cross(up),
+            });
+        }
+        out
     } else {
         match options.contact_mode {
             SweepContactMode::RotationMinimizing => {
@@ -2343,6 +2354,22 @@ mod tests {
         assert!(
             y_guided > 8.0,
             "the rotating guide should roll the wide axis into Y, got {y_guided}"
+        );
+    }
+
+    #[test]
+    fn sweep_guided_handles_guide_meeting_spine() {
+        // The guide starts coincident with the spine (up undefined at t=0) then
+        // diverges — frame continuity must still yield a valid finite solid.
+        let mut topo = Topology::new();
+        let profile = make_square(&mut topo, 3.0);
+        let spine = straight_z_path(10.0);
+        let aux = guide_line(0.0, 0.0, 10.0, 0.0);
+        let solid = sweep_guided(&mut topo, profile, &spine, aux).unwrap();
+        let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+        assert!(
+            vol > 0.0 && vol.is_finite(),
+            "guide-meets-spine should still yield a valid solid, got {vol}"
         );
     }
 

--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -982,6 +982,11 @@ pub struct SweepOptions {
     pub scale_law: Option<Box<dyn Fn(f64) -> f64 + Send + Sync>>,
     /// Number of path segments (0 = auto from control point count).
     pub segments: usize,
+    /// Auxiliary spine (guide curve). When set, the profile is oriented so its
+    /// up-vector points toward this curve at each path parameter — a guided
+    /// (two-rail) sweep — overriding `contact_mode`. Sampled at the same
+    /// parameter as the main path.
+    pub aux_spine: Option<NurbsCurve>,
 }
 
 impl std::fmt::Debug for SweepOptions {
@@ -994,6 +999,7 @@ impl std::fmt::Debug for SweepOptions {
                 &self.scale_law.as_ref().map(|_| "fn(f64)->f64"),
             )
             .field("segments", &self.segments)
+            .field("aux_spine", &self.aux_spine.as_ref().map(|_| "NurbsCurve"))
             .finish()
     }
 }
@@ -1106,47 +1112,68 @@ pub fn sweep_with_options(
     };
 
     // Compute frames based on contact mode (open paths only at this point).
-    let frames = match options.contact_mode {
-        SweepContactMode::RotationMinimizing => {
-            let up_hint = orthogonalize(input_normal, path_tangent_0);
-            compute_frames(path, num_segments, up_hint, false)?
-        }
-        SweepContactMode::Fixed => {
-            // Fixed: use the same orientation at every point
-            let tangent0 = path_tangent_0;
-            let up = orthogonalize(input_normal, tangent0);
-            let right = tangent0.cross(up);
+    let frames: Vec<Frame> = if let Some(aux) = options.aux_spine.as_ref() {
+        // Guided (two-rail) sweep: orient the profile so its up-vector points
+        // toward the auxiliary spine at each path parameter. The tangent still
+        // follows the main path, so this overrides `contact_mode`.
+        (0..=num_segments)
+            .map(|k| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = k as f64 / num_segments as f64;
+                let origin = path.evaluate(t);
+                let tangent = path.tangent(t).unwrap_or(path_tangent_0);
+                let up = orthogonalize(aux.evaluate(t) - origin, tangent);
+                Frame {
+                    origin,
+                    tangent,
+                    up,
+                    right: tangent.cross(up),
+                }
+            })
+            .collect()
+    } else {
+        match options.contact_mode {
+            SweepContactMode::RotationMinimizing => {
+                let up_hint = orthogonalize(input_normal, path_tangent_0);
+                compute_frames(path, num_segments, up_hint, false)?
+            }
+            SweepContactMode::Fixed => {
+                // Fixed: use the same orientation at every point
+                let tangent0 = path_tangent_0;
+                let up = orthogonalize(input_normal, tangent0);
+                let right = tangent0.cross(up);
 
-            (0..=num_segments)
-                .map(|k| {
-                    #[allow(clippy::cast_precision_loss)]
-                    let t = k as f64 / num_segments as f64;
-                    Frame {
-                        origin: path.evaluate(t),
-                        tangent: path.tangent(t).unwrap_or(tangent0),
-                        up,
-                        right,
-                    }
-                })
-                .collect()
-        }
-        SweepContactMode::ConstantNormal(normal_dir) => {
-            // Constant normal: up vector stays aligned to normal_dir
-            (0..=num_segments)
-                .map(|k| {
-                    #[allow(clippy::cast_precision_loss)]
-                    let t = k as f64 / num_segments as f64;
-                    let tangent = path.tangent(t).unwrap_or(Vec3::new(0.0, 0.0, 1.0));
-                    let up = orthogonalize(normal_dir, tangent);
-                    let right = tangent.cross(up);
-                    Frame {
-                        origin: path.evaluate(t),
-                        tangent,
-                        up,
-                        right,
-                    }
-                })
-                .collect()
+                (0..=num_segments)
+                    .map(|k| {
+                        #[allow(clippy::cast_precision_loss)]
+                        let t = k as f64 / num_segments as f64;
+                        Frame {
+                            origin: path.evaluate(t),
+                            tangent: path.tangent(t).unwrap_or(tangent0),
+                            up,
+                            right,
+                        }
+                    })
+                    .collect()
+            }
+            SweepContactMode::ConstantNormal(normal_dir) => {
+                // Constant normal: up vector stays aligned to normal_dir
+                (0..=num_segments)
+                    .map(|k| {
+                        #[allow(clippy::cast_precision_loss)]
+                        let t = k as f64 / num_segments as f64;
+                        let tangent = path.tangent(t).unwrap_or(Vec3::new(0.0, 0.0, 1.0));
+                        let up = orthogonalize(normal_dir, tangent);
+                        let right = tangent.cross(up);
+                        Frame {
+                            origin: path.evaluate(t),
+                            tangent,
+                            up,
+                            right,
+                        }
+                    })
+                    .collect()
+            }
         }
     };
 
@@ -2016,6 +2043,34 @@ fn profile_to_frame_matrix(
     ]))
 }
 
+/// Guided (two-rail) sweep of `profile` along `spine`, oriented by `aux`.
+///
+/// At each path parameter the profile's up-vector points toward the auxiliary
+/// spine `aux`, so the profile rolls to track the guide curve rather than
+/// holding a fixed or rotation-minimizing orientation. Thin wrapper over
+/// [`sweep_with_options`] with `aux_spine` set.
+///
+/// # Errors
+///
+/// Propagates [`sweep_with_options`] errors (e.g. a non-planar profile or a
+/// degenerate path).
+pub fn sweep_guided(
+    topo: &mut Topology,
+    profile: FaceId,
+    spine: &NurbsCurve,
+    aux: NurbsCurve,
+) -> Result<SolidId, crate::OperationsError> {
+    sweep_with_options(
+        topo,
+        profile,
+        spine,
+        &SweepOptions {
+            aux_spine: Some(aux),
+            ..Default::default()
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
@@ -2200,6 +2255,94 @@ mod tests {
         assert!(
             (det - 1.0).abs() < 1e-9,
             "rotation det should be +1, got {det}"
+        );
+    }
+
+    /// Helper: a `2*hx`×`2*hy` rectangle profile at the origin in the XY plane.
+    fn make_rect(topo: &mut Topology, hx: f64, hy: f64) -> FaceId {
+        let t = 1e-7;
+        let v0 = topo.add_vertex(Vertex::new(Point3::new(-hx, -hy, 0.0), t));
+        let v1 = topo.add_vertex(Vertex::new(Point3::new(hx, -hy, 0.0), t));
+        let v2 = topo.add_vertex(Vertex::new(Point3::new(hx, hy, 0.0), t));
+        let v3 = topo.add_vertex(Vertex::new(Point3::new(-hx, hy, 0.0), t));
+        let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+        let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
+        let e2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
+        let e3 = topo.add_edge(Edge::new(v3, v0, EdgeCurve::Line));
+        let wire = Wire::new(
+            vec![
+                OrientedEdge::new(e0, true),
+                OrientedEdge::new(e1, true),
+                OrientedEdge::new(e2, true),
+                OrientedEdge::new(e3, true),
+            ],
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+        topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: 0.0,
+            },
+        ))
+    }
+
+    /// Helper: a degree-1 guide curve from `(x0,y0,0)` to `(x1,y1,10)`.
+    fn guide_line(x0: f64, y0: f64, x1: f64, y1: f64) -> NurbsCurve {
+        NurbsCurve::new(
+            1,
+            vec![0.0, 0.0, 1.0, 1.0],
+            vec![Point3::new(x0, y0, 0.0), Point3::new(x1, y1, 10.0)],
+            vec![1.0, 1.0],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn sweep_guided_produces_valid_solid() {
+        let mut topo = Topology::new();
+        let profile = make_square(&mut topo, 4.0);
+        let spine = straight_z_path(10.0);
+        let aux = guide_line(10.0, 0.0, 10.0, 0.0);
+        let solid = sweep_guided(&mut topo, profile, &spine, aux).unwrap();
+        let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+        assert!(vol > 0.0, "guided sweep volume, got {vol}");
+    }
+
+    #[test]
+    fn sweep_guided_rotating_aux_rolls_profile() {
+        // A wide rectangle swept straight stays flat in Y. A guide that rotates
+        // from +X to +Y over the sweep rolls the rectangle 90°, sweeping its
+        // wide axis into Y — so the Y-extent grows far beyond the flat case.
+        let mut t_plain = Topology::new();
+        let p_plain = make_rect(&mut t_plain, 8.0, 1.0);
+        let s_plain = sweep_with_options(
+            &mut t_plain,
+            p_plain,
+            &straight_z_path(10.0),
+            &SweepOptions::default(),
+        )
+        .unwrap();
+        let bb_plain = crate::measure::solid_bounding_box(&t_plain, s_plain).unwrap();
+        let y_plain = bb_plain.max.y() - bb_plain.min.y();
+
+        let mut t_guided = Topology::new();
+        let p_guided = make_rect(&mut t_guided, 8.0, 1.0);
+        let aux = guide_line(30.0, 0.0, 0.0, 30.0);
+        let s_guided = sweep_guided(&mut t_guided, p_guided, &straight_z_path(10.0), aux).unwrap();
+        let bb_guided = crate::measure::solid_bounding_box(&t_guided, s_guided).unwrap();
+        let y_guided = bb_guided.max.y() - bb_guided.min.y();
+
+        assert!(
+            y_plain < 4.0,
+            "plain sweep keeps the rectangle flat in Y, got {y_plain}"
+        );
+        assert!(
+            y_guided > 8.0,
+            "the rotating guide should roll the wide axis into Y, got {y_guided}"
         );
     }
 

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -670,6 +670,27 @@ impl BrepKernel {
                 .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
+            "guidedSweep" => {
+                let face_id = self
+                    .resolve_face(get_u32(args, "face")?)
+                    .map_err(|e| e.to_string())?;
+                let nurbs_of = |this: &Self, edge: u32| -> Result<NurbsCurve, String> {
+                    let edge_id = this.resolve_edge(edge).map_err(|e| e.to_string())?;
+                    let edge_data = this.topo.edge(edge_id).map_err(|e| e.to_string())?;
+                    match edge_data.curve() {
+                        EdgeCurve::NurbsCurve(c) => Ok(c.clone()),
+                        EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
+                            Err("guidedSweep spine and aux must be NURBS edges".into())
+                        }
+                    }
+                };
+                let spine = nurbs_of(self, get_u32(args, "spineEdge")?)?;
+                let aux = nurbs_of(self, get_u32(args, "auxEdge")?)?;
+                let solid =
+                    brepkit_operations::sweep::sweep_guided(self.topo_mut(), face_id, &spine, aux)
+                        .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!(solid_id_to_u32(solid)))
+            }
             "chamfer" => {
                 let s = get_u32(args, "solid")?;
                 let dist = get_f64(args, "distance")?;

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -674,18 +674,19 @@ impl BrepKernel {
                 let face_id = self
                     .resolve_face(get_u32(args, "face")?)
                     .map_err(|e| e.to_string())?;
-                let nurbs_of = |this: &Self, edge: u32| -> Result<NurbsCurve, String> {
-                    let edge_id = this.resolve_edge(edge).map_err(|e| e.to_string())?;
-                    let edge_data = this.topo.edge(edge_id).map_err(|e| e.to_string())?;
-                    match edge_data.curve() {
-                        EdgeCurve::NurbsCurve(c) => Ok(c.clone()),
-                        EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
-                            Err("guidedSweep spine and aux must be NURBS edges".into())
+                let nurbs_of =
+                    |this: &Self, edge: u32, label: &str| -> Result<NurbsCurve, String> {
+                        let edge_id = this.resolve_edge(edge).map_err(|e| e.to_string())?;
+                        let edge_data = this.topo.edge(edge_id).map_err(|e| e.to_string())?;
+                        match edge_data.curve() {
+                            EdgeCurve::NurbsCurve(c) => Ok(c.clone()),
+                            EdgeCurve::Line | EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
+                                Err(format!("guidedSweep {label} must be a NURBS edge"))
+                            }
                         }
-                    }
-                };
-                let spine = nurbs_of(self, get_u32(args, "spineEdge")?)?;
-                let aux = nurbs_of(self, get_u32(args, "auxEdge")?)?;
+                    };
+                let spine = nurbs_of(self, get_u32(args, "spineEdge")?, "spineEdge")?;
+                let aux = nurbs_of(self, get_u32(args, "auxEdge")?, "auxEdge")?;
                 let solid =
                     brepkit_operations::sweep::sweep_guided(self.topo_mut(), face_id, &spine, aux)
                         .map_err(|e| e.to_string())?;

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -1200,6 +1200,12 @@ impl BrepKernel {
                      weights: Vec<f64>,
                      label: &str|
          -> Result<NurbsCurve, JsError> {
+            if degree < 1 {
+                return Err(WasmError::InvalidInput {
+                    reason: format!("{label}_degree must be at least 1"),
+                }
+                .into());
+            }
             if cps.len() % 3 != 0 {
                 return Err(WasmError::InvalidInput {
                     reason: format!("{label}_control_points length must be a multiple of 3"),

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -1157,6 +1157,7 @@ impl BrepKernel {
             corner_mode: cm,
             scale_law,
             segments: segments as usize,
+            aux_spine: None,
         };
 
         let result = brepkit_operations::sweep::sweep_with_options(
@@ -1166,6 +1167,92 @@ impl BrepKernel {
             &options,
         )?;
         Ok(solid_id_to_u32(result))
+    }
+
+    /// Guided (two-rail) sweep: sweep `face` along a spine, orienting the
+    /// profile so its up-vector tracks an auxiliary spine.
+    ///
+    /// The spine and auxiliary spine are each passed as raw NURBS data
+    /// (`degree`, `knots`, flat `control_points`, `weights`). Returns a solid
+    /// handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-finite or malformed curve, a non-planar
+    /// profile, or a degenerate path.
+    #[wasm_bindgen(js_name = "guidedSweep")]
+    #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+    pub fn guided_sweep(
+        &mut self,
+        face: u32,
+        spine_degree: u32,
+        spine_knots: Vec<f64>,
+        spine_control_points: Vec<f64>,
+        spine_weights: Vec<f64>,
+        aux_degree: u32,
+        aux_knots: Vec<f64>,
+        aux_control_points: Vec<f64>,
+        aux_weights: Vec<f64>,
+    ) -> Result<u32, JsError> {
+        let build = |degree: u32,
+                     knots: Vec<f64>,
+                     cps: Vec<f64>,
+                     weights: Vec<f64>,
+                     label: &str|
+         -> Result<NurbsCurve, JsError> {
+            if cps.len() % 3 != 0 {
+                return Err(WasmError::InvalidInput {
+                    reason: format!("{label}_control_points length must be a multiple of 3"),
+                }
+                .into());
+            }
+            if weights.len() != cps.len() / 3 {
+                return Err(WasmError::InvalidInput {
+                    reason: format!("{label}_weights length must match control point count"),
+                }
+                .into());
+            }
+            for (name, arr) in [
+                ("knots", &knots),
+                ("control_points", &cps),
+                ("weights", &weights),
+            ] {
+                if let Some(pos) = arr.iter().position(|v| !v.is_finite()) {
+                    return Err(WasmError::InvalidInput {
+                        reason: format!("{label}_{name}[{pos}] is not finite"),
+                    }
+                    .into());
+                }
+            }
+            let control_points: Vec<Point3> = cps
+                .chunks_exact(3)
+                .map(|c| Point3::new(c[0], c[1], c[2]))
+                .collect();
+            Ok(NurbsCurve::new(
+                degree as usize,
+                knots,
+                control_points,
+                weights,
+            )?)
+        };
+
+        let spine = build(
+            spine_degree,
+            spine_knots,
+            spine_control_points,
+            spine_weights,
+            "spine",
+        )?;
+        let aux = build(
+            aux_degree,
+            aux_knots,
+            aux_control_points,
+            aux_weights,
+            "aux",
+        )?;
+        let face_id = self.resolve_face(face)?;
+        let solid = brepkit_operations::sweep::sweep_guided(self.topo_mut(), face_id, &spine, aux)?;
+        Ok(solid_id_to_u32(solid))
     }
 
     // ── Point Classification ──────────────────────────────────────
@@ -1619,6 +1706,60 @@ mod tests {
                 "spineEdge": spine,
                 "ruled": true,
             }),
+        );
+        assert!(
+            out.get("ok").and_then(serde_json::Value::as_u64).is_some(),
+            "expected an ok solid handle, got {out}"
+        );
+    }
+
+    #[test]
+    fn guided_sweep_produces_solid() {
+        let mut k = BrepKernel::new();
+        let profile = k.make_circle_face(2.0, 24).unwrap();
+        // Spine: line (0,0,0)→(0,0,20). Aux: parallel guide offset +10 in X.
+        let solid = k
+            .guided_sweep(
+                profile,
+                1,
+                vec![0.0, 0.0, 1.0, 1.0],
+                vec![0.0, 0.0, 0.0, 0.0, 0.0, 20.0],
+                vec![1.0, 1.0],
+                1,
+                vec![0.0, 0.0, 1.0, 1.0],
+                vec![10.0, 0.0, 0.0, 10.0, 0.0, 20.0],
+                vec![1.0, 1.0],
+            )
+            .unwrap();
+        let vol = k.volume(solid, 0.5).unwrap();
+        assert!(vol > 0.0, "guided sweep volume, got {vol}");
+    }
+
+    #[test]
+    fn guided_sweep_batch_dispatch() {
+        let mut k = BrepKernel::new();
+        let profile = k.make_circle_face(2.0, 24).unwrap();
+        let mk_line = |k: &mut BrepKernel, x: f64| {
+            k.make_nurbs_edge(
+                x,
+                0.0,
+                0.0,
+                x,
+                0.0,
+                20.0,
+                1,
+                vec![0.0, 0.0, 1.0, 1.0],
+                vec![x, 0.0, 0.0, x, 0.0, 20.0],
+                vec![1.0, 1.0],
+            )
+            .unwrap()
+        };
+        let spine = mk_line(&mut k, 0.0);
+        let aux = mk_line(&mut k, 10.0);
+        let out = dispatch(
+            &mut k,
+            "guidedSweep",
+            serde_json::json!({ "face": profile, "spineEdge": spine, "auxEdge": aux }),
         );
         assert!(
             out.get("ok").and_then(serde_json::Value::as_u64).is_some(),


### PR DESCRIPTION
## Summary

Implements the **guided-sweep / auxiliary-spine** half of #814 (the `guidedSweepFns` gap). A guided sweep orients the profile so its up-vector points toward a *guide curve* at each path parameter — the profile rolls to track the guide rather than holding a fixed or rotation-minimizing orientation.

### Why this is a genuine gap (not stale)

Unlike multi-section sweep (composable from existing primitives), the brepjs adapter's `sweepPipeShell` **silently dropped the `auxiliary` guide** — it only did contact-mode/smooth/simple-pipe fallbacks, so the guide had no effect. This makes the guide actually work.

### Approach — additive, no enum ripple

`SweepContactMode` derives `Copy`, so a `Guided(NurbsCurve)` variant would break `Copy` and ripple to `sweep_miter`. Instead:

- `SweepOptions` gains an optional **`aux_spine: Option<NurbsCurve>`** (the struct already derives `Default` and is non-`Copy`).
- When set, `sweep_with_options` computes **guided frames** — `up = orthogonalize(aux(t) − spine(t), tangent)` — instead of the `contact_mode` frames, reusing the entire existing swept-solid construction (scale law, caps, side faces). When `None`, behaviour is byte-for-byte unchanged.

Exposed as `operations::sweep::sweep_guided` + the `guidedSweep` WASM binding (profile + spine NURBS + aux NURBS) + batch dispatch (spine/aux by NURBS edge).

### Proof that the guide controls orientation

The key test: a wide rectangle (16×2) swept along a straight spine.
- **Plain sweep** (no guide): stays flat — Y-extent **2.0**.
- **Guided** by a curve that rotates +X→+Y over the sweep: the rectangle rolls 90°, sweeping its wide axis into Y — Y-extent **16.0**.

So the auxiliary spine demonstrably rolls the profile (it is not ignored).

### Tests

- `sweep_guided_produces_valid_solid`, `sweep_guided_rotating_aux_rolls_profile` (the 2→16 orientation proof).
- WASM `guided_sweep_produces_solid` (direct) + `guided_sweep_batch_dispatch`.

Refs #814 — this completes both halves (multi-section sweep landed in #825).