### PR TITLE
feat(operations): edge projection with hidden-line removal (#815)

### DIFF
--- a/crates/operations/src/lib.rs
+++ b/crates/operations/src/lib.rs
@@ -27,6 +27,7 @@ pub mod helix;
 pub mod loft;
 pub mod pipe;
 pub mod primitives;
+pub mod projection;
 pub mod revolve;
 pub mod sweep;
 

--- a/crates/operations/src/projection.rs
+++ b/crates/operations/src/projection.rs
@@ -1,0 +1,176 @@
+//! Edge projection with hidden-line removal (HLR).
+//!
+//! Projects a solid's edges onto a view plane and splits each edge into visible
+//! and hidden polylines. Occlusion is an **exact** point-in-solid test — no
+//! tessellation of faces: a boundary point is hidden when stepping it toward the
+//! camera enters the solid (a face is in front of it). Edges themselves are
+//! sampled to polylines because a projected drawing is inherently polygonal.
+
+use brepkit_math::vec::{Point2, Point3, Vec3};
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+use crate::classify::{PointClassification, classify_point};
+
+/// Projected edges, split into visible and hidden 2D polylines (in the view
+/// plane's `(x, y)` coordinates).
+#[derive(Debug, Clone, Default)]
+pub struct ProjectedEdges {
+    /// Polylines that are not occluded by the solid.
+    pub visible: Vec<Vec<Point2>>,
+    /// Polylines hidden behind the solid (empty when `hidden_lines` is false).
+    pub hidden: Vec<Vec<Point2>>,
+}
+
+/// Project a solid's edges onto the view plane through `origin` with in-plane
+/// x-axis `x_axis`, viewed along `direction` (orthographic), classifying each
+/// segment as visible or hidden.
+///
+/// `direction` points from the camera into the scene. `x_axis` is the horizontal
+/// view direction (re-orthonormalized against `direction`). `deflection` controls
+/// edge-sampling density and the classification tolerance. When `hidden_lines` is
+/// false, hidden segments are dropped and `hidden` is left empty.
+///
+/// # Errors
+///
+/// Returns [`crate::OperationsError::InvalidInput`] if `direction` or `x_axis`
+/// is degenerate, and propagates topology / sampling errors.
+pub fn project_edges(
+    topo: &Topology,
+    solid: SolidId,
+    origin: Point3,
+    direction: Vec3,
+    x_axis: Vec3,
+    hidden_lines: bool,
+    deflection: f64,
+) -> Result<ProjectedEdges, crate::OperationsError> {
+    let view = direction
+        .normalize()
+        .map_err(|_| crate::OperationsError::InvalidInput {
+            reason: "projection direction must be non-zero".into(),
+        })?;
+    // In-plane orthonormal basis: x re-orthonormalized against the view, y = x × view.
+    let x = (x_axis - view * view.dot(x_axis))
+        .normalize()
+        .map_err(|_| crate::OperationsError::InvalidInput {
+            reason: "projection x_axis is parallel to the direction".into(),
+        })?;
+    let y = x.cross(view);
+
+    let project = |p: Point3| -> Point2 {
+        let v = p - origin;
+        Point2::new(x.dot(v), y.dot(v))
+    };
+
+    // Step length for the occlusion probe — clear of the boundary tolerance but
+    // small relative to the model. Keyed to the model's overall extent.
+    let bbox = crate::measure::solid_bounding_box(topo, solid)?;
+    let diag = (bbox.max - bbox.min).length();
+    let eps = (diag * 1e-4).max(1e-6);
+
+    // A boundary point is hidden when stepping toward the camera (−view) lands
+    // inside the solid, i.e. a face is between it and the camera.
+    let is_hidden = |p: Point3| -> bool {
+        classify_point(topo, solid, p - view * eps, deflection, 1e-7)
+            .map(|c| c == PointClassification::Inside)
+            .unwrap_or(false)
+    };
+
+    let lines = crate::tessellate::sample_solid_edges(topo, solid, deflection)?;
+    let n_edges = lines.offsets.len();
+    let mut result = ProjectedEdges::default();
+
+    for i in 0..n_edges {
+        let start = lines.offsets[i];
+        let end = if i + 1 < n_edges {
+            lines.offsets[i + 1]
+        } else {
+            lines.positions.len()
+        };
+        let pts = &lines.positions[start..end];
+        if pts.len() < 2 {
+            continue;
+        }
+
+        // Classify each segment by its midpoint, then merge consecutive
+        // same-visibility segments into polylines (adjacent runs share the
+        // boundary vertex, so the drawing stays connected).
+        let seg_hidden: Vec<bool> = (0..pts.len() - 1)
+            .map(|j| {
+                let mid = Point3::new(
+                    0.5 * (pts[j].x() + pts[j + 1].x()),
+                    0.5 * (pts[j].y() + pts[j + 1].y()),
+                    0.5 * (pts[j].z() + pts[j + 1].z()),
+                );
+                is_hidden(mid)
+            })
+            .collect();
+
+        let mut j = 0;
+        while j < seg_hidden.len() {
+            let hidden = seg_hidden[j];
+            let run_start = j;
+            while j < seg_hidden.len() && seg_hidden[j] == hidden {
+                j += 1;
+            }
+            // Run covers segments [run_start, j), i.e. points [run_start, j].
+            if hidden && !hidden_lines {
+                continue;
+            }
+            let poly: Vec<Point2> = (run_start..=j).map(|k| project(pts[k])).collect();
+            if hidden {
+                result.hidden.push(poly);
+            } else {
+                result.visible.push(poly);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    // An oblique view along (1,1,1): the three edges meeting at the far corner
+    // (10,10,10) are unambiguously occluded by the three near faces.
+    fn oblique() -> (Point3, Vec3, Vec3) {
+        (
+            Point3::new(-100.0, -100.0, -100.0),
+            Vec3::new(1.0, 1.0, 1.0),
+            Vec3::new(1.0, -1.0, 0.0),
+        )
+    }
+
+    #[test]
+    fn project_box_oblique_view_has_visible_and_hidden_edges() {
+        let mut topo = Topology::new();
+        let solid = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let (o, d, x) = oblique();
+        let result = project_edges(&topo, solid, o, d, x, true, 0.1).unwrap();
+        assert!(
+            !result.visible.is_empty(),
+            "oblique view must have visible edges"
+        );
+        assert!(
+            !result.hidden.is_empty(),
+            "the far corner's edges must be hidden behind the box"
+        );
+    }
+
+    #[test]
+    fn project_box_without_hidden_lines_drops_hidden() {
+        let mut topo = Topology::new();
+        let solid = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let (o, d, x) = oblique();
+        let result = project_edges(&topo, solid, o, d, x, false, 0.1).unwrap();
+        assert!(!result.visible.is_empty());
+        assert!(
+            result.hidden.is_empty(),
+            "hidden lines disabled → no hidden polylines"
+        );
+    }
+}

--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -704,6 +704,48 @@ impl BrepKernel {
                         .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(solid)))
             }
+            "projectEdges" => {
+                let solid = self
+                    .resolve_solid(get_u32(args, "solid")?)
+                    .map_err(|e| e.to_string())?;
+                let origin = Point3::new(
+                    get_f64(args, "originX")?,
+                    get_f64(args, "originY")?,
+                    get_f64(args, "originZ")?,
+                );
+                let dir = Vec3::new(
+                    get_f64(args, "dirX")?,
+                    get_f64(args, "dirY")?,
+                    get_f64(args, "dirZ")?,
+                );
+                let x_axis = Vec3::new(
+                    get_f64(args, "xAxisX")?,
+                    get_f64(args, "xAxisY")?,
+                    get_f64(args, "xAxisZ")?,
+                );
+                let hidden_lines = args["hiddenLines"].as_bool().unwrap_or(true);
+                let deflection = get_f64(args, "deflection").unwrap_or(0.1);
+                let result = brepkit_operations::projection::project_edges(
+                    &self.topo,
+                    solid,
+                    origin,
+                    dir,
+                    x_axis,
+                    hidden_lines,
+                    deflection,
+                )
+                .map_err(|e| e.to_string())?;
+                let flatten = |polys: &[Vec<brepkit_math::vec::Point2>]| -> Vec<Vec<f64>> {
+                    polys
+                        .iter()
+                        .map(|poly| poly.iter().flat_map(|p| [p.x(), p.y()]).collect())
+                        .collect()
+                };
+                Ok(serde_json::json!({
+                    "visible": flatten(&result.visible),
+                    "hidden": flatten(&result.hidden),
+                }))
+            }
             "chamfer" => {
                 let s = get_u32(args, "solid")?;
                 let dist = get_f64(args, "distance")?;

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -1278,6 +1278,58 @@ impl BrepKernel {
         Ok(solid_id_to_u32(result))
     }
 
+    /// Project a solid's edges onto a view plane with hidden-line removal.
+    ///
+    /// Viewed along `dir` (orthographic) through `origin`, with in-plane x-axis
+    /// `x_axis`. Returns a JSON string `{"visible": [[x,y,…]], "hidden": [[…]]}`
+    /// — flat 2D polylines in view coordinates. `hidden_lines = false` drops the
+    /// hidden set. Occlusion is an exact point-in-solid test.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid handle, a non-positive `deflection`, or a
+    /// degenerate `dir`/`x_axis`.
+    #[wasm_bindgen(js_name = "projectEdges")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn project_edges(
+        &self,
+        solid: u32,
+        origin_x: f64,
+        origin_y: f64,
+        origin_z: f64,
+        dir_x: f64,
+        dir_y: f64,
+        dir_z: f64,
+        x_axis_x: f64,
+        x_axis_y: f64,
+        x_axis_z: f64,
+        hidden_lines: bool,
+        deflection: f64,
+    ) -> Result<JsValue, JsError> {
+        validate_positive(deflection, "deflection")?;
+        let solid_id = self.resolve_solid(solid)?;
+        let result = brepkit_operations::projection::project_edges(
+            &self.topo,
+            solid_id,
+            Point3::new(origin_x, origin_y, origin_z),
+            Vec3::new(dir_x, dir_y, dir_z),
+            Vec3::new(x_axis_x, x_axis_y, x_axis_z),
+            hidden_lines,
+            deflection,
+        )?;
+        let flatten = |polys: &[Vec<brepkit_math::vec::Point2>]| -> Vec<Vec<f64>> {
+            polys
+                .iter()
+                .map(|poly| poly.iter().flat_map(|p| [p.x(), p.y()]).collect())
+                .collect()
+        };
+        let json = serde_json::json!({
+            "visible": flatten(&result.visible),
+            "hidden": flatten(&result.hidden),
+        });
+        Ok(JsValue::from_str(&json.to_string()))
+    }
+
     // ── Point Classification ──────────────────────────────────────
 
     /// Classify a point relative to a solid using generalized winding numbers.
@@ -1819,6 +1871,32 @@ mod tests {
             out.get("ok").and_then(serde_json::Value::as_u64).is_some(),
             "expected an ok solid handle, got {out}"
         );
+    }
+
+    #[test]
+    fn project_edges_batch_dispatch_box_oblique() {
+        let mut k = BrepKernel::new();
+        let solid =
+            brepkit_operations::primitives::make_box(k.topo_mut(), 10.0, 10.0, 10.0).unwrap();
+        let out = dispatch(
+            &mut k,
+            "projectEdges",
+            serde_json::json!({
+                "solid": solid_id_to_u32(solid),
+                "originX": -100.0, "originY": -100.0, "originZ": -100.0,
+                "dirX": 1.0, "dirY": 1.0, "dirZ": 1.0,
+                "xAxisX": 1.0, "xAxisY": -1.0, "xAxisZ": 0.0,
+                "hiddenLines": true, "deflection": 0.1,
+            }),
+        );
+        let ok = out.get("ok").expect("projectEdges batch should return ok");
+        let nonempty = |key: &str| {
+            ok.get(key)
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|a| !a.is_empty())
+        };
+        assert!(nonempty("visible"), "visible polylines expected, got {out}");
+        assert!(nonempty("hidden"), "hidden polylines expected, got {out}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **HLR / projection** (#815, the last #815 gap): project a solid's edges to a view plane and classify each segment **visible** or **hidden**.

### Why it's a genuine gap

The brepkit adapter's `projectEdges` was a stub ("return all edges as visible outlines, no hidden line removal"). This adds real occlusion.

### Approach (no tessellation in the occlusion test)

`operations::projection::project_edges`:
- Samples each edge to a polyline (the projected drawing is inherently polygonal).
- Classifies each segment by an **exact point-in-solid test**: a boundary sample is hidden iff stepping it toward the camera (`p − ε·dir`) lands `Inside` the solid (a face is in front). Reuses `classify_point` (ray-casting) — no face tessellation.
- Merges consecutive same-visibility segments into polylines and projects via the camera frame `(u,v) = ((p−origin)·x, (p−origin)·y)`.

Exposed as the `projectEdges` WASM binding (returns `{visible, hidden}` flat 2D polylines) + batch dispatch.

### Tests

- `project_box_oblique_view_has_visible_and_hidden_edges` — an oblique (1,1,1) view of a box yields **both** visible and hidden edges (the three far-corner edges are occluded).
- `project_box_without_hidden_lines_drops_hidden`.
- Batch contract test asserting non-empty visible + hidden.

### Known limitation

A view aligned *exactly* to faces (e.g. an exact front view of a box) is degenerate — back edges graze coplanar faces, which point-classification can't disambiguate (OCCT resolves it by convention). The general oblique case is exact; a silhouette-aware refinement could handle the coincident case later.

Refs #815 (projection/HLR). This closes the #815 implementation gaps; convex hull / interference / boolean-evolution were already present (documented on the issue).