### PR TITLE
fix(blend): build circular-arc blend surface for any section count

### DIFF
--- a/crates/blend/src/walker.rs
+++ b/crates/blend/src/walker.rs
@@ -747,6 +747,27 @@ mod tests {
         }
     }
 
+    /// Assert circularity across the *whole* (U, V) grid, including interior
+    /// sections. For `quarter_circle_sections` every cross-section is a unit
+    /// circle centred on the line `(·, 1, 1)` parallel to X — only X shifts
+    /// between sections — so every surface sample must sit at distance 1 from
+    /// that axis: `sqrt((y-1)^2 + (z-1)^2) == 1`. This catches V-interpolation
+    /// regressions (knot vector / evaluator) that endpoint-only sampling misses.
+    fn assert_circular_over_grid(surf: &NurbsSurface) {
+        for ku in 0..=8 {
+            for kv in 0..=8 {
+                let u = f64::from(ku) / 8.0;
+                let v = f64::from(kv) / 8.0;
+                let p = surf.evaluate(u, v);
+                let r = ((p.y() - 1.0).powi(2) + (p.z() - 1.0).powi(2)).sqrt();
+                assert!(
+                    (r - 1.0).abs() < 1e-9,
+                    "U={u} V={v}: off-axis radius {r} != 1 (point {p:?})"
+                );
+            }
+        }
+    }
+
     /// Regression for the transposed control-point grid: the surface must build
     /// for any section count, not only `n == 3`. With the U/V axes swapped, the
     /// arc's 6-knot vector was validated against the section count, so every
@@ -770,6 +791,9 @@ mod tests {
             // (clamped knots interpolate the first and last section exactly).
             assert_circular_arc(&surf, 0.0, &sections[0]);
             assert_circular_arc(&surf, 1.0, &sections[n - 1]);
+
+            // ...and at every interior section, not just the endpoints.
+            assert_circular_over_grid(&surf);
         }
     }
 }

--- a/crates/blend/src/walker.rs
+++ b/crates/blend/src/walker.rs
@@ -371,9 +371,18 @@ pub fn approximate_blend_surface(sections: &[CircSection]) -> Result<NurbsSurfac
     let degree_v = (n - 1).min(3);
     let knots_v = build_uniform_knots(n, degree_v);
 
