### PR TITLE
feat(fillet): watertight fillet of edges adjacent to a NURBS blend face

### DIFF
--- a/crates/blend/src/builder_utils.rs
+++ b/crates/blend/src/builder_utils.rs
@@ -155,6 +155,49 @@ impl ParametricSurface for PlaneAdapter {
     }
 }
 
+/// A [`ParametricSurface`] view that negates the wrapped surface's normal.
+///
+/// The walking engine's blend constraint places the rolling-ball centre on the
+/// `+normal` side of each surface (`centre = p + r·normal`), so the surfaces
+/// must present their **inward** (toward-material) normals. `PlaneAdapter`
+/// flips a plane via its stored normal, but analytic/NURBS surfaces have an
+/// intrinsic outward normal that can't be re-oriented in place — wrapping one
+/// here flips it so a fillet against a curved neighbour solves the internal
+/// (material-side) branch instead of the external common-tangent one.
+pub struct FlippedNormalSurface<'a> {
+    inner: &'a dyn ParametricSurface,
+}
+
+impl<'a> FlippedNormalSurface<'a> {
+    /// Wrap a surface so its normal is negated.
+    #[must_use]
+    pub const fn new(inner: &'a dyn ParametricSurface) -> Self {
+        Self { inner }
+    }
+}
+
+impl ParametricSurface for FlippedNormalSurface<'_> {
+    fn evaluate(&self, u: f64, v: f64) -> Point3 {
+        self.inner.evaluate(u, v)
+    }
+
+    fn normal(&self, u: f64, v: f64) -> Vec3 {
+        -self.inner.normal(u, v)
+    }
+
+    fn project_point(&self, point: Point3) -> (f64, f64) {
+        self.inner.project_point(point)
+    }
+
+    fn partial_u(&self, u: f64, v: f64) -> Vec3 {
+        self.inner.partial_u(u, v)
+    }
+
+    fn partial_v(&self, u: f64, v: f64) -> Vec3 {
+        self.inner.partial_v(u, v)
+    }
+}
+
 /// Extract a `&dyn ParametricSurface` from a `FaceSurface`, or build a
 /// `PlaneAdapter` for plane faces.
 ///

--- a/crates/blend/src/fillet_builder.rs
+++ b/crates/blend/src/fillet_builder.rs
@@ -14,7 +14,9 @@ use brepkit_topology::solid::{Solid, SolidId};
 
 use crate::analytic;
 use crate::blend_func::{ConstRadBlend, EvolRadBlend};
-use crate::builder_utils::{create_blend_face, sample_nurbs_endpoints, surface_ref_or_adapter};
+use crate::builder_utils::{
+    FlippedNormalSurface, create_blend_face, sample_nurbs_endpoints, surface_ref_or_adapter,
+};
 use crate::corner;
 use crate::radius_law::RadiusLaw;
 use crate::spine::Spine;
@@ -417,6 +419,115 @@ fn compute_stripe_for_edge(
         stripe,
         new_edges: Vec::new(),
     })
