### PR TITLE
fix(fillet): watertight rolling-ball fillet of two edges sharing a corner

### DIFF
--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -978,7 +978,7 @@ pub fn fillet_rolling_ball(
                             if let Ok(dir) = (next_pos - pos).normalize() {
                                 let p = pos + dir * radius;
                                 trimmed_verts.push(p);
-                                corner_preserved.insert(vi, p);
+                                corner_preserved.entry(vi).or_insert(p);
                             }
                         }
                     }
@@ -990,7 +990,7 @@ pub fn fillet_rolling_ball(
                             if let Ok(dir) = (prev_pos - pos).normalize() {
                                 let p = pos + dir * radius;
                                 trimmed_verts.push(p);
-                                corner_preserved.insert(vi, p);
+                                corner_preserved.entry(vi).or_insert(p);
                             }
                         }
                         if let Some(&pt) = fillet_contact_map.get(&(vi, ei, fi)) {
@@ -1123,7 +1123,7 @@ pub fn fillet_rolling_ball(
                         if let Ok(dir) = (next_pos - pos).normalize() {
                             let p = pos + dir * radius;
                             new_verts.push(p);
-                            corner_preserved.insert(vi, p);
+                            corner_preserved.entry(vi).or_insert(p);
                         }
                     }
                 }
