### PR TITLE
fix(review): address skipped review on #828 + #830

### DIFF
--- a/crates/operations/src/primitives.rs
+++ b/crates/operations/src/primitives.rs
@@ -804,14 +804,19 @@ pub fn make_convex_hull(
 
 /// Convex Minkowski sum of two solids: `A ⊕ B = { a + b | a ∈ A, b ∈ B }`.
 ///
-/// Computed as the convex hull of all pairwise vertex sums, which is exact when
-/// both inputs are convex (e.g. boxes, or a shape with a tessellated sphere as
-/// the rolling tool) and a convex over-approximation otherwise.
+/// Computed as the convex hull of all pairwise vertex sums. This is exact when
+/// both inputs are convex **polytopes** (e.g. boxes, or a shape with a
+/// tessellated sphere as the rolling tool); for a smooth convex solid the
+/// vertices under-sample the surface, and for non-convex inputs it is a convex
+/// over-approximation.
+///
+/// The vertex sum is `O(|A|·|B|)` points — large meshes can be expensive.
 ///
 /// # Errors
 ///
 /// Returns [`crate::OperationsError::InvalidInput`] if either solid has no
-/// vertices, and propagates [`make_convex_hull`] errors (e.g. degenerate input).
+/// vertices, and propagates [`make_convex_hull`] errors (e.g. when the summed
+/// points are degenerate / coplanar and no hull can be built).
 pub fn make_minkowski_sum(
     topo: &mut Topology,
     a: SolidId,
@@ -833,7 +838,8 @@ pub fn make_minkowski_sum(
         });
     }
 
-    let mut sums = Vec::with_capacity(a_pts.len() * b_pts.len());
+    // saturating_mul: the product is only a capacity hint; never overflow it.
+    let mut sums = Vec::with_capacity(a_pts.len().saturating_mul(b_pts.len()));
     for &p in &a_pts {
         for &q in &b_pts {
             sums.push(Point3::new(p.x() + q.x(), p.y() + q.y(), p.z() + q.z()));
@@ -1378,7 +1384,8 @@ mod tests {
         let a = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
         let b = make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
         let sum = make_minkowski_sum(&mut topo, a, b).unwrap();
-        // [0,1]³ ⊕ [0,1]³ = [0,2]³, volume 8.
+        // Two unit boxes sum to a 2×2×2 box (volume 8), independent of where
+        // make_box places its origin.
         assert_volume_near(&topo, sum, 8.0, 1e-6);
     }
 

--- a/crates/operations/src/primitives.rs
+++ b/crates/operations/src/primitives.rs
@@ -838,8 +838,14 @@ pub fn make_minkowski_sum(
         });
     }
 
