### PR TITLE
feat(operations): convex Minkowski sum of two solids (#815)

### DIFF
--- a/crates/operations/src/primitives.rs
+++ b/crates/operations/src/primitives.rs
@@ -802,6 +802,46 @@ pub fn make_convex_hull(
     Ok(topo.add_solid(solid))
 }
 
+/// Convex Minkowski sum of two solids: `A ⊕ B = { a + b | a ∈ A, b ∈ B }`.
+///
+/// Computed as the convex hull of all pairwise vertex sums, which is exact when
+/// both inputs are convex (e.g. boxes, or a shape with a tessellated sphere as
+/// the rolling tool) and a convex over-approximation otherwise.
+///
+/// # Errors
+///
+/// Returns [`crate::OperationsError::InvalidInput`] if either solid has no
+/// vertices, and propagates [`make_convex_hull`] errors (e.g. degenerate input).
+pub fn make_minkowski_sum(
+    topo: &mut Topology,
+    a: SolidId,
+    b: SolidId,
+) -> Result<SolidId, crate::OperationsError> {
+    use brepkit_topology::explorer::solid_vertices;
+
+    let point_of = |topo: &Topology, ids: &[brepkit_topology::vertex::VertexId]| {
+        ids.iter()
+            .map(|&v| topo.vertex(v).map(brepkit_topology::vertex::Vertex::point))
+            .collect::<Result<Vec<Point3>, _>>()
+    };
+    let a_pts = point_of(topo, &solid_vertices(topo, a)?)?;
+    let b_pts = point_of(topo, &solid_vertices(topo, b)?)?;
+
+    if a_pts.is_empty() || b_pts.is_empty() {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "minkowski sum requires two non-empty solids".into(),
+        });
+    }
+
+    let mut sums = Vec::with_capacity(a_pts.len() * b_pts.len());
+    for &p in &a_pts {
+        for &q in &b_pts {
+            sums.push(Point3::new(p.x() + q.x(), p.y() + q.y(), p.z() + q.z()));
+        }
+    }
+    make_convex_hull(topo, &sums)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -1330,6 +1370,26 @@ mod tests {
         let mut topo = Topology::new();
         let solid = make_convex_hull(&mut topo, &sum_points).unwrap();
         assert_volume_near(&topo, solid, 8.0, 1e-8);
+    }
+
+    #[test]
+    fn minkowski_sum_unit_boxes_volume_8() {
+        let mut topo = Topology::new();
+        let a = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+        let b = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+        let sum = make_minkowski_sum(&mut topo, a, b).unwrap();
+        // [0,1]³ ⊕ [0,1]³ = [0,2]³, volume 8.
+        assert_volume_near(&topo, sum, 8.0, 1e-6);
+    }
+
+    #[test]
+    fn minkowski_sum_box10_box2_volume_1728() {
+        let mut topo = Topology::new();
+        let a = make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let b = make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+        let sum = make_minkowski_sum(&mut topo, a, b).unwrap();
+        // 10-box ⊕ 2-box = 12-box, volume 1728.
+        assert_volume_near(&topo, sum, 1728.0, 1e-4);
     }
 
     #[test]

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -692,6 +692,18 @@ impl BrepKernel {
                         .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
+            "minkowskiSum" => {
+                let a = self
+                    .resolve_solid(get_u32(args, "solidA")?)
+                    .map_err(|e| e.to_string())?;
+                let b = self
+                    .resolve_solid(get_u32(args, "solidB")?)
+                    .map_err(|e| e.to_string())?;
+                let solid =
+                    brepkit_operations::primitives::make_minkowski_sum(self.topo_mut(), a, b)
+                        .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!(solid_id_to_u32(solid)))
+            }
             "chamfer" => {
                 let s = get_u32(args, "solid")?;
                 let dist = get_f64(args, "distance")?;

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -1261,6 +1261,23 @@ impl BrepKernel {
         Ok(solid_id_to_u32(solid))
     }
 
+    /// Convex Minkowski sum of two solids (`A ⊕ B`).
+    ///
+    /// Returns the convex hull of all pairwise vertex sums — exact for convex
+    /// inputs (boxes, or a tessellated-sphere rolling tool), a convex
+    /// over-approximation otherwise. Returns a solid handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either handle is invalid or either solid is empty.
+    #[wasm_bindgen(js_name = "minkowskiSum")]
+    pub fn minkowski_sum(&mut self, solid_a: u32, solid_b: u32) -> Result<u32, JsError> {
+        let a = self.resolve_solid(solid_a)?;
+        let b = self.resolve_solid(solid_b)?;
+        let result = brepkit_operations::primitives::make_minkowski_sum(self.topo_mut(), a, b)?;
+        Ok(solid_id_to_u32(result))
+    }
+
     // ── Point Classification ──────────────────────────────────────
 
     /// Classify a point relative to a solid using generalized winding numbers.
@@ -1629,7 +1646,7 @@ mod tests {
     use brepkit_math::vec::Point3;
     use brepkit_topology::builder::make_polygon_wire;
 
-    use crate::handles::wire_id_to_u32;
+    use crate::handles::{solid_id_to_u32, wire_id_to_u32};
     use crate::helpers::TOL;
     use crate::kernel::BrepKernel;
 
@@ -1766,6 +1783,37 @@ mod tests {
             &mut k,
             "guidedSweep",
             serde_json::json!({ "face": profile, "spineEdge": spine, "auxEdge": aux }),
+        );
+        assert!(
+            out.get("ok").and_then(serde_json::Value::as_u64).is_some(),
+            "expected an ok solid handle, got {out}"
+        );
+    }
+
+    #[test]
+    fn minkowski_sum_binding_box10_box2_is_box12() {
+        let mut k = BrepKernel::new();
+        let a = brepkit_operations::primitives::make_box(k.topo_mut(), 10.0, 10.0, 10.0).unwrap();
+        let b = brepkit_operations::primitives::make_box(k.topo_mut(), 2.0, 2.0, 2.0).unwrap();
+        let sum = k
+            .minkowski_sum(solid_id_to_u32(a), solid_id_to_u32(b))
+            .unwrap();
+        let vol = k.volume(sum, 0.1).unwrap();
+        assert!(
+            (vol - 1728.0).abs() < 0.5,
+            "expected ~1728 (12³), got {vol}"
+        );
+    }
+
+    #[test]
+    fn minkowski_sum_batch_dispatch() {
+        let mut k = BrepKernel::new();
+        let a = brepkit_operations::primitives::make_box(k.topo_mut(), 4.0, 4.0, 4.0).unwrap();
+        let b = brepkit_operations::primitives::make_box(k.topo_mut(), 2.0, 2.0, 2.0).unwrap();
+        let out = dispatch(
+            &mut k,
+            "minkowskiSum",
+            serde_json::json!({ "solidA": solid_id_to_u32(a), "solidB": solid_id_to_u32(b) }),
         );
         assert!(
             out.get("ok").and_then(serde_json::Value::as_u64).is_some(),


### PR DESCRIPTION
## Summary

Implements **Minkowski sum** (#815, the `minkowskiFns` gap): `make_minkowski_sum(A, B)` = the convex hull of all pairwise vertex sums.

### Context

The approach is the standard convex-Minkowski identity (`A ⊕ B = hull{a + b}`), exact when both inputs are convex — boxes, or a shape with a tessellated sphere as the rolling tool. It was already implicitly validated by brepkit's `convex_hull_minkowski_*` tests; this wraps it into a first-class operation + binding. (brepjs's adapter also routes a *sphere* tool to `offset` — that path already works via `offset_solid`; this covers the general convex case.)

### Tests

- `minkowski_sum_unit_boxes_volume_8` — `[0,1]³ ⊕ [0,1]³ = [0,2]³` (volume 8).
- `minkowski_sum_box10_box2_volume_1728` — `box(10) ⊕ box(2) = box(12)` (volume 1728, matching the brepjs bar).
- WASM `minkowskiSum` direct + batch contract tests.

Refs #815 (Minkowski). Remaining #815 gap: HLR/projection.