@@ -1136,7 +1136,7 @@ pub fn fillet_rolling_ball(
                         if let Ok(dir) = (prev_pos - pos).normalize() {
                             let p = pos + dir * radius;
                             new_verts.push(p);
-                            corner_preserved.insert(vi, p);
+                            corner_preserved.entry(vi).or_insert(p);
                         }
                     }
                     if let Some(&pt) = fillet_contact_map.get(&(vi, ei, fi)) {
@@ -1528,6 +1528,7 @@ pub fn fillet_rolling_ball(
         // corners does not apply here because one of its arcs would face the
         // (still sharp) unfilleted edge with nothing to share it.
         if fillet_count == 2 {
+            let mut built = false;
             if let (Some(&p_pt), Some(v_pos)) = (corner_preserved.get(&vi), original_vertex) {
                 if blend_points.len() == 3 {
                     // Sphere centre: corner offset inward by R along each distinct
@@ -1583,8 +1584,21 @@ pub fn fillet_rolling_ball(
                         is_concave,
                     ) {
                         all_specs.push(spec);
+                        built = true;
                     }
                 }
+            }
+            if !built {
+                // The setback gap could not be closed (no preserved point on the
+                // unfilleted edge, contacts that didn't deduplicate to a triangle,
+                // or a degenerate patch). Surface it — the junction may be left
+                // non-watertight rather than failing silently.
+                log::warn!(
+                    "2-edge fillet corner at vertex {vi}: corner patch not built \
+                     (preserved={}, unique_contacts={}); junction may be non-watertight",
+                    corner_preserved.contains_key(&vi),
+                    blend_points.len()
+                );
             }
             continue;
         }

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -825,6 +825,16 @@ pub fn fillet_rolling_ball(
     // Phase 3: Build modified (trimmed) planar faces.
     let mut all_specs: Vec<FaceSpec> = Vec::new();
 
+    // At a corner where exactly two filleted edges meet (sharing one face), the
+    // strips are set back from the vertex and a corner patch fills the gap (see
+    // Phase 5b). The *third*, unfilleted edge at that corner must be preserved
+    // rather than collapsed onto the far corner: each side face trims it to a
+    // point P just inside the corner. Both side faces compute the same P (it is
+    // a fixed distance up the shared unfilleted edge), so the sub-edge survives
+    // as a shared boundary. Phase 5b reads P to close the patch against it.
+    // Key: corner vertex index → preserved trim point P.
+    let mut corner_preserved: HashMap<usize, Point3> = HashMap::new();
+
     for &face_id in &shell_face_ids {
         // Non-planar faces: either pass through or trim at fillet contact points.
         let Some(poly) = face_polygons.get(&face_id.index()) else {
@@ -963,10 +973,26 @@ pub fn fillet_rolling_ball(
                         } else {
                             trimmed_verts.push(pos);
                         }
+                        // Preserve the unfilleted "after" edge at a setback corner.
+                        if setback_map.contains_key(&(ei, vi)) {
+                            if let Ok(dir) = (next_pos - pos).normalize() {
+                                let p = pos + dir * radius;
+                                trimmed_verts.push(p);
+                                corner_preserved.insert(vi, p);
+                            }
+                        }
                     }
                     (false, true, _) => {
                         // The "after" edge is filleted — use its specific contact.
                         let ei = wire_edge_ids[i].index();
+                        // Preserve the unfilleted "before" edge at a setback corner.
+                        if setback_map.contains_key(&(ei, vi)) {
+                            if let Ok(dir) = (prev_pos - pos).normalize() {
+                                let p = pos + dir * radius;
+                                trimmed_verts.push(p);
+                                corner_preserved.insert(vi, p);
+                            }
+                        }
                         if let Some(&pt) = fillet_contact_map.get(&(vi, ei, fi)) {
                             trimmed_verts.push(pt);
                         } else if let Ok(dir) = (prev_pos - pos).normalize() {
@@ -1091,9 +1117,28 @@ pub fn fillet_rolling_ball(
                         let dir = (next_pos - pos).normalize()?;
                         new_verts.push(pos + dir * radius);
                     }
+                    // The "after" edge is the unfilleted edge at this corner.
+                    // If the filleted edge was set back here, preserve it.
+                    if setback_map.contains_key(&(ei, vi)) {
+                        if let Ok(dir) = (next_pos - pos).normalize() {
+                            let p = pos + dir * radius;
+                            new_verts.push(p);
+                            corner_preserved.insert(vi, p);
+                        }
+                    }
                 }
                 (false, true, _) => {
                     let ei = poly.wire_edge_ids[i].index();
+                    // The "before" edge is the unfilleted edge at this corner.
+                    // If the filleted edge was set back here, preserve it by
+                    // emitting a trim point on it *before* the fillet contact.
+                    if setback_map.contains_key(&(ei, vi)) {
+                        if let Ok(dir) = (prev_pos - pos).normalize() {
+                            let p = pos + dir * radius;
+                            new_verts.push(p);
+                            corner_preserved.insert(vi, p);
+                        }
+                    }
                     if let Some(&pt) = fillet_contact_map.get(&(vi, ei, fi)) {
                         new_verts.push(pt);
                     } else {
@@ -1405,7 +1450,7 @@ pub fn fillet_rolling_ball(
     // close with a planar blend face.
     for (&vi, contacts) in &vertex_contacts {
         let fillet_count = vertex_fillet_edges.get(&vi).map_or(0, Vec::len);
-        if fillet_count < 3 {
+        if fillet_count < 2 {
             continue;
         }
 
@@ -1473,6 +1518,68 @@ pub fn fillet_rolling_ball(
         } else {
             blend_normal
         };
+
+        // Two filleted edges meeting at this corner (sharing one face). The two
+        // strips were set back and the third, unfilleted edge was preserved at
+        // P (Phase 3). The gap is a four-sided region P–near1–far–near2: its two
+        // straight P-edges meet the trimmed side faces and its two arc-edges
+        // meet the strip ends. The eighth-sphere triangle used for 3-edge
+        // corners does not apply here because one of its arcs would face the
+        // (still sharp) unfilleted edge with nothing to share it.
+        if fillet_count == 2 {
+            if let (Some(&p_pt), Some(v_pos)) = (corner_preserved.get(&vi), original_vertex) {
+                if blend_points.len() == 3 {
+                    // Sphere centre: corner offset inward by R along each
+                    // distinct contact-face normal (outward normals → subtract
+                    // for a convex corner).
+                    let mut face_normals: Vec<Vec3> = Vec::new();
+                    for &(face_idx, _) in contacts {
+                        if let Some(poly) = face_polygons.get(&face_idx) {
+                            let n = poly.normal;
+                            if !face_normals.iter().any(|e| (*e - n).length() < 1e-10) {
+                                face_normals.push(n);
+                            }
+                        }
+                    }
+                    let normal_sum = face_normals.iter().fold(Vec3::new(0.0, 0.0, 0.0), |a, n| {
+                        Vec3::new(a.x() + n.x(), a.y() + n.y(), a.z() + n.z())
+                    });
+                    let sphere_center = Point3::new(
+                        v_pos.x() - radius * normal_sum.x(),
+                        v_pos.y() - radius * normal_sum.y(),
+                        v_pos.z() - radius * normal_sum.z(),
+                    );
+
+                    // `far` (D) is the contact on the two edges' shared face —
+                    // the point farthest from P. The other two connect to P.
+                    let far_idx = (0..3)
+                        .max_by(|&a, &b| {
+                            (blend_points[a] - p_pt)
+                                .length()
+                                .partial_cmp(&(blend_points[b] - p_pt).length())
+                                .unwrap_or(std::cmp::Ordering::Equal)
+                        })
+                        .unwrap_or(0);
+                    let far = blend_points[far_idx];
+                    let near: Vec<Point3> = (0..3)
+                        .filter(|&i| i != far_idx)
+                        .map(|i| blend_points[i])
+                        .collect();
+
+                    if let Some(spec) = build_two_edge_corner_patch(
+                        p_pt,
+                        near[0],
+                        far,
+                        near[1],
+                        sphere_center,
+                        v_pos,
+                    ) {
+                        all_specs.push(spec);
+                    }
+                }
+            }
+            continue;
+        }
 
         // Order the blend points consistently (counter-clockwise when viewed from
         // the outward normal direction).
@@ -1836,4 +1943,112 @@ pub fn fillet_rolling_ball(
     let _ = crate::heal::unify_faces(topo, solid_id);
 
     Ok(solid_id)
+}
+
+/// Build the corner patch where exactly two filleted edges meet at a vertex
+/// (sharing one face).
+///
+/// The four corners are `p` (the preserved trim point on the third, unfilleted
+/// edge), the two near contacts `near1`/`near2` that join `p` along the trimmed
+/// side faces, and the far contact `far` on the two edges' shared face. The two
+/// `near→far` boundaries are circular arcs of the corner sphere (matching the
+/// setback strip ends); the two `p→near` boundaries are straight (matching the
+/// side faces). Returns a degree-(2,2) rational NURBS patch oriented to face
+/// away from the original corner `v_pos`, or `None` if the geometry is
+/// degenerate.
+fn build_two_edge_corner_patch(
+    p: Point3,
+    near1: Point3,
+    far: Point3,
+    near2: Point3,
+    sphere_center: Point3,
+    v_pos: Point3,
+) -> Option<FaceSpec> {
+    // Rational-quadratic middle control point + weight for the circular arc
+    // a→b on the sphere: the mid CP is the tangent intersection at distance
+    // r/cos(θ/2) from the centre, carrying weight cos(θ/2).
+    let arc_mid = |a: Point3, b: Point3| -> Option<(Point3, f64)> {
+        let va = (a - sphere_center).normalize().ok()?;
+        let vb = (b - sphere_center).normalize().ok()?;
+        let r = (a - sphere_center).length();
+        let sum = va + vb;
+        let len = sum.length();
+        if len < 1e-9 {
+            return None;
+        }
+        let cos_half = len / 2.0;
+        let cp = Point3::new(
+            sphere_center.x() + sum.x() / len * r / cos_half,
+            sphere_center.y() + sum.y() / len * r / cos_half,
+            sphere_center.z() + sum.z() / len * r / cos_half,
+        );
+        Some((cp, cos_half))
+    };
+
+    let (m1f, w1f) = arc_mid(near1, far)?;
+    let (m2f, w2f) = arc_mid(near2, far)?;
+    let mid = |a: Point3, b: Point3| {
+        Point3::new(
+            (a.x() + b.x()) * 0.5,
+            (a.y() + b.y()) * 0.5,
+            (a.z() + b.z()) * 0.5,
+        )
+    };
+    let m_p1 = mid(p, near1);
+    let m_p2 = mid(p, near2);
+
+    // Interior control point: lift the corner centroid onto the sphere so the
+    // patch bulges outward — a sag here would gouge into the corner.
+    let centroid4 = Point3::new(
+        (p.x() + near1.x() + near2.x() + far.x()) * 0.25,
+        (p.y() + near1.y() + near2.y() + far.y()) * 0.25,
+        (p.z() + near1.z() + near2.z() + far.z()) * 0.25,
+    );
+    let r = (far - sphere_center).length();
+    let interior = match (centroid4 - sphere_center).normalize() {
+        Ok(d) => Point3::new(
+            sphere_center.x() + d.x() * r,
+            sphere_center.y() + d.y() * r,
+            sphere_center.z() + d.z() * r,
+        ),
+        Err(_) => centroid4,
+    };
+    let w_int = (w1f * w2f).sqrt();
+
+    // (u,v) control grid — boundary corners traverse p → near1 → far → near2:
+    //   u=0: p     m_p1      near1     (straight p→near1)
+    //   u=1: m_p2  interior  m1f
+    //   u=2: near2 m2f       far       (arc near2→far)
+    // v=0 column is straight p→near2; v=2 column is the arc near1→far.
+    let surface = NurbsSurface::new(
+        2,
+        2,
+        vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        vec![
+            vec![p, m_p1, near1],
+            vec![m_p2, interior, m1f],
+            vec![near2, m2f, far],
+        ],
+        vec![
+            vec![1.0, 1.0, 1.0],
+            vec![1.0, w_int, w1f],
+            vec![1.0, w2f, 1.0],
+        ],
+    )
+    .ok()?;
+
+    // Orient the patch to face away from the original (now removed) corner.
+    let outward = (centroid4 - v_pos)
+        .normalize()
+        .unwrap_or_else(|_| Vec3::new(0.0, 0.0, 1.0));
+    let nrm = surface.normal(0.5, 0.5).unwrap_or(outward);
+    let reversed = nrm.dot(outward) < 0.0;
+
+    Some(FaceSpec::Surface {
+        vertices: vec![p, near1, far, near2],
+        surface: FaceSurface::Nurbs(surface),
+        reversed,
+        inner_wires: vec![],
+    })
 }

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -1441,13 +1441,14 @@ pub fn fillet_rolling_ball(
             .push((f2.index(), contact2_end));
     }
 
-    // Phase 5b: Build vertex blend patches at junctions where 3+ fillet edges meet.
+    // Phase 5b: Build vertex blend patches at junctions where 2+ fillet edges meet.
     // At such a vertex, each fillet strip contributes contact points on two faces.
     // Two fillet strips that share a face will have contact points on that face that
     // are at the same position (both offset R from the vertex along the face).
     // We deduplicate by face, giving exactly N unique contact points for N fillet edges.
-    // These points form a polygon (typically a triangle for 3-edge corners) that we
-    // close with a planar blend face.
+    // For 3+ edges these points form a polygon closed by an eighth-sphere triangle;
+    // for exactly 2 edges they form a four-sided patch that also picks up the
+    // preserved point on the unfilleted edge (see the fillet_count == 2 branch).
     for (&vi, contacts) in &vertex_contacts {
         let fillet_count = vertex_fillet_edges.get(&vi).map_or(0, Vec::len);
         if fillet_count < 2 {
@@ -1529,9 +1530,9 @@ pub fn fillet_rolling_ball(
         if fillet_count == 2 {
             if let (Some(&p_pt), Some(v_pos)) = (corner_preserved.get(&vi), original_vertex) {
                 if blend_points.len() == 3 {
-                    // Sphere centre: corner offset inward by R along each
-                    // distinct contact-face normal (outward normals → subtract
-                    // for a convex corner).
+                    // Sphere centre: corner offset inward by R along each distinct
+                    // contact-face normal. Convex corners subtract Σnormals;
+                    // concave corners add (same rule as the 3-edge path below).
                     let mut face_normals: Vec<Vec3> = Vec::new();
                     for &(face_idx, _) in contacts {
                         if let Some(poly) = face_polygons.get(&face_idx) {
@@ -1544,10 +1545,16 @@ pub fn fillet_rolling_ball(
                     let normal_sum = face_normals.iter().fold(Vec3::new(0.0, 0.0, 0.0), |a, n| {
                         Vec3::new(a.x() + n.x(), a.y() + n.y(), a.z() + n.z())
                     });
+                    let fillet_edges = vertex_fillet_edges
+                        .get(&vi)
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[]);
+                    let is_concave = corner_is_concave(topo, vi, fillet_edges, normal_sum);
+                    let offset_sign = if is_concave { 1.0 } else { -1.0 };
                     let sphere_center = Point3::new(
-                        v_pos.x() - radius * normal_sum.x(),
-                        v_pos.y() - radius * normal_sum.y(),
-                        v_pos.z() - radius * normal_sum.z(),
+                        v_pos.x() + offset_sign * radius * normal_sum.x(),
+                        v_pos.y() + offset_sign * radius * normal_sum.y(),
+                        v_pos.z() + offset_sign * radius * normal_sum.z(),
                     );
 
                     // `far` (D) is the contact on the two edges' shared face —
@@ -1573,6 +1580,7 @@ pub fn fillet_rolling_ball(
                         near[1],
                         sphere_center,
                         v_pos,
+                        is_concave,
                     ) {
                         all_specs.push(spec);
                     }
@@ -1945,6 +1953,44 @@ pub fn fillet_rolling_ball(
     Ok(solid_id)
 }
 
+/// Whether a corner vertex is concave (rolling-ball sphere centre on the
+/// +normal side rather than −normal). Detected by comparing the summed outward
+/// face normals with the summed edge tangents pointing away from the vertex:
+/// they oppose for a convex corner and align for a concave one. Mirrors the
+/// 3-edge concavity test in Phase 5b.
+fn corner_is_concave(
+    topo: &Topology,
+    vi: usize,
+    fillet_edges: &[EdgeId],
+    normal_sum: Vec3,
+) -> bool {
+    let mut tangent_sum = Vec3::new(0.0, 0.0, 0.0);
+    let mut count = 0;
+    for &eid in fillet_edges {
+        let Ok(edge) = topo.edge(eid) else { continue };
+        let (Ok(vs), Ok(ve)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+            continue;
+        };
+        let (p_s, p_e) = (vs.point(), ve.point());
+        let curve = edge.curve().clone();
+        let (t_param, sign) = if edge.start().index() == vi {
+            (curve.domain_with_endpoints(p_s, p_e).0, 1.0)
+        } else {
+            (curve.domain_with_endpoints(p_s, p_e).1, -1.0)
+        };
+        let tan = curve.tangent_with_endpoints(t_param, p_s, p_e);
+        if let Ok(n) = (tan * sign).normalize() {
+            tangent_sum = Vec3::new(
+                tangent_sum.x() + n.x(),
+                tangent_sum.y() + n.y(),
+                tangent_sum.z() + n.z(),
+            );
+            count += 1;
+        }
+    }
+    count >= 2 && normal_sum.dot(tangent_sum) > 0.0
+}
+
 /// Build the corner patch where exactly two filleted edges meet at a vertex
 /// (sharing one face).
 ///
@@ -1963,6 +2009,7 @@ fn build_two_edge_corner_patch(
     near2: Point3,
     sphere_center: Point3,
     v_pos: Point3,
+    is_concave: bool,
 ) -> Option<FaceSpec> {
     // Rational-quadratic middle control point + weight for the circular arc
     // a→b on the sphere: the mid CP is the tangent intersection at distance
@@ -2038,8 +2085,15 @@ fn build_two_edge_corner_patch(
     )
     .ok()?;
 
-    // Orient the patch to face away from the original (now removed) corner.
-    let outward = (centroid4 - v_pos)
+    // Orient the patch outward. For a convex corner the exterior lies away from
+    // the original (now removed) sharp corner; for a concave corner the material
+    // is added, so the reference flips.
+    let outward_ref = if is_concave {
+        v_pos - centroid4
+    } else {
+        centroid4 - v_pos
+    };
+    let outward = outward_ref
         .normalize()
         .unwrap_or_else(|_| Vec3::new(0.0, 0.0, 1.0));
     let nrm = surface.normal(0.5, 0.5).unwrap_or(outward);

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -325,19 +325,119 @@ fn rolling_ball_fillet_multiple_edges() {
     let cube = make_unit_cube_manifold(&mut topo);
 
     let edges = solid_edge_ids(&topo, cube);
-    // Fillet 2 edges
+    // edges[0] and edges[1] share a corner vertex.
     let result = fillet_rolling_ball(&mut topo, cube, &[edges[0], edges[1]], 0.1)
         .expect("multi-edge rolling-ball fillet should succeed");
 
     let s = topo.solid(result).expect("result solid");
     let sh = topo.shell(s.outer_shell()).expect("shell");
 
-    // 6 original + 2 NURBS fillets = 8 faces
+    // 6 trimmed planar + 2 NURBS fillet strips + 1 corner patch (the two
+    // edges share a corner) = 9 faces.
     assert_eq!(
         sh.faces().len(),
-        8,
-        "expected 8 faces after two-edge rolling-ball fillet"
+        9,
+        "expected 9 faces after two-edge shared-corner rolling-ball fillet"
     );
+    validate_shell_manifold(sh, &topo).expect("two-edge fillet should be manifold");
+}
+
+/// Regression for #841: filleting two edges that share a corner vertex in a
+/// single rolling-ball pass must produce a watertight (closed, euler-2) solid.
+/// Previously the corner gap was left open (4 free edges, euler=1) because the
+/// strips were set back but no corner patch closed the junction and the side
+/// faces collapsed the unfilleted edge onto the far corner.
+#[test]
+fn rolling_ball_two_edges_shared_corner_watertight() {
+    // Every adjacent (corner-sharing) pair of bottom-ring edges on a box.
+    let mut topo = Topology::new();
+    let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let all_edges = solid_edge_ids(&topo, cube);
+
+    // Find pairs of edges that share a vertex (a corner).
+    let mut shared_pairs: Vec<(usize, usize)> = Vec::new();
+    for i in 0..all_edges.len() {
+        for j in (i + 1)..all_edges.len() {
+            let ei = topo.edge(all_edges[i]).unwrap();
+            let ej = topo.edge(all_edges[j]).unwrap();
+            let shares = ei.start() == ej.start()
+                || ei.start() == ej.end()
+                || ei.end() == ej.start()
+                || ei.end() == ej.end();
+            if shares {
+                shared_pairs.push((i, j));
+            }
+        }
+    }
+    assert!(
+        !shared_pairs.is_empty(),
+        "box should have corner-sharing edge pairs"
+    );
+
+    // Verify a representative sample of corner-sharing pairs (keeps the test
+    // fast while covering distinct corner orientations).
+    for &(i, j) in shared_pairs.iter().take(6) {
+        let mut t = Topology::new();
+        let box_id = crate::primitives::make_box(&mut t, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edge_ids(&t, box_id);
+        let result = fillet_rolling_ball(&mut t, box_id, &[edges[i], edges[j]], 1.0)
+            .expect("fillet of shared-corner edges should succeed");
+
+        let s = t.solid(result).expect("result solid");
+        let sh = t.shell(s.outer_shell()).expect("shell");
+        assert!(
+            brepkit_topology::validation::validate_shell_closed(sh, &t).is_ok(),
+            "shared-corner pair {i},{j} should be watertight"
+        );
+        assert!(
+            validate_shell_manifold(sh, &t).is_ok(),
+            "shared-corner pair {i},{j} should be manifold"
+        );
+        assert_euler_genus0(&t, result);
+
+        let vol = crate::measure::solid_volume(&t, result, 0.01).unwrap();
+        assert!(
+            (985.0..1000.0).contains(&vol),
+            "shared-corner pair {i},{j}: volume {vol} outside sane range"
+        );
+    }
+}
+
+/// A box edge pair that does NOT share a corner must remain watertight too
+/// (the corner patch must not fire spuriously).
+#[test]
+fn rolling_ball_two_edges_no_shared_corner_watertight() {
+    let mut topo = Topology::new();
+    let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let edges = solid_edge_ids(&topo, cube);
+
+    // Find a pair with no shared vertex.
+    let mut pair = None;
+    'outer: for i in 0..edges.len() {
+        for j in (i + 1)..edges.len() {
+            let ei = topo.edge(edges[i]).unwrap();
+            let ej = topo.edge(edges[j]).unwrap();
+            let shares = ei.start() == ej.start()
+                || ei.start() == ej.end()
+                || ei.end() == ej.start()
+                || ei.end() == ej.end();
+            if !shares {
+                pair = Some((i, j));
+                break 'outer;
+            }
+        }
+    }
+    let (i, j) = pair.expect("box should have a non-corner-sharing edge pair");
+
+    let result = fillet_rolling_ball(&mut topo, cube, &[edges[i], edges[j]], 1.0)
+        .expect("non-shared-corner fillet should succeed");
+    let s = topo.solid(result).expect("result solid");
+    let sh = topo.shell(s.outer_shell()).expect("shell");
+    // 6 trimmed planar + 2 fillet strips = 8 faces, no corner patch.
+    assert_eq!(sh.faces().len(), 8, "non-shared pair should add no patch");
+    brepkit_topology::validation::validate_shell_closed(sh, &topo)
+        .expect("non-shared-corner fillet should be watertight");
+    assert_euler_genus0(&topo, result);
 }
 
 #[test]

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -349,7 +349,7 @@ fn rolling_ball_fillet_multiple_edges() {
 /// faces collapsed the unfilleted edge onto the far corner.
 #[test]
 fn rolling_ball_two_edges_shared_corner_watertight() {
-    // Every adjacent (corner-sharing) pair of bottom-ring edges on a box.
+    // Collect every pair of box edges that share a vertex, then fillet a sample.
     let mut topo = Topology::new();
     let cube = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
     let all_edges = solid_edge_ids(&topo, cube);
@@ -374,8 +374,8 @@ fn rolling_ball_two_edges_shared_corner_watertight() {
         "box should have corner-sharing edge pairs"
     );
 
-    // Verify a representative sample of corner-sharing pairs (keeps the test
-    // fast while covering distinct corner orientations).
+    // Verify the first several corner-sharing pairs (iteration order); capped to
+    // keep the test fast while still exercising multiple corners.
     for &(i, j) in shared_pairs.iter().take(6) {
         let mut t = Topology::new();
         let box_id = crate::primitives::make_box(&mut t, 10.0, 10.0, 10.0).unwrap();


### PR DESCRIPTION
## Summary

Closes #841. Filleting two edges that **share a corner vertex** in a single rolling-ball pass produced a **non-watertight** solid (4 free edges, `euler = 1`). This unblocks the literal 2-edge "fillet a fillet" repro from #834.

## Root cause

At a shared-corner junction the engine sets both strips back from the vertex (`setback_map`), expecting a corner patch to fill the gap. But two things were missing for the **2-edge** case:

1. **Phase 5b's corner patch was gated at `fillet_count >= 3`** — so for exactly two edges nothing closed the gap.
2. **Phase 3's side-face trim collapsed the unfilleted third edge onto the far corner** (e.g. it connected the setback contact straight to `(0,0,10)`) instead of preserving the unfilleted edge near the corner.

The result was a 4-free-edge loop A–B–D–C (A = the far end of the still-sharp unfilleted edge).

## Fix

`crates/operations/src/fillet/rolling_ball.rs`:

- **Phase 3** — at a 2-edge setback corner, preserve the unfilleted edge by emitting a trim point `P` on it (recorded in `corner_preserved`). Both side faces compute the same `P` from the unfilleted edge's far endpoint, so the sub-edge survives as a shared boundary. Gated on `setback_map` containing the filleted edge → single-edge and G1-chain fillets are untouched (no setback there).
- **Phase 5b** — gate lowered to `>= 2`; a new branch builds a four-sided corner patch `P–B–D–C` (`build_two_edge_corner_patch`): the two `near→far` boundaries are sphere arcs matching the strip ends, the two `P→near` boundaries are straight, matching the trimmed side faces. The 3-edge spherical-triangle path is unchanged (the patch's third arc would face the still-sharp unfilleted edge with nothing to share it, so the eighth-sphere isn't applicable here).

The change only fires for `fillet_count == 2` corners with a setback; the 3-edge, single-edge, and G1-chain paths are provably unaffected.

## Verification

- The repro is now **watertight**: 9 faces, 0 free edges, `validate_shell_closed` passes, `euler = 2`, volume ≈ 994.4 (matches the issue's ~994 and the non-shared-corner case).
- New regression tests: `rolling_ball_two_edges_shared_corner_watertight` (6 corner-sharing pairs: closed + manifold + genus-0 + sane volume) and `rolling_ball_two_edges_no_shared_corner_watertight` (no spurious patch).
- Full `brepkit-operations` suite: all pass (690 lib + integration, 0 failed).
- `brepkit-wasm` native suite: 224 passed, 0 failed.
- `cargo clippy --all-targets --all-features` clean; `check-boundaries.sh` clean.

## Risk

HIGH — core fillet engine (`rolling_ball.rs`). Tightly gated and regression-clean, but flagging for human review before merge.