-    // saturating_mul: the product is only a capacity hint; never overflow it.
-    let mut sums = Vec::with_capacity(a_pts.len().saturating_mul(b_pts.len()));
+    // A genuinely overflowing vertex product is an impossibly large input —
+    // return a clean error rather than panicking in `Vec::with_capacity`.
+    let capacity = a_pts.len().checked_mul(b_pts.len()).ok_or_else(|| {
+        crate::OperationsError::InvalidInput {
+            reason: "minkowski sum input too large: vertex-count product overflows".into(),
+        }
+    })?;
+    let mut sums = Vec::with_capacity(capacity);
     for &p in &a_pts {
         for &q in &b_pts {
             sums.push(Point3::new(p.x() + q.x(), p.y() + q.y(), p.z() + q.z()));

--- a/crates/operations/src/projection.rs
+++ b/crates/operations/src/projection.rs
@@ -28,13 +28,14 @@ pub struct ProjectedEdges {
 ///
 /// `direction` points from the camera into the scene. `x_axis` is the horizontal
 /// view direction (re-orthonormalized against `direction`). `deflection` controls
-/// edge-sampling density and the classification tolerance. When `hidden_lines` is
-/// false, hidden segments are dropped and `hidden` is left empty.
+/// edge-sampling density (the point-classification tolerance is fixed). When
+/// `hidden_lines` is false, hidden segments are dropped and `hidden` is left empty.
 ///
 /// # Errors
 ///
 /// Returns [`crate::OperationsError::InvalidInput`] if `direction` or `x_axis`
-/// is degenerate, and propagates topology / sampling errors.
+/// is degenerate, and propagates topology, sampling, and point-classification
+/// errors.
 pub fn project_edges(
     topo: &Topology,
     solid: SolidId,
@@ -62,18 +63,23 @@ pub fn project_edges(
         Point2::new(x.dot(v), y.dot(v))
     };
 
-    // Step length for the occlusion probe — clear of the boundary tolerance but
-    // small relative to the model. Keyed to the model's overall extent.
+    // Step length for the occlusion probe — far enough to clear the boundary
+    // tolerance, small relative to the model. Keyed to the model extent and
+    // capped so a large-coordinate model can't push the probe through thin
+    // features.
     let bbox = crate::measure::solid_bounding_box(topo, solid)?;
     let diag = (bbox.max - bbox.min).length();
-    let eps = (diag * 1e-4).max(1e-6);
+    let eps = (diag * 1e-4).clamp(1e-6, 1e-2);
 
     // A boundary point is hidden when stepping toward the camera (−view) lands
-    // inside the solid, i.e. a face is between it and the camera.
-    let is_hidden = |p: Point3| -> bool {
-        classify_point(topo, solid, p - view * eps, deflection, 1e-7)
-            .map(|c| c == PointClassification::Inside)
-            .unwrap_or(false)
+    // inside the solid, i.e. a face is between it and the camera. A
+    // classification error is propagated rather than silently read as
+    // "visible", so a degenerate solid surfaces instead of yielding wrong HLR.
+    let is_hidden = |p: Point3| -> Result<bool, crate::OperationsError> {
+        Ok(
+            classify_point(topo, solid, p - view * eps, deflection, 1e-7)?
+                == PointClassification::Inside,
+        )
     };
 
     let lines = crate::tessellate::sample_solid_edges(topo, solid, deflection)?;
@@ -104,7 +110,7 @@ pub fn project_edges(
                 );
                 is_hidden(mid)
             })
-            .collect();
+            .collect::<Result<Vec<bool>, _>>()?;
 
         let mut j = 0;
         while j < seg_hidden.len() {

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -1264,12 +1264,13 @@ impl BrepKernel {
     /// Convex Minkowski sum of two solids (`A ⊕ B`).
     ///
     /// Returns the convex hull of all pairwise vertex sums — exact for convex
-    /// inputs (boxes, or a tessellated-sphere rolling tool), a convex
+    /// polytopes (boxes, or a tessellated-sphere rolling tool), a convex
     /// over-approximation otherwise. Returns a solid handle (`u32`).
     ///
     /// # Errors
     ///
-    /// Returns an error if either handle is invalid or either solid is empty.
+    /// Returns an error if either handle is invalid, either solid is empty, or
+    /// the summed points are degenerate so no hull can be built.
     #[wasm_bindgen(js_name = "minkowskiSum")]
     pub fn minkowski_sum(&mut self, solid_a: u32, solid_b: u32) -> Result<u32, JsError> {
         let a = self.resolve_solid(solid_a)?;
@@ -1307,6 +1308,19 @@ impl BrepKernel {
         deflection: f64,
     ) -> Result<JsValue, JsError> {
         validate_positive(deflection, "deflection")?;
+        for (v, name) in [
+            (origin_x, "origin_x"),
+            (origin_y, "origin_y"),
+            (origin_z, "origin_z"),
+            (dir_x, "dir_x"),
+            (dir_y, "dir_y"),
+            (dir_z, "dir_z"),
+            (x_axis_x, "x_axis_x"),
+            (x_axis_y, "x_axis_y"),
+            (x_axis_z, "x_axis_z"),
+        ] {
+            validate_finite(v, name)?;
+        }
         let solid_id = self.resolve_solid(solid)?;
         let result = brepkit_operations::projection::project_edges(
             &self.topo,


### PR DESCRIPTION
Follow-up addressing review findings that were skipped because #828 (Minkowski) and #830 (HLR) auto-merged before their Greptile/Copilot reviews were handled.

## HLR (#830)
- **P1 — missing finiteness validation:** `projectEdges` now validates the nine `origin`/`dir`/`x_axis` floats are finite (not just `deflection`), preventing NaN-propagated math and a `serde_json` panic.
- **P1 — silent classification errors:** `project_edges` now propagates a `classify_point` error instead of `.unwrap_or(false)` (which silently reported "visible" and could mask a degenerate solid).
- **Epsilon clamp (Copilot):** the occlusion-probe step is clamped to `[1e-6, 1e-2]` so a large-coordinate model can't push the probe through thin features.
- **Doc (Copilot):** `deflection` drives edge sampling; the point-classification tolerance is fixed.

## Minkowski (#828)
- **Docstrings (Copilot):** "exact for convex **polytopes**" (not all convex solids); document the `O(|A|·|B|)` cost and the degenerate-hull failure in `# Errors`.
- **Overflow (Copilot):** `saturating_mul` on the `Vec::with_capacity` hint.
- **Test comment (Greptile P2):** no longer assumes where `make_box` puts its origin.

All tests + clippy green. Refs #828, #830.