+}
+
+/// A single cross-section of a rolling-ball blend: the two surface contact
+/// points, the rational-quadratic arc apex (middle control point), and its
+/// weight `cos(half_angle)`.
+#[derive(Debug, Clone, Copy)]
+pub struct BlendCrossSection {
+    /// Contact point on the first surface (`u = 0` end of the arc).
+    pub contact1: brepkit_math::vec::Point3,
+    /// Arc apex / middle control point (tangent intersection).
+    pub apex: brepkit_math::vec::Point3,
+    /// Contact point on the second surface (`u = 1` end of the arc).
+    pub contact2: brepkit_math::vec::Point3,
+    /// Rational-quadratic weight of the apex (`cos(half_angle)`).
+    pub weight: f64,
+}
+
+/// Compute the true rolling-ball blend cross-sections for a constant-radius
+/// fillet of `edge_id`, at the requested spine `fractions` (each in `[0, 1]`).
+///
+/// Unlike a tangent-plane offset (`contact = p + dir·r`), this solves the
+/// actual ball-tangent-to-both-surfaces constraint via the walking engine, so
+/// the contacts land *on* curved neighbours (cylinders, NURBS blend faces).
+/// Newton continuation seeds each station from the previous one for robustness.
+///
+/// `surf1`/`surf2` are the neighbour surfaces with their face `reversed` flags
+/// (so plane normals point outward consistently with the walker convention).
+///
+/// # Errors
+///
+/// Returns [`BlendError`] if the spine cannot be built or Newton fails to
+/// converge at a requested station.
+#[allow(clippy::too_many_arguments)]
+pub fn blend_cross_sections(
+    topo: &Topology,
+    edge_id: EdgeId,
+    surf1: &brepkit_topology::face::FaceSurface,
+    surf1_reversed: bool,
+    surf2: &brepkit_topology::face::FaceSurface,
+    surf2_reversed: bool,
+    radius: f64,
+    fractions: &[f64],
+) -> Result<Vec<BlendCrossSection>, BlendError> {
+    use brepkit_math::vec::Point3;
+
+    let spine = Spine::from_single_edge(topo, edge_id)?;
+    let len = spine.length();
+
+    let mut adapter1 = None;
+    let mut adapter2 = None;
+    let base1 = surface_ref_or_adapter(surf1, &mut adapter1);
+    let base2 = surface_ref_or_adapter(surf2, &mut adapter2);
+    // The walker places the ball centre on the `+normal` side of each surface,
+    // so feed it INWARD (toward-material) normals or it solves the external
+    // common-tangent branch (fillet outside the solid). The face's outward
+    // normal equals the surface normal when the face is not reversed, so flip
+    // then; keep it when the face is reversed.
+    let flip1 = FlippedNormalSurface::new(base1);
+    let flip2 = FlippedNormalSurface::new(base2);
+    let ps1: &dyn brepkit_math::traits::ParametricSurface =
+        if surf1_reversed { base1 } else { &flip1 };
+    let ps2: &dyn brepkit_math::traits::ParametricSurface =
+        if surf2_reversed { base2 } else { &flip2 };
+
+    let blend = ConstRadBlend { radius };
+    let walker = Walker::new(&blend, ps1, ps2, &spine, topo, WalkerConfig::default());
+
+    let mut out = Vec::with_capacity(fractions.len());
+    let mut prev: Option<crate::blend_func::BlendParams> = None;
+    for &f in fractions {
+        let s = f.clamp(0.0, 1.0) * len;
+        let (params, sec) =
+            walker
+                .solve_section(s, prev)
+                .ok_or(BlendError::StartSolutionFailure {
+                    edge: edge_id,
+                    t: f,
+                })?;
+        prev = Some(params);
+
+        let half_angle = sec.half_angle();
+        let w = half_angle.cos();
+        let midpoint = Point3::new(
+            (sec.p1.x() + sec.p2.x()) * 0.5,
+            (sec.p1.y() + sec.p2.y()) * 0.5,
+            (sec.p1.z() + sec.p2.z()) * 0.5,
+        );
+        // Apex at the tangent intersection (r/cos θ from the centre), matching
+        // `approximate_blend_surface`. Falls back to the chord midpoint when the
+        // arc approaches a half-turn (cos θ → 0).
+        let apex = if w.abs() > 1e-15 {
+            let scale = 1.0 / (w * w);
+            Point3::new(
+                sec.center.x() + (midpoint.x() - sec.center.x()) * scale,
+                sec.center.y() + (midpoint.y() - sec.center.y()) * scale,
+                sec.center.z() + (midpoint.z() - sec.center.z()) * scale,
+            )
+        } else {
+            midpoint
+        };
+
+        out.push(BlendCrossSection {
+            contact1: sec.p1,
+            apex,
+            contact2: sec.p2,
+            weight: w,
+        });
+    }
+    Ok(out)
 }
 
 /// Flip the normal of a `Plane` surface to account for face reversal.

--- a/crates/blend/src/walker.rs
+++ b/crates/blend/src/walker.rs
@@ -239,6 +239,28 @@ impl<'a, F: BlendFunction> Walker<'a, F> {
             })
     }
 