-    // Build control point grid: n rows (V) × 3 columns (U).
-    let mut control_points = Vec::with_capacity(n);
-    let mut weights = Vec::with_capacity(n);
+    // Build the control-point grid indexed `[row_u][col_v]`: U is the rational
+    // quadratic arc (3 rows — start / apex / end), V interpolates through the
+    // `n` sections (n columns). Each section contributes one column entry to
+    // each arc row. Laying the grid out section-major would transpose U and V,
+    // making `knots_u` (length 6) be validated against the section count — the
+    // source of `InvalidKnotVector { expected: n+3, got: 6 }` for n != 3.
+    let mut arc_start = Vec::with_capacity(n); // cp0 per section
+    let mut arc_apex = Vec::with_capacity(n); // cp1 per section
+    let mut arc_end = Vec::with_capacity(n); // cp2 per section
+    let mut w_start = Vec::with_capacity(n);
+    let mut w_apex = Vec::with_capacity(n);
+    let mut w_end = Vec::with_capacity(n);
 
     for sec in sections {
         let half_angle = sec.half_angle();
@@ -383,13 +392,14 @@ pub fn approximate_blend_surface(sections: &[CircSection]) -> Result<NurbsSurfac
         let cp0 = sec.p1;
         let cp2 = sec.p2;
 
-        // cp1 = apex of the rational quadratic on the arc.
-        // The weighted midpoint lies at center + radius * mid_direction,
-        // but for a rational Bezier the control point is the intersection
-        // of tangent lines at cp0 and cp2. For a circular arc this is:
-        // cp1 = (cp0 + cp2) / 2 + (1/cos(half_angle) - 1) * (center - midpoint)
-        // Equivalently: cp1 = center + (mid_dir / cos(half_angle)) * radius
-        // where mid_dir bisects the two contact directions.
+        // cp1 = apex (middle control point) of the rational quadratic arc.
+        // For the standard circular-arc representation (apex weight = cos θ),
+        // the apex is the tangent intersection at distance r/cos θ from the
+        // center along the chord-midpoint bisector. The chord midpoint M sits
+        // at distance r·cos θ from the center, so
+        //   apex = center + (M − center) / cos²θ = center + (M − center) / w_mid²
+        // Using 1/w_mid (instead of 1/w_mid²) places the apex on the arc and
+        // yields a non-circular conic.
         let midpoint = Point3::new(
             (cp0.x() + cp2.x()) * 0.5,
             (cp0.y() + cp2.y()) * 0.5,
@@ -397,13 +407,12 @@ pub fn approximate_blend_surface(sections: &[CircSection]) -> Result<NurbsSurfac
         );
 
         let cp1 = if w_mid.abs() > 1e-15 {
-            // Tangent intersection point for the rational quadratic.
             let center_to_mid = Vec3::new(
                 midpoint.x() - sec.center.x(),
                 midpoint.y() - sec.center.y(),
                 midpoint.z() - sec.center.z(),
             );
-            let scale = 1.0 / w_mid;
+            let scale = 1.0 / (w_mid * w_mid);
             Point3::new(
                 sec.center.x() + center_to_mid.x() * scale,
                 sec.center.y() + center_to_mid.y() * scale,
@@ -413,9 +422,16 @@ pub fn approximate_blend_surface(sections: &[CircSection]) -> Result<NurbsSurfac
             midpoint
         };
 
-        control_points.push(vec![cp0, cp1, cp2]);
-        weights.push(vec![1.0, w_mid, 1.0]);
+        arc_start.push(cp0);
+        arc_apex.push(cp1);
+        arc_end.push(cp2);
+        w_start.push(1.0);
+        w_apex.push(w_mid);
+        w_end.push(1.0);
     }
+
+    let control_points = vec![arc_start, arc_apex, arc_end];
+    let weights = vec![w_start, w_apex, w_end];
 
     let surf = NurbsSurface::new(
         degree_u,
@@ -681,6 +697,79 @@ mod tests {
         match result.unwrap_err() {
             BlendError::WalkingFailure { .. } => {} // expected
             other => panic!("expected WalkingFailure, got {other:?}"),
+        }
+    }
+
+    /// Build `n` identical quarter-circle sections of a radius-1 fillet between
+    /// the planes `z = 0` and `y = 0`, swept along +X.
+    fn quarter_circle_sections(n: usize) -> Vec<CircSection> {
+        (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let x = i as f64;
+                CircSection {
+                    p1: Point3::new(x, 1.0, 0.0),
+                    p2: Point3::new(x, 0.0, 1.0),
+                    center: Point3::new(x, 1.0, 1.0),
+                    radius: 1.0,
+                    uv1: (0.0, 0.0),
+                    uv2: (0.0, 0.0),
+                    t: x,
+                }
+            })
+            .collect()
+    }
+
+    /// Assert that the arc cross-section (U direction) of `surf` at parameter
+    /// `v` is an exact radius-1 circular arc from `p1` to `p2` about `center`.
+    fn assert_circular_arc(surf: &NurbsSurface, v: f64, sec: &CircSection) {
+        let start = surf.evaluate(0.0, v);
+        let end = surf.evaluate(1.0, v);
+        assert!(
+            (start - sec.p1).length() < 1e-9,
+            "arc start {start:?} != p1 {:?}",
+            sec.p1
+        );
+        assert!(
+            (end - sec.p2).length() < 1e-9,
+            "arc end {end:?} != p2 {:?}",
+            sec.p2
+        );
+        // Every point along U must lie on the circle of radius 1 about center.
+        for k in 0..=8 {
+            let u = f64::from(k) / 8.0;
+            let p = surf.evaluate(u, v);
+            let r = (p - sec.center).length();
+            assert!(
+                (r - 1.0).abs() < 1e-9,
+                "U={u} V={v}: radius {r} != 1 (point {p:?} not on the fillet arc)"
+            );
+        }
+    }
+
+    /// Regression for the transposed control-point grid: the surface must build
+    /// for any section count, not only `n == 3`. With the U/V axes swapped, the
+    /// arc's 6-knot vector was validated against the section count, so every
+    /// `n != 3` failed with `InvalidKnotVector { expected: n + 3, got: 6 }`.
+    #[test]
+    fn approximate_blend_surface_handles_many_sections() {
+        for n in [2usize, 3, 4, 5, 8, 21] {
+            let sections = quarter_circle_sections(n);
+            let surf = approximate_blend_surface(&sections)
+                .unwrap_or_else(|e| panic!("n={n} sections should build a surface, got {e:?}"));
+
+            // U is the rational quadratic arc; V interpolates the sections.
+            assert_eq!(surf.degree_u(), 2, "U (arc) must be degree 2 for n={n}");
+            assert_eq!(
+                surf.degree_v(),
+                (n - 1).min(3),
+                "V (sections) degree for n={n}"
+            );
+
+            // The arc shape must be preserved at both ends of the section span
+            // (clamped knots interpolate the first and last section exactly).
+            assert_circular_arc(&surf, 0.0, &sections[0]);
+            assert_circular_arc(&surf, 1.0, &sections[n - 1]);
         }
     }
 }


### PR DESCRIPTION
## Summary

`approximate_blend_surface` (the walker fillet/chamfer blend-surface builder) had two latent bugs that made it usable only for an exact 3-section blend, and even then it produced a non-circular cross section. This fixes both and adds a geometric regression test.

### Bug 1 — transposed U/V axes (`InvalidKnotVector`)

`NurbsSurface::new` pairs `degree_u`/`knots_u` with the control-grid **rows** and `degree_v`/`knots_v` with the **columns**. The function intends *U = the rational quadratic arc* (degree 2, 3 control points) and *V = interpolation through the `n` sections*, but it built the grid **section-major** (`[n sections][3 arc points]`). So the arc's 6-element knot vector was validated against the section count:

```
InvalidKnotVector { expected: n + 3, got: 6 }
```

Only `n == 3` validated, because the grid was square (3×3). Every other section count — i.e. any blend walked against a curved spine, fine sampling, or a NURBS neighbour — failed.

**Fix:** lay the grid out arc-major (`[3 arc points][n sections]`).

### Bug 2 — apex off the circle (non-circular arc)

The middle control point was placed at distance `r` from the centre (i.e. *on* the arc), but the standard rational-quadratic circle representation (apex weight `cos θ`) requires the apex at the **tangent intersection**, distance `r / cos θ`. The chord midpoint `M` sits at `r·cos θ` from the centre, so the correct scale of `(M − centre)` is `1/cos²θ`; the code used `1/cos θ`, yielding a non-circular conic.

**Fix:** scale the apex by `1/w_mid²` (`w_mid = cos θ`).

## Verification

- New test `approximate_blend_surface_handles_many_sections` builds quarter-circle blends for `n = 2, 3, 4, 5, 8, 21` and asserts every U sample lies on the radius-1 fillet circle (`|p − centre| = 1` within 1e-9) and that the arc endpoints equal the section contacts. Deterministic 10/10 in fresh processes.
- No regressions: `brepkit-blend` (93), `brepkit-operations` lib (687) + golden (8) + blend integration (11), `brepkit-wasm` native (223). `check-boundaries.sh` clean.
- The `n = 3` surface is geometrically identical after the transpose (both axes are degree-2 with the same knots when square), so existing 3-section paths are unaffected by Bug 1; Bug 2 makes the 3-section arc correctly circular too.

## Scope / relation to #834

This lands the **surface-construction layer** of the NURBS-neighbour "fillet a fillet" workflow. On a watertight NURBS-blend box, the second fillet on the two end-cap edges previously died here with `InvalidKnotVector`; it now builds the blend surface. It does **not** close #834 — the remaining, separable follow-ups are:

1. Walker `find_start` convergence on the straight contact edges (still "no start solution").
2. Trimming the NURBS blend face along the new contact curve.
3. Watertight assembly of the second fillet (`fillet_v2` leaves free edges today).

Diagnosis correction worth noting on the issue: the single-edge rolling-ball path **already** produces a watertight solid with a shared NURBS-blend border (euler = 2, every blend-border edge shared by 2 faces), so #834's "unshared edges" Layer 1 is not a blocker on that path — it afflicts the multi-edge / `FilletBuilder` assembly instead.

## Risk

Core blend engine, but narrow: the change only affects `approximate_blend_surface`, which was previously erroring for every section count ≠ 3 and is bypassed entirely by the analytic (cylinder) and rolling-ball fillet paths. It can only turn former errors into valid surfaces; the one working case (`n = 3`) is provably unchanged by Bug 1. Flagging for human merge per core-engine policy.