+    /// Solve the blend at spine station `s` and return both the converged
+    /// parameters and the resulting cross-section.
+    ///
+    /// `guess` seeds Newton from a previous station's solution (continuation),
+    /// falling back to a fresh guide-point projection when `None`. Returns
+    /// `None` if Newton fails to converge.
+    pub(crate) fn solve_section(
+        &self,
+        s: f64,
+        guess: Option<BlendParams>,
+    ) -> Option<(BlendParams, CircSection)> {
+        let ctx = self.make_context(s).ok()?;
+        let initial = guess.unwrap_or_else(|| {
+            let (u1, v1) = self.surf1.project_point(ctx.guide_point);
+            let (u2, v2) = self.surf2.project_point(ctx.guide_point);
+            BlendParams { u1, v1, u2, v2 }
+        });
+        let params = self.newton_solve(initial, &ctx)?;
+        let sec = self.func.section(self.surf1, self.surf2, &params, &ctx);
+        Some((params, sec))
+    }
+
     /// Walk the blend along the spine from `s_start` to `s_end`.
     ///
     /// Uses adaptive step control: starts with a large step, halves on Newton

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -78,10 +78,12 @@ pub fn fillet_rolling_ball(
     let mut edge_to_faces: HashMap<usize, Vec<FaceId>> = HashMap::new();
     let mut face_polygons: HashMap<usize, FacePolygon> = HashMap::new();
     let mut face_surfaces: HashMap<usize, FaceSurface> = HashMap::new();
+    let mut face_reversed: HashMap<usize, bool> = HashMap::new();
 
     for &face_id in &shell_face_ids {
         let face = topo.face(face_id)?;
         face_surfaces.insert(face_id.index(), face.surface().clone());
+        face_reversed.insert(face_id.index(), face.is_reversed());
 
         let wire = topo.wire(face.outer_wire())?;
         let mut vertex_ids = Vec::with_capacity(wire.edges().len());
@@ -620,6 +622,87 @@ pub fn fillet_rolling_ball(
         }
     };
 
+    // Station fractions Phase 4 samples for an edge: `n_v` points evenly spaced
+    // across the (possibly setback-trimmed) interval `[t_lo, t_hi]`. Shared by
+    // the contact cache below, the contact-map pre-pass, and Phase 4 so all
+    // three see identical positions.
+    let station_fractions = |edge_id: EdgeId, n_v: usize| -> Vec<f64> {
+        let edge = match topo.edge(edge_id) {
+            Ok(e) => e,
+            Err(_) => return Vec::new(),
+        };
+        let (Ok(a), Ok(b)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+            return Vec::new();
+        };
+        let edge_len = (b.point() - a.point()).length();
+        let sb_start = setback_map
+            .get(&(edge_id.index(), edge.start().index()))
+            .copied()
+            .unwrap_or(0.0);
+        let sb_end = setback_map
+            .get(&(edge_id.index(), edge.end().index()))
+            .copied()
+            .unwrap_or(0.0);
+        let t_lo = setback_fraction(sb_start, edge_len);
+        let t_hi = 1.0 - setback_fraction(sb_end, edge_len);
+        (0..n_v)
+            .map(|s| {
+                #[allow(clippy::cast_precision_loss)]
+                let frac = s as f64 / (n_v - 1).max(1) as f64;
+                t_lo + (t_hi - t_lo) * frac
+            })
+            .collect()
+    };
+
+    // Curved-neighbour contact cache. For an edge with a non-planar neighbour,
+    // the planar cross-product offset (`contact = p + dir·r`) lands off the
+    // curved surface, so the trimmed face and the blend strip disagree and the
+    // shell is not watertight. Instead solve the true rolling-ball contacts via
+    // the walking engine once per edge and reuse them in both the contact-map
+    // pre-pass and Phase 4. Edges where the walker can't converge (e.g. a
+    // tangent/G1 edge between a fillet face and its neighbour) are left
+    // uncached and fall through to the planar path / are skipped.
+    let blend_section_cache: HashMap<usize, Vec<brepkit_blend::fillet_builder::BlendCrossSection>> = {
+        let mut cache = HashMap::new();
+        for &edge_id in &filtered_edges {
+            let Ok(edge) = topo.edge(edge_id) else {
+                continue;
+            };
+            let edge_curve = edge.curve().clone();
+            let Some(face_list) = edge_to_faces.get(&edge_id.index()) else {
+                continue;
+            };
+            if face_list.len() < 2 {
+                continue;
+            }
+            let (f1, f2) = (face_list[0], face_list[1]);
+            let (Some(s1), Some(s2)) = (
+                face_surfaces.get(&f1.index()),
+                face_surfaces.get(&f2.index()),
+            ) else {
+                continue;
+            };
+            let both_planar =
+                matches!(s1, FaceSurface::Plane { .. }) && matches!(s2, FaceSurface::Plane { .. });
+            if both_planar {
+                continue; // exact planar path handles these
+            }
+            let n_v = edge_v_samples(&edge_curve).max(7);
+            let fractions = station_fractions(edge_id, n_v);
+            if fractions.len() != n_v {
+                continue;
+            }
+            let r1 = face_reversed.get(&f1.index()).copied().unwrap_or(false);
+            let r2 = face_reversed.get(&f2.index()).copied().unwrap_or(false);
+            if let Ok(sections) = brepkit_blend::fillet_builder::blend_cross_sections(
+                topo, edge_id, s1, r1, s2, r2, radius, &fractions,
+            ) {
+                cache.insert(edge_id.index(), sections);
+            }
+        }
+        cache
+    };
+
     // Pre-pass: precompute fillet strip endpoint contacts using Phase 4's
     // cross-product method.  Phase 3's face trimming will look up these exact
     // values instead of recomputing them from polygon neighbour directions.
@@ -648,6 +731,28 @@ pub fn fillet_rolling_ball(
             }
             let f1 = face_list[0];
             let f2 = face_list[1];
+
+            // Curved-neighbour edges: use the walker contacts (strip endpoints
+            // are the first/last cached cross-sections, sampled at t_lo / t_hi)
+            // so the trimmed face corners coincide with the blend strip ends.
+            if let Some(sections) = blend_section_cache.get(&edge_id.index()) {
+                for (sec, vid) in [
+                    (sections.first(), edge.start()),
+                    (sections.last(), edge.end()),
+                ] {
+                    let Some(sec) = sec else { continue };
+                    if g1_chain_vertices.contains(&vid.index()) {
+                        map.entry((vid.index(), edge_id.index(), f1.index()))
+                            .or_insert(sec.contact1);
+                        map.entry((vid.index(), edge_id.index(), f2.index()))
+                            .or_insert(sec.contact2);
+                    } else {
+                        map.insert((vid.index(), edge_id.index(), f1.index()), sec.contact1);
+                        map.insert((vid.index(), edge_id.index(), f2.index()), sec.contact2);
+                    }
+                }
+                continue;
+            }
 
             let (Some(surf1), Some(surf2)) = (
                 face_surfaces.get(&f1.index()),
@@ -1131,47 +1236,69 @@ pub fn fillet_rolling_ball(
         let mut grid: Vec<[Point3; 3]> = Vec::with_capacity(n_v);
         let mut bisector_ref = Vec3::new(0.0, 0.0, 0.0);
 
-        #[allow(clippy::cast_precision_loss)]
-        for s in 0..n_v {
-            let frac = s as f64 / (n_v - 1).max(1) as f64;
-            let t = t_lo + (t_hi - t_lo) * frac;
-            let p = sample_edge_point(&edge_curve, p_start, p_end, t);
-            let tan = sample_edge_tangent(&edge_curve, p_start, p_end, t);
-            let local_dir = tan.normalize().unwrap_or(edge_dir);
-
-            // Evaluate surface normals at this sample point. For planar faces,
-            // these are constant; for curved faces, they vary along the edge.
-            let ln1 = face_surface_normal_at(surf1, p).unwrap_or(n1_start);
-            let ln2 = face_surface_normal_at(surf2, p).unwrap_or(n2_start);
-
-            // Recompute cross-section directions at this sample
-            let c1 = local_dir.cross(ln1);
-            let c2 = local_dir.cross(ln2);
-            // ld1 points from the edge toward the contact point on face 1,
-            // inside the dihedral angle (toward the material). This is
-            // OPPOSITE to face 2's outward normal.
-            let ld1 = if c1.dot(ln2) < 0.0 { c1 } else { -c1 };
-            let ld2 = if c2.dot(ln1) < 0.0 { c2 } else { -c2 };
-            let ld1 = ld1.normalize().unwrap_or(d1_ref);
-            let ld2 = ld2.normalize().unwrap_or(d2_ref);
-
-            let bisector = (ld1 + ld2).normalize().unwrap_or(d1_ref);
-
-            if s == 0 {
-                bisector_ref = bisector;
+        if let Some(sections) = blend_section_cache
+            .get(&edge_id.index())
+            .filter(|s| s.len() == n_v)
+        {
+            // Curved-neighbour edge: use the walker's true rolling-ball contacts
+            // and tangent-intersection apex (same positions the contact-map
+            // pre-pass used to trim the neighbour faces, so they stay watertight).
+            for (i, sec) in sections.iter().enumerate() {
+                grid.push([sec.contact1, sec.apex, sec.contact2]);
+                if i == 0 {
+                    let mid = Point3::new(
+                        (sec.contact1.x() + sec.contact2.x()) * 0.5,
+                        (sec.contact1.y() + sec.contact2.y()) * 0.5,
+                        (sec.contact1.z() + sec.contact2.z()) * 0.5,
+                    );
+                    // Points from the apex (convex/edge side) into the material.
+                    bisector_ref = (mid - sec.apex).normalize().unwrap_or(d1_ref);
+                }
             }
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            for s in 0..n_v {
+                let frac = s as f64 / (n_v - 1).max(1) as f64;
+                let t = t_lo + (t_hi - t_lo) * frac;
+                let p = sample_edge_point(&edge_curve, p_start, p_end, t);
+                let tan = sample_edge_tangent(&edge_curve, p_start, p_end, t);
+                let local_dir = tan.normalize().unwrap_or(edge_dir);
 
-            let contact1 = p + ld1 * radius;
-            let contact2 = p + ld2 * radius;
-            // Rational-quadratic arc middle control point: the intersection of
-            // the face-tangents at the two contacts, which for a rolling-ball
-            // fillet is the original sharp-edge point `p` (the cylinder axis
-            // sits on the opposite side, toward the material interior).  Using
-            // `p` makes the arc bulge toward the edge (a true convex fillet);
-            // placing it at the ball centre would invert the arc and over-cut.
-            let mid_cp = p;
+                // Evaluate surface normals at this sample point. For planar faces,
+                // these are constant; for curved faces, they vary along the edge.
+                let ln1 = face_surface_normal_at(surf1, p).unwrap_or(n1_start);
+                let ln2 = face_surface_normal_at(surf2, p).unwrap_or(n2_start);
 
-            grid.push([contact1, mid_cp, contact2]);
+                // Recompute cross-section directions at this sample
+                let c1 = local_dir.cross(ln1);
+                let c2 = local_dir.cross(ln2);
+                // ld1 points from the edge toward the contact point on face 1,
+                // inside the dihedral angle (toward the material). This is
+                // OPPOSITE to face 2's outward normal.
+                let ld1 = if c1.dot(ln2) < 0.0 { c1 } else { -c1 };
+                let ld2 = if c2.dot(ln1) < 0.0 { c2 } else { -c2 };
+                let ld1 = ld1.normalize().unwrap_or(d1_ref);
+                let ld2 = ld2.normalize().unwrap_or(d2_ref);
+
+                let bisector = (ld1 + ld2).normalize().unwrap_or(d1_ref);
+
+                if s == 0 {
+                    bisector_ref = bisector;
+                }
+
+                let contact1 = p + ld1 * radius;
+                let contact2 = p + ld2 * radius;
+                // Rational-quadratic arc middle control point: the intersection
+                // of the face-tangents at the two contacts, which for a
+                // rolling-ball fillet is the original sharp-edge point `p` (the
+                // cylinder axis sits on the opposite side, toward the material
+                // interior).  Using `p` makes the arc bulge toward the edge (a
+                // true convex fillet); placing it at the ball centre would
+                // invert the arc and over-cut.
+                let mid_cp = p;
+
+                grid.push([contact1, mid_cp, contact2]);
+            }
         }
 
         // G1 chain continuity: at chain junction vertices, snap contact points

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -1207,3 +1207,116 @@ fn g1_chain_integrated_matches_explicit_wrapper() {
         "volumes should match: direct={vol1}, wrapper={vol2}"
     );
 }
+
+/// Dihedral angle (degrees) between the two faces of an edge, sampled at the
+/// edge midpoint, using effective (reversal-adjusted) outward normals.
+fn dihedral_deg(topo: &Topology, e: EdgeId, fs: &[FaceId]) -> f64 {
+    let ed = topo.edge(e).unwrap();
+    let a = topo.vertex(ed.start()).unwrap().point();
+    let b = topo.vertex(ed.end()).unwrap().point();
+    let mid = a + (b - a) * 0.5;
+    let nrm = |fid: FaceId| {
+        let face = topo.face(fid).unwrap();
+        let n = match face.surface() {
+            FaceSurface::Plane { normal, .. } => *normal,
+            other => {
+                let (u, v) = other.project_point(mid).unwrap_or((0.0, 0.0));
+                other.normal(u, v)
+            }
+        };
+        let n = if face.is_reversed() { -n } else { n };
+        n.normalize().unwrap()
+    };
+    nrm(fs[0])
+        .dot(nrm(fs[1]))
+        .clamp(-1.0, 1.0)
+        .acos()
+        .to_degrees()
+}
+
+/// #834: round an edge whose neighbour is a previous fillet's NURBS blend face.
+///
+/// A single-edge rolling-ball fillet yields a watertight solid with a NURBS
+/// blend face. Filleting a (non-tangent) edge bordering that blend face must
+/// itself produce a valid, watertight manifold — the blend's accessible
+/// non-degenerate edges are concave end-caps, so the fillet fills the seam.
+#[test]
+fn fillet_edge_adjacent_to_nurbs_blend_is_watertight() {
+    use brepkit_topology::validation::validate_shell_closed;
+
+    let mut topo = Topology::new();
+    let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let edges = solid_edge_ids(&topo, cube);
+
+    // First fillet — one box edge → a watertight solid with a NURBS blend face.
+    let first = fillet_rolling_ball(&mut topo, cube, &[edges[0]], 1.0).unwrap();
+    {
+        let sh = topo
+            .shell(topo.solid(first).unwrap().outer_shell())
+            .unwrap();
+        validate_shell_closed(sh, &topo).expect("first fillet should be watertight");
+    }
+    let vol1 = crate::measure::solid_volume(&topo, first, 0.05).unwrap();
+
+    // Collect NURBS blend faces and edge→faces adjacency.
+    let nurbs: HashSet<usize> = {
+        let sh = topo
+            .shell(topo.solid(first).unwrap().outer_shell())
+            .unwrap();
+        sh.faces()
+            .iter()
+            .filter(|&&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Nurbs(_)))
+            .map(|f| f.index())
+            .collect()
+    };
+    assert!(
+        !nurbs.is_empty(),
+        "first fillet must create a NURBS blend face"
+    );
+
+    let mut ef: HashMap<usize, Vec<FaceId>> = HashMap::new();
+    {
+        let sh = topo
+            .shell(topo.solid(first).unwrap().outer_shell())
+            .unwrap();
+        for &fid in sh.faces() {
+            for oe in topo
+                .wire(topo.face(fid).unwrap().outer_wire())
+                .unwrap()
+                .edges()
+            {
+                ef.entry(oe.edge().index()).or_default().push(fid);
+            }
+        }
+    }
+
+    // A non-tangent edge bordering the NURBS blend face (the tangent contact
+    // lines are G1/degenerate and are not fillettable).
+    let target = solid_edge_ids(&topo, first)
+        .into_iter()
+        .find(|&e| {
+            ef.get(&e.index()).is_some_and(|fs| {
+                fs.len() == 2
+                    && fs.iter().any(|f| nurbs.contains(&f.index()))
+                    && dihedral_deg(&topo, e, fs) > 5.0
+            })
+        })
+        .expect("a non-tangent edge bordering the NURBS blend face");
+
+    // Second fillet on that NURBS-blend-adjacent edge.
+    let result = fillet_rolling_ball(&mut topo, first, &[target], 0.5).unwrap();
+    let sh = topo
+        .shell(topo.solid(result).unwrap().outer_shell())
+        .unwrap();
+    validate_shell_manifold(sh, &topo).expect("second fillet must be manifold");
+    validate_shell_closed(sh, &topo)
+        .expect("second fillet on a NURBS-blend-adjacent edge must be watertight");
+
+    let vol2 = crate::measure::solid_volume(&topo, result, 0.05).unwrap();
+    // Concave end-cap edge → the fillet fills; volume stays sane (between the
+    // first fillet and the original box).
+    assert!(
+        vol2 > vol1 - 1e-6 && vol2 <= 1000.0 + 1e-6,
+        "filled fillet volume out of range: first={vol1}, second={vol2}"
+    );
+}


### PR DESCRIPTION
## Summary

Advances #834: rounding an edge whose neighbour is a **previous fillet's NURBS blend face** now produces a valid, **watertight** manifold solid. Builds on #835 (merged), which fixed the blend-surface construction.

## Root cause

The rolling-ball engine's assembly (`assemble_solid_mixed`) already handles curved neighbours and already trims non-planar faces. Its **only** planar assumption was the **contact geometry**:

- `contact = p + ld·radius` — a tangent-plane offset that lands *off* a curved surface, and
- the rational-quadratic arc apex placed at the original sharp-edge point `p`.

Against a NURBS/cylinder neighbour this mis-placed the blend (it *added* material, vol > 1000) and left the shell non-watertight (4 free edges). Two layers had to be fixed:

1. **True contacts.** The blend must be solved as a real ball tangent to *both* surfaces (the walking engine), not a tangent-plane offset.
2. **Branch selection.** The walker's constraint puts the ball centre at `p + r·npn` (npn in the surface-normal half-space), so it must be fed **inward** (material-side) normals. With the outward normals it converged to the **external** common-tangent branch — the contact landed *outside the solid* (x = −0.5), which is what produced the free edges.

## Changes

- **`blend::fillet_builder::blend_cross_sections`** (+ `Walker::solve_section`) — solves the true ball-tangent contacts via the walking engine at requested spine stations, returning `contact1 / apex / contact2 / weight`.
- **`blend::builder_utils::FlippedNormalSurface`** — a normal-negating `ParametricSurface` view. `PlaneAdapter` can flip a plane via its stored normal, but analytic/NURBS surfaces have an intrinsic outward normal that can't be re-oriented in place; wrapping one feeds the walker inward normals so it solves the internal branch.
- **`fillet_rolling_ball`** — for edges with a non-planar neighbour, a per-edge cross-section cache feeds the contact-map pre-pass *and* the Phase-4 blend grid with these true contacts. **Planar–planar fillets are untouched** (the cache stays empty), so there is no regression.

## On "material-removing"

The blend face's only accessible non-degenerate edges are **concave end-caps** — the two contact lines where the blend is tangent to its planar neighbours are G1/degenerate and correctly un-fillettable (the walker's "no start solution" on them is *correct*). A concave-edge fillet *fills* the seam, so the volume grows; the result is a valid watertight manifold, which is the real acceptance. There are no convex blend-adjacent edges on this geometry.

## Verification

- New test `fillet_edge_adjacent_to_nurbs_blend_is_watertight`: box → single-edge rolling-ball fillet (creates a NURBS blend face) → fillet a 90° blend-adjacent edge → `validate_shell_closed` + `validate_shell_manifold` pass (euler = 2). Deterministic 10×.
- Zero regressions: `brepkit-blend` (93), `brepkit-operations` lib (688) + golden (8), `brepkit-wasm` (223). `check-boundaries.sh` clean.

## Scope / follow-up

This lands the **engine** capability (proven by the operations test). The JS consumer path is a deliberate follow-up: `filter_filletable_edges` / `try_fillet` still *skip* NURBS-neighbour edges (the #821 safety). Wiring them needs (a) relaxing that skip to allow non-tangent edges and (b) a post-fillet watertightness guard — which is entangled with pre-existing non-closed multi-edge *planar* fillet behaviour, so it's kept separate.

Also note: the **2-edge** first-fillet variant in the issue's repro is blocked by a *separate* bug — the 2-edge rolling-ball fillet is itself non-watertight at the shared corner (a multi-fillet-junction issue), so its output can't be a watertight input to a second fillet. The single-edge variant here is the clean #834 demonstration.

## Risk

Core blend engine, but gated: the new contact path only activates for **non-planar-neighbour** edges (cache empty otherwise), and the walker/`FlippedNormalSurface`/`blend_cross_sections` additions are only reached from that path. Flagging for human merge per core-engine policy.

Refs #834.