### PR TITLE
chore(cleanup): remove redundant narration comments

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -202,7 +202,6 @@ fn perform_loops(topo: &Topology, faces: &[FaceId]) -> Result<Vec<Vec<FaceId>>, 
         shell.push(start_face);
         queue.push_back(start_face);
 
-        // Count edges of start face
         if let Some(keys) = face_edges.get(&start_face) {
             for key in keys {
                 *shell_edge_count.entry(*key).or_default() += 1;
@@ -224,7 +223,6 @@ fn perform_loops(topo: &Topology, faces: &[FaceId]) -> Result<Vec<Vec<FaceId>>, 
                     continue;
                 };
 
-                // Filter to unvisited faces
                 let unvisited: Vec<FaceId> = candidates
                     .iter()
                     .filter(|&&f| f != current && !visited.contains(&f))
@@ -235,7 +233,6 @@ fn perform_loops(topo: &Topology, faces: &[FaceId]) -> Result<Vec<Vec<FaceId>>, 
                     continue;
                 }
 
-                // Select best face
                 let selected = if unvisited.len() == 1 {
                     unvisited[0]
                 } else if let Some((start, end)) = edge_positions.get(key) {
@@ -249,7 +246,6 @@ fn perform_loops(topo: &Topology, faces: &[FaceId]) -> Result<Vec<Vec<FaceId>>, 
                 shell.push(selected);
                 queue.push_back(selected);
 
-                // Update edge counts
                 if let Some(sel_keys) = face_edges.get(&selected) {
                     for k in sel_keys {
                         *shell_edge_count.entry(*k).or_default() += 1;
@@ -289,7 +285,7 @@ pub fn get_face_off(
     if edge_len < 1e-12 {
         return candidates.first().copied();
     }
-    let t = edge_dir * (1.0 / edge_len); // unit tangent
+    let t = edge_dir * (1.0 / edge_len);
 
     let mid = Point3::new(
         (edge_start.x() + edge_end.x()) * 0.5,
@@ -336,7 +332,6 @@ pub fn get_face_off(
             angle = std::f64::consts::TAU; // deprioritize identical geometry
         }
 
-        // Normalize to positive
         if angle < 0.0 {
             angle += std::f64::consts::TAU;
         }
@@ -361,7 +356,6 @@ fn angle_with_ref(d1: Vec3, d2: Vec3, d_ref: Vec3) -> f64 {
 
     let mut angle = sin_val.atan2(cos_val);
 
-    // Determine sign from reference direction
     if cross.dot(d_ref) < 0.0 {
         angle = -angle;
     }
@@ -452,7 +446,6 @@ fn signed_volume_of_shell(topo: &Topology, faces: &[FaceId]) -> f64 {
             continue;
         };
 
-        // Collect wire vertices
         let mut verts = Vec::new();
         for oe in wire.edges() {
             let Ok(edge) = topo.edge(oe.edge()) else {
@@ -1145,7 +1138,6 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
         }
     }
 
-    // Step 2: Group edges by quantized position pair.
     // Find groups where multiple DIFFERENT EdgeIds share the same qpair.
     let mut groups: HashMap<QPosEdge, Vec<EdgeId>> = HashMap::new();
     for entry in &entries {
@@ -1192,9 +1184,6 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
 
     let merge_count = replacements.len();
 
-    // Step 3: Rebuild faces that have replaced edges.
-    // Snapshot face data, then create new faces.
-    //
     // Sort the face indices before iterating so that `topo.add_wire` and
     // `topo.add_face` are called in a deterministic order. Iterating the
     // HashSet directly picks up a random per-process iteration order,
@@ -1213,7 +1202,6 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
     for &fi in &faces_to_rebuild_sorted {
         let fid = face_ids[fi];
 
-        // Snapshot
         let (surface, is_reversed, outer_oes, inner_oes_list) = {
             let face = topo.face(fid)?;
             let surface = face.surface().clone();
@@ -1241,7 +1229,6 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
             (surface, is_reversed, outer_oes, inner_oes_list)
         };
 
-        // Rebuild outer wire with replaced edges + orientation correction
         let new_outer_oes: Vec<_> = outer_oes
             .iter()
             .map(|(eid, fwd)| {
@@ -1258,7 +1245,6 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
         };
         let new_outer_id = topo.add_wire(new_outer);
 
-        // Rebuild inner wires
         let mut new_inner_ids = Vec::new();
         for inner_oes in &inner_oes_list {
             let new_oes: Vec<_> = inner_oes

--- a/crates/algo/src/builder/classify_2d.rs
+++ b/crates/algo/src/builder/classify_2d.rs
@@ -24,13 +24,12 @@ pub fn sample_interior_point(loop_pts: &[Point2]) -> Point2 {
         return Point2::new(cx, cy);
     }
 
-    // 1. Compute centroid.
     let n = loop_pts.len() as f64;
     let cx = loop_pts.iter().map(|p| p.x()).sum::<f64>() / n;
     let cy = loop_pts.iter().map(|p| p.y()).sum::<f64>() / n;
     let centroid = Point2::new(cx, cy);
 
-    // 2. If centroid is inside, use it. A centroid that lands on the
+    // If centroid is inside, use it. A centroid that lands on the
     // boundary itself (e.g. the reflex corner of an L-shaped loop) passes
     // the even-odd test unpredictably and is not a safe interior sample.
     if point_in_polygon_2d(centroid, loop_pts)
@@ -39,7 +38,6 @@ pub fn sample_interior_point(loop_pts: &[Point2]) -> Point2 {
         return centroid;
     }
 
-    // 3. Fallback: try midpoint of each edge, nudged inward.
     let area = signed_area_2d(loop_pts);
     for i in 0..loop_pts.len() {
         let j = (i + 1) % loop_pts.len();

--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -40,7 +40,6 @@ pub(super) fn split_boundary_edges_at_3d_points(
             continue;
         }
 
-        // Split edge into segments.
         let mut prev_uv = edge.start_uv;
         let mut prev_3d = edge.start_3d;
         for &(t, _) in &splits {
@@ -66,7 +65,6 @@ pub(super) fn split_boundary_edges_at_3d_points(
             prev_uv = split_uv;
             prev_3d = split_3d;
         }
-        // Final segment.
         let pcurve =
             compute_pcurve_on_surface(&edge.curve_3d, prev_3d, edge.end_3d, surface, &[], frame);
         result.push(OrientedPCurveEdge {

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -284,7 +284,6 @@ pub fn split_face_2d(
     // end at u=2pi connects to seam start at u=0). Keep it enabled.
     let (u_periodic, v_periodic) = info.map_or((false, false), SurfaceInfo::periodicity);
 
-    // Convert boundary edges to OrientedPCurveEdge.
     let mut boundary_edges = if is_plane {
         boundary_edges_to_pcurve(topo, face.outer_wire(), &surface, &wire_pts, Some(frame))
     } else {
@@ -500,7 +499,6 @@ pub fn split_face_2d(
         );
     }
 
-    // Stage 2: Split boundary edges at section edge endpoints (3D matching).
     let mut split_pts_3d: Vec<Point3> = sections.iter().flat_map(|s| [s.start, s.end]).collect();
 
     // For periodic faces, align closed boundary edge UV with seam edge UV.
@@ -888,7 +886,6 @@ pub fn split_face_2d(
         outers.push((holes.remove(0), area));
     }
 
-    // Match holes to containing outer wires.
     let mut sub_faces = Vec::new();
     for (outer_wire, _area) in outers {
         sub_faces.push(SplitSubFace {
@@ -1051,7 +1048,6 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
 
         if let Some(test_3d) = eval_3d(interior_uv) {
             for hole in &sub_face.inner_wires {
-                // Compute hole centroid in 3D.
                 if hole.is_empty() {
                     continue;
                 }
@@ -1062,7 +1058,6 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
                     let n = hole.len() as f64;
                     Point3::new(sum.x() / n, sum.y() / n, sum.z() / n)
                 };
-                // Compute hole boundary radius from centroid.
                 let max_r = hole
                     .iter()
                     .map(|e| (e.start_3d - hc).length())

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -582,9 +582,6 @@ pub(super) fn split_face_with_internal_loops(
             // Preserve the section's pave_block_id so cross-face edge
             // sharing (box face inner wire ↔ cylinder face outer wire)
             // works through `resolve_edge_vertices`'s PaveBlock path.
-            // Previously dropped to None, which forced position-fallback
-            // lookup that created duplicate vertices on the cylinder
-            // side of cylinder-cut booleans.
             pave_block_id: section.pave_block_id,
         });
     }
@@ -601,7 +598,6 @@ pub(super) fn split_face_with_internal_loops(
         let mut chain = vec![forward_edges[start_idx].clone()];
         let loop_start_3d = chain[0].start_3d;
 
-        // Follow the chain until we close the loop.
         loop {
             let last_end = chain.last().map_or(loop_start_3d, |e| e.end_3d);
 
@@ -656,7 +652,6 @@ pub(super) fn split_face_with_internal_loops(
         loops.iter().map(Vec::len).collect::<Vec<_>>()
     );
 
-    // Build sub-faces.
     let mut result = Vec::new();
 
     // For each closed loop: create an "inside" sub-face.

--- a/crates/algo/src/builder/fill_images.rs
+++ b/crates/algo/src/builder/fill_images.rs
@@ -24,7 +24,6 @@ pub fn fill_edge_images(arena: &GfaArena) -> HashMap<EdgeId, Vec<EdgeId>> {
     for (&original_edge, pb_ids) in &arena.edge_pave_blocks {
         let leaves = arena.collect_leaf_pave_blocks(pb_ids);
 
-        // Collect (start_parameter, split_edge) for sorting
         let mut split_with_param: Vec<(f64, EdgeId)> = Vec::new();
 
         for leaf_id in leaves {

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -224,9 +224,6 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
         pool
     };
 
-    // (pb_vertex_registry and CB pre-pass moved above rank pool)
-
-    // Pre-compute which faces have section edges from which curves
     let section_map = build_section_map(topo, arena);
 
     // ── Periodic seam anchor pre-pass ───────────────────────────────
@@ -294,7 +291,6 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
             continue;
         }
 
-        // Build SectionEdge entries from pave block data
         let sections = build_section_edges(
             topo,
             arena,
@@ -326,7 +322,6 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
         // Build SurfaceInfo for periodicity
         let info = build_surface_info(topo, face_id);
 
-        // Call the face splitter
         let split_results = split_face_2d(
             topo,
             face_id,
@@ -848,14 +843,12 @@ fn rebuild_face_with_cb_edges(
                 };
                 let qs = qpt(sv.point());
                 let qe = qpt(ev.point());
-                // Check CB edge replacement
                 let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
                 if let Some(&cb_edge) = cb_qpair_edges.get(&key) {
                     if cb_edge != oe.edge() {
                         return true;
                     }
                 }
-                // Check VV vertex canonicalization
                 if vv_vertex_seed
                     .get(&qs)
                     .is_some_and(|&vid| vid != edge.start())

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -162,14 +162,12 @@ impl Builder {
 
     /// Phase 1: map edges to split images and build sub-faces.
     fn fill_images(&mut self) {
-        // Step 1: edge images
         let edge_images = fill_images::fill_edge_images(&self.arena);
         log::debug!(
             "Builder: {} original edges mapped to split images",
             edge_images.len()
         );
 
-        // Step 2: face images (sub-faces)
         self.sub_faces = fill_images_faces::fill_images_faces(
             &mut self.topo,
             &self.arena,
@@ -244,14 +242,11 @@ impl Builder {
                 continue;
             }
 
-            // Determine the opposing solid
             let opposing_solid = match sf.rank {
                 Rank::A => self.solid_b,
                 Rank::B => self.solid_a,
             };
 
-            // Use pre-computed interior point if available (from face splitter),
-            // otherwise sample from face geometry.
             let sample = if let Some(pt) = sf.interior_point {
                 Ok(pt)
             } else {
@@ -368,8 +363,6 @@ fn sample_face_interior(
         }
     }
 
-    // Compute face bounding box diagonal for size-relative offset.
-    // Sample all edge endpoints to estimate face extent.
     let mut min_pt = Point3::new(f64::MAX, f64::MAX, f64::MAX);
     let mut max_pt = Point3::new(f64::MIN, f64::MIN, f64::MIN);
     let mut point_count = 0_usize;
@@ -397,7 +390,6 @@ fn sample_face_interior(
         )));
     }
     let diag = (max_pt - min_pt).length();
-    // Use 1e-4 of the diagonal, but at least the linear tolerance
     let offset_scale = (diag * 1e-4).max(tol.linear);
 
     // Take the longest boundary edge and evaluate at its midpoint. The
@@ -425,13 +417,11 @@ fn sample_face_interior(
         .curve()
         .evaluate_with_endpoints(t_mid, start_pos, end_pos);
 
-    // Get the edge tangent and face normal at the midpoint
     let tangent = edge
         .curve()
         .tangent_with_endpoints(t_mid, start_pos, end_pos);
     let surface = face.surface();
 
-    // Use the surface normal at the midpoint (project first to get UV)
     let face_normal = if let Some((u, v)) = surface.project_point(mid_pt) {
         surface.normal(u, v)
     } else {

--- a/crates/algo/src/builder/pcurve_compute.rs
+++ b/crates/algo/src/builder/pcurve_compute.rs
@@ -57,7 +57,6 @@ pub fn compute_pcurve_on_surface(
         // Curved edge on plane: sample and project via PlaneFrame below.
     }
 
-    // Sample along the 3D curve and project to UV.
     // For plane surfaces with curved edges, use PlaneFrame for projection.
     let uv_pts = if let FaceSurface::Plane { normal, .. } = surface {
         let owned;
@@ -188,7 +187,6 @@ pub(super) fn sample_edge_to_uv(
         pts_3d.push(p);
     }
 
-    // Project each to UV.
     let mut uv_pts: Vec<Point2> = pts_3d
         .iter()
         .map(|&p| {
@@ -374,14 +372,12 @@ fn fit_nurbs2d_through_points(pts: &[Point2]) -> Curve2D {
         Curve2D::Line(make_line2d_safe(p0, dir))
     };
 
-    // Lift to 3D for interpolation.
     let pts_3d: Vec<Point3> = pts.iter().map(|p| Point3::new(p.x(), p.y(), 0.0)).collect();
     let degree = 3.min(pts_3d.len() - 1);
     let Ok(nurbs_3d) = brepkit_math::nurbs::fitting::interpolate(&pts_3d, degree) else {
         return fallback();
     };
 
-    // Extract 2D control points from the 3D curve.
     let cp_2d: Vec<Point2> = nurbs_3d
         .control_points()
         .iter()

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -98,7 +98,6 @@ pub fn detect_same_domain<S: BuildHasher>(
         return SameDomainResult::default();
     }
 
-    // Step 1: Compute canonical edge sets for each sub-face.
     // Use quantized vertex positions (not VertexId) so that VV-merged
     // vertices from different solids that share the same position produce
     // matching edge sets.
@@ -109,7 +108,6 @@ pub fn detect_same_domain<S: BuildHasher>(
         .map(|sf| compute_edge_set_quantized(topo, arena, sf.face_id, scale))
         .collect();
 
-    // Step 2: Group sub-faces by edge-set hash.
     // Key = edge set, Value = list of sub-face indices with that set.
     let mut groups: HashMap<EdgeSet, Vec<usize>> = HashMap::new();
     for (idx, edge_set) in edge_sets.iter().enumerate() {
@@ -120,8 +118,6 @@ pub fn detect_same_domain<S: BuildHasher>(
         }
     }
 
-    // Step 3: For each group with 2+ faces from opposing solids,
-    // verify surface equivalence and build SD pairs.
     let surfaces: Vec<Option<&FaceSurface>> = sub_faces
         .iter()
         .map(|sf| {
@@ -170,7 +166,6 @@ pub fn detect_same_domain<S: BuildHasher>(
                     continue;
                 };
 
-                // Verify surface equivalence.
                 if let Some(same_dir) = surfaces_same_domain(surf_i, surf_j, tol) {
                     uf.union(i, j);
                     let key = (i.min(j), i.max(j));
@@ -221,7 +216,6 @@ pub fn detect_same_domain<S: BuildHasher>(
         }
     }
 
-    // Step 4: Build SD pairs from union-find groups.
     // Collect all roots that participate in pairs (O(m) not O(n*m)).
     let mut active_roots: HashSet<usize> = HashSet::new();
     for &(a, b) in pair_data.keys() {

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -110,7 +110,6 @@ pub fn build_wire_loops_with_winding(
     let mut loops = Vec::new();
 
     loop {
-        // Find first unused edge to start a new loop.
         let Some(start_idx) = used.iter().position(|u| !u) else {
             break;
         };

--- a/crates/algo/src/classifier/mod.rs
+++ b/crates/algo/src/classifier/mod.rs
@@ -33,11 +33,9 @@ pub fn classify_point(
     solid: SolidId,
     point: Point3,
 ) -> Result<FaceClass, AlgoError> {
-    // Try analytic first (O(1) for convex analytic solids)
     if let Some(class) = classify_analytic(topo, solid, point) {
         return Ok(class);
     }
 
-    // Fall back to ray casting
     classify_ray_cast(topo, solid, point)
 }

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -101,7 +101,6 @@ fn wire_polygon(
 ) -> Result<Vec<Point3>, AlgoError> {
     let wire = topo.wire(wire_id)?;
 
-    // Sample each edge into a polyline in its oriented direction.
     let mut polylines: Vec<Vec<Point3>> = Vec::with_capacity(wire.edges().len());
     for oe in wire.edges() {
         let edge = topo.edge(oe.edge())?;
@@ -124,7 +123,6 @@ fn wire_polygon(
         polylines.push(pts);
     }
 
-    // Chain polylines by endpoint proximity.
     let join_tol = 1e-6;
     let mut used = vec![false; polylines.len()];
     let mut verts: Vec<Point3> = Vec::new();
@@ -241,7 +239,6 @@ fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, 
             }
         }
 
-        // Compute face normal.
         let raw_normal =
             if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = face.surface() {
                 *normal

--- a/crates/algo/src/ds/shape_store.rs
+++ b/crates/algo/src/ds/shape_store.rs
@@ -267,22 +267,18 @@ mod tests {
         let mut source = Topology::default();
         let solid = make_unit_cube_manifold_at(&mut source, 0.0, 0.0, 0.0);
 
-        // Import into store
         let store = GfaShapeStore::new(&source, solid, solid).unwrap();
 
-        // Verify store has the solid
         let s = store.topo.solid(store.solid_a).unwrap();
         let sh = store.topo.shell(s.outer_shell()).unwrap();
         assert_eq!(sh.faces().len(), 6, "box should have 6 faces");
 
-        // Export back to a new topology
         let mut target = Topology::default();
         let exported = store.export_solid(&mut target, store.solid_a).unwrap();
         let s2 = target.solid(exported).unwrap();
         let sh2 = target.shell(s2.outer_shell()).unwrap();
         assert_eq!(sh2.faces().len(), 6, "exported box should have 6 faces");
 
-        // Verify face counts match between source and exported
         let source_faces = brepkit_topology::explorer::solid_faces(&source, solid).unwrap();
         let target_faces = brepkit_topology::explorer::solid_faces(&target, exported).unwrap();
         assert_eq!(source_faces.len(), target_faces.len());

--- a/crates/algo/src/lib.rs
+++ b/crates/algo/src/lib.rs
@@ -25,7 +25,6 @@ pub mod gfa;
 mod builder;
 pub mod classifier;
 
-// Re-export types used by both algo and operations.
 pub use builder::FaceClass;
 pub use builder::pcurve_compute::compute_pcurve_on_surface;
 pub use builder::plane_frame::PlaneFrame;

--- a/crates/algo/src/pave_filler/fill_face_info.rs
+++ b/crates/algo/src/pave_filler/fill_face_info.rs
@@ -42,7 +42,6 @@ pub fn perform(topo: &Topology, arena: &mut GfaArena) -> Result<(), AlgoError> {
 /// For each face, find its boundary edges and map their leaf pave blocks
 /// into `pave_blocks_on`.
 fn fill_boundary_on(topo: &Topology, arena: &mut GfaArena) -> Result<(), AlgoError> {
-    // Collect all faces that have face_info entries or appear in FF interference
     let mut all_faces: HashSet<FaceId> = arena.face_info.keys().copied().collect();
     for interf in &arena.interference.ff {
         if let Interference::FF { f1, f2, .. } = interf {
@@ -54,7 +53,6 @@ fn fill_boundary_on(topo: &Topology, arena: &mut GfaArena) -> Result<(), AlgoErr
     for fid in all_faces {
         let face = topo.face(fid)?;
 
-        // Collect all boundary edge IDs from outer + inner wires
         let mut boundary_edges: HashSet<EdgeId> = HashSet::new();
 
         let outer_wire = topo.wire(face.outer_wire())?;
@@ -69,7 +67,6 @@ fn fill_boundary_on(topo: &Topology, arena: &mut GfaArena) -> Result<(), AlgoErr
             }
         }
 
-        // Map each boundary edge's leaf pave blocks into ON.
         // Snapshot pave block data first to avoid aliasing arena borrows.
         let mut on_entries: Vec<(PaveBlockId, VertexId, VertexId)> = Vec::new();
         for eid in boundary_edges {

--- a/crates/algo/src/pave_filler/force_interf_ee.rs
+++ b/crates/algo/src/pave_filler/force_interf_ee.rs
@@ -26,14 +26,12 @@ use crate::error::AlgoError;
 /// Returns [`AlgoError`] if topology lookups fail.
 #[allow(clippy::too_many_lines)]
 pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<(), AlgoError> {
-    // Collect all leaf PBs with their 3D endpoint data
     let all_edge_pbs: Vec<(EdgeId, Vec<PaveBlockId>)> = arena
         .edge_pave_blocks
         .iter()
         .map(|(&eid, pbs)| (eid, arena.collect_leaf_pave_blocks(pbs)))
         .collect();
 
-    // Flatten to (pb_id, original_edge, start_pos, end_pos)
     let mut leaf_data: Vec<(
         PaveBlockId,
         EdgeId,
@@ -64,12 +62,10 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
         for j in (i + 1)..n {
             let (pb_j, edge_j, start_j, end_j) = &leaf_data[j];
 
-            // Must be from different original edges
             if edge_i == edge_j {
                 continue;
             }
 
-            // Already in same CB
             if arena.pb_to_cb.contains_key(pb_i)
                 && arena.pb_to_cb.get(pb_i) == arena.pb_to_cb.get(pb_j)
             {
@@ -86,14 +82,12 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
                 continue;
             }
 
-            // Check curve compatibility
             let curve_i = topo.edge(*edge_i)?.curve();
             let curve_j = topo.edge(*edge_j)?.curve();
             if !curves_compatible(curve_i, curve_j, tol) {
                 continue;
             }
 
-            // Record overlap
             overlap_map.entry(*pb_i).or_default().push(*pb_j);
             overlap_map.entry(*pb_j).or_default().push(*pb_i);
         }

--- a/crates/algo/src/pave_filler/link_existing.rs
+++ b/crates/algo/src/pave_filler/link_existing.rs
@@ -74,7 +74,6 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
         )
     };
 
-    // Build index of boundary PBs by quantized endpoint position pair.
     let mut boundary_index: std::collections::HashMap<QPair, Vec<PaveBlockId>> =
         std::collections::HashMap::new();
 
@@ -121,7 +120,6 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
         }
     }
 
-    // For each section PB, check if a boundary PB has matching endpoints.
     let mut linked = 0_usize;
 
     // Collect section PB IDs upfront to avoid borrowing arena.curves while mutating arena.
@@ -134,7 +132,6 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
     for root_pb_id in &section_pb_ids {
         let leaves = arena.collect_leaf_pave_blocks(&[*root_pb_id]);
         for section_pb_id in leaves {
-            // Already in a CB — skip
             if arena.pb_to_cb.contains_key(&section_pb_id) {
                 continue;
             }
@@ -238,7 +235,6 @@ fn try_link(
         return false;
     }
 
-    // Already in same CB
     if arena.pb_to_cb.get(&boundary_pb_id) == arena.pb_to_cb.get(&section_pb_id)
         && arena.pb_to_cb.contains_key(&section_pb_id)
     {
@@ -258,7 +254,6 @@ fn try_link(
         return false;
     }
 
-    // Link: add section PB to boundary PB's CB, or create new CB
     if let Some(&cb_id) = arena.pb_to_cb.get(&boundary_pb_id) {
         if let Some(cb) = arena.common_blocks.get_mut(cb_id) {
             cb.pave_blocks.push(section_pb_id);

--- a/crates/algo/src/pave_filler/make_blocks.rs
+++ b/crates/algo/src/pave_filler/make_blocks.rs
@@ -45,12 +45,10 @@ pub fn perform(arena: &mut GfaArena) -> Result<(), AlgoError> {
                     (pb.original_edge, pb.start, pb.end, pb.extra_paves.clone())
                 };
 
-                // Sort and deduplicate extra paves by parameter
                 let mut sorted_paves = extra_paves;
                 sorted_paves.sort_by(|a, b| a.parameter.total_cmp(&b.parameter));
                 sorted_paves.dedup_by(|a, b| (a.parameter - b.parameter).abs() < 1e-10);
 
-                // Create child pave blocks for each segment
                 let mut prev_pave = start;
                 let mut children = Vec::new();
 
@@ -68,12 +66,10 @@ pub fn perform(arena: &mut GfaArena) -> Result<(), AlgoError> {
                     prev_pave = *pave;
                 }
 
-                // Final segment from last split point to end
                 let last_child = crate::ds::PaveBlock::new(original_edge, prev_pave, end);
                 let last_id = arena.pave_blocks.alloc(last_child);
                 children.push(last_id);
 
-                // Record children on the parent
                 if let Some(pb) = arena.pave_blocks.get_mut(pb_id) {
                     pb.children.clone_from(&children);
                 }

--- a/crates/algo/src/pave_filler/make_split_edges.rs
+++ b/crates/algo/src/pave_filler/make_split_edges.rs
@@ -34,7 +34,6 @@ pub fn perform(topo: &mut Topology, arena: &mut GfaArena) -> Result<(), AlgoErro
     // Track processed CommonBlocks to avoid creating duplicate edges
     let mut processed_cbs: HashSet<CommonBlockId> = HashSet::new();
 
-    // Collect all leaf pave block IDs that need edges
     let leaf_ids: Vec<_> = arena
         .pave_blocks
         .iter()
@@ -43,7 +42,6 @@ pub fn perform(topo: &mut Topology, arena: &mut GfaArena) -> Result<(), AlgoErro
         .collect();
 
     for pb_id in leaf_ids {
-        // Check if this PB is part of a CommonBlock
         if let Some(&cb_id) = arena.pb_to_cb.get(&pb_id) {
             if !processed_cbs.insert(cb_id) {
                 // CB already processed — reuse its split edge
@@ -87,7 +85,6 @@ pub fn perform(topo: &mut Topology, arena: &mut GfaArena) -> Result<(), AlgoErro
                 all_pbs.len()
             );
         } else {
-            // No CB — create individual split edge as before
             let edge_id = create_split_edge(topo, arena, pb_id)?;
             if let Some(pb) = arena.pave_blocks.get_mut(pb_id) {
                 pb.split_edge = Some(edge_id);

--- a/crates/algo/src/pave_filler/mod.rs
+++ b/crates/algo/src/pave_filler/mod.rs
@@ -83,28 +83,16 @@ impl<'a> PaveFiller<'a> {
     ///
     /// Returns [`AlgoError`] if any topology lookup or intersection fails.
     pub fn perform(&mut self, arena: &mut GfaArena) -> Result<(), AlgoError> {
-        // Phase 0: Initialize pave blocks for all edges
         self.init_pave_blocks(arena)?;
 
-        // Phase 1: Vertex-vertex coincidence
         phase_vv::perform(self.topo, self.solid_a, self.solid_b, self.tol, arena)?;
-
-        // Phase 2: Vertex-on-edge detection
         phase_ve::perform(self.topo, self.solid_a, self.solid_b, self.tol, arena)?;
-
-        // Phase 3: Edge-edge intersection
         phase_ee::perform(self.topo, self.solid_a, self.solid_b, self.tol, arena)?;
-
-        // Phase 4: Vertex-on-face detection
         phase_vf::perform(self.topo, self.solid_a, self.solid_b, self.tol, arena)?;
-
-        // Phase 5: Edge-face intersection
         phase_ef::perform(self.topo, self.solid_a, self.solid_b, self.tol, arena)?;
-
-        // Phase 6: Face-face intersection (creates vertices + edges for curves)
         phase_ff::perform(self.topo, self.solid_a, self.solid_b, self.tol, arena)?;
 
-        // Phase 6b: Coplanar face splitting (parallel planes skipped by Phase FF)
+        // Coplanar face splitting: parallel planes are skipped by Phase FF.
         phase_ff_coplanar::perform(self.topo, self.solid_a, self.solid_b, self.tol, arena)?;
 
         Ok(())

--- a/crates/algo/src/pave_filler/phase_ee.rs
+++ b/crates/algo/src/pave_filler/phase_ee.rs
@@ -47,7 +47,6 @@ pub fn perform(
                 continue;
             }
 
-            // Quick AABB rejection
             if !aabbs_overlap(
                 &ea_data.bbox_min,
                 &ea_data.bbox_max,
@@ -58,21 +57,17 @@ pub fn perform(
                 continue;
             }
 
-            // Find intersection points
             let crossings = find_edge_edge_crossings(topo, ea_id, ea_data, eb_id, eb_data, tol)?;
 
             for (t_a, t_b, point) in crossings {
-                // Check if the intersection point is already a known vertex
                 let existing = find_nearby_pave_vertex(topo, arena, point, tol);
 
                 let vertex_id = if let Some(vid) = existing {
                     vid
                 } else {
-                    // No existing vertex near this point — create one.
                     topo.add_vertex(Vertex::new(point, tol.linear))
                 };
 
-                // Add extra paves to both edges
                 add_pave_to_edge(arena, ea_id, Pave::new(vertex_id, t_a));
                 add_pave_to_edge(arena, eb_id, Pave::new(vertex_id, t_b));
 
@@ -119,7 +114,6 @@ fn collect_edge_data(topo: &Topology, edges: &[EdgeId]) -> Result<Vec<EdgeData>,
         let end_pos = topo.vertex(edge.end())?.point();
         let (t0, t1) = edge.curve().domain_with_endpoints(start_pos, end_pos);
 
-        // Compute AABB by sampling
         let n: usize = 16;
         let mut min = start_pos;
         let mut max = start_pos;
@@ -176,7 +170,6 @@ fn find_edge_edge_crossings(
     let edge_a = topo.edge(ea_id)?;
     let edge_b = topo.edge(eb_id)?;
 
-    // For Line-Line: algebraic intersection
     if matches!(edge_a.curve(), EdgeCurve::Line) && matches!(edge_b.curve(), EdgeCurve::Line) {
         return Ok(line_line_intersection(ea, eb, tol));
     }
@@ -195,11 +188,9 @@ fn find_edge_edge_crossings(
         }
     }
 
-    // General case: sample both edges and find close segment pairs
     let n: usize = 32;
     let mut crossings = Vec::new();
 
-    // Sample edge A
     let pts_a: Vec<SegmentEndpoint> = (0..=n)
         .map(|i| {
             let t = ea.t0 + (ea.t1 - ea.t0) * (i as f64 / n as f64);
@@ -210,7 +201,6 @@ fn find_edge_edge_crossings(
         })
         .collect();
 
-    // Sample edge B
     let pts_b: Vec<SegmentEndpoint> = (0..=n)
         .map(|i| {
             let t = eb.t0 + (eb.t1 - eb.t0) * (i as f64 / n as f64);
@@ -221,7 +211,6 @@ fn find_edge_edge_crossings(
         })
         .collect();
 
-    // Find closest approach between segment pairs
     let domain_a = (ea.t0 - tol.linear)..=(ea.t1 + tol.linear);
     let domain_b = (eb.t0 - tol.linear)..=(eb.t1 + tol.linear);
 
@@ -242,13 +231,11 @@ fn find_edge_edge_crossings(
                 continue;
             }
 
-            // Refine: find closest approach between segments
             if let Some((t_a, t_b, pt)) = closest_segment_pair(
                 [&pts_a[i], &pts_a[i + 1]],
                 [&pts_b[j], &pts_b[j + 1]],
                 tol.linear,
             ) {
-                // Ensure within domain
                 if domain_a.contains(&t_a) && domain_b.contains(&t_b) {
                     // Deduplicate: skip if too close to existing crossing
                     let is_dup = crossings

--- a/crates/algo/src/pave_filler/phase_ef.rs
+++ b/crates/algo/src/pave_filler/phase_ef.rs
@@ -44,7 +44,6 @@ pub fn perform(
     tol: Tolerance,
     arena: &mut GfaArena,
 ) -> Result<(), AlgoError> {
-    // AABB pre-filter: skip if solids are disjoint
     let bbox_a = crate::classifier::compute_solid_bbox(topo, solid_a)?;
     let bbox_b = crate::classifier::compute_solid_bbox(topo, solid_b)?;
     if !bbox_a
@@ -65,10 +64,7 @@ pub fn perform(
     let face_boundary_edges_b = collect_face_boundary_edges(topo, &faces_b)?;
     let face_boundary_edges_a = collect_face_boundary_edges(topo, &faces_a)?;
 
-    // Edges of A against faces of B
     check_edge_face_pairs(topo, &edges_a, &faces_b, &face_boundary_edges_b, tol, arena)?;
-
-    // Edges of B against faces of A
     check_edge_face_pairs(topo, &edges_b, &faces_a, &face_boundary_edges_a, tol, arena)?;
 
     Ok(())
@@ -261,7 +257,6 @@ fn check_edge_face_pairs(
         };
 
         for (face_idx, &fid) in faces.iter().enumerate() {
-            // Skip if edge is already a boundary edge of this face
             if face_boundary_edges[face_idx].contains(&eid) {
                 continue;
             }
@@ -311,17 +306,14 @@ fn check_edge_face_pairs(
                     continue;
                 }
 
-                // Check if an existing vertex is at this point
                 let existing = find_nearby_vertex(topo, arena, pt, tol);
 
                 let vertex_id = if let Some(vid) = existing {
                     vid
                 } else {
-                    // No existing vertex near this point — create one.
                     topo.add_vertex(Vertex::new(pt, tol.linear))
                 };
 
-                // Add extra pave to the edge
                 let pave = Pave::new(vertex_id, t);
                 add_pave_to_edge(arena, eid, pave);
 
@@ -332,7 +324,6 @@ fn check_edge_face_pairs(
                     parameter: Some(t),
                 });
 
-                // Add vertex to face info
                 arena.face_info_mut(fid).vertices_in.insert(vertex_id);
 
                 log::debug!("EF: edge {eid:?} crosses face {fid:?} at t={t:.6}",);
@@ -356,7 +347,6 @@ fn find_edge_plane_crossings(
     tol: Tolerance,
 ) -> Vec<(f64, Point3)> {
     if matches!(curve, EdgeCurve::Line) {
-        // Algebraic: line-plane intersection
         let dir = end_pos - start_pos;
         let denom = dir.dot(normal);
 
@@ -381,7 +371,6 @@ fn find_edge_plane_crossings(
         let t = s_clamped.mul_add(t1 - t0, t0);
         vec![(t, pt)]
     } else {
-        // General case: sample and find sign changes
         find_crossings_by_sampling(
             curve,
             start_pos,
@@ -404,7 +393,6 @@ fn find_edge_surface_crossings(
     surface: &FaceSurface,
     tol: Tolerance,
 ) -> Vec<(f64, Point3)> {
-    // Sample and find places where distance to surface is minimal
     let n = N_SAMPLES;
     let mut crossings = Vec::new();
     let mut prev_dist = f64::MAX;
@@ -415,20 +403,15 @@ fn find_edge_surface_crossings(
         let pt = curve.evaluate_with_endpoints(t, start_pos, end_pos);
         let dist = distance_to_surface(pt, surface);
 
-        // Check if we've found a close approach or sign change in
-        // the signed distance proxy
         if i > 0 && dist < tol.linear {
-            // Already within tolerance — record
             let is_dup = crossings
                 .iter()
                 .any(|&(ct, _): &(f64, Point3)| (t - ct).abs() < (t1 - t0) / (n as f64) * 2.0);
             if !is_dup {
-                // Refine with bisection
                 let refined = refine_crossing(curve, start_pos, end_pos, prev_t, t, surface, tol);
                 crossings.push(refined);
             }
         } else if i > 0 && prev_dist > tol.linear && dist > tol.linear {
-            // Check for a minimum between these two samples
             let mid_t = f64::midpoint(prev_t, t);
             let mid_pt = curve.evaluate_with_endpoints(mid_t, start_pos, end_pos);
             let mid_dist = distance_to_surface(mid_pt, surface);
@@ -508,9 +491,7 @@ fn find_crossings_by_sampling(
         let (t_a, sd_a) = samples[i];
         let (t_b, sd_b) = samples[i + 1];
 
-        // Sign change indicates a crossing
         if sd_a * sd_b < 0.0 {
-            // Bisect to find exact crossing
             let mut lo = t_a;
             let mut hi = t_b;
             let mut sd_lo = sd_a;

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -96,7 +96,6 @@ pub fn perform(
 
             let surf_b = &surfs_b[idx_b];
 
-            // Compute raw intersection curves
             let v_range_a = v_ranges_a[idx_a];
             let v_range_b = v_ranges_b[idx_b];
             let raw_curves =
@@ -285,11 +284,9 @@ pub fn perform(
                         .unwrap_or_else(|| topo.add_vertex(Vertex::new(raw.p_end, tol.linear)))
                 };
 
-                // Create a topology edge for this intersection curve.
                 let edge = Edge::new(start_vid, end_vid, raw.curve.clone());
                 let edge_id = topo.add_edge(edge);
 
-                // Create a pave block spanning the full parameter range.
                 let start_pave = Pave::new(start_vid, raw.t_range.0);
                 let end_pave = Pave::new(end_vid, raw.t_range.1);
                 let pb = PaveBlock::new(edge_id, start_pave, end_pave);
@@ -571,7 +568,6 @@ fn compute_face_bbox(topo: &Topology, face_id: FaceId) -> Result<Aabb3, AlgoErro
         let end_pos = topo.vertex(edge.end())?.point();
         let (t0, t1) = edge.curve().domain_with_endpoints(start_pos, end_pos);
 
-        // Sample edge at several points
         let n: usize = 8;
         for i in 0..=n {
             let t = t0 + (t1 - t0) * (i as f64 / n as f64);
@@ -657,12 +653,10 @@ fn compute_raw_curves(
     v_range_b: Option<(f64, f64)>,
 ) -> Result<Vec<RawCurve>, AlgoError> {
     match (surf_a, surf_b) {
-        // Plane-Plane
         (FaceSurface::Plane { normal: na, d: da }, FaceSurface::Plane { normal: nb, d: db }) => {
             plane_plane_intersection(*na, *da, *nb, *db, bbox_a, bbox_b)
         }
 
-        // Plane-Analytic (plane is A)
         (FaceSurface::Plane { normal, d }, other) if other.as_analytic().is_some() => {
             if let Some(analytic) = other.as_analytic() {
                 plane_analytic_intersection(*normal, *d, &analytic)
@@ -671,7 +665,6 @@ fn compute_raw_curves(
             }
         }
 
-        // Analytic-Plane (plane is B, swap)
         (other, FaceSurface::Plane { normal, d }) if other.as_analytic().is_some() => {
             if let Some(analytic) = other.as_analytic() {
                 plane_analytic_intersection(*normal, *d, &analytic)
@@ -680,7 +673,6 @@ fn compute_raw_curves(
             }
         }
 
-        // Analytic-Analytic
         (a, b) if a.as_analytic().is_some() && b.as_analytic().is_some() => {
             if let (Some(aa), Some(ab)) = (a.as_analytic(), b.as_analytic()) {
                 analytic_analytic_intersection(&aa, &ab, v_range_a, v_range_b)
@@ -689,13 +681,11 @@ fn compute_raw_curves(
             }
         }
 
-        // Plane-NURBS
         (FaceSurface::Plane { normal, d }, FaceSurface::Nurbs(nurbs))
         | (FaceSurface::Nurbs(nurbs), FaceSurface::Plane { normal, d }) => {
             plane_nurbs_intersection(*normal, *d, nurbs)
         }
 
-        // Analytic-NURBS or NURBS-Analytic
         (analytic_surf, FaceSurface::Nurbs(nurbs)) if analytic_surf.as_analytic().is_some() => {
             // Deferred to later phases -- analytic-NURBS is complex
             let _ = nurbs;
@@ -706,7 +696,6 @@ fn compute_raw_curves(
             Ok(Vec::new())
         }
 
-        // NURBS-NURBS
         (FaceSurface::Nurbs(na), FaceSurface::Nurbs(nb)) => nurbs_nurbs_intersection(na, nb),
 
         // Fallback: unsupported pair

--- a/crates/algo/src/pave_filler/phase_ff_coplanar.rs
+++ b/crates/algo/src/pave_filler/phase_ff_coplanar.rs
@@ -37,7 +37,6 @@ pub fn perform(
     let faces_a = brepkit_topology::explorer::solid_faces(topo, solid_a)?;
     let faces_b = brepkit_topology::explorer::solid_faces(topo, solid_b)?;
 
-    // Collect plane face data: (FaceId, normal, d)
     let planes_a = collect_plane_faces(topo, &faces_a)?;
     let planes_b = collect_plane_faces(topo, &faces_b)?;
 
@@ -45,7 +44,6 @@ pub fn perform(
         return Ok(());
     }
 
-    // Pre-compute AABBs
     let bboxes_a = compute_face_bboxes(topo, &planes_a)?;
     let bboxes_b = compute_face_bboxes(topo, &planes_b)?;
 
@@ -55,26 +53,24 @@ pub fn perform(
         planes_b.len()
     );
 
-    // Find coplanar pairs
     for (idx_a, &(fa, na, da)) in planes_a.iter().enumerate() {
         let bbox_a = &bboxes_a[idx_a];
 
         for (idx_b, &(fb, nb, db)) in planes_b.iter().enumerate() {
             let bbox_b = &bboxes_b[idx_b];
 
-            // Check parallel: |dot(na, nb)| > 1 - angular_tol
             let dot = na.dot(nb);
             if dot.abs() < 1.0 - tol.angular {
                 continue;
             }
 
-            // Check coplanar: same plane distance (accounting for normal direction)
+            // Coplanar test accounts for normal direction: anti-parallel
+            // normals describe the same plane when da == -db.
             let sign = if dot > 0.0 { 1.0 } else { -1.0 };
             if (da - db * sign).abs() > tol.linear {
                 continue;
             }
 
-            // AABB overlap check
             if !bbox_a
                 .expanded(tol.linear)
                 .intersects(bbox_b.expanded(tol.linear))
@@ -82,12 +78,10 @@ pub fn perform(
                 continue;
             }
 
-            // Skip pairs that already have FF section edges
             if has_existing_ff_interference(arena, fa, fb) {
                 continue;
             }
 
-            // Process this coplanar pair
             process_coplanar_pair(topo, fa, na, fb, tol, arena)?;
         }
     }
@@ -166,7 +160,6 @@ fn has_existing_section_at(
     tol: Tolerance,
 ) -> bool {
     for curve in &arena.curves {
-        // Must involve at least one of our faces
         if curve.face_a != face_a
             && curve.face_a != face_b
             && curve.face_b != face_a
@@ -175,7 +168,6 @@ fn has_existing_section_at(
             continue;
         }
 
-        // Check AABB overlap
         let edge_min = Point3::new(
             p_start.x().min(p_end.x()),
             p_start.y().min(p_end.y()),
@@ -237,15 +229,12 @@ fn process_coplanar_pair(
     tol: Tolerance,
     arena: &mut GfaArena,
 ) -> Result<(), AlgoError> {
-    // Build a 2D projection frame from the shared plane
     let origin = first_wire_vertex(topo, face_a)?;
     let frame = PlaneFrame2D::new(normal, origin);
 
-    // Collect boundary polygons in 2D for both faces
     let poly_a = face_boundary_polygon_2d(topo, face_a, &frame)?;
     let poly_b = face_boundary_polygon_2d(topo, face_b, &frame)?;
 
-    // Collect boundary edges with their 2D endpoints
     let edges_a = face_boundary_edges_2d(topo, face_a, &frame)?;
     let edges_b = face_boundary_edges_2d(topo, face_b, &frame)?;
 
@@ -261,7 +250,6 @@ fn process_coplanar_pair(
         }
     }
 
-    // For each boundary edge of face_a, check if it's inside face_b
     for &(_, p2d_start, p2d_end, p3d_start, p3d_end) in &edges_a {
         if should_create_section_edge(p2d_start, p2d_end, &poly_b, &edges_b, tol.linear)
             && !has_existing_section_at(arena, face_a, face_b, p3d_start, p3d_end, tol)
@@ -279,7 +267,6 @@ fn process_coplanar_pair(
         let end_edge = which_boundary_edge(p2d_end, &edges_a, tol.linear);
         if let (Some(si), Some(ei)) = (start_edge, end_edge) {
             if si == ei {
-                // B's edge coincides with A's edge at index si.
                 let a_eid = edges_a[si].0;
                 create_coplanar_common_block(arena, a_eid, b_eid, tol.linear);
             }
@@ -388,7 +375,6 @@ fn should_create_section_edge(
         }
     }
 
-    // Check if the edge midpoint is inside the target polygon
     let mid = Point2::new(
         (p2d_start.x() + p2d_end.x()) * 0.5,
         (p2d_start.y() + p2d_end.y()) * 0.5,
@@ -409,7 +395,6 @@ fn create_coplanar_common_block(
     b_edge: brepkit_topology::edge::EdgeId,
     tol: f64,
 ) {
-    // Find leaf PaveBlocks for each edge
     let get_leaves = |edge: brepkit_topology::edge::EdgeId| -> Vec<PaveBlockId> {
         arena
             .edge_pave_blocks
@@ -468,11 +453,9 @@ fn create_section_edge(
         return Ok(());
     }
 
-    // Find or create vertices at the endpoints
     let start_vid = find_or_create_vertex(topo, arena, p3d_start, tol);
     let end_vid = find_or_create_vertex(topo, arena, p3d_end, tol);
 
-    // Create a topology edge (Line between the two points)
     let edge = Edge::new(start_vid, end_vid, EdgeCurve::Line);
     let edge_id = topo.add_edge(edge);
 
@@ -492,7 +475,6 @@ fn create_section_edge(
         .or_default()
         .push(pb_id);
 
-    // Create the intersection curve entry
     let bbox = Aabb3 {
         min: Point3::new(
             p3d_start.x().min(p3d_end.x()),
@@ -628,13 +610,11 @@ fn point_on_segment_2d(pt: Point2, a: Point2, b: Point2, tol: f64) -> bool {
         return ap.x() * ap.x() + ap.y() * ap.y() <= tol * tol;
     }
 
-    // Project pt onto the line through a→b
     let t = (ap.x() * ab.x() + ap.y() * ab.y()) / ab_len_sq;
     if t < -tol || t > 1.0 + tol {
         return false;
     }
 
-    // Distance from pt to the closest point on the segment
     let closest_x = a.x() + t.clamp(0.0, 1.0) * ab.x();
     let closest_y = a.y() + t.clamp(0.0, 1.0) * ab.y();
     let dx = pt.x() - closest_x;

--- a/crates/algo/src/pave_filler/phase_ve.rs
+++ b/crates/algo/src/pave_filler/phase_ve.rs
@@ -45,10 +45,7 @@ pub fn perform(
     let edges_a = brepkit_topology::explorer::solid_edges(topo, solid_a)?;
     let edges_b = brepkit_topology::explorer::solid_edges(topo, solid_b)?;
 
-    // Check vertices of A against edges of B
     check_vertex_edge_pairs(topo, &verts_a, &edges_b, tol, arena)?;
-
-    // Check vertices of B against edges of A
     check_vertex_edge_pairs(topo, &verts_b, &edges_a, tol, arena)?;
 
     Ok(())
@@ -79,20 +76,16 @@ fn check_vertex_edge_pairs(
                 continue;
             }
 
-            // Get edge domain
             let start_pos = topo.vertex(edge.start())?.point();
             let end_pos = topo.vertex(edge.end())?.point();
             let (t0, t1) = edge.curve().domain_with_endpoints(start_pos, end_pos);
 
-            // Project vertex onto edge curve
             let param = project_point_on_edge(topo, eid, pos)?;
 
-            // Check if the parameter is within the edge domain
             if param < t0 - 1e-10 || param > t1 + 1e-10 {
                 continue;
             }
 
-            // Evaluate edge at the found parameter
             let edge_pt = edge
                 .curve()
                 .evaluate_with_endpoints(param, start_pos, end_pos);
@@ -100,7 +93,6 @@ fn check_vertex_edge_pairs(
 
             let combined_tol = vtol + tol.linear;
             if dist <= combined_tol {
-                // Add extra pave to the pave blocks that contain this parameter
                 let pave = Pave::new(resolved_vid, param);
                 if let Some(pb_ids) = arena.edge_pave_blocks.get(&eid) {
                     let pb_ids_copy: Vec<_> = pb_ids.clone();
@@ -114,7 +106,6 @@ fn check_vertex_edge_pairs(
                     }
                 }
 
-                // Record interference
                 arena.interference.ve.push(Interference::VE {
                     vertex: resolved_vid,
                     edge: eid,
@@ -145,7 +136,6 @@ fn project_point_on_edge(
     let end_pos = topo.vertex(edge.end())?.point();
     let (t0, t1) = edge.curve().domain_with_endpoints(start_pos, end_pos);
 
-    // Sample the edge at N points and find the closest
     let n_samples: usize = 32;
     let mut best_t = t0;
     let mut best_dist_sq = f64::MAX;
@@ -160,7 +150,6 @@ fn project_point_on_edge(
         }
     }
 
-    // Refine with ternary search in the neighborhood
     let dt = (t1 - t0) / n_samples as f64;
     let mut lo = (best_t - dt).max(t0);
     let mut hi = (best_t + dt).min(t1);

--- a/crates/algo/src/pave_filler/phase_vf.rs
+++ b/crates/algo/src/pave_filler/phase_vf.rs
@@ -88,7 +88,6 @@ fn check_vertex_face_pairs(
         let vtol = vertex.tolerance();
 
         for (face_idx, &fid) in faces.iter().enumerate() {
-            // Skip if vertex is already on this face's boundary
             if face_edge_verts[face_idx].contains(&resolved_vid) {
                 continue;
             }
@@ -121,7 +120,6 @@ fn check_vertex_face_pairs(
                     }
                 }
                 _ => {
-                    // Parametric surface: project and evaluate
                     if let Some((u, v)) = surface.project_point(pos) {
                         if let Some(surf_pt) = surface.evaluate(u, v) {
                             let dist = (pos - surf_pt).length();

--- a/crates/algo/src/pave_filler/phase_vv.rs
+++ b/crates/algo/src/pave_filler/phase_vv.rs
@@ -51,18 +51,15 @@ pub fn perform(
             let pos_b = vertex_b.point();
             let tol_b = vertex_b.tolerance();
 
-            // Combined tolerance: sum of vertex tolerances + linear tolerance
             let combined_tol = tol_a + tol_b + tol.linear;
             let dist = (pos_a - pos_b).length();
 
             if dist <= combined_tol {
-                // Record the interference
                 arena
                     .interference
                     .vv
                     .push(Interference::VV { v1: va, v2: vb });
 
-                // Merge into same-domain
                 arena.merge_vertices(va, vb);
 
                 log::debug!("VV: vertices {va:?} and {vb:?} coincide (dist={dist:.2e})",);

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -24,7 +24,6 @@ fn make_box(topo: &mut Topology, min: [f64; 3], max: [f64; 3]) -> brepkit_topolo
     let [x0, y0, z0] = min;
     let [x1, y1, z1] = max;
 
-    // 8 vertices
     let v = [
         topo.add_vertex(Vertex::new(Point3::new(x0, y0, z0), 1e-7)),
         topo.add_vertex(Vertex::new(Point3::new(x1, y0, z0), 1e-7)),
@@ -219,7 +218,6 @@ fn gfa_boolean_fuse_two_boxes() {
     match &result {
         Ok(solid_id) => {
             eprintln!("GFA fuse succeeded: solid {:?}", solid_id);
-            // Check that the result solid exists and has faces
             let faces = brepkit_topology::explorer::solid_faces(&topo, *solid_id).unwrap();
             eprintln!("  Result has {} faces", faces.len());
             assert!(!faces.is_empty(), "fuse result should have faces");
@@ -321,7 +319,6 @@ fn force_interf_ee_adjacent_boxes_creates_common_blocks() {
     let tol = Tolerance::default();
     let mut arena = GfaArena::new();
 
-    // Run PaveFiller intersection phases
     {
         let mut filler = PaveFiller::with_tolerance(&mut topo, a, b, tol);
         filler.perform(&mut arena).unwrap();
@@ -640,7 +637,6 @@ fn debug_overlapping_boxes_section_pbs() {
     crate::pave_filler::make_blocks::perform(&mut arena).unwrap();
     crate::pave_filler::force_interf_ee::perform(&topo, tol, &mut arena).unwrap();
 
-    // Count section PBs
     let section_pb_count: usize = arena.curves.iter().map(|c| c.pave_blocks.len()).sum();
     let boundary_pb_count: usize = arena.edge_pave_blocks.values().map(Vec::len).sum();
     let cb_count = arena.common_blocks.iter().count();
@@ -650,7 +646,6 @@ fn debug_overlapping_boxes_section_pbs() {
     );
     eprintln!("curves: {}", arena.curves.len());
 
-    // Run link_existing
     crate::pave_filler::link_existing::perform(&topo, tol, &mut arena).unwrap();
     let cb_count_after = arena.common_blocks.iter().count();
     eprintln!("CBs after link_existing: {cb_count_after}");
@@ -664,10 +659,8 @@ fn debug_overlapping_boxes_section_pbs() {
         .count();
     eprintln!("CBs with split_edge: {cbs_with_split}/{cb_count_after}");
 
-    // Dump VV merge map
     eprintln!("VV merges: {}", arena.same_domain_vertices.len());
 
-    // Dump section PB endpoints and check if they match boundary PBs
     let scale = 1.0 / tol.linear;
     let qpt = |p: Point3| -> (i64, i64, i64) {
         (
@@ -677,7 +670,6 @@ fn debug_overlapping_boxes_section_pbs() {
         )
     };
 
-    // Build boundary PB position index
     #[allow(clippy::type_complexity)]
     let mut boundary_positions: std::collections::HashSet<((i64, i64, i64), (i64, i64, i64))> =
         std::collections::HashSet::new();
@@ -696,7 +688,6 @@ fn debug_overlapping_boxes_section_pbs() {
         }
     }
 
-    // Check each section PB
     let mut matched = 0;
     let mut unmatched = 0;
     for curve in &arena.curves {
@@ -775,7 +766,6 @@ fn trace_builder_overlapping_box_fuse() {
     eprintln!("sub_faces: {}", sub_faces.len());
     eprintln!("sd_pairs: {}", sd_pairs.len());
 
-    // Dump each sub-face: rank, classification, surface type
     for (i, sf) in sub_faces.iter().enumerate() {
         let surface_desc = match topo
             .face(sf.face_id)
@@ -807,7 +797,6 @@ fn trace_builder_overlapping_box_fuse() {
         );
     }
 
-    // Dump SD pairs
     for (i, pair) in sd_pairs.iter().enumerate() {
         eprintln!(
             "  SD[{i}]: A={} B={} same_ori={} contained={}",
@@ -856,7 +845,6 @@ fn trace_builder_overlapping_box_fuse() {
         }
     }
 
-    // Simulate BOP selection
     let selected = crate::bop::select_faces(sub_faces, crate::bop::BooleanOp::Fuse, sd_pairs, &[]);
     eprintln!("BOP selected: {} faces", selected.len());
     for (i, sf) in selected.iter().enumerate() {
@@ -944,7 +932,6 @@ fn trace_builder_z_axis_overlap() {
     let mut arena = crate::ds::GfaArena::new();
     crate::pave_filler::run_pave_filler(&mut topo, a, b, tol, &mut arena).unwrap();
 
-    // Dump FF interferences
     eprintln!(
         "\n=== Z-axis overlap: {} FF interferences ===",
         arena.interference.ff.len()
@@ -984,7 +971,6 @@ fn trace_builder_z_axis_overlap() {
                     _ => "Other".to_string(),
                 })
                 .unwrap_or_default();
-            // Dump PB endpoints
             for &pb_id in &curve.pave_blocks {
                 if let Some(pb) = arena.pave_blocks.get(pb_id) {
                     let sv = arena.resolve_vertex(pb.start.vertex);
@@ -1106,7 +1092,6 @@ fn gfa_fuse_z_axis_overlapping_manifold_boxes() {
     }
 
     let non_manifold = edge_face_count.values().filter(|&&n| n != 2).count();
-    // Count unique vertices
     let mut verts: std::collections::HashSet<brepkit_topology::vertex::VertexId> =
         std::collections::HashSet::new();
     for &fid in shell.faces() {
@@ -1124,7 +1109,6 @@ fn gfa_fuse_z_axis_overlapping_manifold_boxes() {
     let euler = v as i64 - e as i64 + face_count as i64;
     eprintln!("{e} edges, {v} verts, euler={euler}, {non_manifold} non-manifold");
 
-    // Dump non-manifold edge details
     for (&eid, &count) in &edge_face_count {
         if count != 2 {
             if let Ok(e) = topo.edge(eid) {

--- a/crates/blend/src/adaptive_tolerance.rs
+++ b/crates/blend/src/adaptive_tolerance.rs
@@ -41,7 +41,6 @@ mod tests {
         // edge_length * 0.001 is the limiting factor (smaller than radius * 0.01)
         let t1 = snap_tolerance(0.1, 1.0);
         let t2 = snap_tolerance(0.01, 1.0);
-        // Shorter edge -> smaller tolerance
         assert!(t2 < t1, "tolerance should decrease with shorter edges");
     }
 
@@ -50,17 +49,14 @@ mod tests {
         // radius * 0.01 is the limiting factor (smaller than edge_length * 0.001)
         let t1 = snap_tolerance(1.0, 0.01);
         let t2 = snap_tolerance(1.0, 0.001);
-        // Smaller radius -> smaller tolerance
         assert!(t2 < t1, "tolerance should decrease with smaller radius");
     }
 
     #[test]
     fn test_snap_tolerance_clamped_to_range() {
-        // Very large inputs -> clamped to 1e-4
         let t_large = snap_tolerance(1000.0, 1000.0);
         assert!(t_large <= 1e-4, "tolerance must not exceed 1e-4");
 
-        // Very small inputs -> clamped to 1e-10
         let t_small = snap_tolerance(1e-12, 1e-12);
         assert!(t_small >= 1e-10, "tolerance must not go below 1e-10");
     }

--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -365,15 +365,12 @@ fn dihedral_half_angle(n1: Vec3, n2: Vec3) -> f64 {
 /// Returns `(bisector, cross_dir)` where bisector points from edge toward
 /// fillet center and `cross_dir` is perpendicular to both in the section plane.
 fn section_basis(n1: Vec3, n2: Vec3, spine_tangent: Vec3) -> (Vec3, Vec3) {
-    // Bisector of the two normals — points from the edge toward the fillet center
     let bisector_raw = n1 + n2;
     let bisector = bisector_raw.normalize().unwrap_or_else(|_| {
         // Normals are antiparallel (180 deg) — use cross product with tangent
         spine_tangent.cross(n1)
     });
 
-    // In the section plane, the direction perpendicular to the bisector
-    // that lies in the plane of the two normals.
     let cross_dir_raw = spine_tangent.cross(bisector);
     let cross_dir = cross_dir_raw
         .normalize()
@@ -387,7 +384,6 @@ fn section_basis(n1: Vec3, n2: Vec3, spine_tangent: Vec3) -> (Vec3, Vec3) {
 /// This is the component of the bisector projected onto the plane surface,
 /// pointing away from the edge toward where the fillet touches the plane.
 fn compute_contact_direction(normal: Vec3, bisector: Vec3) -> Vec3 {
-    // Project bisector onto the plane (remove component along normal)
     let proj = bisector - normal * bisector.dot(normal);
     proj.normalize().unwrap_or(bisector)
 }
@@ -423,12 +419,10 @@ fn plane_plane_fillet(
     face1: FaceId,
     face2: FaceId,
 ) -> Result<StripeResult, BlendError> {
-    // Spine endpoints and tangent
     let p_start = spine.evaluate(topo, 0.0)?;
     let p_end = spine.evaluate(topo, spine.length())?;
     let tangent = spine.tangent(topo, 0.0)?;
 
-    // Dihedral geometry
     let half_angle = dihedral_half_angle(n1, n2);
     let sin_half = half_angle.sin();
     let cos_half = half_angle.cos();
@@ -440,25 +434,19 @@ fn plane_plane_fillet(
 
     let (bisector, _cross_dir) = section_basis(n1, n2, tangent);
 
-    // Center offset from the edge along the bisector
     let center_offset = radius / sin_half;
 
-    // Cylinder origin: on the center line at the spine start
     let cyl_origin = p_start + bisector * center_offset;
     let cyl_axis = tangent;
 
-    // Create the cylindrical surface
     let cylinder = CylindricalSurface::new(cyl_origin, cyl_axis, radius)?;
 
-    // Contact point offsets from the edge
     // The contact point on each plane is at distance R/tan(half_angle) from the edge.
     let contact_offset = radius * cos_half / sin_half; // = R / tan(half_angle)
 
-    // Direction from edge toward contact on each plane
     let contact_dir1 = compute_contact_direction(n1, bisector);
     let contact_dir2 = compute_contact_direction(n2, bisector);
 
-    // Contact lines (straight lines on each plane)
     let c1_start = p_start + contact_dir1 * contact_offset;
     let c1_end = p_end + contact_dir1 * contact_offset;
     let c2_start = p_start + contact_dir2 * contact_offset;
@@ -467,7 +455,6 @@ fn plane_plane_fillet(
     let contact1 = nurbs_line(c1_start, c1_end)?;
     let contact2 = nurbs_line(c2_start, c2_end)?;
 
-    // PCurves: project 3D contact endpoints onto each face surface to get UV
     let pcurve1 = {
         let adapter = crate::builder_utils::PlaneAdapter::from_normal_and_d(n1, 0.0);
         let (u0, v0) = adapter.project_point(c1_start);
@@ -487,7 +474,6 @@ fn plane_plane_fillet(
         )?)
     };
 
-    // Cross-sections at start and end
     let section_start = CircSection {
         p1: c1_start,
         p2: c2_start,
@@ -548,18 +534,15 @@ fn plane_plane_chamfer(
     face1: FaceId,
     face2: FaceId,
 ) -> Result<StripeResult, BlendError> {
-    // Spine endpoints and tangent
     let p_start = spine.evaluate(topo, 0.0)?;
     let p_end = spine.evaluate(topo, spine.length())?;
     let tangent = spine.tangent(topo, 0.0)?;
 
     let (bisector, _cross_dir) = section_basis(n1, n2, tangent);
 
-    // Contact directions on each plane
     let contact_dir1 = compute_contact_direction(n1, bisector);
     let contact_dir2 = compute_contact_direction(n2, bisector);
 
-    // Contact lines at specified distances
     let c1_start = p_start + contact_dir1 * d1;
     let c1_end = p_end + contact_dir1 * d1;
     let c2_start = p_start + contact_dir2 * d2;
@@ -577,10 +560,8 @@ fn plane_plane_chamfer(
         .normalize()
         .map_err(|_| BlendError::Math(brepkit_math::MathError::ZeroVector))?;
 
-    // Signed distance from origin
     let chamfer_d = chamfer_normal.dot(Vec3::new(c1_start.x(), c1_start.y(), c1_start.z()));
 
-    // PCurves: project 3D contact endpoints onto each face surface to get UV
     let pcurve1 = {
         let adapter = crate::builder_utils::PlaneAdapter::from_normal_and_d(n1, 0.0);
         let (u0, v0) = adapter.project_point(c1_start);
@@ -600,7 +581,6 @@ fn plane_plane_chamfer(
         )?)
     };
 
-    // Sections at start and end
     let midpoint_start = midpoint_3d(c1_start, c2_start);
     let midpoint_end = midpoint_3d(c1_end, c2_end);
     let chamfer_radius = (c1_start - c2_start).length() / 2.0;
@@ -2433,7 +2413,6 @@ pub fn sphere_sphere_fillet(
         return Ok(None);
     }
 
-    // Spine span (closed-circle aware).
     let edges = spine.edges();
     let is_closed_spine = if edges.len() == 1 {
         let e = topo.edge(edges[0])?;
@@ -2476,7 +2455,6 @@ pub fn sphere_sphere_fillet(
         ref_dir,
     )?;
 
-    // Spine plane center (where the spine circle lies).
     let spine_plane_center = c1 + axis * a0;
 
     // u-parameter for a point on a contact circle around the axis.
@@ -2549,7 +2527,6 @@ pub fn sphere_sphere_fillet(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // Cross-sections at spine endpoints.
     let p1_at = |u: f64| contact1_circle.evaluate(u);
     let p2_at = |u: f64| contact2_circle.evaluate(u);
     let center_at = |u: f64| {
@@ -2718,7 +2695,6 @@ pub fn sphere_cylinder_fillet(
     }
     let spine_sign = if sample_axial >= 0.0 { 1.0 } else { -1.0 };
 
-    // Effective radii.
     let q_s = big_r_s + s_sphere * radius;
     let q_c = r_c + s_cyl * radius;
     if q_s <= tol_lin || q_c <= tol_lin {
@@ -2739,7 +2715,6 @@ pub fn sphere_cylinder_fillet(
         return Ok(None);
     }
 
-    // Build the torus.
     let cyl_x = cyl.x_axis();
     let cyl_y = cyl.y_axis();
     let ref_dir = if cyl_x.cross(cyl_axis).length() > tol_ang {
@@ -2756,7 +2731,6 @@ pub fn sphere_cylinder_fillet(
         ref_dir,
     )?;
 
-    // Spine plane center on cylinder axis at axial = sample_axial.
     let spine_plane_center = c_s + cyl_axis * sample_axial;
     let perp_y = cyl_axis.cross(ref_dir).normalize()?;
     let u_at = |p: Point3| {
@@ -3064,7 +3038,6 @@ pub fn sphere_cone_fillet(
         return Ok(None);
     }
 
-    // Build the torus.
     let cone_x = cone.x_axis();
     let ref_dir = cone_x;
 
@@ -3077,7 +3050,6 @@ pub fn sphere_cone_fillet(
         ref_dir,
     )?;
 
-    // Spine plane center.
     let spine_plane_center = c_s + cone_axis * spine_z;
     let perp_y = cone_axis.cross(ref_dir).normalize()?;
     let u_at = |p: Point3| {
@@ -3159,7 +3131,6 @@ pub fn sphere_cone_fillet(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // Cross-sections.
     let p_sph_at = |u: f64| contact_sph_circle.evaluate(u);
     let p_cone_at = |u: f64| contact_cone_circle.evaluate(u);
     let section_at = |u: f64, t: f64| CircSection {
@@ -3290,7 +3261,6 @@ pub fn sphere_sphere_chamfer(
         return Ok(None);
     }
 
-    // Spine geometry.
     let a0 = (big_r1 * big_r1 - big_r2 * big_r2 + big_d * big_d) / (2.0 * big_d);
     let r_p_sq = big_r1 * big_r1 - a0 * a0;
     if r_p_sq <= tol_lin * tol_lin {
@@ -3362,7 +3332,6 @@ pub fn sphere_sphere_chamfer(
 
     let chamfer_apex_pos = c1 + axis * z_apex_from_c1;
 
-    // Spine span (closed-circle aware).
     let edges = spine.edges();
     let is_closed_spine = if edges.len() == 1 {
         let e = topo.edge(edges[0])?;
@@ -3388,7 +3357,6 @@ pub fn sphere_sphere_chamfer(
     let chamfer_cone =
         ConicalSurface::with_ref_dir(chamfer_apex_pos, cone_axis, cone_half_angle, ref_dir)?;
 
-    // Spine plane center.
     let spine_plane_center = c1 + axis * a0;
     let perp_y = axis.cross(ref_dir).normalize()?;
     let u_at = |p: Point3| {
@@ -3409,7 +3377,6 @@ pub fn sphere_sphere_chamfer(
         }
     };
 
-    // 3D contact circles.
     let contact1_center = c1 + axis * p1_z_from_c1;
     let contact1_circle =
         brepkit_math::curves::Circle3D::with_axes(contact1_center, axis, p1_r, ref_dir, perp_y)?;
@@ -3433,7 +3400,6 @@ pub fn sphere_sphere_chamfer(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // Cross-sections.
     let p1_at = |u: f64| contact1_circle.evaluate(u);
     let p2_at = |u: f64| contact2_circle.evaluate(u);
     let section_at = |u: f64, t: f64| {
@@ -3575,7 +3541,6 @@ pub fn sphere_cylinder_chamfer(
     let h_s_sq = big_r_s * big_r_s - r_c * r_c;
     let h_s = h_s_sq.sqrt();
 
-    // Spine validation.
     let edges = spine.edges();
     let is_closed_spine = if edges.len() == 1 {
         let e = topo.edge(edges[0])?;
@@ -3649,7 +3614,6 @@ pub fn sphere_cylinder_chamfer(
     let chamfer_cone =
         ConicalSurface::with_ref_dir(chamfer_apex_pos, chamfer_axis, cone_half_angle, ref_dir)?;
 
-    // Spine plane center.
     let spine_plane_center = c_s + cyl_axis * a_spine;
     let perp_y = cyl_axis.cross(ref_dir).normalize()?;
     let u_at = |p: Point3| {
@@ -3669,7 +3633,6 @@ pub fn sphere_cylinder_chamfer(
         }
     };
 
-    // Contact circles.
     let sph_contact_center = c_s + cyl_axis * z_sph;
     let contact_sph_circle = brepkit_math::curves::Circle3D::with_axes(
         sph_contact_center,
@@ -3704,7 +3667,6 @@ pub fn sphere_cylinder_chamfer(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // Cross-sections.
     let p_sph_at = |u: f64| contact_sph_circle.evaluate(u);
     let p_cyl_at = |u: f64| contact_cyl_circle.evaluate(u);
     let section_at = |u: f64, t: f64| {
@@ -3958,7 +3920,6 @@ pub fn sphere_cone_chamfer(
     let chamfer_cone =
         ConicalSurface::with_ref_dir(chamfer_apex_pos, chamfer_axis, cone_half_angle, ref_dir)?;
 
-    // Spine plane center.
     let spine_plane_center = c_s + cone_axis * spine_z;
     let perp_y = cone_axis.cross(ref_dir).normalize()?;
     let u_at = |p: Point3| {
@@ -3978,7 +3939,6 @@ pub fn sphere_cone_chamfer(
         }
     };
 
-    // Contact circles.
     let sph_contact_center = c_s + cone_axis * z_sph;
     let contact_sph_circle = brepkit_math::curves::Circle3D::with_axes(
         sph_contact_center,
@@ -4012,7 +3972,6 @@ pub fn sphere_cone_chamfer(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // Cross-sections.
     let p_sph_at = |u: f64| contact_sph_circle.evaluate(u);
     let p_cone_at = |u: f64| contact_cone_circle.evaluate(u);
     let section_at = |u: f64, t: f64| {
@@ -4197,7 +4156,6 @@ pub fn cylinder_cylinder_fillet(
     };
     let y_sign = if y_spine >= 0.0 { 1.0 } else { -1.0 };
 
-    // Effective radii.
     let q1 = r1 + s1 * radius;
     let q2 = r2 + s2 * radius;
     if q1 <= tol_lin || q2 <= tol_lin {
@@ -4212,7 +4170,6 @@ pub fn cylinder_cylinder_fillet(
     }
     let y_ball = y_sign * y_ball_sq.sqrt();
 
-    // Spine endpoints in 3D.
     let p_spine_start = p_spine_sample;
     let spine_tangent = spine.tangent(topo, 0.0)?;
     // Confirm spine direction is parallel to the cyl axis (linear spine
@@ -4271,7 +4228,6 @@ pub fn cylinder_cylinder_fillet(
         brepkit_math::vec::Vec2::new(0.0, v2_end - v2_start),
     )?);
 
-    // Cross-sections at spine endpoints.
     let section_start = CircSection {
         p1: c1_start,
         p2: c2_start,
@@ -4439,7 +4395,6 @@ pub fn cone_cone_coaxial_fillet(
         return Ok(None);
     }
 
-    // Spine validation.
     let edges = spine.edges();
     let is_closed_spine = if edges.len() == 1 {
         let e = topo.edge(edges[0])?;
@@ -4464,7 +4419,6 @@ pub fn cone_cone_coaxial_fillet(
         return Ok(None);
     }
 
-    // Build the torus.
     let ref_dir = cone1.x_axis();
     let torus_center = apex1 + a_cone * z_b;
     let torus = ToroidalSurface::with_axis_and_ref_dir(
@@ -4475,7 +4429,6 @@ pub fn cone_cone_coaxial_fillet(
         ref_dir,
     )?;
 
-    // Spine plane center at apex1 + z_spine.
     let spine_plane_center = apex1 + a_cone * z_spine;
     let perp_y = a_cone.cross(ref_dir).normalize()?;
     let u_at = |p: Point3| {
@@ -4542,7 +4495,6 @@ pub fn cone_cone_coaxial_fillet(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // Cross-sections.
     let p1_at = |u: f64| contact1_circle.evaluate(u);
     let p2_at = |u: f64| contact2_circle.evaluate(u);
     let section_at = |u: f64, t: f64| CircSection {
@@ -4680,7 +4632,6 @@ pub fn cone_cone_coaxial_chamfer(
         return Ok(None);
     }
 
-    // Spine geometry (shared with fillet).
     let z_spine = h_2 * cos_b2 * sin_b1 / sin_minus;
     let cot_b1 = cos_b1 / sin_b1;
     let r_spine = z_spine * cot_b1;
@@ -4688,7 +4639,6 @@ pub fn cone_cone_coaxial_chamfer(
         return Ok(None);
     }
 
-    // Spine validation.
     let edges = spine.edges();
     let is_closed_spine = if edges.len() == 1 {
         let e = topo.edge(edges[0])?;
@@ -4757,7 +4707,6 @@ pub fn cone_cone_coaxial_chamfer(
     let chamfer_cone =
         ConicalSurface::with_ref_dir(chamfer_apex_pos, chamfer_axis, cone_half_angle, ref_dir)?;
 
-    // Spine plane center.
     let spine_plane_center = apex1 + a_cone * z_spine;
     let perp_y = a_cone.cross(ref_dir).normalize()?;
     let u_at = |p: Point3| {
@@ -4777,7 +4726,6 @@ pub fn cone_cone_coaxial_chamfer(
         }
     };
 
-    // Contact circles.
     let c1_center = apex1 + a_cone * z_c1;
     let contact1_circle =
         brepkit_math::curves::Circle3D::with_axes(c1_center, a_cone, r_c1, ref_dir, perp_y)?;
@@ -4801,7 +4749,6 @@ pub fn cone_cone_coaxial_chamfer(
         brepkit_math::vec::Vec2::new(u_end - u_start, 0.0),
     )?);
 
-    // Cross-sections.
     let p1_at = |u: f64| contact1_circle.evaluate(u);
     let p2_at = |u: f64| contact2_circle.evaluate(u);
     let section_at = |u: f64, t: f64| {
@@ -5038,7 +4985,6 @@ pub fn cylinder_cylinder_chamfer(
         brepkit_math::vec::Vec2::new(0.0, v2_end - v2_start),
     )?);
 
-    // Cross-sections at spine endpoints.
     let chamfer_radius = (c1_start - c2_start).length() * 0.5;
     let section_start = CircSection {
         p1: c1_start,

--- a/crates/blend/src/blend_func.rs
+++ b/crates/blend/src/blend_func.rs
@@ -123,10 +123,6 @@ pub fn project_normal_to_section(normal: Vec3, nplan: Vec3) -> Vec3 {
     )
 }
 
-// ---------------------------------------------------------------------------
-// Constant-radius fillet
-// ---------------------------------------------------------------------------
-
 /// Constant-radius fillet blend function.
 ///
 /// Implements the OCCT `BlendFunc_ConstRad` constraint system:
@@ -335,10 +331,6 @@ impl BlendFunction for ConstRadBlend {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Evolving-radius fillet
-// ---------------------------------------------------------------------------
-
 /// Variable-radius fillet blend function.
 ///
 /// Delegates to the [`ConstRadBlend`] math with the radius evaluated from
@@ -383,10 +375,6 @@ impl BlendFunction for EvolRadBlend {
         ConstRadBlend::section_with_radius(r, surf1, surf2, params, ctx)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Two-distance chamfer
-// ---------------------------------------------------------------------------
 
 /// Two-distance chamfer blend function.
 ///
@@ -532,10 +520,6 @@ impl BlendFunction for ChamferBlend {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Distance-angle chamfer
-// ---------------------------------------------------------------------------
 
 /// Distance-angle chamfer blend function.
 ///
@@ -723,7 +707,6 @@ mod tests {
         let jac = blend.jacobian(&p1, &p2, &params, &ctx);
         let h = 1e-6;
 
-        // Central differences for each column
         let perturbations: [(usize, &str); 4] = [(0, "u1"), (1, "v1"), (2, "u2"), (3, "v2")];
 
         for &(col, name) in &perturbations {
@@ -768,7 +751,6 @@ mod tests {
     fn project_normal_perpendicular_to_nplan() {
         let nplan = Vec3::new(0.0, 1.0, 0.0);
 
-        // Test several normals
         let normals = [
             Vec3::new(0.0, 0.0, 1.0),
             Vec3::new(1.0, 0.0, 0.0),

--- a/crates/blend/src/builder_utils.rs
+++ b/crates/blend/src/builder_utils.rs
@@ -35,7 +35,6 @@ pub fn create_blend_face(topo: &mut Topology, stripe: &Stripe) -> Result<FaceId,
     let (t0_1, t1_1) = stripe.contact1.domain();
     let (t0_2, t1_2) = stripe.contact2.domain();
 
-    // Four corner points of the blend quad.
     let p1_start = stripe.contact1.evaluate(t0_1);
     let p1_end = stripe.contact1.evaluate(t1_1);
     let p2_start = stripe.contact2.evaluate(t0_2);

--- a/crates/blend/src/chamfer_builder.rs
+++ b/crates/blend/src/chamfer_builder.rs
@@ -127,7 +127,6 @@ impl<'a> ChamferBuilder<'a> {
     /// [`BlendResult::failed`] rather than aborting the whole operation.
     #[allow(clippy::too_many_lines)]
     pub fn build(self) -> Result<BlendResult, BlendError> {
-        // ── Validate input ──────────────────────────────────────────────
         let all_edges: Vec<(EdgeId, f64, f64)> = self
             .edge_sets
             .into_iter()
@@ -157,17 +156,13 @@ impl<'a> ChamferBuilder<'a> {
 
         let topo = self.topo;
 
-        // ── Build adjacency ─────────────────────────────────────────────
         let adjacency = topo.build_adjacency(self.solid)?;
 
-        // Collect all original face IDs.
         let shell_id = topo.solid(self.solid)?.outer_shell();
         let original_faces: Vec<FaceId> = topo.shell(shell_id)?.faces().to_vec();
 
-        // Track which faces are touched (adjacent to a chamfer edge).
         let mut touched_faces: HashSet<FaceId> = HashSet::new();
 
-        // ── Phase 1: Compute stripes ────────────────────────────────────
         let mut succeeded: Vec<EdgeId> = Vec::new();
         let mut failed: Vec<(EdgeId, BlendError)> = Vec::new();
         let mut stripe_results: Vec<StripeResult> = Vec::new();
@@ -197,7 +192,6 @@ impl<'a> ChamferBuilder<'a> {
             });
         }
 
-        // ── Phase 2: Trim faces ─────────────────────────────────────────
         let mut face_replacements: std::collections::HashMap<FaceId, FaceId> =
             std::collections::HashMap::new();
 
@@ -207,7 +201,6 @@ impl<'a> ChamferBuilder<'a> {
             let contact1_pts = sample_nurbs_endpoints(&stripe.contact1);
             let contact2_pts = sample_nurbs_endpoints(&stripe.contact2);
 
-            // Compute trim side from chamfer geometry.
             let keep_side1 =
                 if let (Some(sec), Ok(face)) = (stripe.sections.first(), topo.face(stripe.face1)) {
                     let n = face.surface().normal(0.0, 0.0);
@@ -231,7 +224,6 @@ impl<'a> ChamferBuilder<'a> {
                     TrimSide::Right
                 };
 
-            // Trim face 1.
             let current_face1 = face_replacements
                 .get(&stripe.face1)
                 .copied()
@@ -254,7 +246,6 @@ impl<'a> ChamferBuilder<'a> {
                 }
             }
 
-            // Trim face 2.
             let current_face2 = face_replacements
                 .get(&stripe.face2)
                 .copied()
@@ -278,7 +269,6 @@ impl<'a> ChamferBuilder<'a> {
             }
         }
 
-        // ── Phase 3: Create blend faces ─────────────────────────────────
         let mut blend_face_ids: Vec<FaceId> = Vec::new();
 
         for sr in &stripe_results {
@@ -286,26 +276,21 @@ impl<'a> ChamferBuilder<'a> {
             blend_face_ids.push(blend_face_id);
         }
 
-        // ── Phase 4: Assemble solid ─────────────────────────────────────
         let mut result_faces: Vec<FaceId> = Vec::new();
 
-        // Add untouched original faces.
         for &fid in &original_faces {
             if !touched_faces.contains(&fid) {
                 result_faces.push(fid);
             }
         }
 
-        // Add trimmed replacements (or originals if not replaced).
         for &fid in &touched_faces {
             let replacement = face_replacements.get(&fid).copied();
             result_faces.push(replacement.unwrap_or(fid));
         }
 
-        // Add blend faces.
         result_faces.extend(&blend_face_ids);
 
-        // Build shell and solid.
         let new_shell = Shell::new(result_faces)?;
         let new_shell_id = topo.add_shell(new_shell);
         let new_solid = Solid::new(new_shell_id, Vec::new());
@@ -334,10 +319,8 @@ fn compute_chamfer_stripe(
     d1: f64,
     d2: f64,
 ) -> Result<StripeResult, BlendError> {
-    // Find the two adjacent faces.
     let adj_faces = adjacency.faces_for_edge(edge_id);
     if adj_faces.len() != 2 {
-        // Non-manifold (3+ faces) or boundary (0-1 faces) edge cannot be chamfered.
         log::warn!(
             "edge {edge_id:?} has {} adjacent faces (expected 2) — cannot chamfer non-manifold or boundary edges",
             adj_faces.len()
@@ -350,14 +333,11 @@ fn compute_chamfer_stripe(
     let face1 = adj_faces[0];
     let face2 = adj_faces[1];
 
-    // Snapshot surface data.
     let surf1 = topo.face(face1)?.surface().clone();
     let surf2 = topo.face(face2)?.surface().clone();
 
-    // Build a single-edge spine.
     let spine = Spine::from_single_edge(topo, edge_id)?;
 
-    // Try analytic fast path.
     if let Some(result) =
         analytic::try_analytic_chamfer(&surf1, &surf2, &spine, topo, d1, d2, face1, face2)?
     {
@@ -374,10 +354,6 @@ fn compute_chamfer_stripe(
         ),
     })
 }
-
-// ===========================================================================
-// Tests
-// ===========================================================================
 
 #[cfg(test)]
 mod tests {
@@ -420,7 +396,6 @@ mod tests {
         builder.add_edges_symmetric(&[target_edge], 0.1);
         let result = builder.build().expect("chamfer build should succeed");
 
-        // The result solid should exist and have more faces.
         let result_solid = topo.solid(result.solid).unwrap();
         let result_shell = topo.shell(result_solid.outer_shell()).unwrap();
 
@@ -435,7 +410,6 @@ mod tests {
         assert!(result.failed.is_empty());
         assert!(!result.is_partial);
 
-        // The blend surface should be a plane (plane-plane chamfer).
         let mut found_chamfer_plane = false;
         for &fid in result_shell.faces() {
             let face = topo.face(fid).unwrap();
@@ -483,7 +457,6 @@ mod tests {
         let solid = make_unit_cube_manifold(&mut topo);
 
         let builder = ChamferBuilder::new(&mut topo, solid);
-        // No edges added — should error.
         let result = builder.build();
         assert!(result.is_err(), "empty edge set should produce an error");
     }

--- a/crates/blend/src/corner.rs
+++ b/crates/blend/src/corner.rs
@@ -24,8 +24,6 @@ use crate::section::CircSection;
 use crate::spherical_triangle::{VertexContactData, build_n_edge_corner, build_spherical_corner};
 use crate::stripe::Stripe;
 
-// ── Types ──────────────────────────────────────────────────────────
-
 /// Classification of a vertex blend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CornerType {
@@ -48,8 +46,6 @@ pub struct CornerResult {
     /// New vertices created for the corner patch.
     pub new_vertices: Vec<VertexId>,
 }
-
-// ── Helpers ────────────────────────────────────────────────────────
 
 /// Tolerance for floating-point comparisons.
 const TOL: f64 = 1e-7;
@@ -93,10 +89,8 @@ fn contact_points_at_vertex(
         return Option::None;
     }
 
-    // Check if vertex is at start of first edge
     let first_edge = topo.edge(edges[0]).ok()?;
     if first_edge.start() == vertex_id || first_edge.end() == vertex_id {
-        // Determine if it's the start or end of the spine
         let is_start = first_edge.start() == vertex_id;
         if is_start {
             let sec = stripe.sections.first()?;
@@ -104,7 +98,6 @@ fn contact_points_at_vertex(
         }
     }
 
-    // Check if vertex is at end of last edge
     let last_edge = topo.edge(edges[edges.len() - 1]).ok()?;
     if last_edge.end() == vertex_id || last_edge.start() == vertex_id {
         let is_end = last_edge.end() == vertex_id;
@@ -137,7 +130,6 @@ fn collect_contact_points(
     let mut points = Vec::new();
     for &idx in stripe_indices {
         if let Some((p1, p2)) = contact_points_at_vertex(vertex_id, &stripes[idx], topo) {
-            // Add if not duplicate
             if !points.iter().any(|q: &Point3| (*q - p1).length() < TOL) {
                 points.push(p1);
             }
@@ -169,21 +161,18 @@ fn contact_section_at_vertex<'a>(
         return Option::None;
     }
 
-    // Check start of first edge
     if let Ok(first_edge) = topo.edge(edges[0]) {
         if first_edge.start() == vertex_id {
             return stripe.sections.first();
         }
     }
 
-    // Check end of last edge
     if let Ok(last_edge) = topo.edge(edges[edges.len() - 1]) {
         if last_edge.end() == vertex_id {
             return stripe.sections.last();
         }
     }
 
-    // Proximity fallback
     let vpos = topo.vertex(vertex_id).ok()?.point();
     let first = stripe.sections.first()?;
     let last = stripe.sections.last()?;
@@ -228,8 +217,6 @@ fn build_triangular_patch(
     Ok((surface, vec![v0, v1, v2], vec![e0, e1, e2]))
 }
 
-// ── Classification ─────────────────────────────────────────────────
-
 /// Classify the vertex blend type based on the stripes meeting at this vertex.
 #[must_use]
 pub fn classify_corner(vertex_id: VertexId, stripes: &[Stripe], topo: &Topology) -> CornerType {
@@ -241,8 +228,6 @@ pub fn classify_corner(vertex_id: VertexId, stripes: &[Stripe], topo: &Topology)
         n => CornerType::MultiEdge(n),
     }
 }
-
-// ── Multi-Edge Builder (spherical triangle) ───────────────────────
 
 /// Build corner patches for 3+ stripes meeting at a vertex using
 /// spherical triangle patches from the `spherical_triangle` module.
@@ -266,18 +251,15 @@ fn build_multi_edge_corner(
         return Err(BlendError::CornerFailure { vertex: vertex_id });
     }
 
-    // Get the fillet radius from the first stripe at this vertex.
     let radius = stripe_radius_at_vertex(vertex_id, &stripes[indices[0]], topo)
         .ok_or(BlendError::CornerFailure { vertex: vertex_id })?;
 
-    // Gather face normals from the faces adjacent to the stripes at this vertex.
     let mut face_normals: Vec<Vec3> = Vec::new();
     for &idx in &indices {
         let stripe = &stripes[idx];
         for face_id in [stripe.face1, stripe.face2] {
             let face_surf = topo.face(face_id)?.surface().clone();
             let n = face_surf.normal(0.0, 0.0);
-            // Only add if not a near-duplicate.
             let is_dup = face_normals
                 .iter()
                 .any(|existing| existing.dot(n).abs() > 1.0 - ORTHO_COS_TOL);
@@ -321,15 +303,12 @@ fn build_multi_edge_corner(
         vertex_id,
     };
 
-    // Delegate to the spherical triangle module.
     let spherical_results = if data.contact_points.len() == 3 {
         vec![build_spherical_corner(&data)?]
     } else {
         build_n_edge_corner(&data)?
     };
 
-    // Convert each SphericalCornerResult into a CornerResult by creating
-    // face topology from the surface and boundary curves.
     let mut results = Vec::with_capacity(spherical_results.len());
 
     for sr in spherical_results {
@@ -337,14 +316,12 @@ fn build_multi_edge_corner(
         let mut new_vertices = Vec::with_capacity(n_curves);
         let mut new_edges = Vec::with_capacity(n_curves);
 
-        // Create vertices at the start of each boundary curve.
         for curve in &sr.boundary_curves {
             let pt = curve.evaluate(0.0);
             let vid = topo.add_vertex(Vertex::new(pt, TOL));
             new_vertices.push(vid);
         }
 
-        // Create edges with the boundary curves as NurbsCurve geometry.
         for i in 0..n_curves {
             let v_start = new_vertices[i];
             let v_end = new_vertices[(i + 1) % n_curves];
@@ -353,7 +330,6 @@ fn build_multi_edge_corner(
             new_edges.push(eid);
         }
 
-        // Build wire from oriented edges.
         let oriented_edges: Vec<OrientedEdge> = new_edges
             .iter()
             .map(|&eid| OrientedEdge::new(eid, true))
@@ -361,7 +337,6 @@ fn build_multi_edge_corner(
         let wire = Wire::new(oriented_edges, true)?;
         let wire_id = topo.add_wire(wire);
 
-        // Create the face.
         let face = Face::new(wire_id, Vec::new(), sr.surface.clone());
         let face_id = topo.add_face(face);
 
@@ -375,8 +350,6 @@ fn build_multi_edge_corner(
 
     Ok(results)
 }
-
-// ── Two-Edge Builder ───────────────────────────────────────────────
 
 /// Build a simple triangular fill for 2 stripes meeting at a vertex.
 ///
@@ -419,8 +392,6 @@ fn build_two_edge_patch(
     })
 }
 
-// ── Top-Level Entry Point ──────────────────────────────────────────
-
 /// Compute vertex blend patches for all corners where multiple stripes meet.
 ///
 /// Iterates over all vertices of the solid, classifies each, and builds
@@ -457,8 +428,6 @@ pub fn compute_corners(
     Ok(results)
 }
 
-// ── Tests ──────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -485,7 +454,6 @@ mod tests {
     ) {
         let mut topo = Topology::new();
 
-        // Box vertices at unit cube corners
         let v000 = topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 0.0), TOL));
         let v100 = topo.add_vertex(Vertex::new(Point3::new(1.0, 0.0, 0.0), TOL));
         let v010 = topo.add_vertex(Vertex::new(Point3::new(0.0, 1.0, 0.0), TOL));
@@ -495,12 +463,10 @@ mod tests {
         let v011 = topo.add_vertex(Vertex::new(Point3::new(0.0, 1.0, 1.0), TOL));
         let v111 = topo.add_vertex(Vertex::new(Point3::new(1.0, 1.0, 1.0), TOL));
 
-        // Edges along X, Y, Z from origin vertex
         let ex = topo.add_edge(Edge::new(v000, v100, EdgeCurve::Line));
         let ey = topo.add_edge(Edge::new(v000, v010, EdgeCurve::Line));
         let ez = topo.add_edge(Edge::new(v000, v001, EdgeCurve::Line));
 
-        // Additional edges for face closure (minimal for test)
         let exy = topo.add_edge(Edge::new(v100, v110, EdgeCurve::Line));
         let eyx = topo.add_edge(Edge::new(v010, v110, EdgeCurve::Line));
         let exz = topo.add_edge(Edge::new(v100, v101, EdgeCurve::Line));
@@ -508,7 +474,6 @@ mod tests {
         let eyz = topo.add_edge(Edge::new(v010, v011, EdgeCurve::Line));
         let ezy = topo.add_edge(Edge::new(v001, v011, EdgeCurve::Line));
 
-        // Faces adjacent to the origin corner (XY, XZ, YZ planes)
         let face_xy = {
             let w = Wire::new(
                 vec![
@@ -578,7 +543,6 @@ mod tests {
             topo.add_face(f)
         };
 
-        // Opposite faces (for a complete shell)
         let e_top1 = topo.add_edge(Edge::new(v101, v111, EdgeCurve::Line));
         let e_top2 = topo.add_edge(Edge::new(v011, v111, EdgeCurve::Line));
         let face_top = {
@@ -650,7 +614,6 @@ mod tests {
             topo.add_face(f)
         };
 
-        // Build shell and solid
         let shell = Shell::new(vec![
             face_xy, face_xz, face_yz, face_top, face_right, face_back,
         ])
@@ -659,11 +622,8 @@ mod tests {
         let solid = Solid::new(shell_id, vec![]);
         let solid_id = topo.add_solid(solid);
 
-        // Create 3 stripes along the 3 edges from the origin vertex.
-        // Each stripe has a radius and sections with contact points.
         let radius = 0.2;
 
-        // Stripe along X edge (between face_xy and face_xz)
         let spine_x = Spine::from_single_edge(&topo, ex).unwrap();
         let stripe_x = Stripe {
             spine: spine_x,
@@ -723,7 +683,6 @@ mod tests {
             ],
         };
 
-        // Stripe along Y edge (between face_xy and face_yz)
         let spine_y = Spine::from_single_edge(&topo, ey).unwrap();
         let stripe_y = Stripe {
             spine: spine_y,
@@ -783,7 +742,6 @@ mod tests {
             ],
         };
 
-        // Stripe along Z edge (between face_xz and face_yz)
         let spine_z = Spine::from_single_edge(&topo, ez).unwrap();
         let stripe_z = Stripe {
             spine: spine_z,

--- a/crates/blend/src/fillet_builder.rs
+++ b/crates/blend/src/fillet_builder.rs
@@ -83,7 +83,6 @@ impl<'a> FilletBuilder<'a> {
     /// [`BlendResult::failed`] rather than aborting the whole operation.
     #[allow(clippy::too_many_lines)]
     pub fn build(self) -> Result<BlendResult, BlendError> {
-        // ── Validate input ──────────────────────────────────────────────
         // Expand edge sets: keep actual RadiusLaw references via indices.
         let mut all_edges: Vec<(EdgeId, usize)> = Vec::new();
         let mut laws: Vec<RadiusLaw> = Vec::with_capacity(self.edge_sets.len());
@@ -104,17 +103,14 @@ impl<'a> FilletBuilder<'a> {
 
         let topo = self.topo;
 
-        // ── Build adjacency ─────────────────────────────────────────────
         let adjacency = topo.build_adjacency(self.solid)?;
 
-        // Collect all original face IDs.
         let shell_id = topo.solid(self.solid)?.outer_shell();
         let original_faces: Vec<FaceId> = topo.shell(shell_id)?.faces().to_vec();
 
         // Track which faces are touched (adjacent to a fillet edge).
         let mut touched_faces: HashSet<FaceId> = HashSet::new();
 
-        // ── Phase 1: Compute stripes ────────────────────────────────────
         let mut succeeded: Vec<EdgeId> = Vec::new();
         let mut failed: Vec<(EdgeId, BlendError)> = Vec::new();
         let mut stripe_results: Vec<StripeResult> = Vec::new();
@@ -134,7 +130,6 @@ impl<'a> FilletBuilder<'a> {
             }
         }
 
-        // If no stripes succeeded, return the original solid with all failures.
         if stripe_results.is_empty() {
             return Ok(BlendResult {
                 solid: self.solid,
@@ -144,7 +139,6 @@ impl<'a> FilletBuilder<'a> {
             });
         }
 
-        // ── Phase 2: Compute corner patches ────────────────────────────
         let stripes: Vec<Stripe> = stripe_results.iter().map(|sr| sr.stripe.clone()).collect();
         let corner_results = match corner::compute_corners(topo, &stripes, self.solid) {
             Ok(results) => results,
@@ -154,13 +148,11 @@ impl<'a> FilletBuilder<'a> {
             }
         };
 
-        // Add corner faces to the result and mark their adjacent faces as touched.
         let mut corner_face_ids: Vec<FaceId> = Vec::new();
         for cr in &corner_results {
             corner_face_ids.push(cr.face_id);
         }
 
-        // ── Phase 3: Trim faces ─────────────────────────────────────────
         // Map from original face ID to its latest trimmed replacement.
         let mut face_replacements: std::collections::HashMap<FaceId, FaceId> =
             std::collections::HashMap::new();
@@ -168,7 +160,6 @@ impl<'a> FilletBuilder<'a> {
         for sr in &stripe_results {
             let stripe = &sr.stripe;
 
-            // Collect contact points for trimming.
             let contact1_pts = sample_nurbs_endpoints(&stripe.contact1);
             let contact2_pts = sample_nurbs_endpoints(&stripe.contact2);
 
@@ -218,7 +209,6 @@ impl<'a> FilletBuilder<'a> {
                 }
             }
 
-            // Trim face 2.
             let current_face2 = face_replacements
                 .get(&stripe.face2)
                 .copied()
@@ -236,41 +226,32 @@ impl<'a> FilletBuilder<'a> {
             }
         }
 
-        // ── Phase 3: Create blend faces ─────────────────────────────────
         let mut blend_face_ids: Vec<FaceId> = Vec::new();
 
         for sr in &stripe_results {
             let stripe = &sr.stripe;
 
-            // Create a face for the blend surface.
             // For v1, we create a minimal wire from the contact curve endpoints.
             let blend_face_id = create_blend_face(topo, stripe)?;
             blend_face_ids.push(blend_face_id);
         }
 
-        // ── Phase 4: Assemble solid ─────────────────────────────────────
         let mut result_faces: Vec<FaceId> = Vec::new();
 
-        // Add untouched original faces.
         for &fid in &original_faces {
             if !touched_faces.contains(&fid) {
                 result_faces.push(fid);
             }
         }
 
-        // Add trimmed replacements (or originals if not replaced).
         for &fid in &touched_faces {
             let replacement = face_replacements.get(&fid).copied();
             result_faces.push(replacement.unwrap_or(fid));
         }
 
-        // Add blend faces.
         result_faces.extend(&blend_face_ids);
-
-        // Add corner patch faces.
         result_faces.extend(&corner_face_ids);
 
-        // Build shell and solid.
         let new_shell = Shell::new(result_faces)?;
         let new_shell_id = topo.add_shell(new_shell);
         let new_solid = Solid::new(new_shell_id, Vec::new());
@@ -299,7 +280,6 @@ fn compute_stripe_for_edge(
     edge_id: EdgeId,
     law: &RadiusLaw,
 ) -> Result<StripeResult, BlendError> {
-    // Find the two adjacent faces.
     let adj_faces = adjacency.faces_for_edge(edge_id);
     if adj_faces.len() != 2 {
         // Non-manifold (3+ faces) or boundary (0-1 faces) edge cannot be filleted.
@@ -323,7 +303,6 @@ fn compute_stripe_for_edge(
     let surf2 = face2_data.surface().clone();
     let face2_reversed = face2_data.is_reversed();
 
-    // Build a single-edge spine.
     let spine = Spine::from_single_edge(topo, edge_id)?;
 
     // Get radius at the spine midpoint for the analytic path.
@@ -352,7 +331,6 @@ fn compute_stripe_for_edge(
         }
     }
 
-    // ── Walking fallback for non-analytic surface pairs ─────────────
     // Build ParametricSurface references via PlaneAdapter for planes.
     // When a face is reversed, the outward normal is flipped. For PlaneAdapter,
     // we negate the normal. For analytic/NURBS surfaces the ParametricSurface
@@ -376,7 +354,6 @@ fn compute_stripe_for_edge(
 
     let config = WalkerConfig::default();
 
-    // Choose blend function based on law type.
     let walk_result = if let RadiusLaw::Constant(r) = law {
         let blend = ConstRadBlend { radius: *r };
         let walker = Walker::new(&blend, ps1, ps2, &spine, topo, config);
@@ -391,15 +368,12 @@ fn compute_stripe_for_edge(
         walker.walk(start, 0.0, spine.length())?
     };
 
-    // Build NURBS surface from the walked sections.
     let blend_surface = approximate_blend_surface(&walk_result.sections)?;
     let blend_face_surface = brepkit_topology::face::FaceSurface::Nurbs(blend_surface);
 
-    // Build contact curves from the sections.
     let contact1 = sections_to_contact_curve(&walk_result.sections, |s| s.p1)?;
     let contact2 = sections_to_contact_curve(&walk_result.sections, |s| s.p2)?;
 
-    // PCurves: project contact 3D endpoints onto each face surface.
     let pcurve1 = build_pcurve_from_contact(ps1, &contact1)?;
     let pcurve2 = build_pcurve_from_contact(ps2, &contact2)?;
 
@@ -619,10 +593,6 @@ fn build_pcurve_from_contact(
     Ok(brepkit_math::curves2d::Curve2D::Line(line))
 }
 
-// ===========================================================================
-// Tests
-// ===========================================================================
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -638,7 +608,6 @@ mod tests {
         let solid = make_unit_cube_manifold(&mut topo);
 
         let builder = FilletBuilder::new(&mut topo, solid);
-        // No edges added — should error.
         let result = builder.build();
         assert!(result.is_err(), "empty edge set should produce an error");
     }
@@ -648,12 +617,10 @@ mod tests {
         let mut topo = Topology::new();
         let solid = make_unit_cube_manifold(&mut topo);
 
-        // Find a manifold edge (any of the 12 edges should work).
         let adjacency = AdjacencyIndex::build(&topo, solid).unwrap();
         let shell_id = topo.solid(solid).unwrap().outer_shell();
         let faces = topo.shell(shell_id).unwrap().faces().to_vec();
 
-        // Find the first edge shared by two faces.
         let mut target_edge = None;
         'outer: for &fid in &faces {
             let face = topo.face(fid).unwrap();
@@ -668,13 +635,11 @@ mod tests {
         }
         let target_edge = target_edge.expect("cube should have manifold edges");
 
-        // Build fillet.
         let original_face_count = faces.len();
         let mut builder = FilletBuilder::new(&mut topo, solid);
         builder.add_edges(&[target_edge], 0.1);
         let result = builder.build().expect("fillet build should succeed");
 
-        // The result solid should exist.
         let result_solid = topo.solid(result.solid).unwrap();
         let result_shell = topo.shell(result_solid.outer_shell()).unwrap();
 
@@ -686,12 +651,10 @@ mod tests {
             original_face_count,
         );
 
-        // Edge should be in the succeeded list.
         assert!(result.succeeded.contains(&target_edge));
         assert!(result.failed.is_empty());
         assert!(!result.is_partial);
 
-        // The blend surface should be a cylinder (plane-plane fillet).
         let mut found_cylinder = false;
         for &fid in result_shell.faces() {
             let face = topo.face(fid).unwrap();
@@ -710,7 +673,6 @@ mod tests {
         let mut topo = Topology::new();
         let solid = make_unit_cube_manifold(&mut topo);
 
-        // Create a fake edge that is not part of the solid (will fail adjacency).
         let v0 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
             brepkit_math::vec::Point3::new(10.0, 10.0, 10.0),
             1e-7,
@@ -729,7 +691,6 @@ mod tests {
         builder.add_edges(&[fake_edge], 0.2);
         let result = builder.build().expect("build should succeed (partial)");
 
-        // The fake edge should be in failed.
         assert!(result.failed.len() == 1);
         assert_eq!(result.failed[0].0, fake_edge);
         // With no successes, the original solid is returned.

--- a/crates/blend/src/g1_chain.rs
+++ b/crates/blend/src/g1_chain.rs
@@ -67,7 +67,6 @@ pub fn expand_g1_chain(
     let shell = topo.shell(solid_data.outer_shell())?;
     let shell_face_ids: Vec<FaceId> = shell.faces().to_vec();
 
-    // Build edge->faces and vertex->edges maps for the full shell.
     let mut edge_to_faces: HashMap<usize, Vec<FaceId>> = HashMap::new();
     let mut vertex_to_edges: HashMap<usize, Vec<EdgeId>> = HashMap::new();
     let mut edge_ids: HashMap<usize, EdgeId> = HashMap::new();
@@ -101,7 +100,6 @@ pub fn expand_g1_chain(
         edges.dedup_by_key(|e: &mut EdgeId| e.index());
     }
 
-    // Iterative BFS expansion.
     let mut expanded: HashSet<usize> = seed_edges.iter().map(|e| e.index()).collect();
     let mut queue: Vec<EdgeId> = seed_edges.to_vec();
 

--- a/crates/blend/src/spherical_triangle.rs
+++ b/crates/blend/src/spherical_triangle.rs
@@ -18,8 +18,6 @@ use crate::BlendError;
 /// Tolerance for geometric checks.
 const TOL: f64 = 1e-6;
 
-// ── Types ──────────────────────────────────────────────────────────
-
 /// Input data for building a spherical corner patch at a vertex.
 pub struct VertexContactData {
     /// Position of the vertex in 3D space.
@@ -43,8 +41,6 @@ pub struct SphericalCornerResult {
     /// The 3 boundary arcs (great-circle arcs on the sphere).
     pub boundary_curves: Vec<NurbsCurve>,
 }
-
-// ── Sphere center ──────────────────────────────────────────────────
 
 /// Compute the sphere center and actual sphere radius from vertex
 /// position, face normals, and the fillet radius.
@@ -77,7 +73,6 @@ fn compute_sphere_center(data: &VertexContactData) -> Result<(Point3, f64), Blen
         data.vertex_pos - offset
     };
 
-    // Derive the actual sphere radius from the first contact point.
     if data.contact_points.is_empty() {
         return Err(BlendError::CornerFailure {
             vertex: data.vertex_id,
@@ -103,8 +98,6 @@ fn compute_sphere_center(data: &VertexContactData) -> Result<(Point3, f64), Blen
 
     Ok((center, sphere_radius))
 }
-
-// ── Great-circle arc ───────────────────────────────────────────────
 
 /// Build a rational quadratic NURBS curve representing a great-circle
 /// arc on the sphere from `q_start` to `q_end` centered at `center`.
@@ -139,8 +132,6 @@ fn build_great_circle_arc(
     Ok(NurbsCurve::new(2, knots, control_points, weights)?)
 }
 
-// ── 3-edge corner ──────────────────────────────────────────────────
-
 /// Build a spherical triangle corner patch for a standard 3-edge vertex.
 ///
 /// The result is a degree-(2,2) rational NURBS surface that exactly
@@ -168,7 +159,6 @@ pub fn build_spherical_corner(
     let q2 = data.contact_points[1];
     let q3 = data.contact_points[2];
 
-    // Direction vectors from center to each contact point.
     let dir1 = (q1 - center) * (1.0 / r);
     let dir2 = (q2 - center) * (1.0 / r);
     let dir3 = (q3 - center) * (1.0 / r);
@@ -178,7 +168,6 @@ pub fn build_spherical_corner(
     let mid_q2q3 = edge_mid_cp(center, r, dir2, dir3, vid)?;
     let mid_q3q1 = edge_mid_cp(center, r, dir3, dir1, vid)?;
 
-    // Cosine of half-angle for each edge.
     let w_q1q2 = cos_half_angle(dir1, dir2);
     let w_q2q3 = cos_half_angle(dir2, dir3);
     let w_q3q1 = cos_half_angle(dir3, dir1);
@@ -192,7 +181,6 @@ pub fn build_spherical_corner(
     let apex_dir = apex_dir_raw * (1.0 / apex_dir_len);
     let apex = center + apex_dir * r;
 
-    // Apex weight: product of adjacent edge-mid weights.
     let w_apex = w_q1q2 * w_q2q3 * w_q3q1;
 
     // Build 3x3 control point grid (degree 2x2).
@@ -216,7 +204,6 @@ pub fn build_spherical_corner(
 
     let surface = NurbsSurface::new(2, 2, knots.clone(), knots, control_points, weights)?;
 
-    // Build the 3 boundary arcs.
     let arc_q1q2 = build_great_circle_arc(center, r, q1, q2, vid)?;
     let arc_q2q3 = build_great_circle_arc(center, r, q2, q3, vid)?;
     let arc_q3q1 = build_great_circle_arc(center, r, q3, q1, vid)?;
@@ -226,8 +213,6 @@ pub fn build_spherical_corner(
         boundary_curves: vec![arc_q1q2, arc_q2q3, arc_q3q1],
     })
 }
-
-// ── N-edge corner (centroid fan) ───────────────────────────────────
 
 /// Build spherical corner patches for a vertex with N > 3 edges.
 ///
@@ -336,8 +321,6 @@ fn build_triangle_on_sphere(
     })
 }
 
-// ── Helpers ────────────────────────────────────────────────────────
-
 /// Compute the tangent-intersection midpoint control point for a
 /// rational quadratic arc between two directions on the sphere.
 fn edge_mid_cp(
@@ -371,8 +354,6 @@ fn cos_half_angle(dir_a: Vec3, dir_b: Vec3) -> f64 {
     let bisector = bisector_raw * (1.0 / bisector_len);
     dir_a.dot(bisector)
 }
-
-// ── Tests ──────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -449,13 +430,11 @@ mod tests {
 
         let result = build_spherical_corner(&data).expect("should build corner");
 
-        // Extract the NurbsSurface from FaceSurface::Nurbs.
         let nurbs = match &result.surface {
             FaceSurface::Nurbs(s) => s,
             _ => panic!("expected Nurbs surface"),
         };
 
-        // Sample at a grid of (u, v) values and check distance to center.
         let n_samples = 5;
         for i in 0..=n_samples {
             for j in 0..=n_samples {

--- a/crates/blend/src/trimmer.rs
+++ b/crates/blend/src/trimmer.rs
@@ -79,7 +79,6 @@ pub fn trim_face(
     contact_uv: &[(f64, f64)],
     keep_side: TrimSide,
 ) -> Result<TrimResult, BlendError> {
-    // ── Guard: only planar faces for v1 ──────────────────────────────
     let face = topo.face(face_id)?;
     if !face.surface().is_planar() {
         log::warn!(
@@ -94,7 +93,6 @@ pub fn trim_face(
         });
     }
 
-    // ── Snapshot the face data (borrow rules) ────────────────────────
     let surface = face.surface().clone();
     let reversed = face.is_reversed();
     let outer_wire_id = face.outer_wire();
@@ -102,7 +100,6 @@ pub fn trim_face(
     let outer_wire = topo.wire(outer_wire_id)?;
     let oriented_edges: Vec<OrientedEdge> = outer_wire.edges().to_vec();
 
-    // Need at least 2 UV points to define the contact line.
     if contact_uv.len() < 2 {
         return Err(BlendError::TrimmingFailure { face: face_id });
     }
@@ -110,9 +107,7 @@ pub fn trim_face(
     let uv_start = contact_uv[0];
     let uv_end = contact_uv[contact_uv.len() - 1];
 
-    // ── Snapshot all edge data ───────────────────────────────────────
-    // For each oriented edge, record:
-    //   (oriented_edge, start_point, end_point, start_uv, end_uv)
+    // For each oriented edge, record (oriented_edge, start_point, end_point)
     // where "start" / "end" follow the orientation.
     let mut edge_data: Vec<(OrientedEdge, Point3, Point3)> =
         Vec::with_capacity(oriented_edges.len());
@@ -125,7 +120,6 @@ pub fn trim_face(
         edge_data.push((oe, start_pt, end_pt));
     }
 
-    // ── Project boundary vertices to 2D using the face plane ─────────
     // For a planar face we use a local 2D coordinate system derived from
     // the first two edge directions.
     let (origin, u_axis, v_axis) = plane_local_frame(&surface, &edge_data, face_id)?;
@@ -147,7 +141,6 @@ pub fn trim_face(
         (uv_start, uv_end)
     };
 
-    // ── Find boundary-edge intersections ─────────────────────────────
     let mut hits: Vec<BoundaryHit> = Vec::new();
 
     for (idx, &(_, start_pt, end_pt)) in edge_data.iter().enumerate() {
@@ -185,46 +178,33 @@ pub fn trim_face(
     let hit_a = &hits[0];
     let hit_b = &hits[1];
 
-    // ── Create intersection vertices ─────────────────────────────────
     let va_id = topo.add_vertex(Vertex::new(hit_a.point_3d, VERTEX_TOL));
     let vb_id = topo.add_vertex(Vertex::new(hit_b.point_3d, VERTEX_TOL));
 
-    // ── Split boundary edges at intersection points ──────────────────
     // Each hit splits one oriented edge into two sub-edges:
     //   original: oriented from S→E
     //   sub-edge 1: S → V_hit  (forward w.r.t. original orientation)
     //   sub-edge 2: V_hit → E
-
-    // Split edge A
     let (sub_a1, sub_a2) = split_edge_at(topo, &edge_data[hit_a.edge_idx].0, va_id)?;
-
-    // Split edge B
     let (sub_b1, sub_b2) = split_edge_at(topo, &edge_data[hit_b.edge_idx].0, vb_id)?;
 
-    // ── Contact edge ─────────────────────────────────────────────────
     // The contact edge connects the two intersection vertices.
     // Its direction determines which side is "left" vs "right".
     let contact_edge_id = topo.add_edge(Edge::new(va_id, vb_id, EdgeCurve::Line));
 
-    // ── Determine which side to keep ─────────────────────────────────
     // The contact line divides the boundary edges into two chains:
     //   Chain 1: edges from hit_a to hit_b (in wire order)
     //   Chain 2: edges from hit_b to hit_a (wrapping around)
     // "Left" = chain 1 side, "Right" = chain 2 side (relative to
     // the contact direction va→vb and the face normal).
 
-    // Build chain 1: sub_a2, edges between A and B, sub_b1
-    // Build chain 2: sub_b2, edges after B wrapping to before A, sub_a1
-
     let n_edges = edge_data.len();
 
     let mut chain1: Vec<OrientedEdge> = Vec::new();
     let mut chain2: Vec<OrientedEdge> = Vec::new();
 
-    // Chain 1: from hit_a to hit_b
     chain1.push(sub_a2);
     if hit_a.edge_idx != hit_b.edge_idx {
-        // Add full edges between A's edge and B's edge
         for i in (hit_a.edge_idx + 1)..hit_b.edge_idx {
             chain1.push(oriented_edges[i]);
         }
@@ -240,7 +220,6 @@ pub fn trim_face(
         return Err(BlendError::TrimmingFailure { face: face_id });
     }
 
-    // Chain 2: from hit_b to hit_a (wrapping)
     chain2.push(sub_b2);
     for i in (hit_b.edge_idx + 1)..n_edges {
         chain2.push(oriented_edges[i]);
@@ -250,7 +229,6 @@ pub fn trim_face(
     }
     chain2.push(sub_a1);
 
-    // ── Pick the kept chain based on TrimSide ────────────────────────
     // Use the face plane normal and contact direction to determine left/right.
     let face_normal = match &surface {
         FaceSurface::Plane { normal, .. } => {
@@ -300,7 +278,6 @@ pub fn trim_face(
         }
     };
 
-    // ── Build the trimmed wire ───────────────────────────────────────
     let mut loop_edges = kept_chain;
     loop_edges.push(OrientedEdge::new(contact_edge_id, contact_forward));
 
@@ -308,14 +285,12 @@ pub fn trim_face(
         Wire::new(loop_edges, true).map_err(|_| BlendError::TrimmingFailure { face: face_id })?;
     let trimmed_wire_id = topo.add_wire(trimmed_wire);
 
-    // ── Build the trimmed face ───────────────────────────────────────
     let mut trimmed_face = Face::new(trimmed_wire_id, Vec::new(), surface);
     if reversed {
         trimmed_face.set_reversed(true);
     }
     let trimmed_face_id = topo.add_face(trimmed_face);
 
-    // ── Collect results ──────────────────────────────────────────────
     let new_edges = vec![sub_a1.edge(), sub_a2.edge(), sub_b1.edge(), sub_b2.edge()];
 
     Ok(TrimResult {
@@ -340,9 +315,6 @@ fn split_edge_at(
     let end_vid = oe.oriented_end(edge);
     let curve = edge.curve().clone();
 
-    // Sub-edge 1: original start → split vertex
-    // Sub-edge 2: split vertex → original end
-    // Both use the same curve type (Line for planar faces in v1).
     let e1_id = topo.add_edge(Edge::new(start_vid, split_vertex, curve.clone()));
     let e2_id = topo.add_edge(Edge::new(split_vertex, end_vid, curve));
 
@@ -503,7 +475,6 @@ pub fn trim_face_general(
 
     // Planar path: construct UV from plane frame and delegate
     if let FaceSurface::Plane { normal, d } = &surface {
-        // Build a local 2D frame on the plane
         let arbitrary = if normal.x().abs() < 0.9 {
             brepkit_math::vec::Vec3::new(1.0, 0.0, 0.0)
         } else {
@@ -546,14 +517,12 @@ pub fn trim_face_general(
         return Ok(untrimmed_result(face_id));
     };
 
-    // Snapshot boundary edges
     let face = topo.face(face_id)?;
     let reversed = face.is_reversed();
     let outer_wire_id = face.outer_wire();
     let outer_wire = topo.wire(outer_wire_id)?;
     let oriented_edges: Vec<OrientedEdge> = outer_wire.edges().to_vec();
 
-    // Project boundary edge endpoints to UV
     #[allow(clippy::type_complexity)]
     let mut edge_data_uv: Vec<(OrientedEdge, Point3, Point3, (f64, f64), (f64, f64))> =
         Vec::with_capacity(oriented_edges.len());
@@ -581,7 +550,6 @@ pub fn trim_face_general(
         edge_data_uv.push((oe, s3, e3, s_uv, e_uv));
     }
 
-    // Find boundary intersections in UV space
     let mut hits: Vec<BoundaryHit> = Vec::new();
     for (edge_idx, (_oe, s3, e3, s_uv, e_uv)) in edge_data_uv.iter().enumerate() {
         if let Some(t) = line_segment_intersect_2d(*s_uv, *e_uv, uv_s, uv_e) {
@@ -605,13 +573,11 @@ pub fn trim_face_general(
     // Sort hits by edge index (to process in wire order)
     hits.sort_by_key(|h| (h.edge_idx, (h.t * 1e10) as i64));
 
-    // Create intersection vertices
     let hit_a = &hits[0];
     let hit_b = &hits[1];
     let va = topo.add_vertex(Vertex::new(hit_a.point_3d, VERTEX_TOL));
     let vb = topo.add_vertex(Vertex::new(hit_b.point_3d, VERTEX_TOL));
 
-    // Split boundary edges at the intersection points
     let oe_a = edge_data_uv[hit_a.edge_idx].0;
     let edge_a = topo.edge(oe_a.edge())?;
     let (sa, ea) = if oe_a.is_forward() {
@@ -630,13 +596,11 @@ pub fn trim_face_general(
     };
     let curve_b = edge_b.curve().clone();
 
-    // Sub-edges for the split edges
     let ea_pre = topo.add_edge(Edge::new(sa, va, curve_a.clone()));
     let ea_post = topo.add_edge(Edge::new(va, ea, curve_a));
     let eb_pre = topo.add_edge(Edge::new(sb, vb, curve_b.clone()));
     let eb_post = topo.add_edge(Edge::new(vb, eb, curve_b));
 
-    // Contact edge between the two intersection points
     let contact_eid = topo.add_edge(Edge::new(va, vb, EdgeCurve::Line));
 
     // Build the trimmed wire loop: walk the boundary, replacing split edges,
@@ -661,7 +625,6 @@ pub fn trim_face_general(
     left_edges.push(OrientedEdge::new(eb_pre, true));
     left_edges.push(OrientedEdge::new(contact_eid, false));
 
-    // Build "right" side wire: remaining edges + contact edge
     let mut right_edges: Vec<OrientedEdge> = Vec::new();
     right_edges.push(OrientedEdge::new(eb_post, true));
     let n = oriented_edges.len();

--- a/crates/blend/src/walker.rs
+++ b/crates/blend/src/walker.rs
@@ -26,7 +26,6 @@ use crate::spine::Spine;
 /// Returns `None` if the matrix is singular (pivot below `1e-30`).
 #[must_use]
 pub fn solve_4x4(a: &[[f64; 4]; 4], b: &[f64; 4]) -> Option<[f64; 4]> {
-    // Copy into augmented matrix.
     let mut m = [[0.0_f64; 5]; 4];
     for i in 0..4 {
         for j in 0..4 {
@@ -37,7 +36,6 @@ pub fn solve_4x4(a: &[[f64; 4]; 4], b: &[f64; 4]) -> Option<[f64; 4]> {
 
     // Forward elimination with partial pivoting.
     for col in 0..4 {
-        // Find pivot.
         let mut max_abs = m[col][col].abs();
         let mut max_row = col;
         for row in (col + 1)..4 {
@@ -52,12 +50,10 @@ pub fn solve_4x4(a: &[[f64; 4]; 4], b: &[f64; 4]) -> Option<[f64; 4]> {
             return None;
         }
 
-        // Swap rows.
         if max_row != col {
             m.swap(col, max_row);
         }
 
-        // Eliminate below.
         let pivot = m[col][col];
         for row in (col + 1)..4 {
             let factor = m[row][col] / pivot;
@@ -206,7 +202,6 @@ impl<'a, F: BlendFunction> Walker<'a, F> {
             params.v2 += delta[3];
         }
 
-        // Check final residual.
         let f = self.func.value(self.surf1, self.surf2, &params, ctx);
         if Self::residual_norm(&f) < self.config.tol_3d {
             Some(params)
@@ -285,7 +280,6 @@ impl<'a, F: BlendFunction> Walker<'a, F> {
         let mut sections = Vec::new();
         let mut step_count = 0_usize;
 
-        // Collect the starting section.
         let ctx0 = self.make_context(s)?;
         let sec0 = self.func.section(self.surf1, self.surf2, &params, &ctx0);
         sections.push(sec0);
@@ -333,7 +327,6 @@ impl<'a, F: BlendFunction> Walker<'a, F> {
             // Corrector: Newton at the new spine station.
             let ctx_next = self.make_context(s_next)?;
             if let Some(converged) = self.newton_solve(predicted, &ctx_next) {
-                // Accept step.
                 prev_params = Some(params);
                 prev_s = s;
                 params = converged;
@@ -344,10 +337,8 @@ impl<'a, F: BlendFunction> Walker<'a, F> {
                     .section(self.surf1, self.surf2, &params, &ctx_next);
                 sections.push(sec);
 
-                // Increase step (but don't exceed max).
                 step = (step * 1.5).min(self.config.max_step_fraction * span);
             } else {
-                // Halve step and retry.
                 step *= 0.5;
                 if step < self.config.min_step {
                     let f = self.func.value(self.surf1, self.surf2, &params, &ctx_next);
@@ -410,7 +401,6 @@ pub fn approximate_blend_surface(sections: &[CircSection]) -> Result<NurbsSurfac
         let half_angle = sec.half_angle();
         let w_mid = half_angle.cos();
 
-        // cp0 = p1, cp2 = p2.
         let cp0 = sec.p1;
         let cp2 = sec.p2;
 
@@ -499,8 +489,6 @@ mod tests {
     use brepkit_topology::edge::{Edge, EdgeCurve};
     use brepkit_topology::vertex::Vertex;
 
-    // ── Test plane surface ──
-
     struct TestPlane {
         origin: Point3,
         u_dir: Vec3,
@@ -558,8 +546,6 @@ mod tests {
         let v1 = topo.add_vertex(Vertex::new(b, 1e-7));
         topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line))
     }
-
-    // ── solve_4x4 tests ──
 
     #[test]
     fn solve_4x4_identity() {

--- a/crates/check/src/classify/boundary.rs
+++ b/crates/check/src/classify/boundary.rs
@@ -19,10 +19,6 @@ use crate::CheckError;
 use crate::classify::ray_surface;
 use crate::util::{face_polygon, point_in_polygon_3d};
 
-// ---------------------------------------------------------------------------
-// Tolerance constants
-// ---------------------------------------------------------------------------
-
 /// Minimum positive ray parameter to count as a forward hit.
 const RAY_T_MIN: f64 = 1e-12;
 
@@ -31,10 +27,6 @@ const HALF_SPACE_EPS: f64 = 1e-10;
 
 /// Threshold for coincident vertex detection (squared distance).
 const COINCIDENT_SQ: f64 = 1e-12;
-
-// ---------------------------------------------------------------------------
-// Angular unwrapping
-// ---------------------------------------------------------------------------
 
 /// Unwrap a step in a periodic (angular) coordinate so the difference
 /// lies in `[-PI, PI)`.
@@ -47,10 +39,6 @@ fn unwrap_angle(prev: f64, next: f64) -> f64 {
     let diff = next - prev;
     prev + diff - tau * ((diff + PI) / tau).floor()
 }
-
-// ---------------------------------------------------------------------------
-// UV boundary construction
-// ---------------------------------------------------------------------------
 
 /// Build a UV boundary polygon from 3D face boundary vertices,
 /// with proper unwrapping of periodic coordinates.
@@ -76,10 +64,6 @@ where
     uv
 }
 
-// ---------------------------------------------------------------------------
-// UV containment test
-// ---------------------------------------------------------------------------
-
 /// Test if a (u,v) point is inside the UV boundary polygon.
 ///
 /// Adjusts the test point's u coordinate (and v when periodic) to lie within
@@ -90,7 +74,6 @@ fn point_in_uv_boundary(
     uv_boundary: &[(f64, f64)],
     v_periodic: bool,
 ) -> bool {
-    // Find the u range of the unwrapped boundary.
     let u_min = uv_boundary
         .iter()
         .map(|(u, _)| *u)
@@ -128,20 +111,12 @@ fn point_in_uv_boundary(
     point_in_polygon(test, &poly)
 }
 
-// ---------------------------------------------------------------------------
-// Polygon normal (Newell's method) — delegated to util
-// ---------------------------------------------------------------------------
-
 /// Compute the normal of a polygon via Newell's method.
 ///
 /// Returns a unit-length normal, or `(0,0,1)` for degenerate polygons.
 pub fn polygon_normal(verts: &[Point3]) -> Vec3 {
     crate::util::polygon_normal(verts)
 }
-
-// ---------------------------------------------------------------------------
-// Crossing counters
-// ---------------------------------------------------------------------------
 
 /// Count crossings for analytic (non-planar) faces using UV containment.
 ///
@@ -171,7 +146,6 @@ where
         return Ok(0);
     }
 
-    // Build UV boundary polygon from face wire.
     let verts = face_polygon(topo, face_id)?;
 
     // Detect degenerate boundary: a "full-surface" face whose wire has fewer
@@ -374,7 +348,6 @@ fn ray_crossings_nurbs(
         return Ok(0);
     }
 
-    // Build UV boundary from face wire vertices.
     let verts = face_polygon(topo, face_id)?;
     if verts.len() < 3 {
         // Full-surface face — every forward hit is a crossing.

--- a/crates/check/src/classify/mod.rs
+++ b/crates/check/src/classify/mod.rs
@@ -64,7 +64,6 @@ pub fn classify_point(
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
 
-    // Boundary check: project point onto each face, check distance.
     if is_on_boundary(topo, shell.faces(), point, options.tolerance)? {
         return Ok(PointClassification::OnBoundary);
     }
@@ -186,7 +185,6 @@ fn is_on_boundary(
             }
         };
         if dist < tolerance {
-            // Also check if point projects inside the face boundary.
             let polygon = crate::util::face_polygon(topo, fid)?;
             if polygon.len() >= 3 {
                 let normal = boundary::polygon_normal(&polygon);
@@ -259,7 +257,6 @@ pub fn classify_point_robust(
     if w < 0.4 {
         return Ok(PointClassification::Outside);
     }
-    // Ambiguous — fall back to ray casting.
     classify_point(topo, solid, point, options)
 }
 
@@ -275,7 +272,6 @@ fn count_ray_crossings(
 ) -> Result<u32, CheckError> {
     use brepkit_math::bvh::Bvh;
 
-    // Build face AABBs and BVH for broad-phase filtering.
     let face_aabbs: Vec<(usize, brepkit_math::aabb::Aabb3)> = faces
         .iter()
         .enumerate()

--- a/crates/check/src/distance/mod.rs
+++ b/crates/check/src/distance/mod.rs
@@ -54,7 +54,6 @@ pub fn point_to_solid(
 ) -> Result<DistanceResult, CheckError> {
     let face_ids = collect_solid_faces(topo, solid)?;
 
-    // Build AABBs and BVH.
     let mut face_aabbs: Vec<(usize, Aabb3)> = Vec::with_capacity(face_ids.len());
     for (i, &fid) in face_ids.iter().enumerate() {
         let aabb = crate::util::face_aabb(topo, fid)?;
@@ -73,7 +72,6 @@ pub fn point_to_solid(
         da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    // Use BVH closest hint to potentially reorder.
     if let Some(closest_idx) = bvh.query_closest(point) {
         if let Some(pos) = candidates
             .iter()
@@ -182,7 +180,6 @@ pub fn solid_to_solid(
     solid_a: SolidId,
     solid_b: SolidId,
 ) -> Result<DistanceResult, CheckError> {
-    // Collect vertex positions from each solid.
     let verts_a = collect_solid_vertices(topo, solid_a)?;
     let verts_b = collect_solid_vertices(topo, solid_b)?;
 
@@ -345,7 +342,6 @@ fn collect_solid_edge_segments(
         let shell = topo.shell(sid)?;
         for &fid in shell.faces() {
             let face = topo.face(fid)?;
-            // Iterate outer wire + inner wires (holes)
             let mut wire_ids = vec![face.outer_wire()];
             wire_ids.extend(face.inner_wires().iter().copied());
             for wid in wire_ids {
@@ -485,16 +481,13 @@ fn point_to_polygon_distance(
         return None;
     }
 
-    // Project point onto plane.
     let (_, projected) = analytic::point_to_plane(point, normal, d);
 
-    // Check if projected point is inside polygon.
     if crate::util::point_in_polygon_3d(&projected, polygon, &normal) {
         let dist = (point - projected).length();
         return Some((dist, projected));
     }
 
-    // Otherwise, find closest point on polygon edges.
     let mut best_dist = f64::INFINITY;
     let mut best_pt = polygon[0];
     let n = polygon.len();

--- a/crates/check/src/properties/bbox.rs
+++ b/crates/check/src/properties/bbox.rs
@@ -20,7 +20,6 @@ pub fn bounding_box(topo: &Topology, solid: SolidId) -> Result<Aabb3, CheckError
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
 
-    // Collect all vertex positions
     let mut points = Vec::new();
     for &fid in shell.faces() {
         let face = topo.face(fid)?;
@@ -35,7 +34,6 @@ pub fn bounding_box(topo: &Topology, solid: SolidId) -> Result<Aabb3, CheckError
     let mut aabb = Aabb3::try_from_points(points.iter().copied())
         .ok_or_else(|| CheckError::ClassificationFailed("solid has no vertices".into()))?;
 
-    // Expand for surface curvature
     for &fid in shell.faces() {
         if let Ok(face) = topo.face(fid) {
             expand_aabb_for_surface(&mut aabb, face.surface());

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -176,7 +176,6 @@ fn face_uv_bounds<S: ParametricSurface>(
     let face = topo.face(face_id)?;
     let wire = topo.wire(face.outer_wire())?;
 
-    // Collect projected UV values for each boundary vertex (in edge order).
     let mut uvs = Vec::new();
     for oe in wire.edges() {
         let edge = topo.edge(oe.edge())?;
@@ -588,13 +587,11 @@ fn integrate_parametric_trimmed<S: ParametricSurface>(
     let v_scale = (v_range.1 - v_range.0) / 2.0;
     let v_mid = f64::midpoint(v_range.0, v_range.1);
 
-    // Pre-build UV polygon for containment tests.
     let uv_poly: Vec<Point2> = uv_boundary
         .iter()
         .map(|(u, v)| Point2::new(*u, *v))
         .collect();
 
-    // Pre-compute boundary u-range for periodic shifting.
     let u_bcenter = if u_periodic {
         let bmin = uv_boundary
             .iter()
@@ -623,7 +620,6 @@ fn integrate_parametric_trimmed<S: ParametricSurface>(
         for gpv in gauss_pts {
             let v = v_scale.mul_add(gpv.x, v_mid);
 
-            // UV containment check for trimmed faces.
             let test_u = if u_periodic {
                 let tau = std::f64::consts::TAU;
                 let diff = u - u_bcenter;
@@ -694,7 +690,6 @@ where
 
     let mut uv: Vec<(f64, f64)> = polygon.iter().map(|&p| project(p)).collect();
 
-    // Unwrap periodic u-coordinates.
     for i in 1..uv.len() {
         if u_periodic {
             uv[i].0 = unwrap_angle(uv[i - 1].0, uv[i].0);

--- a/crates/check/src/validate/checks.rs
+++ b/crates/check/src/validate/checks.rs
@@ -10,12 +10,10 @@ use brepkit_topology::wire::WireId;
 /// Identifies a specific validation check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CheckId {
-    // Vertex checks
     /// Vertex not on edge 3D curve within tolerance.
     VertexOnCurve,
     /// Vertex not on face surface within tolerance.
     VertexOnSurface,
-    // Edge checks
     /// Edge has no 3D curve representation.
     EdgeNoCurve3D,
     /// 3D curve deviates from PCurve(surface) beyond tolerance.
@@ -24,7 +22,6 @@ pub enum CheckId {
     EdgeRangeValid,
     /// Edge is degenerate (zero length).
     EdgeDegenerate,
-    // Wire checks
     /// Wire contains no edges.
     WireEmpty,
     /// Consecutive edges not connected at shared vertices.
@@ -35,12 +32,10 @@ pub enum CheckId {
     WireRedundantEdge,
     /// Wire has a self-intersection (non-adjacent edges cross).
     WireSelfIntersection,
-    // Face checks
     /// Face has no surface.
     FaceNoSurface,
     /// Face orientation inconsistent with wire winding.
     FaceOrientationConsistency,
-    // Shell checks
     /// Shell contains no faces.
     ShellEmpty,
     /// Shell faces not all connected via shared edges.
@@ -49,7 +44,6 @@ pub enum CheckId {
     ShellClosed,
     /// Adjacent faces use shared edge in same direction (orientation inconsistent).
     ShellOrientationConsistent,
-    // Solid checks
     /// Euler characteristic V-E+F != 2 for genus-0 solid.
     SolidEulerCharacteristic,
     /// Same face ID appears in multiple shells.

--- a/crates/check/src/validate/edge.rs
+++ b/crates/check/src/validate/edge.rs
@@ -63,7 +63,6 @@ pub fn check_edge_degenerate(
             }
         }
         EdgeCurve::NurbsCurve(nc) => {
-            // Sample curve length
             let (t0, t1) = nc.domain();
             let n_samples = 10;
             let mut length = 0.0;
@@ -100,7 +99,6 @@ pub fn check_edge_same_parameter(
     face_id: FaceId,
     tolerance: f64,
 ) -> Result<Vec<ValidationIssue>, CheckError> {
-    // Get the PCurve for this edge on this face.
     let pcurve = match topo.pcurves().get(edge_id, face_id) {
         Some(pc) => pc,
         None => return Ok(vec![]), // No PCurve registered — can't check
@@ -117,7 +115,6 @@ pub fn check_edge_same_parameter(
         return Ok(vec![]);
     }
 
-    // Sample N points along the PCurve parameter range.
     let n_samples = 10;
     let mut max_deviation = 0.0f64;
 
@@ -129,7 +126,6 @@ pub fn check_edge_same_parameter(
         let t_norm = i as f64 / n_samples as f64;
         let t_pcurve = pcurve.t_start() + (pcurve.t_end() - pcurve.t_start()) * t_norm;
 
-        // Evaluate PCurve to get (u, v) on surface.
         let uv = pcurve.evaluate(t_pcurve);
 
         // Evaluate surface at (u, v) to get 3D point from PCurve path.

--- a/crates/check/src/validate/face.rs
+++ b/crates/check/src/validate/face.rs
@@ -33,13 +33,11 @@ pub fn check_face_orientation(
         return Ok(vec![]); // Can't determine winding for degenerate polygon
     }
 
-    // Compute polygon normal via Newell's method
     let wire_normal = newell_normal(&polygon);
     if wire_normal.length() < 1e-15 {
         return Ok(vec![]); // Degenerate polygon
     }
 
-    // Get surface normal at polygon centroid
     let face = topo.face(face_id)?;
     let centroid = polygon_centroid(&polygon);
 

--- a/crates/check/src/validate/mod.rs
+++ b/crates/check/src/validate/mod.rs
@@ -51,7 +51,6 @@ pub fn validate_solid(
     let mut report = ValidationReport::default();
     let solid_data = topo.solid(solid_id)?;
 
-    // Solid-level checks
     if !options
         .disabled_checks
         .contains(&CheckId::SolidEulerCharacteristic)
@@ -67,7 +66,6 @@ pub fn validate_solid(
             .extend(solid::check_duplicate_faces(topo, solid_id)?);
     }
 
-    // Shell checks on outer shell + inner shells
     let shells: Vec<_> = std::iter::once(solid_data.outer_shell())
         .chain(solid_data.inner_shells().iter().copied())
         .collect();
@@ -107,7 +105,6 @@ fn validate_shell_checks(
 ) -> Result<Vec<ValidationIssue>, CheckError> {
     let mut issues = Vec::new();
 
-    // Shell checks
     if !options.disabled_checks.contains(&CheckId::ShellEmpty) {
         issues.extend(shell::check_shell_empty(topo, shell_id)?);
     }
@@ -124,7 +121,6 @@ fn validate_shell_checks(
         issues.extend(shell::check_shell_orientation(topo, shell_id)?);
     }
 
-    // Wire checks for each face's outer + inner wires
     let shell = topo.shell(shell_id)?;
     let mut checked_wires = HashSet::new();
     for &fid in shell.faces() {
@@ -162,7 +158,6 @@ fn validate_shell_checks(
         }
     }
 
-    // Face checks
     let mut checked_faces = HashSet::new();
     for &fid in shell.faces() {
         if checked_faces.insert(fid) {
@@ -178,7 +173,6 @@ fn validate_shell_checks(
         }
     }
 
-    // Edge and vertex checks
     let mut checked_edges = HashSet::new();
     for &fid in shell.faces() {
         let face = topo.face(fid)?;
@@ -203,7 +197,6 @@ fn validate_shell_checks(
                             options.tolerance_scale * 1e-7,
                         )?);
                     }
-                    // Vertex-on-curve checks
                     if !options.disabled_checks.contains(&CheckId::VertexOnCurve) {
                         let edge_data = topo.edge(eid)?;
                         issues.extend(vertex::check_vertex_on_curve(
@@ -221,7 +214,6 @@ fn validate_shell_checks(
                             )?);
                         }
                     }
-                    // Vertex-on-surface checks
                     if !options.disabled_checks.contains(&CheckId::VertexOnSurface) {
                         let edge_data = topo.edge(eid)?;
                         issues.extend(vertex::check_vertex_on_surface(

--- a/crates/check/src/validate/shell.rs
+++ b/crates/check/src/validate/shell.rs
@@ -59,7 +59,6 @@ pub fn check_shell_connected(
         return Ok(vec![]);
     }
 
-    // Build edge -> face-index adjacency
     let mut edge_to_faces: HashMap<EdgeId, Vec<usize>> = HashMap::new();
     for (fi, &fid) in faces.iter().enumerate() {
         for eid in face_edge_ids(topo, fid)? {
@@ -67,7 +66,6 @@ pub fn check_shell_connected(
         }
     }
 
-    // BFS from face 0
     let mut visited = HashSet::new();
     let mut queue = VecDeque::new();
     visited.insert(0usize);
@@ -111,12 +109,10 @@ pub fn check_shell_orientation(
 ) -> Result<Vec<ValidationIssue>, CheckError> {
     let shell = topo.shell(shell_id)?;
 
-    // Map each edge to its (face_index, effective_forward) pairs
     let mut edge_uses: HashMap<EdgeId, Vec<(usize, bool)>> = HashMap::new();
 
     for (fi, &fid) in shell.faces().iter().enumerate() {
         let face = topo.face(fid)?;
-        // Account for face reversal
         let face_reversed = face.is_reversed();
         let wire = topo.wire(face.outer_wire())?;
         for oe in wire.edges() {

--- a/crates/check/src/validate/wire.rs
+++ b/crates/check/src/validate/wire.rs
@@ -126,10 +126,9 @@ pub fn check_wire_self_intersection(
     let wire = topo.wire(wire_id)?;
     let edges = wire.edges();
     if edges.len() < 3 {
-        return Ok(vec![]); // Need at least 3 edges for self-intersection
+        return Ok(vec![]);
     }
 
-    // Sample each edge into polyline segments.
     let samples_per_edge = 8usize;
     let mut edge_segments: Vec<Vec<Point3>> = Vec::new();
 
@@ -207,7 +206,6 @@ pub fn check_wire_self_intersection(
         }
     }
 
-    // Check for segment-segment intersections between non-adjacent edges.
     let n_edges = edge_segments.len();
     for i in 0..n_edges {
         for j in (i + 2)..n_edges {

--- a/crates/geometry/src/convert/surface_to_nurbs.rs
+++ b/crates/geometry/src/convert/surface_to_nurbs.rs
@@ -115,12 +115,10 @@ mod tests {
     fn cylinder_to_nurbs_evaluates() {
         let cyl = CylindricalSurface::new(origin(), z_axis(), 2.0).unwrap();
         let nurbs = cylinder_to_nurbs(&cyl, (0.0, 5.0)).unwrap();
-        // The domain should be defined.
         let (u0, u1) = nurbs.domain_u();
         let (v0, v1) = nurbs.domain_v();
         assert!(u1 > u0);
         assert!(v1 > v0);
-        // Evaluate and check reasonable position.
         let pt = nurbs.evaluate((u0 + u1) * 0.5, (v0 + v1) * 0.5);
         let dist_from_axis = (Vec3::new(pt.x(), pt.y(), 0.0)).length();
         assert!((dist_from_axis - 2.0).abs() < 0.1);
@@ -148,7 +146,6 @@ mod tests {
         let (v0, v1) = nurbs.domain_v();
         assert!(u1 > u0);
         assert!(v1 > v0);
-        // Just check it evaluates without panic.
         let _pt = nurbs.evaluate((u0 + u1) * 0.5, (v0 + v1) * 0.5);
     }
 

--- a/crates/geometry/src/sampling/curvature.rs
+++ b/crates/geometry/src/sampling/curvature.rs
@@ -70,10 +70,8 @@ fn subdivide(
     let t_m = 0.5 * (t_a + t_b);
     let p_m = curve.evaluate(t_m);
 
-    // Left half
     subdivide(curve, t_a, p_a, t_m, p_m, tolerance, depth + 1, out);
     out.push((t_m, p_m));
-    // Right half
     subdivide(curve, t_m, p_m, t_b, p_b, tolerance, depth + 1, out);
 }
 

--- a/crates/geometry/src/sampling/deflection.rs
+++ b/crates/geometry/src/sampling/deflection.rs
@@ -48,10 +48,8 @@ fn subdivide<C: ParametricCurve>(
         return;
     }
 
-    // Left half
     subdivide(curve, t_a, p_a, t_m, p_m, max_deflection, depth + 1, out);
     out.push((t_m, p_m));
-    // Right half
     subdivide(curve, t_m, p_m, t_b, p_b, max_deflection, depth + 1, out);
 }
 

--- a/crates/geometry/src/sampling/uniform.rs
+++ b/crates/geometry/src/sampling/uniform.rs
@@ -86,8 +86,6 @@ mod tests {
     #[test]
     fn four_samples_on_unit_circle() {
         let c = unit_circle();
-        // Per task spec: sample_uniform on Circle3D(r=1) with n=4 → 4 points.
-        // Use the full domain [0, TAU].
         let pairs = sample_uniform_with_params(&c, 0.0, TAU, 4);
         assert_eq!(pairs.len(), 4);
 

--- a/crates/heal/src/analysis/curve.rs
+++ b/crates/heal/src/analysis/curve.rs
@@ -30,7 +30,6 @@ pub struct CurveAnalysis {
 pub fn analyze_curve(curve: &NurbsCurve, tolerance: &Tolerance) -> CurveAnalysis {
     let (t_min, t_max) = ParametricCurve::domain(curve);
 
-    // Approximate arc length.
     let mut length = 0.0;
     let mut prev = ParametricCurve::evaluate(curve, t_min);
     for i in 1..=ARC_LENGTH_SAMPLES {
@@ -42,7 +41,6 @@ pub fn analyze_curve(curve: &NurbsCurve, tolerance: &Tolerance) -> CurveAnalysis
 
     let is_degenerate = length < tolerance.linear;
 
-    // Detect C0 continuity breaks: internal knots with multiplicity == degree.
     let continuity_breaks = detect_continuity_breaks(curve);
 
     let mut status = Status::OK;
@@ -71,7 +69,6 @@ fn detect_continuity_breaks(curve: &NurbsCurve) -> Vec<f64> {
     let mut i = 0;
     while i < knots.len() {
         let val = knots[i];
-        // Count multiplicity.
         let mut mult = 0;
         while i + mult < knots.len() && (knots[i + mult] - val).abs() < 1e-15 {
             mult += 1;

--- a/crates/heal/src/analysis/face.rs
+++ b/crates/heal/src/analysis/face.rs
@@ -36,7 +36,6 @@ pub fn analyze_face(
     let face = topo.face(face_id)?;
     let wire_count = 1 + face.inner_wires().len();
 
-    // Collect all vertex positions from all wires.
     let wire_ids: Vec<_> = std::iter::once(face.outer_wire())
         .chain(face.inner_wires().iter().copied())
         .collect();

--- a/crates/heal/src/analysis/free_bounds.rs
+++ b/crates/heal/src/analysis/free_bounds.rs
@@ -23,7 +23,6 @@ use crate::HealError;
 pub fn find_free_bounds(topo: &Topology, shell_id: ShellId) -> Result<Vec<Vec<EdgeId>>, HealError> {
     let shell = topo.shell(shell_id)?;
 
-    // Count how many times each edge is used across all face wires.
     let mut edge_use_count: HashMap<usize, (EdgeId, u32)> = HashMap::new();
 
     for &face_id in shell.faces() {
@@ -43,7 +42,6 @@ pub fn find_free_bounds(topo: &Topology, shell_id: ShellId) -> Result<Vec<Vec<Ed
         }
     }
 
-    // Collect free edges (used by exactly 1 face).
     let free_edges: Vec<EdgeId> = edge_use_count
         .values()
         .filter(|(_, count)| *count == 1)
@@ -54,8 +52,6 @@ pub fn find_free_bounds(topo: &Topology, shell_id: ShellId) -> Result<Vec<Vec<Ed
         return Ok(Vec::new());
     }
 
-    // Build vertex-to-edge adjacency for free edges.
-    // Each free edge contributes two vertex connections.
     let mut vertex_to_edges: HashMap<usize, Vec<EdgeId>> = HashMap::new();
     let free_set: HashSet<usize> = free_edges.iter().map(|e| e.index()).collect();
 
@@ -71,7 +67,6 @@ pub fn find_free_bounds(topo: &Topology, shell_id: ShellId) -> Result<Vec<Vec<Ed
             .push(eid);
     }
 
-    // Group free edges into connected loops by walking the adjacency.
     let mut visited: HashSet<usize> = HashSet::new();
     let mut loops = Vec::new();
 

--- a/crates/heal/src/analysis/shell.rs
+++ b/crates/heal/src/analysis/shell.rs
@@ -45,7 +45,6 @@ pub fn analyze_shell(topo: &Topology, shell_id: ShellId) -> Result<ShellAnalysis
     let faces = shell.faces();
     let face_count = faces.len();
 
-    // Build edge-to-face usage map.
     let mut edge_uses: HashMap<usize, EdgeUse> = HashMap::new();
 
     for &face_id in faces {
@@ -70,7 +69,6 @@ pub fn analyze_shell(topo: &Topology, shell_id: ShellId) -> Result<ShellAnalysis
         }
     }
 
-    // Classify edges.
     let mut boundary_edges = Vec::new();
     let mut non_manifold_edges = Vec::new();
 
@@ -101,7 +99,6 @@ pub fn analyze_shell(topo: &Topology, shell_id: ShellId) -> Result<ShellAnalysis
         }
     }
 
-    // Connected components via union-find on face indices.
     let connected_components = count_connected_components(faces, &edge_uses);
 
     let mut status = Status::OK;
@@ -130,7 +127,6 @@ pub fn analyze_shell(topo: &Topology, shell_id: ShellId) -> Result<ShellAnalysis
 
 /// Count connected components among faces using edge adjacency.
 fn count_connected_components(faces: &[FaceId], edge_uses: &HashMap<usize, EdgeUse>) -> usize {
-    // Find with path compression.
     fn find(parent: &mut [usize], mut x: usize) -> usize {
         while parent[x] != x {
             parent[x] = parent[parent[x]];
@@ -139,7 +135,6 @@ fn count_connected_components(faces: &[FaceId], edge_uses: &HashMap<usize, EdgeU
         x
     }
 
-    // Union.
     fn union(parent: &mut [usize], a: usize, b: usize) {
         let ra = find(parent, a);
         let rb = find(parent, b);
@@ -152,7 +147,6 @@ fn count_connected_components(faces: &[FaceId], edge_uses: &HashMap<usize, EdgeU
         return 0;
     }
 
-    // Map face index (in the shell's face list) to a contiguous 0..N range.
     let mut face_to_idx: HashMap<usize, usize> = HashMap::new();
     for (i, fid) in faces.iter().enumerate() {
         face_to_idx.insert(fid.index(), i);
@@ -161,7 +155,6 @@ fn count_connected_components(faces: &[FaceId], edge_uses: &HashMap<usize, EdgeU
     let n = faces.len();
     let mut parent: Vec<usize> = (0..n).collect();
 
-    // Connect faces that share an edge.
     for eu in edge_uses.values() {
         if eu.faces.len() >= 2 {
             if let Some(&idx_a) = face_to_idx.get(&eu.faces[0].0.index()) {
@@ -174,7 +167,6 @@ fn count_connected_components(faces: &[FaceId], edge_uses: &HashMap<usize, EdgeU
         }
     }
 
-    // Count distinct roots.
     let mut roots = std::collections::HashSet::new();
     for i in 0..n {
         roots.insert(find(&mut parent, i));

--- a/crates/heal/src/analysis/surface.rs
+++ b/crates/heal/src/analysis/surface.rs
@@ -108,7 +108,6 @@ fn analyze_nurbs_surface(
 
     let tol = tolerance.linear;
 
-    // Check U-closure: first row vs last row.
     let is_closed_u = n_rows >= 2
         && n_cols > 0
         && cps[0]
@@ -116,7 +115,6 @@ fn analyze_nurbs_surface(
             .zip(cps[n_rows - 1].iter())
             .all(|(a, b)| (*a - *b).length() < tol);
 
-    // Check V-closure: first column vs last column.
     let is_closed_v = n_cols >= 2
         && cps
             .iter()

--- a/crates/heal/src/analysis/wire.rs
+++ b/crates/heal/src/analysis/wire.rs
@@ -84,7 +84,6 @@ pub fn analyze_wire(
         });
     }
 
-    // Collect oriented start/end vertex positions for each edge.
     let mut starts = Vec::with_capacity(edge_count);
     let mut ends = Vec::with_capacity(edge_count);
     let mut lengths = Vec::with_capacity(edge_count);
@@ -96,7 +95,6 @@ pub fn analyze_wire(
         starts.push(s);
         ends.push(e);
 
-        // Approximate arc length.
         let start_pos = topo.vertex(edge.start())?.point();
         let end_pos = topo.vertex(edge.end())?.point();
         let (t_min, t_max) = edge.curve().domain_with_endpoints(start_pos, end_pos);
@@ -114,7 +112,6 @@ pub fn analyze_wire(
         lengths.push(len);
     }
 
-    // Check ordering and gaps.
     let mut is_ordered = true;
     let mut gaps = Vec::new();
     for i in 0..edge_count.saturating_sub(1) {
@@ -129,7 +126,6 @@ pub fn analyze_wire(
         }
     }
 
-    // Check closure (last end -> first start).
     let closure_dist = (starts[0] - ends[edge_count - 1]).length();
     let is_closed = closure_dist <= tolerance.linear;
     if !is_closed && wire.is_closed() {
@@ -141,7 +137,6 @@ pub fn analyze_wire(
         });
     }
 
-    // Small edges.
     let mut small_edges = Vec::new();
     for (i, oe) in oe_list.iter().enumerate() {
         if lengths[i] < tolerance.linear {
@@ -153,7 +148,6 @@ pub fn analyze_wire(
         }
     }
 
-    // Degenerate edges (closed vertex + zero length).
     let mut degenerate_edges = Vec::new();
     for (i, oe) in oe_list.iter().enumerate() {
         let edge = topo.edge(oe.edge())?;
@@ -162,8 +156,6 @@ pub fn analyze_wire(
         }
     }
 
-    // Self-intersection: sample each edge and check for proximity between
-    // non-adjacent edge pairs.
     let self_intersections = detect_self_intersections(topo, oe_list, edge_count, tolerance)?;
 
     let mut status = Status::OK;
@@ -203,7 +195,6 @@ fn detect_self_intersections(
         return Ok(Vec::new());
     }
 
-    // Sample points for each edge.
     let mut edge_samples: Vec<Vec<brepkit_math::vec::Point3>> = Vec::with_capacity(edge_count);
     for oe in oe_list {
         let edge = topo.edge(oe.edge())?;

--- a/crates/heal/src/analysis/wire_order.rs
+++ b/crates/heal/src/analysis/wire_order.rs
@@ -46,7 +46,6 @@ pub fn compute_wire_order(topo: &Topology, wire_id: WireId) -> Result<WireOrderR
         });
     }
 
-    // Snapshot all edge endpoint positions.
     let mut starts: Vec<Point3> = Vec::with_capacity(n);
     let mut ends: Vec<Point3> = Vec::with_capacity(n);
 
@@ -58,13 +57,11 @@ pub fn compute_wire_order(topo: &Topology, wire_id: WireId) -> Result<WireOrderR
         ends.push(e);
     }
 
-    // Greedy nearest-neighbor ordering.
     let mut used = vec![false; n];
     let mut order = Vec::with_capacity(n);
     let mut flips = Vec::with_capacity(n);
     let mut max_gap = 0.0_f64;
 
-    // Start with edge 0 in its original orientation.
     order.push(0);
     flips.push(false);
     used[0] = true;
@@ -79,14 +76,12 @@ pub fn compute_wire_order(topo: &Topology, wire_id: WireId) -> Result<WireOrderR
             if used[j] {
                 continue;
             }
-            // Try forward: current_end -> starts[j]
             let d_fwd = (starts[j] - current_end).length_squared();
             if d_fwd < best_dist {
                 best_dist = d_fwd;
                 best_idx = j;
                 best_flip = false;
             }
-            // Try reversed: current_end -> ends[j]
             let d_rev = (ends[j] - current_end).length_squared();
             if d_rev < best_dist {
                 best_dist = d_rev;

--- a/crates/heal/src/construct/convert_curve.rs
+++ b/crates/heal/src/construct/convert_curve.rs
@@ -288,13 +288,11 @@ mod tests {
         let end = Point3::new(3.0, 4.0, 0.0);
         let nurbs = line_to_nurbs(start, end).unwrap();
 
-        // Evaluate at t=0 and t=1.
         let p0 = nurbs.evaluate(0.0);
         let p1 = nurbs.evaluate(1.0);
         assert!((p0 - start).length() < 1e-10);
         assert!((p1 - end).length() < 1e-10);
 
-        // Midpoint.
         let mid = nurbs.evaluate(0.5);
         let expected_mid = Point3::new(1.5, 2.0, 0.0);
         assert!((mid - expected_mid).length() < 1e-10);
@@ -322,7 +320,6 @@ mod tests {
             );
         }
 
-        // Check quarter points are exact.
         let p0 = nurbs.evaluate(0.0);
         let p1 = nurbs.evaluate(1.0);
         let p2 = nurbs.evaluate(2.0);

--- a/crates/heal/src/construct/convert_surface.rs
+++ b/crates/heal/src/construct/convert_surface.rs
@@ -45,7 +45,6 @@ pub fn plane_to_nurbs(
     u_range: (f64, f64),
     v_range: (f64, f64),
 ) -> Result<NurbsSurface, HealError> {
-    // Build a local frame on the plane.
     let origin = Point3::new(0.0, 0.0, 0.0) + normal * d;
     let (u_axis, v_axis) = plane_frame_axes(normal);
 

--- a/crates/heal/src/custom/bspline_restriction.rs
+++ b/crates/heal/src/custom/bspline_restriction.rs
@@ -59,7 +59,6 @@ pub fn check_bspline_restrictions(
 ) -> Result<usize, HealError> {
     let mut violations = 0usize;
 
-    // ── Check edges ──────────────────────────────────────────────
     // Walk outer + inner (cavity) shells. NURBS degree/segment
     // restrictions apply to every edge and surface in the solid,
     // including those bounding cavity volumes — restricting only
@@ -110,7 +109,6 @@ pub fn check_bspline_restrictions(
             }
         }
 
-        // ── Check face surface ───────────────────────────────────
         let face_data = topo.face(fid)?;
         if let FaceSurface::Nurbs(ref ns) = *face_data.surface() {
             let degree_u = ns.degree_u();

--- a/crates/heal/src/custom/convert_to_elementary.rs
+++ b/crates/heal/src/custom/convert_to_elementary.rs
@@ -36,7 +36,6 @@ pub fn convert_to_elementary(
 
     let mut converted = 0;
 
-    // Snapshot surfaces.
     let surfaces: Vec<(FaceId, FaceSurface)> = face_ids
         .iter()
         .map(|&fid| topo.face(fid).map(|f| (fid, f.surface().clone())))

--- a/crates/heal/src/fix/config.rs
+++ b/crates/heal/src/fix/config.rs
@@ -35,7 +35,6 @@ impl FixMode {
 #[derive(Debug, Clone)]
 #[allow(clippy::struct_field_names)]
 pub struct FixConfig {
-    // ── Wire fixes ──────────────────────────────────────────────
     /// Reorder edges in wires to form a connected chain.
     pub fix_reorder: FixMode,
     /// Close gaps between consecutive edges by adjusting vertices.
@@ -61,7 +60,6 @@ pub struct FixConfig {
     /// Fix intersecting adjacent edges.
     pub fix_intersecting_edges: FixMode,
 
-    // ── Face fixes ──────────────────────────────────────────────
     /// Fix wire orientation relative to face normal.
     pub fix_wire_orientation: FixMode,
     /// Add natural boundary wire to faces on closed surfaces.
@@ -75,11 +73,9 @@ pub struct FixConfig {
     /// Fix intersecting wires within a face.
     pub fix_intersecting_wires: FixMode,
 
-    // ── Shell fixes ─────────────────────────────────────────────
     /// Fix shell orientation (outward-facing normals).
     pub fix_orientation: FixMode,
 
-    // ── Edge fixes ──────────────────────────────────────────────
     /// Fix SameParameter: ensure PCurve and 3D curve agree.
     pub fix_same_parameter: FixMode,
     /// Adjust vertex tolerances to match edge geometry.
@@ -87,11 +83,9 @@ pub struct FixConfig {
     /// Rebuild PCurves to match 3D curves.
     pub fix_pcurve: FixMode,
 
-    // ── Solid fixes ─────────────────────────────────────────────
     /// Merge coincident vertices across the solid.
     pub fix_coincident_vertices: FixMode,
 
-    // ── Global fixes ────────────────────────────────────────────
     /// Fix wireframe: repair missing or misaligned edges in shells.
     pub fix_wireframe: FixMode,
     /// Split vertices shared by too many non-adjacent edges.

--- a/crates/heal/src/fix/edge.rs
+++ b/crates/heal/src/fix/edge.rs
@@ -40,19 +40,16 @@ pub fn fix_edge(
 ) -> Result<FixResult, HealError> {
     let mut result = FixResult::ok();
 
-    // 1. Vertex tolerance check.
     if config.fix_vertex_tolerance != FixMode::Off {
         let r = fix_vertex_tolerance(topo, edge_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 2. Degenerate edge detection and removal.
     if config.fix_degenerate_edges != FixMode::Off {
         let r = fix_degenerate(topo, edge_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 3. SameParameter stub (no face context).
     if config.fix_same_parameter != FixMode::Off {
         let r = fix_same_parameter_stub(ctx, config);
         result.merge(&r);
@@ -91,7 +88,6 @@ pub fn fix_same_parameter_on_face(
     let has_pcurve = topo.pcurves().contains(edge_id, face_id);
 
     if has_pcurve {
-        // Check deviation between existing PCurve and 3D curve.
         let max_dev = compute_pcurve_deviation(topo, edge_id, face_id)?;
         let tol = ctx.tolerance.linear;
         let needs_fix = max_dev > tol;
@@ -118,7 +114,6 @@ pub fn fix_same_parameter_on_face(
         ));
     }
 
-    // Build a new PCurve via projection.
     let nurbs_3d = crate::construct::project_curve::project_edge_to_pcurve(
         topo,
         edge_id,
@@ -143,7 +138,6 @@ pub fn fix_same_parameter_on_face(
         ))
     })?;
 
-    // Determine parameter range from the knot vector.
     let t_start = knots[degree];
     let t_end = knots[knots.len() - degree - 1];
 
@@ -270,11 +264,9 @@ fn compute_pcurve_deviation(
         #[allow(clippy::cast_precision_loss)]
         let frac = i as f64 / SAME_PARAM_SAMPLES as f64;
 
-        // 3D curve point.
         let t_3d = t0_3d + (t1_3d - t0_3d) * frac;
         let pt_3d = curve.evaluate_with_endpoints(t_3d, start_pos, end_pos);
 
-        // PCurve -> surface point.
         let t_pc = t0_pc + (t1_pc - t0_pc) * frac;
         let uv = pcurve.evaluate(t_pc);
 

--- a/crates/heal/src/fix/face.rs
+++ b/crates/heal/src/fix/face.rs
@@ -31,7 +31,6 @@ pub fn fix_face(
 ) -> Result<FixResult, HealError> {
     let mut result = FixResult::ok();
 
-    // 1. Fix all wires in this face (outer + inner).
     let face = topo.face(face_id)?;
     let wire_ids: Vec<_> = std::iter::once(face.outer_wire())
         .chain(face.inner_wires().iter().copied())
@@ -88,19 +87,16 @@ pub fn fix_face(
         }
     }
 
-    // 3. Fix wire orientation relative to the face normal.
     if config.fix_wire_orientation != FixMode::Off {
         let r = fix_wire_orientation(topo, face_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 3. Small area check.
     if config.fix_small_area != FixMode::Off {
         let r = fix_small_area(topo, face_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 4. Duplicate face detection stub.
     if config.fix_duplicate_faces != FixMode::Off {
         let r = fix_duplicate_faces(ctx, config);
         result.merge(&r);
@@ -108,8 +104,6 @@ pub fn fix_face(
 
     Ok(result)
 }
-
-// ── Fix implementations ─────────────────────────────────────────────────
 
 /// Fix wire orientation: outer wire should be CCW when viewed from the
 /// surface normal.
@@ -130,14 +124,12 @@ fn fix_wire_orientation(
     let surface = face.surface().clone();
     let outer_wire_id = face.outer_wire();
 
-    // Compute the face centroid from outer wire vertices.
     let wire = topo.wire(outer_wire_id)?;
     let edges = wire.edges();
     if edges.is_empty() {
         return Ok(FixResult::ok());
     }
 
-    // Collect vertex positions from the outer wire.
     let mut positions: Vec<Point3> = Vec::new();
     for oe in edges {
         let edge = topo.edge(oe.edge())?;
@@ -149,7 +141,6 @@ fn fix_wire_orientation(
         return Ok(FixResult::ok());
     }
 
-    // Compute face normal at a representative point.
     let face_normal = match &surface {
         FaceSurface::Plane { normal, .. } => *normal,
         _ => {
@@ -160,7 +151,6 @@ fn fix_wire_orientation(
         }
     };
 
-    // Compute signed area of the wire polygon projected onto the normal.
     let signed_area = projected_signed_area(&positions, &face_normal);
 
     // If signed_area < 0 the wire is CW (wrong orientation).
@@ -174,8 +164,6 @@ fn fix_wire_orientation(
         return Ok(FixResult::ok());
     }
 
-    // Fix: for planar faces, flip the normal.
-    // For non-planar faces, toggle the reversed flag.
     if let FaceSurface::Plane { normal, d } = &surface {
         let flipped_normal = -*normal;
         let flipped_d = -*d;
@@ -185,7 +173,6 @@ fn fix_wire_orientation(
             d: flipped_d,
         });
     } else {
-        // For analytic/NURBS surfaces, toggle the reversed flag.
         let face_data = topo.face(face_id)?;
         let was_reversed = face_data.is_reversed();
         let face_mut = topo.face_mut(face_id)?;
@@ -235,8 +222,6 @@ fn fix_duplicate_faces(ctx: &mut HealContext, config: &FixConfig) -> FixResult {
     ctx.warn("Duplicate face fix: not yet implemented (TODO)".to_string());
     FixResult::ok()
 }
-
-// ── Geometry helpers ────────────────────────────────────────────────────
 
 /// Compute the normal of a polygon via Newell's method.
 ///

--- a/crates/heal/src/fix/mod.rs
+++ b/crates/heal/src/fix/mod.rs
@@ -69,7 +69,6 @@ pub fn fix_shape(
     let mut ctx = HealContext::new();
     let result = solid::fix_solid(topo, solid_id, &mut ctx, config)?;
 
-    // Apply all accumulated replacements.
     let new_solid = ctx.reshape.apply(topo, solid_id)?;
 
     Ok((new_solid, result))

--- a/crates/heal/src/fix/shell.rs
+++ b/crates/heal/src/fix/shell.rs
@@ -31,7 +31,6 @@ pub fn fix_shell(
 ) -> Result<FixResult, HealError> {
     let mut result = FixResult::ok();
 
-    // ── 1. Run analysis to detect issues ────────────────────────────
     let analysis = crate::analysis::shell::analyze_shell(topo, shell_id)?;
 
     if !analysis.boundary_edges.is_empty() {
@@ -47,7 +46,6 @@ pub fn fix_shell(
         ));
     }
 
-    // ── 2. Fix each face individually ───────────────────────────────
     let shell = topo.shell(shell_id)?;
     let face_ids: Vec<_> = shell.faces().to_vec();
 
@@ -56,7 +54,6 @@ pub fn fix_shell(
         result.merge(&face_result);
     }
 
-    // ── 3. Fix orientation consistency ──────────────────────────────
     let should_fix_orientation = config
         .fix_orientation
         .should_fix(!analysis.orientation_consistent);
@@ -91,14 +88,12 @@ fn fix_orientation(
         return Ok(FixResult::ok());
     }
 
-    // Map face arena index -> position in face_ids slice.
     let _face_idx_map: HashMap<usize, usize> = face_ids
         .iter()
         .enumerate()
         .map(|(i, fid)| (fid.index(), i))
         .collect();
 
-    // Snapshot: collect all (face_position, edge_index, is_forward) triples.
     let mut face_edge_info: Vec<(usize, usize, bool)> = Vec::new();
 
     for (i, &fid) in face_ids.iter().enumerate() {
@@ -115,7 +110,6 @@ fn fix_orientation(
         }
     }
 
-    // Build edge-to-face adjacency from snapshots.
     // Key: edge index. Value: vec of (face_position, is_forward).
     let mut edge_faces: HashMap<usize, Vec<(usize, bool)>> = HashMap::new();
     for &(face_pos, edge_idx, is_forward) in &face_edge_info {
@@ -132,7 +126,6 @@ fn fix_orientation(
         face_edges[face_pos].push((edge_idx, is_forward));
     }
 
-    // BFS: start from face 0, flip neighbors that disagree.
     let mut visited = vec![false; n];
     let mut needs_flip = vec![false; n];
     let mut queue = std::collections::VecDeque::new();
@@ -168,7 +161,6 @@ fn fix_orientation(
         }
     }
 
-    // Apply flips.
     let mut flipped_count = 0usize;
     for (i, &fid) in face_ids.iter().enumerate() {
         if needs_flip[i] {

--- a/crates/heal/src/fix/solid.rs
+++ b/crates/heal/src/fix/solid.rs
@@ -35,14 +35,12 @@ pub fn fix_solid(
 ) -> Result<FixResult, HealError> {
     let mut result = FixResult::ok();
 
-    // ── 1. Fix outer shell ──────────────────────────────────────────
     let solid = topo.solid(solid_id)?;
     let shell_id = solid.outer_shell();
 
     let shell_result = super::shell::fix_shell(topo, shell_id, ctx, config)?;
     result.merge(&shell_result);
 
-    // ── 2. Fix inner shells (voids) ─────────────────────────────────
     let solid = topo.solid(solid_id)?;
     let inner_shells: Vec<_> = solid.inner_shells().to_vec();
     for shell_id in inner_shells {
@@ -50,7 +48,6 @@ pub fn fix_solid(
         result.merge(&inner_result);
     }
 
-    // ── 3. Merge coincident vertices ────────────────────────────────
     // Always detected (cheap), applied per config mode.
     let should_merge = config.fix_coincident_vertices.should_fix(true);
     if should_merge {
@@ -58,7 +55,6 @@ pub fn fix_solid(
         result.merge(&merge_result);
     }
 
-    // ── 4. Remove small faces ───────────────────────────────────────
     let should_fix_small = config.fix_small_faces.should_fix(true);
     if should_fix_small {
         let small_result = super::small_face::fix_small_faces(topo, solid_id, ctx, config)?;
@@ -84,7 +80,6 @@ fn merge_coincident_vertices(
     let tol = ctx.tolerance.linear;
     let tol_sq = tol * tol;
 
-    // Collect all unique vertex IDs and positions from the solid.
     let solid_data = topo.solid(solid_id)?;
     let shell_id = solid_data.outer_shell();
     let shell = topo.shell(shell_id)?;
@@ -140,9 +135,7 @@ fn merge_coincident_vertices(
         return Ok(FixResult::ok());
     }
 
-    // Record vertex replacements in the reshape tracker.
     for (&from_idx, &to_vid) in &merge_to {
-        // Reconstruct the VertexId from index — find it in our collected list.
         if let Some(&from_vid) = vertex_ids.iter().find(|v| v.index() == from_idx) {
             ctx.reshape.replace_vertex(from_vid, to_vid);
         }
@@ -166,7 +159,6 @@ fn merge_coincident_vertices(
     edge_ids.sort_by_key(|e| e.index());
     edge_ids.dedup_by_key(|e| e.index());
 
-    // Snapshot edge updates.
     let updates: Vec<_> = edge_ids
         .iter()
         .filter_map(|&eid| {
@@ -187,7 +179,6 @@ fn merge_coincident_vertices(
         })
         .collect();
 
-    // Apply updates.
     for (eid, new_start, new_end, curve) in updates {
         let edge = topo.edge_mut(eid)?;
         *edge = Edge::new(new_start, new_end, curve);

--- a/crates/heal/src/fix/split_vertex.rs
+++ b/crates/heal/src/fix/split_vertex.rs
@@ -47,7 +47,6 @@ pub fn fix_split_common_vertex(
     // miss those cases.
     let face_ids = solid_faces(topo, solid_id)?;
 
-    // Count edges per vertex and collect edge-face associations.
     let mut vertex_edge_count: HashMap<usize, (VertexId, usize)> = HashMap::new();
 
     for &fid in &face_ids {
@@ -76,7 +75,6 @@ pub fn fix_split_common_vertex(
         }
     }
 
-    // Detect over-connected vertices.
     let mut over_connected: Vec<VertexId> = Vec::new();
     for &(vid, count) in vertex_edge_count.values() {
         if count > MAX_VERTEX_EDGES {
@@ -129,13 +127,10 @@ fn split_vertex(
     solid_id: SolidId,
     ctx: &mut HealContext,
 ) -> Result<usize, HealError> {
-    // ── Step 1: Find all edges connected to this vertex ──────────
     // Walk outer + inner (cavity) shells (see top-level comment in
     // `fix_split_common_vertex`).
     let face_ids = solid_faces(topo, solid_id)?;
 
-    // Build: edge_id -> set of face_ids that reference it
-    // Also: collect edges that touch our vertex
     let mut edge_faces: HashMap<usize, HashSet<usize>> = HashMap::new();
     let mut vertex_edges: Vec<EdgeId> = Vec::new();
     let mut vertex_edges_set: HashSet<usize> = HashSet::new();
@@ -152,13 +147,11 @@ fn split_vertex(
                 let eid = oe.edge();
                 let edge = topo.edge(eid)?;
 
-                // Record face membership for this edge.
                 edge_faces
                     .entry(eid.index())
                     .or_default()
                     .insert(fid.index());
 
-                // Track edges touching our vertex.
                 if (edge.start() == vertex_id || edge.end() == vertex_id)
                     && vertex_edges_set.insert(eid.index())
                 {
@@ -172,7 +165,6 @@ fn split_vertex(
         return Ok(0);
     }
 
-    // ── Step 2: Group edges by face adjacency ────────────────────
     // Two edges belong to the same group if they share at least one face.
     // Use union-find via BFS on the edge adjacency graph.
     let n = vertex_edges.len();
@@ -204,7 +196,6 @@ fn split_vertex(
                     None => continue,
                 };
 
-                // Check if they share any face.
                 let shares_face = current_faces.iter().any(|f| neighbor_faces.contains(f));
                 if shares_face {
                     groups[neighbor_idx] = group_id;
@@ -222,13 +213,10 @@ fn split_vertex(
         return Ok(0);
     }
 
-    // ── Step 3: Snapshot vertex data ─────────────────────────────
     let vertex_data = topo.vertex(vertex_id)?;
     let position = vertex_data.point();
     let vtx_tolerance = vertex_data.tolerance();
 
-    // ── Step 4: Allocate new vertices and update edges ───────────
-    // Group edges by their group index for batch vertex creation.
     let mut group_edges: HashMap<usize, Vec<(EdgeId, bool, bool)>> = HashMap::new();
     for (i, &eid) in vertex_edges.iter().enumerate() {
         #[allow(clippy::cast_sign_loss)]
@@ -247,10 +235,8 @@ fn split_vertex(
 
     let mut new_vertices_created = 0usize;
     for edges in group_edges.values() {
-        // Create a new vertex at the same position.
         let new_vid = topo.add_vertex(Vertex::new(position, vtx_tolerance));
 
-        // Update all edges in this group to use the new vertex.
         for &(eid, update_start, update_end) in edges {
             let edge = topo.edge_mut(eid)?;
             if update_start {

--- a/crates/heal/src/fix/wire.rs
+++ b/crates/heal/src/fix/wire.rs
@@ -71,55 +71,46 @@ fn fix_wire_impl(
 ) -> Result<FixResult, HealError> {
     let mut result = FixResult::ok();
 
-    // 1. Reorder edges to form a connected chain.
     if config.fix_reorder != FixMode::Off {
         let r = fix_reorder(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 2. Close gaps between consecutive edges.
     if config.fix_connectivity != FixMode::Off {
         let r = fix_connected(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 3. Ensure wire closure.
     if config.fix_closure != FixMode::Off {
         let r = fix_closed(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 4. Remove small edges.
     if config.fix_small_edges != FixMode::Off {
         let r = fix_small(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 5. Remove degenerate edges (closed + zero length).
     if config.fix_degenerate_edges != FixMode::Off {
         let r = fix_degenerate(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 6. Close 3D gaps (delegates to connectivity fix).
     if config.fix_gaps_3d != FixMode::Off {
         let r = fix_gaps_3d(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 7. Remove trailing short edges.
     if config.fix_tail != FixMode::Off {
         let r = fix_tail(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 8. Self-intersection detection.
     if config.fix_self_intersection != FixMode::Off {
         let r = fix_self_intersection(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 9. Lacking (PCurve/3D divergence) fix.
     if config.fix_lacking != FixMode::Off {
         if let Some(fid) = face_id {
             let r = fix_lacking(topo, wire_id, fid, ctx, config)?;
@@ -127,19 +118,16 @@ fn fix_wire_impl(
         }
     }
 
-    // 10. Notched edges fix.
     if config.fix_notched != FixMode::Off {
         let r = fix_notched(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 11. Intersecting edges fix.
     if config.fix_intersecting_edges != FixMode::Off {
         let r = fix_intersecting_edges(topo, wire_id, ctx, config)?;
         result.merge(&r);
     }
 
-    // 12. Missing seam fix.
     if config.fix_missing_seam != FixMode::Off {
         if let Some(fid) = face_id {
             let r = fix_missing_seam(topo, wire_id, fid, ctx, config)?;
@@ -149,8 +137,6 @@ fn fix_wire_impl(
 
     Ok(result)
 }
-
-// ── Fix implementations ─────────────────────────────────────────────────
 
 /// Reorder edges to form a connected chain.
 ///
@@ -171,14 +157,12 @@ fn fix_reorder(
 
     let order_result = crate::analysis::wire_order::compute_wire_order(topo, wire_id)?;
 
-    // If already in order, nothing to do.
     let is_identity = order_result.order.iter().enumerate().all(|(i, &o)| o == i)
         && order_result.flips.iter().all(|&f| !f);
     if is_identity {
         return Ok(FixResult::ok());
     }
 
-    // Snapshot: read original edges.
     let wire = topo.wire(wire_id)?;
     let old_edges: Vec<OrientedEdge> = wire.edges().to_vec();
     let is_closed = wire.is_closed();
@@ -187,7 +171,6 @@ fn fix_reorder(
         return Ok(FixResult::ok());
     }
 
-    // Build reordered edge list.
     let mut new_edges = Vec::with_capacity(old_edges.len());
     for (idx, &orig_idx) in order_result.order.iter().enumerate() {
         let oe = old_edges[orig_idx];
@@ -200,7 +183,6 @@ fn fix_reorder(
         new_edges.push(OrientedEdge::new(oe.edge(), forward));
     }
 
-    // Allocate new wire.
     let new_wire = Wire::new(new_edges, is_closed)?;
     let new_wire_id = topo.add_wire(new_wire);
     ctx.reshape.replace_wire(wire_id, new_wire_id);
@@ -251,7 +233,6 @@ fn fix_connected_with_tol(
         return Ok(FixResult::ok());
     }
 
-    // Snapshot: read wire edges and gather vertex pairs to merge.
     let wire = topo.wire(wire_id)?;
     let edges_list: Vec<OrientedEdge> = wire.edges().to_vec();
     let n_edges = edges_list.len();
@@ -263,7 +244,6 @@ fn fix_connected_with_tol(
     let tol_sq = merge_tol * merge_tol;
     let mut merge_pairs: Vec<(VertexId, VertexId)> = Vec::new();
 
-    // Snapshot all oriented endpoint vertex IDs.
     let mut end_vids = Vec::with_capacity(n_edges);
     let mut start_vids = Vec::with_capacity(n_edges);
     for oe in &edges_list {
@@ -272,7 +252,6 @@ fn fix_connected_with_tol(
         start_vids.push(oe.oriented_start(edge));
     }
 
-    // Compare consecutive edge pairs (including wrap-around for closed wires).
     let pairs = if n_edges > 1 { n_edges } else { 0 };
     for i in 0..pairs {
         let next_i = (i + 1) % n_edges;
@@ -302,7 +281,6 @@ fn fix_connected_with_tol(
 
     let gaps_closed = merge_pairs.len();
 
-    // Record vertex replacements in reshape.
     for (from_vid, to_vid) in &merge_pairs {
         ctx.reshape.replace_vertex(*from_vid, *to_vid);
     }
@@ -337,7 +315,6 @@ fn fix_closed(
         return Ok(FixResult::ok());
     }
 
-    // Get last edge's oriented end and first edge's oriented start.
     let last_edge = topo.edge(edges_list[n - 1].edge())?;
     let first_edge = topo.edge(edges_list[0].edge())?;
     let last_end = edges_list[n - 1].oriented_end(last_edge);
@@ -367,7 +344,6 @@ fn fix_closed(
         });
     }
 
-    // Merge first_start into last_end to close the wire.
     ctx.reshape.replace_vertex(first_start, last_end);
 
     ctx.info(format!(
@@ -397,7 +373,6 @@ fn fix_small(
 
     let mut removed = 0;
     for se in &analysis.small_edges {
-        // Snapshot edge data before modifying.
         let edge = topo.edge(se.edge_id)?;
         let start_vid = edge.start();
         let end_vid = edge.end();
@@ -407,7 +382,6 @@ fn fix_small(
             continue;
         }
 
-        // Merge end vertex into start vertex and remove the edge.
         ctx.reshape.replace_vertex(end_vid, start_vid);
         ctx.reshape.remove_edge(se.edge_id);
         removed += 1;
@@ -444,7 +418,6 @@ fn fix_degenerate(
         return Ok(FixResult::ok());
     }
 
-    // Snapshot: read the wire's edge list.
     let wire = topo.wire(wire_id)?;
     let edges_list: Vec<OrientedEdge> = wire.edges().to_vec();
     let is_closed = wire.is_closed();
@@ -469,7 +442,6 @@ fn fix_degenerate(
         return Ok(FixResult::ok());
     }
 
-    // Rebuild wire without degenerate edges, if any remain.
     if !new_edges.is_empty() {
         let new_wire = Wire::new(new_edges, is_closed)?;
         let new_wire_id = topo.add_wire(new_wire);
@@ -507,7 +479,6 @@ fn fix_gaps_3d(
 ) -> Result<FixResult, HealError> {
     let mut result = fix_connected(topo, wire_id, ctx, config)?;
 
-    // Re-analyze: did nominal-tolerance pass close every gap?
     let post = crate::analysis::wire::analyze_wire(topo, wire_id, &ctx.tolerance)?;
     if post.gaps.is_empty() {
         return Ok(result);
@@ -562,7 +533,6 @@ fn fix_tail(
 
     let tol = ctx.tolerance.linear;
 
-    // Check trailing edge (last edge).
     let last_oe = edges_list[n - 1];
     let last_edge = topo.edge(last_oe.edge())?;
     let last_start = topo.vertex(last_edge.start())?.point();
@@ -579,7 +549,6 @@ fn fix_tail(
         return Ok(FixResult::ok());
     }
 
-    // Remove trailing edge.
     let new_edges: Vec<OrientedEdge> = edges_list[..n - 1].to_vec();
     if new_edges.is_empty() {
         return Ok(FixResult::ok());
@@ -601,8 +570,6 @@ fn fix_tail(
     })
 }
 
-// ── Wire fix implementations ─────────────────────────────────────────
-
 /// Detect self-intersections in the wire by checking non-adjacent edge
 /// pairs for polyline crossings.
 ///
@@ -615,7 +582,6 @@ fn fix_self_intersection(
     ctx: &mut HealContext,
     config: &FixConfig,
 ) -> Result<FixResult, HealError> {
-    // Snapshot wire edges.
     let wire = topo.wire(wire_id)?;
     let edges_list: Vec<OrientedEdge> = wire.edges().to_vec();
     let n = edges_list.len();
@@ -625,7 +591,6 @@ fn fix_self_intersection(
         return Ok(FixResult::ok());
     }
 
-    // Sample each edge to a polyline of 10 points.
     let num_samples = 10;
     let mut polylines: Vec<Vec<brepkit_math::vec::Point3>> = Vec::with_capacity(n);
     for oe in &edges_list {
@@ -642,12 +607,10 @@ fn fix_self_intersection(
         polylines.push(pts);
     }
 
-    // Find the dominant projection plane from all points.
     let dominant_axis = find_dominant_axis(&polylines);
 
     let mut crossings_found = 0usize;
 
-    // Check all non-adjacent edge pairs.
     for i in 0..n {
         for j in (i + 2)..n {
             // Skip adjacent pair (last, first) in closed wires.
@@ -683,7 +646,6 @@ fn fix_self_intersection(
 fn find_dominant_axis(polylines: &[Vec<brepkit_math::vec::Point3>]) -> usize {
     use brepkit_math::vec::Vec3;
 
-    // Compute centroid.
     let mut sum = Vec3::new(0.0, 0.0, 0.0);
     let mut count = 0usize;
     for pts in polylines {
@@ -701,7 +663,6 @@ fn find_dominant_axis(polylines: &[Vec<brepkit_math::vec::Point3>]) -> usize {
     let cy = sum.y() * inv;
     let cz = sum.z() * inv;
 
-    // Compute variance per axis.
     let mut vx = 0.0_f64;
     let mut vy = 0.0_f64;
     let mut vz = 0.0_f64;
@@ -799,8 +760,6 @@ fn fix_lacking(
     ctx: &mut HealContext,
     config: &FixConfig,
 ) -> Result<FixResult, HealError> {
-    // Snapshot edge data: for each edge, store (edge_id, curve_type,
-    // start_vid, end_vid, start_pos, end_pos, domain).
     struct EdgeSnapshot {
         start_vid: VertexId,
         end_vid: VertexId,
@@ -845,7 +804,6 @@ fn fix_lacking(
     for snap in &snapshots {
         let start_dev = (snap.start_pos - snap.curve_start).length();
         if start_dev > tol {
-            // Create a new vertex at the corrected position and replace via reshape.
             let new_vid =
                 topo.add_vertex(brepkit_topology::vertex::Vertex::new(snap.curve_start, tol));
             ctx.reshape.replace_vertex(snap.start_vid, new_vid);
@@ -895,7 +853,6 @@ fn fix_notched(
     ctx: &mut HealContext,
     config: &FixConfig,
 ) -> Result<FixResult, HealError> {
-    // Snapshot edge data for cusp detection.
     struct EdgeInfo {
         oe: OrientedEdge,
         start_vid: VertexId,
@@ -925,7 +882,6 @@ fn fix_notched(
         let length = (o_end_pos - o_start_pos).length();
 
         let (t0, t1) = edge.curve().domain_with_endpoints(raw_start, raw_end);
-        // Tangent at the oriented start and end.
         let (ts, te) = if oe.is_forward() {
             (
                 edge.curve().tangent_with_endpoints(t0, raw_start, raw_end),
@@ -952,7 +908,6 @@ fn fix_notched(
     let mut cusps_found = 0usize;
     let mut edges_to_remove = std::collections::HashSet::new();
 
-    // Check consecutive pairs for cusps.
     let pairs = if topo.wire(wire_id)?.is_closed() {
         n
     } else {
@@ -967,7 +922,6 @@ fn fix_notched(
         let end_tan = infos[i].end_tangent;
         let start_tan = infos[j].start_tangent;
 
-        // Normalize tangents for dot product.
         let end_len = end_tan.length();
         let start_len = start_tan.length();
         if end_len < 1e-15 || start_len < 1e-15 {
@@ -976,7 +930,6 @@ fn fix_notched(
         let dot = end_tan.dot(start_tan) / (end_len * start_len);
 
         if dot < -0.9 {
-            // Cusp detected. Remove the shorter edge if below tolerance.
             let (remove_idx, keep_idx) = if infos[i].length <= infos[j].length {
                 (i, j)
             } else {
@@ -985,7 +938,6 @@ fn fix_notched(
 
             if infos[remove_idx].length < tol {
                 edges_to_remove.insert(remove_idx);
-                // Merge vertices of the removed edge.
                 let from = infos[remove_idx].end_vid;
                 let to = infos[keep_idx].start_vid;
                 if from != to {
@@ -1042,7 +994,6 @@ fn fix_intersecting_edges(
         return Ok(FixResult::ok());
     }
 
-    // Sample each edge to a polyline of 20 points.
     let num_samples = 20;
     let mut polylines: Vec<Vec<brepkit_math::vec::Point3>> = Vec::with_capacity(n);
     for oe in &edges_list {
@@ -1062,7 +1013,6 @@ fn fix_intersecting_edges(
     let dominant_axis = find_dominant_axis(&polylines);
     let mut crossings_found = 0usize;
 
-    // Check consecutive edge pairs (excluding the shared vertex endpoints).
     let pairs = if topo.wire(wire_id)?.is_closed() {
         n
     } else {
@@ -1124,7 +1074,6 @@ fn fix_missing_seam(
 ) -> Result<FixResult, HealError> {
     use std::f64::consts::TAU;
 
-    // Check if the face surface is periodic.
     let face = topo.face(face_id)?;
     let surface = face.surface().clone();
 
@@ -1134,13 +1083,10 @@ fn fix_missing_seam(
         | FaceSurface::Sphere(_)
         | FaceSurface::Torus(_) => TAU,
         FaceSurface::Plane { .. } | FaceSurface::Nurbs(_) => {
-            // Not periodic.
             return Ok(FixResult::ok());
         }
     };
 
-    // Sample wire edge endpoints and project onto the surface to get
-    // the u-parameter range.
     let wire = topo.wire(wire_id)?;
     let edges_list: Vec<OrientedEdge> = wire.edges().to_vec();
 

--- a/crates/heal/src/fix/wireframe.rs
+++ b/crates/heal/src/fix/wireframe.rs
@@ -38,7 +38,6 @@ pub fn fix_wireframe(
     let shell = topo.shell(shell_id)?;
     let face_ids: Vec<_> = shell.faces().to_vec();
 
-    // Build edge usage map: edge index -> list of face IDs that reference it.
     let mut edge_face_count: HashMap<usize, (EdgeId, Vec<FaceId>)> = HashMap::new();
 
     for &fid in &face_ids {
@@ -60,7 +59,6 @@ pub fn fix_wireframe(
         }
     }
 
-    // Detect free edges (used by exactly one face).
     let mut free_edges: Vec<EdgeId> = Vec::new();
     for (edge_id, faces) in edge_face_count.values() {
         if faces.len() == 1 {
@@ -77,14 +75,12 @@ pub fn fix_wireframe(
         free_edges.len()
     ));
 
-    // Attempt to sew coincident free-edge pairs.
     let sewn = sew_free_edges(topo, &free_edges, ctx)?;
 
     if sewn > 0 {
         ctx.info(format!("sewn {sewn} free-edge pairs by merging vertices"));
     }
 
-    // Log remaining unsewn free edges.
     let remaining = free_edges.len().saturating_sub(sewn * 2);
     if remaining > 0 {
         ctx.warn(format!(
@@ -133,7 +129,6 @@ fn sew_free_edges(
 ) -> Result<usize, HealError> {
     let tolerance = ctx.tolerance.linear;
 
-    // Snapshot all free edge geometry.
     let mut snapshots: Vec<FreeEdgeSnapshot> = Vec::with_capacity(free_edges.len());
     for &eid in free_edges {
         let edge = topo.edge(eid)?;
@@ -152,7 +147,6 @@ fn sew_free_edges(
         });
     }
 
-    // Find coincident pairs and record vertex merges.
     // A merge is (victim_vertex, target_vertex) — victim gets replaced by target.
     let mut merges: Vec<(EdgeId, VertexId, VertexId, VertexId, VertexId)> = Vec::new();
 
@@ -192,7 +186,6 @@ fn sew_free_edges(
         }
     }
 
-    // Apply vertex merges: update edge b to use edge a's vertices.
     for &(edge_id, _old_start, new_start, _old_end, new_end) in &merges {
         let edge = topo.edge_mut(edge_id)?;
         edge.set_start(new_start);

--- a/crates/heal/src/pipeline/builtin.rs
+++ b/crates/heal/src/pipeline/builtin.rs
@@ -30,8 +30,6 @@ pub fn register_builtins(registry: &mut OperatorRegistry) {
     registry.register("fix_wireframe", Box::new(FixWireframeOp));
 }
 
-// ── fix_shape ──────────────────────────────────────────────────────
-
 /// Full recursive shape fix (solid → shell → face → wire → edge).
 #[derive(Debug)]
 struct FixShapeOp;
@@ -52,8 +50,6 @@ impl HealOperator for FixShapeOp {
         Ok((new_solid, result))
     }
 }
-
-// ── unify_same_domain ──────────────────────────────────────────────
 
 /// Merge adjacent faces sharing the same surface.
 #[derive(Debug)]
@@ -89,8 +85,6 @@ impl HealOperator for UnifySameDomainOp {
     }
 }
 
-// ── direct_faces ───────────────────────────────────────────────────
-
 /// Orient all faces so normals point outward.
 #[derive(Debug)]
 struct DirectFacesOp;
@@ -110,15 +104,12 @@ impl HealOperator for DirectFacesOp {
             fix_orientation: crate::fix::FixMode::On,
             ..Default::default()
         };
-        // Only run shell orientation fix.
         let solid_data = topo.solid(solid_id)?;
         let shell_id = solid_data.outer_shell();
         let result = crate::fix::shell::fix_shell(topo, shell_id, ctx, &config)?;
         Ok((solid_id, result))
     }
 }
-
-// ── same_parameter ─────────────────────────────────────────────────
 
 /// Fix PCurve/3D curve consistency for all edges.
 #[derive(Debug)]
@@ -167,8 +158,6 @@ impl HealOperator for SameParameterOp {
     }
 }
 
-// ── merge_vertices ─────────────────────────────────────────────────
-
 /// Merge coincident vertices across the solid.
 #[derive(Debug)]
 struct MergeVerticesOp;
@@ -193,8 +182,6 @@ impl HealOperator for MergeVerticesOp {
         Ok((new_solid, result))
     }
 }
-
-// ── drop_small_edges ───────────────────────────────────────────────
 
 /// Remove edges shorter than tolerance.
 #[derive(Debug)]
@@ -221,8 +208,6 @@ impl HealOperator for DropSmallEdgesOp {
     }
 }
 
-// ── drop_small_faces ───────────────────────────────────────────────
-
 /// Remove faces with area below tolerance.
 #[derive(Debug)]
 struct DropSmallFacesOp;
@@ -247,8 +232,6 @@ impl HealOperator for DropSmallFacesOp {
         Ok((new_solid, result))
     }
 }
-
-// ── remove_internal_wires ──────────────────────────────────────────
 
 /// Drop internal (hole) wires from all faces.
 #[derive(Debug)]
@@ -280,8 +263,6 @@ impl HealOperator for RemoveInternalWiresOp {
         ))
     }
 }
-
-// ── sew_shells ─────────────────────────────────────────────────────
 
 /// Sew free boundaries in shells.
 #[derive(Debug)]
@@ -316,8 +297,6 @@ impl HealOperator for SewShellsOp {
     }
 }
 
-// ── split_common_vertex ────────────────────────────────────────────
-
 /// Split vertices shared by too many non-adjacent edges.
 #[derive(Debug)]
 struct SplitCommonVertexOp;
@@ -342,8 +321,6 @@ impl HealOperator for SplitCommonVertexOp {
         Ok((solid_id, result))
     }
 }
-
-// ── convert_to_bspline ─────────────────────────────────────────────
 
 /// Convert all geometry to B-Spline representation.
 #[derive(Debug)]
@@ -376,8 +353,6 @@ impl HealOperator for ConvertToBSplineOp {
         ))
     }
 }
-
-// ── convert_to_elementary ──────────────────────────────────────────
 
 /// Recognize and replace NURBS surfaces AND curves with their elementary
 /// analytic forms. Runs surface recognition (face NURBS → analytic
@@ -422,8 +397,6 @@ impl HealOperator for ConvertToElementaryOp {
         ))
     }
 }
-
-// ── fix_wireframe ──────────────────────────────────────────────────
 
 /// Repair missing or misaligned edges in shells.
 #[derive(Debug)]

--- a/crates/heal/src/reshape.rs
+++ b/crates/heal/src/reshape.rs
@@ -267,7 +267,6 @@ impl ReShape {
         let shell = topo.shell(solid_data.outer_shell())?;
         let face_ids: Vec<_> = shell.faces().to_vec();
 
-        // Collect all unique edge IDs.
         let mut edge_ids = Vec::new();
         for &fid in &face_ids {
             let face = topo.face(fid)?;
@@ -285,7 +284,6 @@ impl ReShape {
         edge_ids.sort_by_key(|e| e.index());
         edge_ids.dedup_by_key(|e| e.index());
 
-        // Snapshot updates.
         let updates: Vec<_> = edge_ids
             .iter()
             .filter_map(|&eid| {
@@ -300,7 +298,6 @@ impl ReShape {
             })
             .collect();
 
-        // Apply.
         for (eid, new_start, new_end, curve) in updates {
             let edge = topo.edge_mut(eid)?;
             *edge = Edge::new(new_start, new_end, curve);

--- a/crates/heal/src/upgrade/collapse_collinear_vertices.rs
+++ b/crates/heal/src/upgrade/collapse_collinear_vertices.rs
@@ -89,7 +89,6 @@ pub fn collapse_collinear_wire_vertices(
         }
     }
 
-    // 3. Build vertex → incident-edges map from the snapshot.
     let mut vertex_edges: HashMap<VertexId, Vec<EdgeId>> = HashMap::new();
     for (&eid, &(start, end)) in &edges_in_solid {
         vertex_edges.entry(start).or_default().push(eid);

--- a/crates/heal/src/upgrade/shell_sewing.rs
+++ b/crates/heal/src/upgrade/shell_sewing.rs
@@ -25,7 +25,6 @@ pub fn sew_shell(
 ) -> Result<usize, HealError> {
     let tol_sq = tolerance * tolerance;
 
-    // Build edge usage count.
     let shell = topo.shell(shell_id)?;
     let face_ids: Vec<_> = shell.faces().to_vec();
 
@@ -47,7 +46,6 @@ pub fn sew_shell(
         }
     }
 
-    // Free edges: used by exactly 1 face.
     let free_edges: Vec<EdgeId> = all_edge_ids
         .iter()
         .filter(|eid| edge_usage.get(&eid.index()).copied().unwrap_or(0) == 1)
@@ -58,7 +56,6 @@ pub fn sew_shell(
         return Ok(0);
     }
 
-    // Try to match free edges by vertex proximity.
     let mut sewn = 0;
     let mut matched: Vec<bool> = vec![false; free_edges.len()];
 
@@ -78,13 +75,10 @@ pub fn sew_shell(
             let sj = topo.vertex(ej.start())?.point();
             let tj = topo.vertex(ej.end())?.point();
 
-            // Check forward matching: si≈sj and ti≈tj
             let fwd = (si - sj).length_squared() < tol_sq && (ti - tj).length_squared() < tol_sq;
-            // Check reverse matching: si≈tj and ti≈sj
             let rev = (si - tj).length_squared() < tol_sq && (ti - sj).length_squared() < tol_sq;
 
             if fwd || rev {
-                // Merge vertices of edge j into edge i.
                 let (_merge_s, _merge_t) = if fwd {
                     (ej.start(), ej.end())
                 } else {
@@ -93,7 +87,6 @@ pub fn sew_shell(
                 let target_s = ei.start();
                 let target_t = ei.end();
 
-                // Update edge j's vertices to match edge i.
                 let curve_j = topo.edge(free_edges[j])?.curve().clone();
                 let ej_mut = topo.edge_mut(free_edges[j])?;
                 *ej_mut = brepkit_topology::edge::Edge::new(

--- a/crates/heal/src/upgrade/split_curve.rs
+++ b/crates/heal/src/upgrade/split_curve.rs
@@ -36,7 +36,6 @@ pub fn find_continuity_breaks(curve: &NurbsCurve, min_continuity: usize) -> Vec<
     // i.e., degree - m <= min_continuity, i.e., m >= degree - min_continuity.
     let break_threshold = degree.saturating_sub(min_continuity);
 
-    // Iterate unique internal knots.
     let mut breaks = Vec::new();
     let mut i = degree + 1; // Skip the first (degree+1) clamped knots.
     let end = knots.len().saturating_sub(degree + 1);
@@ -81,7 +80,6 @@ pub fn split_curve_at_params(
         return Ok(vec![curve.clone()]);
     }
 
-    // Sort and deduplicate split parameters.
     let mut sorted_params: Vec<f64> = params.to_vec();
     sorted_params.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     sorted_params.dedup_by(|a, b| (*a - *b).abs() < KNOT_EPS);

--- a/crates/heal/src/upgrade/unify_same_domain.rs
+++ b/crates/heal/src/upgrade/unify_same_domain.rs
@@ -55,8 +55,6 @@ pub struct UnifyResult {
     pub status: Status,
 }
 
-// ── Union-Find ──────────────────────────────────────────────────────
-
 struct UnionFind {
     parent: Vec<usize>,
     rank: Vec<u8>,
@@ -134,7 +132,6 @@ pub fn unify_same_domain(
         ));
     }
 
-    // 1. Build edge → face adjacency.
     let mut edge_faces: HashMap<usize, Vec<usize>> = HashMap::new();
     for (fi, &fid) in face_ids.iter().enumerate() {
         let face = topo.face(fid)?;
@@ -150,13 +147,11 @@ pub fn unify_same_domain(
         }
     }
 
-    // 2. Snapshot face surfaces for comparison.
     let face_surfaces: Vec<_> = face_ids
         .iter()
         .map(|&fid| topo.face(fid).map(|f| f.surface().clone()))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // 3. Union-find: group adjacent faces with equivalent surfaces.
     let mut uf = UnionFind::new(n_faces);
     let tol = brepkit_math::tolerance::Tolerance {
         linear: options.linear_tolerance,
@@ -174,7 +169,6 @@ pub fn unify_same_domain(
         }
     }
 
-    // 4. Group faces by root.
     let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
     for i in 0..n_faces {
         groups.entry(uf.find(i)).or_default().push(i);
@@ -199,7 +193,6 @@ pub fn unify_same_domain(
         ));
     }
 
-    // 5. Merge each group.
     let mut faces_to_remove: HashSet<FaceId> = HashSet::new();
     let mut new_faces_to_add: Vec<FaceId> = Vec::new();
     let mut total_merged = 0;
@@ -241,7 +234,6 @@ pub fn unify_same_domain(
         new_faces_to_add.extend(new_face_ids);
     }
 
-    // 6. Rebuild shell.
     if total_merged > 0 {
         let shell = topo.shell(shell_id)?;
         let current_faces: Vec<FaceId> = shell.faces().to_vec();
@@ -257,7 +249,6 @@ pub fn unify_same_domain(
         *shell_mut = new_shell;
     }
 
-    // 7. Merge collinear adjacent edges in the newly created wires.
     let mut total_edges_merged = 0;
     if options.unify_edges && total_merged > 0 {
         for &fid in &new_faces_to_add {

--- a/crates/io/src/gltf/reader.rs
+++ b/crates/io/src/gltf/reader.rs
@@ -25,7 +25,6 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
         });
     }
 
-    // Validate magic
     let magic = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
     if magic != 0x4654_6C67 {
         return Err(crate::IoError::ParseError {
@@ -33,7 +32,6 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
         });
     }
 
-    // Version
     let version = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
     if version != 2 {
         return Err(crate::IoError::ParseError {
@@ -41,7 +39,6 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
         });
     }
 
-    // Parse chunks
     let mut offset = 12;
     let mut json_data: Option<&[u8]> = None;
     let mut bin_data: Option<&[u8]> = None;
@@ -81,7 +78,6 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
         reason: "GLB missing BIN chunk".into(),
     })?;
 
-    // Parse JSON to extract accessor info
     let json_str = std::str::from_utf8(json_bytes).map_err(|_| crate::IoError::ParseError {
         reason: "GLB JSON is not valid UTF-8".into(),
     })?;
@@ -104,7 +100,6 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
     for prim in &primitives {
         let vertex_offset = positions.len();
 
-        // Read positions
         if let Some(pos_idx) = prim.position_accessor {
             let accessor = accessors
                 .get(pos_idx)
@@ -125,7 +120,6 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
             }
         }
 
-        // Read normals
         if let Some(norm_idx) = prim.normal_accessor {
             if let Some(accessor) = accessors.get(norm_idx) {
                 if let Some(view) = buffer_views.get(accessor.buffer_view) {
@@ -141,7 +135,6 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
             }
         }
 
-        // Read indices
         if let Some(idx_accessor_idx) = prim.indices_accessor {
             let accessor =
                 accessors
@@ -315,7 +308,6 @@ fn parse_mesh_primitives(json: &str) -> Vec<MeshPrimitive> {
     let meshes_arr_offset = meshes_start + arr_start;
     let meshes_str = extract_json_array(json, meshes_arr_offset);
 
-    // Find all "primitives" arrays within the meshes array
     let mut search_offset = 0;
     while let Some(prim_key_pos) = meshes_str[search_offset..].find("\"primitives\"") {
         let prim_key_abs = search_offset + prim_key_pos;
@@ -323,7 +315,6 @@ fn parse_mesh_primitives(json: &str) -> Vec<MeshPrimitive> {
             let prim_arr_offset = prim_key_abs + prim_arr_start;
             let prim_arr_str = extract_json_array(meshes_str, prim_arr_offset);
 
-            // Each primitive is a JSON object within the primitives array.
             for prim_obj in split_json_objects(prim_arr_str) {
                 let pos = extract_attribute_accessor(prim_obj, "POSITION");
                 let norm = extract_attribute_accessor(prim_obj, "NORMAL");
@@ -431,7 +422,6 @@ fn extract_int(text: &str, key: &str) -> Option<usize> {
     let colon_pos = after.find(':')?;
     let value_str = after[colon_pos + 1..].trim();
 
-    // Read digits
     let digits: String = value_str.chars().take_while(char::is_ascii_digit).collect();
     digits.parse().ok()
 }
@@ -715,13 +705,11 @@ mod tests {
         assert_eq!(mesh.indices[4], 4); // 1 + vertex_offset(3)
         assert_eq!(mesh.indices[5], 5); // 2 + vertex_offset(3)
 
-        // Check that second primitive positions are correct
         assert!((mesh.positions[3].x() - 2.0).abs() < 1e-6);
     }
 
     #[test]
     fn roundtrip_multi_solid_glb() {
-        // Write two separate solids to a GLB and read them back
         let mut topo = brepkit_topology::Topology::new();
         let box1 = brepkit_operations::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
         let box2 = brepkit_operations::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
@@ -733,8 +721,6 @@ mod tests {
         assert!(!mesh.indices.is_empty(), "should have indices");
         assert_eq!(mesh.indices.len() % 3, 0, "should be triangles");
     }
-
-    // ── read_glb_solid smoke test ───────────────────────────────────
 
     #[test]
     fn read_glb_solid_returns_solid_id() {

--- a/crates/io/src/gltf/writer.rs
+++ b/crates/io/src/gltf/writer.rs
@@ -110,7 +110,6 @@ pub fn write_glb(
         bin_buffer.push(0);
     }
 
-    // Build JSON
     let json = format!(
         r#"{{"asset":{{"version":"2.0","generator":"brepkit"}},"scene":0,"scenes":[{{"nodes":[0]}}],"nodes":[{{"mesh":0}}],"meshes":[{{"primitives":[{{"attributes":{{"POSITION":0,"NORMAL":1}},"indices":2}}]}}],"accessors":[{{"bufferView":0,"componentType":5126,"count":{vertex_count},"type":"VEC3","min":[{min0},{min1},{min2}],"max":[{max0},{max1},{max2}]}},{{"bufferView":1,"componentType":5126,"count":{vertex_count},"type":"VEC3"}},{{"bufferView":2,"componentType":5125,"count":{index_count},"type":"SCALAR"}}],"bufferViews":[{{"buffer":0,"byteOffset":0,"byteLength":{pos_bytes}}},{{"buffer":0,"byteOffset":{norm_offset},"byteLength":{norm_bytes}}},{{"buffer":0,"byteOffset":{idx_offset},"byteLength":{idx_bytes}}}],"buffers":[{{"byteLength":{buf_len}}}]}}"#,
         vertex_count = vertex_count,
@@ -140,7 +139,6 @@ pub fn write_glb(
 
     let mut glb = Vec::with_capacity(total_len);
 
-    // Header
     glb.write_all(&0x4654_6C67_u32.to_le_bytes()).ok(); // magic: "glTF"
     glb.write_all(&2_u32.to_le_bytes()).ok(); // version: 2
     #[allow(clippy::cast_possible_truncation)]
@@ -204,7 +202,6 @@ mod tests {
         let json_type = u32::from_le_bytes([glb[16], glb[17], glb[18], glb[19]]);
         assert_eq!(json_type, 0x4E4F_534A); // "JSON"
 
-        // JSON content should contain "asset" and "version"
         let json_str = std::str::from_utf8(&glb[20..20 + json_len]).unwrap();
         assert!(json_str.contains("\"version\":\"2.0\""));
         assert!(json_str.contains("\"generator\":\"brepkit\""));
@@ -229,7 +226,6 @@ mod tests {
 
         let glb = write_glb(&topo, &[solid], 0.1).unwrap();
 
-        // Total length should be 4-byte aligned
         assert_eq!(glb.len() % 4, 0, "GLB should be 4-byte aligned");
     }
 }

--- a/crates/io/src/iges/reader.rs
+++ b/crates/io/src/iges/reader.rs
@@ -47,7 +47,6 @@ struct IgesEntity {
 
 /// Parse all entities from an IGES file.
 fn parse_iges_entities(input: &str) -> Result<Vec<IgesEntity>, IoError> {
-    // Separate lines by section.
     let mut d_lines: Vec<&str> = Vec::new();
     let mut p_lines: Vec<&str> = Vec::new();
 
@@ -102,7 +101,6 @@ fn parse_iges_entities(input: &str) -> Result<Vec<IgesEntity>, IoError> {
             .push_str(data_part.trim_end());
     }
 
-    // Build entities.
     let mut entities = Vec::new();
     for (entity_type, _pd_start, de_seq) in &dir_entries {
         let params = pd_by_de.get(de_seq).cloned().unwrap_or_default();
@@ -149,7 +147,6 @@ fn build_topology(topo: &mut Topology, entities: &[IgesEntity]) -> Result<Vec<So
 
     for entity in entities {
         if entity.entity_type == 108 {
-            // Plane entity — create a planar face.
             if let Ok(face_id) = build_plane_face(topo, &entity.params) {
                 face_ids.push(face_id);
             }
@@ -162,7 +159,6 @@ fn build_topology(topo: &mut Topology, entities: &[IgesEntity]) -> Result<Vec<So
         return Ok(Vec::new());
     }
 
-    // Assemble all faces into a single solid.
     let shell = Shell::new(face_ids).map_err(|e| IoError::ParseError {
         reason: format!("failed to build shell: {e}"),
     })?;
@@ -202,7 +198,6 @@ fn build_plane_face(
         normal.z() / norm_len,
     );
 
-    // Compute a point on the plane and two tangent directions.
     let origin = Point3::new(
         unit_normal.x() * d / norm_len,
         unit_normal.y() * d / norm_len,
@@ -221,7 +216,6 @@ fn build_plane_face(
     let u_dir = Vec3::new(u_dir.x() / u_len, u_dir.y() / u_len, u_dir.z() / u_len);
     let v_dir = unit_normal.cross(u_dir);
 
-    // Create a 1×1 square face using linear combination of tangent vectors.
     let half = 0.5;
     let p0 = offset_point(origin, u_dir, -half, v_dir, -half);
     let p1 = offset_point(origin, u_dir, half, v_dir, -half);
@@ -296,8 +290,6 @@ mod tests {
     use super::*;
     use crate::iges::writer;
 
-    // ── Round-trip tests ────────────────────────────────────────
-
     #[test]
     fn roundtrip_unit_cube() {
         let mut write_topo = Topology::new();
@@ -329,16 +321,12 @@ mod tests {
         assert_eq!(solids.len(), 1);
     }
 
-    // ── Error handling ──────────────────────────────────────────
-
     #[test]
     fn empty_file_returns_empty() {
         let mut topo = Topology::new();
         let solids = read_iges("", &mut topo).unwrap();
         assert!(solids.is_empty());
     }
-
-    // ── Parsing helpers ─────────────────────────────────────────
 
     #[test]
     fn parse_float_params_basic() {

--- a/crates/io/src/iges/writer.rs
+++ b/crates/io/src/iges/writer.rs
@@ -97,7 +97,6 @@ impl IgesWriteContext {
             }
         }
 
-        // Write edges as line or NURBS curve entities.
         let wire = topo.wire(face.outer_wire()).map_err(topo_err)?;
         for oe in wire.edges() {
             let edge = topo.edge(oe.edge()).map_err(topo_err)?;
@@ -439,7 +438,6 @@ mod tests {
 
         let iges_str = write_iges(&topo, &[solid]).unwrap();
 
-        // Should contain plane entities (type 108).
         assert!(
             iges_str.contains("108"),
             "should contain plane entity type 108"
@@ -453,7 +451,6 @@ mod tests {
 
         let iges_str = write_iges(&topo, &[solid]).unwrap();
 
-        // Should contain line entities (type 110).
         assert!(
             iges_str.contains("110"),
             "should contain line entity type 110"
@@ -478,7 +475,6 @@ mod tests {
 
         let iges_str = write_iges(&topo, &[s1, s2]).unwrap();
 
-        // Should have entities from both solids.
         let plane_count = iges_str.matches("     108").count();
         assert!(
             plane_count >= 12,

--- a/crates/io/src/obj/reader.rs
+++ b/crates/io/src/obj/reader.rs
@@ -59,12 +59,10 @@ pub fn read_obj(input: &str) -> Result<TriangleMesh, crate::IoError> {
         }
     }
 
-    // If no normals were provided, generate per-face normals
     if normals.is_empty() {
         normals = compute_vertex_normals(&positions, &indices);
     }
 
-    // Ensure normals vector matches positions length
     normals.resize(positions.len(), Vec3::new(0.0, 0.0, 1.0));
 
     Ok(TriangleMesh {
@@ -142,7 +140,6 @@ fn compute_vertex_normals(positions: &[Point3], indices: &[u32]) -> Vec<Vec3> {
         normals[i2] += face_normal;
     }
 
-    // Normalize
     for n in &mut normals {
         let len = n.length();
         if len > 1e-15 {
@@ -274,8 +271,6 @@ f 1 2 3
             );
         }
     }
-
-    // ── read_obj_solid smoke test ───────────────────────────────────
 
     #[test]
     fn read_obj_solid_returns_solid_id() {

--- a/crates/io/src/obj/writer.rs
+++ b/crates/io/src/obj/writer.rs
@@ -51,12 +51,10 @@ pub fn write_obj(
         merged.indices.len() / 3,
     );
 
-    // Vertices
     for pos in &merged.positions {
         let _ = writeln!(output, "v {:.6} {:.6} {:.6}", pos.x(), pos.y(), pos.z());
     }
 
-    // Normals
     for normal in &merged.normals {
         let _ = writeln!(
             output,
@@ -97,11 +95,9 @@ mod tests {
         assert!(obj.contains("vn "));
         assert!(obj.contains("f "));
 
-        // Count vertex lines
         let v_count = obj.lines().filter(|l| l.starts_with("v ")).count();
         assert!(v_count > 0, "should have vertices");
 
-        // Count face lines
         let f_count = obj.lines().filter(|l| l.starts_with("f ")).count();
         assert!(f_count > 0, "should have faces");
     }
@@ -113,7 +109,6 @@ mod tests {
 
         let obj = write_obj(&topo, &[solid], 0.1).unwrap();
 
-        // Verify all face indices are within range
         let v_count = obj.lines().filter(|l| l.starts_with("v ")).count();
         for line in obj.lines().filter(|l| l.starts_with("f ")) {
             for token in line.split_whitespace().skip(1) {

--- a/crates/io/src/ply/reader.rs
+++ b/crates/io/src/ply/reader.rs
@@ -14,7 +14,6 @@ use brepkit_topology::solid::SolidId;
 ///
 /// Returns an error if the file is malformed.
 pub fn read_ply(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
-    // Parse header to determine format
     let header_end = find_header_end(data)?;
     let header_text =
         std::str::from_utf8(&data[..header_end]).map_err(|_| crate::IoError::ParseError {
@@ -112,7 +111,6 @@ fn parse_ascii_body(header: &PlyHeader, body: &[u8]) -> Result<TriangleMesh, cra
     let mut normals = Vec::with_capacity(header.vertex_count);
     let mut indices = Vec::new();
 
-    // Parse vertices
     for _ in 0..header.vertex_count {
         let line = lines.next().ok_or_else(|| crate::IoError::ParseError {
             reason: "unexpected end of PLY vertex data".into(),
@@ -135,7 +133,6 @@ fn parse_ascii_body(header: &PlyHeader, body: &[u8]) -> Result<TriangleMesh, cra
         }
     }
 
-    // Parse faces
     for _ in 0..header.face_count {
         let line = lines.next().ok_or_else(|| crate::IoError::ParseError {
             reason: "unexpected end of PLY face data".into(),
@@ -165,7 +162,6 @@ fn parse_ascii_body(header: &PlyHeader, body: &[u8]) -> Result<TriangleMesh, cra
         }
     }
 
-    // Generate normals if not in file
     if normals.is_empty() {
         normals = compute_normals(&positions, &indices);
     }
@@ -238,7 +234,6 @@ fn parse_binary_body(header: &PlyHeader, body: &[u8]) -> Result<TriangleMesh, cr
         }
     }
 
-    // Parse faces
     let mut indices = Vec::new();
     for _ in 0..header.face_count {
         if offset >= body.len() {
@@ -387,8 +382,6 @@ mod tests {
         let data = b"not a ply file";
         assert!(read_ply(data).is_err());
     }
-
-    // ── read_ply_solid smoke test ───────────────────────────────────
 
     #[test]
     fn read_ply_solid_returns_solid_id() {

--- a/crates/io/src/ply/writer.rs
+++ b/crates/io/src/ply/writer.rs
@@ -157,13 +157,10 @@ mod tests {
 
         let ply = write_ply(&topo, &[solid], 0.1, PlyFormat::BinaryLittleEndian).unwrap();
 
-        // Should start with "ply\n"
         assert!(ply.starts_with(b"ply\n"));
-        // Should contain binary header
         let header_end = ply.windows(11).position(|w| w == b"end_header\n").unwrap();
         assert!(header_end > 0);
 
-        // Binary data follows header
         assert!(ply.len() > header_end + 11);
     }
 }

--- a/crates/io/src/step/reader.rs
+++ b/crates/io/src/step/reader.rs
@@ -379,7 +379,6 @@ impl<'a> StepBuilder<'a> {
         let start_vp = self.build_vertex_point(refs[0])?;
         let end_vp = self.build_vertex_point(refs[1])?;
 
-        // Resolve the actual curve geometry from the third reference.
         let curve = self.build_curve_geometry(refs[2])?;
 
         let edge_id = self.topo.add_edge(Edge::new(start_vp, end_vp, curve));
@@ -703,7 +702,6 @@ fn parse_ints_in_parens(s: &str) -> Vec<u32> {
 /// `RATIONAL_B_SPLINE_SURFACE((...weights...))` and parses the weight list.
 /// Falls back to uniform weights if parsing fails.
 fn extract_rational_weights(attrs: &str, expected_count: usize) -> Vec<f64> {
-    // Find the RATIONAL section.
     let marker = if attrs.contains("RATIONAL_B_SPLINE_SURFACE") {
         "RATIONAL_B_SPLINE_SURFACE"
     } else {
@@ -712,10 +710,8 @@ fn extract_rational_weights(attrs: &str, expected_count: usize) -> Vec<f64> {
 
     if let Some(pos) = attrs.find(marker) {
         let after = &attrs[pos + marker.len()..];
-        // Find the opening '(' and extract the weight list.
         if let Some(paren_start) = after.find('(') {
             let rest = &after[paren_start + 1..];
-            // Parse floats from the parenthesized group(s).
             let weights = parse_weight_list(rest);
             if weights.len() >= expected_count {
                 return weights[..expected_count].to_vec();
@@ -786,7 +782,6 @@ fn extract_rational_weight_grid(attrs: &str, n_rows: usize, n_cols: usize) -> Ve
     let flat = extract_rational_weights(attrs, n_rows * n_cols);
     let tol = brepkit_math::tolerance::Tolerance::new();
     if flat.len() == n_rows * n_cols && flat.iter().any(|&w| !tol.approx_eq(w, 1.0)) {
-        // Reshape flat weights into a 2D grid.
         flat.chunks(n_cols).map(<[f64]>::to_vec).collect()
     } else {
         vec![vec![1.0; n_cols]; n_rows]
@@ -887,11 +882,9 @@ fn parse_bspline_surface_attrs(
     // Parse control point grid: nested ((#1, #2), (#3, #4))
     let cp_grid = parse_nested_refs(&groups[0]);
 
-    // Parse multiplicities (integers).
     let u_mults = parse_ints_in_parens(&groups[1]);
     let v_mults = parse_ints_in_parens(&groups[2]);
 
-    // Parse knot values (floats).
     let u_knots = parse_floats(&groups[3]);
     let v_knots = parse_floats(&groups[4]);
 
@@ -1003,7 +996,6 @@ fn parse_bspline_curve_attrs(attrs: &str) -> Option<(usize, Vec<u64>, Vec<u32>, 
         tokens.push(current.trim().to_string());
     }
 
-    // Extract degree.
     let mut degree = None;
     for tok in &tokens {
         if tok.starts_with('\'') || tok.starts_with('.') {
@@ -1176,14 +1168,12 @@ mod tests {
 
         let step_str = writer::write_step(&write_topo, &[solid]).unwrap();
 
-        // Verify STEP contains CYLINDRICAL_SURFACE.
         assert!(step_str.contains("CYLINDRICAL_SURFACE"));
 
         let mut read_topo = Topology::new();
         let solids = read_step(&step_str, &mut read_topo).unwrap();
         assert!(!solids.is_empty(), "should import at least one solid");
 
-        // Verify the imported solid has a cylindrical face.
         let read_solid = read_topo.solid(solids[0]).unwrap();
         let shell = read_topo.shell(read_solid.outer_shell()).unwrap();
 
@@ -1231,7 +1221,6 @@ mod tests {
         }
         let solid = brepkit_operations::loft::loft_smooth(&mut write_topo, &profiles).unwrap();
 
-        // Verify the original has NURBS faces.
         let orig_solid = write_topo.solid(solid).unwrap();
         let orig_shell = write_topo.shell(orig_solid.outer_shell()).unwrap();
         let orig_nurbs_count = orig_shell
@@ -1246,19 +1235,16 @@ mod tests {
             .count();
         assert!(orig_nurbs_count > 0, "lofted solid should have NURBS faces");
 
-        // Write to STEP.
         let step_str = writer::write_step(&write_topo, &[solid]).unwrap();
         assert!(
             step_str.contains("B_SPLINE_SURFACE_WITH_KNOTS"),
             "STEP output should contain B_SPLINE_SURFACE_WITH_KNOTS"
         );
 
-        // Read back.
         let mut read_topo = Topology::new();
         let solids = read_step(&step_str, &mut read_topo).unwrap();
         assert!(!solids.is_empty(), "should import at least one solid");
 
-        // Verify the imported solid has NURBS faces.
         let read_solid = read_topo.solid(solids[0]).unwrap();
         let shell = read_topo.shell(read_solid.outer_shell()).unwrap();
 
@@ -1316,11 +1302,9 @@ mod tests {
 
         let step_str = writer::write_step(&write_topo, &[solid]).unwrap();
 
-        // Check that B_SPLINE_CURVE_WITH_KNOTS is in the output.
         let has_bspline_curve = step_str.contains("B_SPLINE_CURVE_WITH_KNOTS");
 
         if has_bspline_curve {
-            // Read back and verify NURBS curves are imported.
             let mut read_topo = Topology::new();
             let solids = read_step(&step_str, &mut read_topo).unwrap();
             assert!(!solids.is_empty());

--- a/crates/io/src/step/writer.rs
+++ b/crates/io/src/step/writer.rs
@@ -36,18 +36,15 @@ pub fn write_step(topo: &Topology, solids: &[SolidId]) -> Result<String, IoError
 
     let mut ctx = StepWriteContext::new();
 
-    // Write product structure and geometric context.
     let repr_context_id = ctx.write_geometric_context();
     let product_ids = ctx.write_product_structure();
 
-    // Write each solid.
     let mut brep_ids = Vec::new();
     for &solid_id in solids {
         let brep_id = ctx.write_solid(topo, solid_id)?;
         brep_ids.push(brep_id);
     }
 
-    // Write shape representation containing all solids.
     let items: Vec<String> = brep_ids.iter().map(|id| format!("#{id}")).collect();
     let shape_repr_id = ctx.next_id();
     ctx.write_entity(
@@ -60,7 +57,6 @@ pub fn write_step(topo: &Topology, solids: &[SolidId]) -> Result<String, IoError
         ),
     );
 
-    // Link shape representation to product definition.
     let prod_def_shape_id = ctx.next_id();
     ctx.write_entity(
         prod_def_shape_id,
@@ -825,12 +821,10 @@ mod tests {
 
         let step_str = write_step(&topo, &[solid]).unwrap();
 
-        // Verify CYLINDRICAL_SURFACE entity is present.
         assert!(
             step_str.contains("CYLINDRICAL_SURFACE"),
             "STEP export should contain CYLINDRICAL_SURFACE entity"
         );
-        // Verify the file is structurally valid.
         assert!(step_str.contains("MANIFOLD_SOLID_BREP"));
     }
 
@@ -867,7 +861,6 @@ mod tests {
 
         let step_str = write_step(&topo, &[solid]).unwrap();
 
-        // Every CIRCLE entity line should end with ");".
         for line in step_str.lines() {
             if line.contains("= CIRCLE(") {
                 assert!(

--- a/crates/io/src/stl/import.rs
+++ b/crates/io/src/stl/import.rs
@@ -38,7 +38,6 @@ pub fn import_mesh(
         });
     }
 
-    // Build a vertex map: merge coincident positions.
     let vertex_ids = build_vertex_map(topo, &mesh.positions, tolerance);
 
     // Determine whether the mesh winding needs to be flipped.
@@ -53,7 +52,6 @@ pub fn import_mesh(
     let flip_all = if has_normals {
         false // per-triangle correction below handles it
     } else {
-        // Compute signed volume from raw vertex positions.
         let mut total = 0.0;
         for tri in mesh.indices.chunks_exact(3) {
             let p0 = mesh.positions[tri[0] as usize];
@@ -127,7 +125,6 @@ fn build_vertex_map(
     let mut map = Vec::with_capacity(positions.len());
 
     for &pos in positions {
-        // Check if a nearby vertex already exists.
         let existing = unique_verts.iter().find(|(p, _)| {
             let dx = p.x() - pos.x();
             let dy = p.y() - pos.y();
@@ -154,12 +151,10 @@ fn build_triangle_face(
     v1: brepkit_topology::vertex::VertexId,
     v2: brepkit_topology::vertex::VertexId,
 ) -> Result<brepkit_topology::face::FaceId, IoError> {
-    // Create edges.
     let e01 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
     let e12 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
     let e20 = topo.add_edge(Edge::new(v2, v0, EdgeCurve::Line));
 
-    // Build wire.
     let oriented = vec![
         OrientedEdge::new(e01, true),
         OrientedEdge::new(e12, true),
@@ -170,7 +165,6 @@ fn build_triangle_face(
     })?;
     let wire_id = topo.add_wire(wire);
 
-    // Compute face normal.
     let p0 = topo.vertex(v0).map_err(topo_err)?.point();
     let p1 = topo.vertex(v1).map_err(topo_err)?.point();
     let p2 = topo.vertex(v2).map_err(topo_err)?.point();
@@ -305,7 +299,6 @@ mod tests {
         let mut import_topo = Topology::new();
         let imported = import_mesh(&mut import_topo, &mesh, 1e-4).unwrap();
 
-        // Test both volume methods
         let vol_from_faces =
             brepkit_operations::measure::solid_volume_from_faces(&import_topo, imported, 0.01)
                 .unwrap();
@@ -374,7 +367,6 @@ mod tests {
 
     #[test]
     fn import_stl_roundtrip_unit_cube() {
-        // Write a unit cube to STL, read it back, import to topology.
         let mut write_topo = Topology::new();
         let solid = make_unit_cube_non_manifold(&mut write_topo);
 

--- a/crates/io/src/stl/reader.rs
+++ b/crates/io/src/stl/reader.rs
@@ -142,7 +142,6 @@ fn read_ascii_stl(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
         // Skip: solid, outer loop, endloop, endfacet, endsolid.
     }
 
-    // Validate: vertex count must be a multiple of 3.
     if mesh.positions.len() % 3 != 0 {
         return Err(crate::IoError::ParseError {
             reason: format!(
@@ -230,14 +229,11 @@ mod tests {
     use super::*;
     use crate::stl::writer::{self, StlFormat};
 
-    // ── Round-trip tests ────────────────────────────────────────────
-
     #[test]
     fn roundtrip_binary_stl_unit_cube() {
         let mut topo = Topology::new();
         let solid = make_unit_cube_non_manifold(&mut topo);
 
-        // Write → read round-trip.
         let bytes = writer::write_stl(&topo, &[solid], 0.1, StlFormat::Binary).unwrap();
         let mesh = read_stl(&bytes).unwrap();
 
@@ -272,8 +268,6 @@ mod tests {
         assert_eq!(mesh.positions.len(), 36);
     }
 
-    // ── Format detection tests ──────────────────────────────────────
-
     #[test]
     fn detect_ascii_format() {
         let data = b"solid test\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 0\n      vertex 1 0 0\n      vertex 0 1 0\n    endloop\n  endfacet\nendsolid test\n";
@@ -287,8 +281,6 @@ mod tests {
         let bytes = writer::write_stl(&topo, &[solid], 0.1, StlFormat::Binary).unwrap();
         assert!(!is_ascii_stl(&bytes));
     }
-
-    // ── Error handling tests ────────────────────────────────────────
 
     #[test]
     fn binary_stl_too_short() {
@@ -313,8 +305,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ── Minimal valid files ─────────────────────────────────────────
-
     #[test]
     fn read_minimal_ascii_single_triangle() {
         let data = b"solid minimal\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 0\n      vertex 1 0 0\n      vertex 0 1 0\n    endloop\n  endfacet\nendsolid minimal\n";
@@ -323,18 +313,15 @@ mod tests {
         assert_eq!(mesh.positions.len(), 3);
         assert_eq!(mesh.indices.len(), 3);
 
-        // Check vertex positions.
         assert!((mesh.positions[0].x() - 0.0).abs() < 1e-6);
         assert!((mesh.positions[1].x() - 1.0).abs() < 1e-6);
         assert!((mesh.positions[2].y() - 1.0).abs() < 1e-6);
 
-        // Check normal was propagated.
         assert!((mesh.normals[0].z() - 1.0).abs() < 1e-6);
     }
 
     #[test]
     fn read_minimal_binary_single_triangle() {
-        // Build a minimal binary STL with 1 triangle.
         let mut data = Vec::new();
 
         // 80-byte header.
@@ -371,8 +358,6 @@ mod tests {
         assert_eq!(mesh.indices.len(), 3);
     }
 
-    // ── Vertex data integrity ───────────────────────────────────────
-
     #[test]
     fn binary_roundtrip_preserves_vertex_positions() {
         let mut topo = Topology::new();
@@ -388,8 +373,6 @@ mod tests {
             assert!(pos.z() >= -0.01 && pos.z() <= 1.01);
         }
     }
-
-    // ── read_stl_solid smoke test ───────────────────────────────────
 
     #[test]
     fn read_stl_solid_returns_solid_id() {

--- a/crates/io/src/stl/writer.rs
+++ b/crates/io/src/stl/writer.rs
@@ -90,7 +90,9 @@ fn write_binary_stl(mesh: &TriangleMesh) -> Vec<u8> {
 
     let header = b"brepkit STL export";
     buf.extend_from_slice(header);
-    buf.extend_from_slice(&[0u8; 80 - 18]);
+    // The STL binary header is a fixed 80 bytes; zero-pad whatever the
+    // header string didn't fill.
+    buf.resize(80, 0);
 
     #[allow(clippy::cast_possible_truncation)]
     buf.extend_from_slice(&(tri_count as u32).to_le_bytes());

--- a/crates/io/src/stl/writer.rs
+++ b/crates/io/src/stl/writer.rs
@@ -88,12 +88,10 @@ fn write_binary_stl(mesh: &TriangleMesh) -> Vec<u8> {
     // 80-byte header + 4-byte count + 50 bytes per triangle.
     let mut buf = Vec::with_capacity(84 + tri_count * 50);
 
-    // Header (80 bytes).
     let header = b"brepkit STL export";
     buf.extend_from_slice(header);
-    buf.extend_from_slice(&[0u8; 80 - 18]); // Pad to 80 bytes.
+    buf.extend_from_slice(&[0u8; 80 - 18]);
 
-    // Triangle count (little-endian u32).
     #[allow(clippy::cast_possible_truncation)]
     buf.extend_from_slice(&(tri_count as u32).to_le_bytes());
 
@@ -178,7 +176,6 @@ mod tests {
         // Header: 80 bytes + count: 4 bytes = 84 bytes header.
         assert!(bytes.len() >= 84);
 
-        // Parse triangle count from the binary.
         let tri_count = u32::from_le_bytes([bytes[80], bytes[81], bytes[82], bytes[83]]) as usize;
 
         // Unit cube with 6 faces × 2 triangles each = 12 triangles.
@@ -201,7 +198,6 @@ mod tests {
         assert!(text.contains("vertex"));
         assert!(text.trim().ends_with("endsolid brepkit"));
 
-        // Count facets.
         let facet_count = text.matches("facet normal").count();
         assert_eq!(facet_count, 12, "expected 12 facets for unit cube");
     }

--- a/crates/io/src/threemf/reader.rs
+++ b/crates/io/src/threemf/reader.rs
@@ -191,7 +191,6 @@ fn build_mesh(vertices: &[Point3], indices: &[u32]) -> Result<TriangleMesh, IoEr
         });
     }
 
-    // Accumulate face normals into per-vertex normals.
     let mut normals = vec![Vec3::new(0.0, 0.0, 0.0); vertices.len()];
 
     for tri in indices.chunks_exact(3) {
@@ -221,7 +220,6 @@ fn build_mesh(vertices: &[Point3], indices: &[u32]) -> Result<TriangleMesh, IoEr
         normals[i2] += face_normal;
     }
 
-    // Normalize accumulated normals.
     let up = Vec3::new(0.0, 0.0, 1.0);
     for n in &mut normals {
         *n = n.normalize().unwrap_or(up);
@@ -289,8 +287,6 @@ mod tests {
     use super::*;
     use crate::threemf::writer;
 
-    // ── Round-trip tests ────────────────────────────────────────────
-
     #[test]
     fn roundtrip_unit_cube() {
         let mut topo = Topology::new();
@@ -332,8 +328,6 @@ mod tests {
         assert_eq!(meshes.len(), 2);
     }
 
-    // ── Vertex data integrity ───────────────────────────────────────
-
     #[test]
     fn roundtrip_preserves_vertex_bounds() {
         let mut topo = Topology::new();
@@ -366,8 +360,6 @@ mod tests {
         }
     }
 
-    // ── Error handling tests ────────────────────────────────────────
-
     #[test]
     fn invalid_zip_data() {
         let result = read_threemf(b"this is not a zip file");
@@ -376,7 +368,6 @@ mod tests {
 
     #[test]
     fn missing_model_entry() {
-        // Create a valid ZIP but without the required model file.
         let buf = std::io::Cursor::new(Vec::new());
         let mut zip = zip::ZipWriter::new(buf);
         let options = zip::write::SimpleFileOptions::default();
@@ -387,8 +378,6 @@ mod tests {
         let result = read_threemf(&cursor.into_inner());
         assert!(result.is_err());
     }
-
-    // ── read_threemf_solid smoke test ───────────────────────────────
 
     #[test]
     fn read_threemf_solid_returns_solid_id() {

--- a/crates/io/src/threemf/writer.rs
+++ b/crates/io/src/threemf/writer.rs
@@ -226,7 +226,6 @@ mod tests {
 
         let bytes = write_threemf(&topo, &[solid], 0.1).unwrap();
 
-        // Verify it's a valid ZIP with the expected entries.
         let reader = zip::ZipArchive::new(Cursor::new(&bytes)).unwrap();
         assert_eq!(reader.len(), 3);
         assert!(reader.file_names().any(|n| n == "[Content_Types].xml"));
@@ -241,7 +240,6 @@ mod tests {
 
         let bytes = write_threemf(&topo, &[solid], 0.1).unwrap();
 
-        // Verify the model XML contains expected elements.
         let mut archive = zip::ZipArchive::new(Cursor::new(&bytes)).unwrap();
         let mut model_file = archive.by_name("3D/3dmodel.model").unwrap();
         let mut xml_str = String::new();
@@ -287,7 +285,6 @@ mod tests {
         let mut xml_str = String::new();
         std::io::Read::read_to_string(&mut model_file, &mut xml_str).unwrap();
 
-        // Two objects and two build items.
         assert_eq!(xml_str.matches("<object").count(), 2);
         assert_eq!(xml_str.matches("<item").count(), 2);
     }
@@ -359,7 +356,6 @@ mod tests {
         let bytes = write_threemf(&topo, &[solid], 0.5).unwrap();
         let xml = extract_model_xml(&bytes);
 
-        // No NaN or Infinity should appear in vertex coordinates.
         assert!(!xml.contains("NaN"));
         assert!(!xml.contains("Infinity"));
         assert!(!xml.contains("inf"));

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -385,7 +385,6 @@ fn sample_plane_torus(
     normal: Vec3,
     d: f64,
 ) -> Result<Vec<Vec<Point3>>, MathError> {
-    // Delegate to the full version and extract just the points.
     let curves = intersect_plane_torus(torus, normal, d)?;
     Ok(curves
         .into_iter()

--- a/crates/math/src/cdt/constraints.rs
+++ b/crates/math/src/cdt/constraints.rs
@@ -13,12 +13,10 @@ impl Cdt {
         let max_iter = self.triangles.len() * 4 + 100;
 
         for _ in 0..max_iter {
-            // Check if the edge already exists.
             if self.edge_exists(v0, v1) {
                 return Ok(());
             }
 
-            // Find an edge that intersects the segment (v0, v1) and flip it.
             if let Some((ti, local)) = self.find_intersecting_edge(v0, v1) {
                 let adj = match self.triangles[ti].adj[local] {
                     Some(a) => a,

--- a/crates/math/src/cdt/mod.rs
+++ b/crates/math/src/cdt/mod.rs
@@ -119,7 +119,6 @@ pub struct Cdt {
     vertex_tri: Vec<usize>,
 }
 
-/// Tolerance for duplicate point detection.
 /// Duplicate point detection tolerance.
 ///
 /// Aligned with the snap tolerance (1e-8) to avoid near-coincident points
@@ -197,7 +196,6 @@ impl Cdt {
     /// Returns [`MathError::ConvergenceFailure`] if the point cannot be
     /// located in any triangle (should not happen for valid inputs).
     pub fn insert_point(&mut self, p: Point2) -> Result<usize, MathError> {
-        // Check for duplicate using spatial hash grid (O(1) amortized).
         let cell = dup_grid_cell(p);
         // Check the cell and its 8 neighbors to handle points near cell boundaries.
         for dx in -1..=1_i64 {
@@ -219,7 +217,6 @@ impl Cdt {
         self.vertex_tri.push(0); // will be updated by split_triangle/split_edge
         self.dup_grid.entry(cell).or_default().push(vi);
 
-        // Find the triangle containing the point.
         let (tri_idx, location) = self.locate_point(p)?;
         self.last_located = tri_idx;
 
@@ -249,7 +246,6 @@ impl Cdt {
             return Ok(Vec::new());
         }
 
-        // Compute bounding box of input points.
         let mut min_x = f64::INFINITY;
         let mut max_x = f64::NEG_INFINITY;
         let mut min_y = f64::INFINITY;
@@ -522,7 +518,6 @@ impl Cdt {
 
         let sc = self.super_count;
 
-        // Collect indices of all live interior triangles.
         let live_tris: Vec<usize> = self
             .triangles
             .iter()

--- a/crates/math/src/cdt/tests.rs
+++ b/crates/math/src/cdt/tests.rs
@@ -92,7 +92,6 @@ fn cdt_triangle_area_conservation() {
     let tris = cdt.triangles();
     assert_eq!(tris.len(), 1, "triangle should produce 1 triangle");
 
-    // Check area.
     let verts = cdt.vertices();
     let (a, b, c) = tris[0];
     let area = 0.5
@@ -127,7 +126,6 @@ fn cdt_constraint_diagonal() {
     cdt.insert_constraint(v1, v2).unwrap();
     cdt.insert_constraint(v2, v3).unwrap();
     cdt.insert_constraint(v3, v0).unwrap();
-    // Add diagonal constraint.
     cdt.insert_constraint(v0, v2).unwrap();
 
     cdt.remove_exterior(&[(v0, v1), (v1, v2), (v2, v3), (v3, v0)]);
@@ -139,7 +137,6 @@ fn cdt_constraint_diagonal() {
         "square with diagonal should have 2 triangles"
     );
 
-    // Verify the diagonal (v0, v2) exists as an edge.
     let has_diagonal = tris.iter().any(|&(a, b, c)| {
         let edges = [(a, b), (b, c), (c, a)];
         edges

--- a/crates/math/src/convex_hull.rs
+++ b/crates/math/src/convex_hull.rs
@@ -37,7 +37,6 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
         return None;
     }
 
-    // Deduplicate points within tolerance.
     let tol = 1e-10;
     let mut pts: Vec<Point3> = Vec::with_capacity(points.len());
     for &p in points {
@@ -50,10 +49,8 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
         return None;
     }
 
-    // --- Step 1: Find initial tetrahedron ---
     let tet = find_initial_tetrahedron(&pts)?;
 
-    // Build initial face list (4 triangles of the tetrahedron).
     let mut faces: Vec<HullFace> = Vec::new();
     let tet_faces = [
         [tet[0], tet[1], tet[2]],
@@ -89,7 +86,6 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
         }
     }
 
-    // --- Step 2-5: Incremental insertion ---
     let tet_set: std::collections::HashSet<usize> = tet.iter().copied().collect();
 
     for (pi, &point) in pts.iter().enumerate() {
@@ -97,7 +93,6 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
             continue;
         }
 
-        // Find visible faces.
         let mut visible: Vec<usize> = Vec::new();
         for (fi, face) in faces.iter().enumerate() {
             if face.alive && signed_distance(face, point) > tol {
@@ -109,7 +104,7 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
             continue; // Point is inside the hull.
         }
 
-        // Find horizon edges (edges shared by exactly one visible face).
+        // Horizon edges are shared by exactly one visible face.
         let mut horizon: Vec<[usize; 2]> = Vec::new();
         for &fi in &visible {
             let f = &faces[fi];
@@ -125,12 +120,10 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
             }
         }
 
-        // Kill visible faces.
         for &fi in &visible {
             faces[fi].alive = false;
         }
 
-        // Create new faces from horizon edges to the new point.
         for &[a, b] in &horizon {
             let normal = face_normal(&pts, a, b, pi);
             let d = -(normal.x() * pts[a].x() + normal.y() * pts[a].y() + normal.z() * pts[a].z());
@@ -154,7 +147,6 @@ pub fn convex_hull_3d(points: &[Point3]) -> Option<ConvexHull> {
         }
     }
 
-    // Collect alive faces.
     let alive_faces: Vec<[usize; 3]> = faces.iter().filter(|f| f.alive).map(|f| f.verts).collect();
 
     if alive_faces.is_empty() {

--- a/crates/math/src/nurbs/decompose.rs
+++ b/crates/math/src/nurbs/decompose.rs
@@ -20,7 +20,6 @@ pub fn curve_to_bezier_segments(curve: &NurbsCurve) -> Result<Vec<NurbsCurve>, M
     let p = curve.degree();
     let knots = curve.knots();
 
-    // Collect unique interior knots and their deficiencies.
     let mut unique_interior = Vec::new();
     let mut i = p + 1;
     while i < knots.len() - p - 1 {
@@ -42,7 +41,7 @@ pub fn curve_to_bezier_segments(curve: &NurbsCurve) -> Result<Vec<NurbsCurve>, M
         refined = curve_knot_insert(&refined, u, deficit)?;
     }
 
-    // Now extract Bezier segments: each spans p+1 consecutive control points.
+    // Each Bezier segment spans p+1 consecutive control points.
     let ref_knots = refined.knots();
     let ref_cps = refined.control_points();
     let ref_ws = refined.weights();
@@ -261,11 +260,9 @@ pub fn curve_degree_elevate(curve: &NurbsCurve, t: usize) -> Result<NurbsCurve, 
     let p = curve.degree();
     let new_p = p + t;
 
-    // First decompose into Bezier segments.
     let segments = curve_to_bezier_segments(curve)?;
     let n_segs = segments.len();
 
-    // Precompute binomial coefficients for degree elevation.
     let bezalfs = compute_bezalfs(p, t);
 
     let mut all_cps: Vec<[f64; 4]> = Vec::new();
@@ -280,7 +277,6 @@ pub fn curve_degree_elevate(curve: &NurbsCurve, t: usize) -> Result<NurbsCurve, 
             .map(|(pt, &w)| [pt.x() * w, pt.y() * w, pt.z() * w, w])
             .collect();
 
-        // Degree-elevate this Bezier segment.
         let mut elevated = vec![[0.0; 4]; new_p + 1];
         for i in 0..=new_p {
             for j in i.saturating_sub(t)..=(i.min(p)) {

--- a/crates/math/src/nurbs/fitting.rs
+++ b/crates/math/src/nurbs/fitting.rs
@@ -45,17 +45,10 @@ pub fn interpolate(points: &[Point3], degree: usize) -> Result<NurbsCurve, MathE
         return Err(MathError::EmptyInput);
     }
 
-    // Clamp degree to at most n-1.
     let p = degree.min(n - 1);
 
-    // Step 1: chord-length parameterization.
     let params = chord_length_params(points);
-
-    // Step 2: build clamped knot vector.
     let knots = build_interpolation_knots(&params, p, n);
-
-    // Step 3: solve for control points.
-    // Build the basis function matrix N[i][j] = N_{j,p}(params[i]).
     let control_points = solve_interpolation(points, &params, &knots, p)?;
 
     let weights = vec![1.0; n];
@@ -94,7 +87,6 @@ pub fn approximate(
         });
     }
 
-    // If num_control_points == n, this is exact interpolation.
     if num_control_points == n {
         return interpolate(points, degree);
     }
@@ -102,10 +94,7 @@ pub fn approximate(
     let p = degree.min(num_control_points - 1);
     let m = num_control_points;
 
-    // Parameterize data points.
     let params = chord_length_params(points);
-
-    // Build knot vector for m control points.
     let knots = build_approximation_knots(&params, p, m, n);
 
     // Solve least-squares: N^T * N * P = N^T * Q
@@ -226,7 +215,6 @@ fn solve_interpolation(
 ) -> Result<Vec<Point3>, MathError> {
     let n = points.len();
 
-    // Build the basis function matrix.
     let mut matrix = vec![vec![0.0; n]; n];
     for (i, &t) in params.iter().enumerate() {
         let span = find_span(t, degree, knots, n);
@@ -239,12 +227,10 @@ fn solve_interpolation(
         }
     }
 
-    // Right-hand side: [Qx, Qy, Qz] columns.
     let mut rhs_x: Vec<f64> = points.iter().map(|p| p.x()).collect();
     let mut rhs_y: Vec<f64> = points.iter().map(|p| p.y()).collect();
     let mut rhs_z: Vec<f64> = points.iter().map(|p| p.z()).collect();
 
-    // Gaussian elimination with partial pivoting.
     gauss_solve(&mut matrix, &mut rhs_x)?;
     // Re-build matrix (it was modified in-place).
     let mut matrix2 = vec![vec![0.0; n]; n];
@@ -296,7 +282,6 @@ fn solve_approximation(
 ) -> Result<Vec<Point3>, MathError> {
     let n = points.len();
 
-    // Build basis function matrix N: n×m.
     let mut mat_n = vec![vec![0.0; m]; n];
     for (i, &t) in params.iter().enumerate() {
         let span = find_span(t, degree, knots, m);
@@ -328,8 +313,8 @@ fn solve_approximation(
         }
     }
 
-    // Fix first and last control points.
-    // Zero out the first and last rows/cols, set diagonal to 1.
+    // Fix first and last control points: zero the first/last rows and cols,
+    // set diagonal to 1 so the endpoints are interpolated exactly.
     for j in 0..m {
         ntn[0][j] = 0.0;
         ntn[m - 1][j] = 0.0;
@@ -391,7 +376,6 @@ fn gauss_solve(a: &mut [Vec<f64>], b: &mut [f64]) -> Result<(), MathError> {
 
     // Forward elimination.
     for k in 0..n {
-        // Find pivot.
         let mut max_val = a[k][k].abs();
         let mut max_row = k;
         for i in (k + 1)..n {
@@ -405,13 +389,11 @@ fn gauss_solve(a: &mut [Vec<f64>], b: &mut [f64]) -> Result<(), MathError> {
             return Err(MathError::SingularMatrix);
         }
 
-        // Swap rows.
         if max_row != k {
             a.swap(k, max_row);
             b.swap(k, max_row);
         }
 
-        // Eliminate.
         for i in (k + 1)..n {
             let factor = a[i][k] / a[k][k];
             for j in (k + 1)..n {
@@ -450,8 +432,7 @@ fn compute_lspia_step_size(basis_data: &[(usize, Vec<f64>)], degree: usize, m: u
     }
 
     for _ in 0..20 {
-        // w = N^T N v
-        // First compute Nv (length = n_data).
+        // w = N^T N v, computed as N^T (N v) to avoid forming N^T N.
         let nv: Vec<f64> = basis_data
             .iter()
             .map(|(span, n_vals)| {
@@ -465,7 +446,6 @@ fn compute_lspia_step_size(basis_data: &[(usize, Vec<f64>)], degree: usize, m: u
                 sum
             })
             .collect();
-        // Then compute N^T (Nv).
         let mut w = vec![0.0f64; m];
         for (i, (span, n_vals)) in basis_data.iter().enumerate() {
             for (k, &bk) in n_vals.iter().enumerate() {
@@ -638,13 +618,10 @@ pub fn approximate_lspia(
     let p = degree.min(n - 1);
     let m = num_control_points.min(n).max(p + 1);
 
-    // Step 1: chord-length parameterization.
     let params = chord_length_params(points);
-
-    // Step 2: build knot vector for m control points.
     let knots = build_approximation_knots(&params, p, m, n);
 
-    // Step 3: initialize control points by sampling closest data points.
+    // Initialize control points by sampling closest data points.
     let mut control_points = Vec::with_capacity(m);
     for i in 0..m {
         let t = if m > 1 {
@@ -666,7 +643,6 @@ pub fn approximate_lspia(
 
     let weights = vec![1.0; m];
 
-    // Precompute basis function values for all data points.
     let mut basis_data: Vec<(usize, Vec<f64>)> = Vec::with_capacity(n);
     for &u in &params {
         let span = find_span(u, p, &knots, m);
@@ -674,12 +650,10 @@ pub fn approximate_lspia(
         basis_data.push((span, n_vals));
     }
 
-    // Compute step size mu for LSPIA convergence.
     // mu = 2 / (lambda_min + lambda_max) where lambda are eigenvalues of N^T N.
     // We approximate lambda_max via the power method and use a conservative mu.
     let mu = compute_lspia_step_size(&basis_data, p, m);
 
-    // Step 4: iterate.
     for iter in 0..max_iterations {
         let curve = NurbsCurve::new(p, knots.clone(), control_points.clone(), weights.clone())?;
 
@@ -771,13 +745,10 @@ pub(crate) fn approximate_lspia_weighted(
     let p = degree.min(n - 1);
     let m = num_control_points.min(n).max(p + 1);
 
-    // Step 1: chord-length parameterization.
     let params = chord_length_params(points);
-
-    // Step 2: build knot vector.
     let knots = build_approximation_knots(&params, p, m, n);
 
-    // Step 3: initialize control points by sampling closest data points.
+    // Initialize control points by sampling closest data points.
     let mut control_points = Vec::with_capacity(m);
     for i in 0..m {
         let t = if m > 1 {
@@ -799,7 +770,6 @@ pub(crate) fn approximate_lspia_weighted(
 
     let weights = vec![1.0; m];
 
-    // Precompute basis function values.
     let mut basis_data: Vec<(usize, Vec<f64>)> = Vec::with_capacity(n);
     for &u in &params {
         let span = find_span(u, p, &knots, m);
@@ -807,10 +777,8 @@ pub(crate) fn approximate_lspia_weighted(
         basis_data.push((span, n_vals));
     }
 
-    // Compute step size mu for LSPIA convergence.
     let mu = compute_lspia_step_size_weighted(&basis_data, point_weights, p, m);
 
-    // Step 4: iterate.
     for iter in 0..max_iterations {
         let curve = NurbsCurve::new(p, knots.clone(), control_points.clone(), weights.clone())?;
 
@@ -889,7 +857,6 @@ mod tests {
         let curve = interpolate(&pts, 3).unwrap();
 
         let tol = Tolerance::new();
-        // Check endpoints.
         let p0 = curve.evaluate(0.0);
         let p1 = curve.evaluate(1.0);
         assert!(tol.approx_eq(p0.x(), 0.0), "start x: {}", p0.x());
@@ -1006,7 +973,6 @@ mod tests {
             .collect();
         let curve = approximate_lspia(&points, 3, 15, 1e-4, 200).unwrap();
 
-        // Check that points are near the circle.
         for i in 0..10 {
             let t = i as f64 / 9.0;
             let p = curve.evaluate(t);

--- a/crates/math/src/nurbs/intersection/mod.rs
+++ b/crates/math/src/nurbs/intersection/mod.rs
@@ -31,7 +31,6 @@ mod surface_seeding;
 use crate::nurbs::curve::NurbsCurve;
 use crate::vec::Point3;
 
-// Re-export all public items.
 pub use chaining::chain_intersection_points;
 pub use curve_surface::{CurveSurfaceHit, intersect_curve_surface};
 pub use line::intersect_line_nurbs;

--- a/crates/math/src/nurbs/power_basis.rs
+++ b/crates/math/src/nurbs/power_basis.rs
@@ -83,7 +83,6 @@ impl PowerBasis1D {
             // For each basis function, solve Newton interpolation then convert
             // to monomial form.
             for j in 0..=p {
-                // Copy samples for this basis function.
                 for k in 0..=p {
                     samples[k] = all_samples[j * (p + 1) + k];
                 }

--- a/crates/math/src/nurbs/projection.rs
+++ b/crates/math/src/nurbs/projection.rs
@@ -171,7 +171,6 @@ fn curve_newton_refine(
 
         let dist_sq = diff.length_squared();
 
-        // Track best solution.
         if dist_sq < best_dist_sq {
             best_dist_sq = dist_sq;
             best_u = u;

--- a/crates/math/src/nurbs/surface_fitting.rs
+++ b/crates/math/src/nurbs/surface_fitting.rs
@@ -57,7 +57,6 @@ pub fn interpolate_surface(
         return Err(MathError::EmptyInput);
     }
 
-    // Validate grid consistency.
     for row in points {
         if row.len() != num_cols {
             return Err(MathError::InvalidControlPointGrid {
@@ -152,7 +151,6 @@ pub fn approximate_surface_lspia(
     tolerance: f64,
     max_iterations: usize,
 ) -> Result<NurbsSurface, MathError> {
-    // Validate input grid.
     if points.is_empty() || points[0].is_empty() {
         return Err(MathError::EmptyInput);
     }
@@ -172,11 +170,9 @@ pub fn approximate_surface_lspia(
     let mu = num_cps_u.min(rows).max(pu + 1);
     let mv = num_cps_v.min(cols).max(pv + 1);
 
-    // Compute parameters for rows (u) and columns (v).
     let params_u = compute_grid_params_u(points, rows, cols);
     let params_v = compute_grid_params_v(points, rows, cols);
 
-    // Build knot vectors.
     let knots_u = fitting::build_approximation_knots(&params_u, pu, mu, rows);
     let knots_v = fitting::build_approximation_knots(&params_v, pv, mv, cols);
 
@@ -194,7 +190,6 @@ pub fn approximate_surface_lspia(
 
     let weights = vec![vec![1.0; mv]; mu];
 
-    // Precompute basis values.
     let basis_u_data: Vec<(usize, Vec<f64>)> = params_u
         .iter()
         .map(|&u| {
@@ -223,7 +218,6 @@ pub fn approximate_surface_lspia(
         1.0 / lambda_max
     };
 
-    // Iterate.
     for iter in 0..max_iterations {
         let surface = NurbsSurface::new(
             pu,

--- a/crates/math/src/obb.rs
+++ b/crates/math/src/obb.rs
@@ -52,7 +52,6 @@ impl Obb3 {
 
         let n = pts.len() as f64;
 
-        // Compute centroid.
         let mut cx = 0.0_f64;
         let mut cy = 0.0_f64;
         let mut cz = 0.0_f64;
@@ -65,7 +64,7 @@ impl Obb3 {
         cy /= n;
         cz /= n;
 
-        // Compute covariance matrix (symmetric 3x3).
+        // Covariance matrix (symmetric 3x3).
         let mut cov = [0.0_f64; 6]; // [xx, xy, xz, yy, yz, zz]
         for p in pts {
             let dx = p.x() - cx;
@@ -115,7 +114,6 @@ impl Obb3 {
 
         let n = pts.len() as f64;
 
-        // Centroid.
         let mut cx = 0.0_f64;
         let mut cy = 0.0_f64;
         let mut cz = 0.0_f64;

--- a/crates/offset/src/analyse.rs
+++ b/crates/offset/src/analyse.rs
@@ -44,7 +44,6 @@ pub fn analyse_edges(
         PI
     };
 
-    // Track which vertices are incident to which edge classifications
     let mut vertex_edges: BTreeMap<usize, Vec<EdgeClass>> = BTreeMap::new();
 
     for (&edge_idx, face_ids) in &edge_face_map {
@@ -63,7 +62,6 @@ pub fn analyse_edges(
 
         data.edge_class.insert(edge_idx, class);
 
-        // Record edge class for start and end vertices
         let edge_data = topo.edge(edge_id)?;
         vertex_edges
             .entry(edge_data.start().index())
@@ -75,7 +73,6 @@ pub fn analyse_edges(
             .push(class);
     }
 
-    // Classify vertices based on incident edge classifications
     for (&vid_idx, classes) in &vertex_edges {
         let has_convex = classes
             .iter()
@@ -131,7 +128,6 @@ fn classify_edge(
     let n_a = face_outward_normal(topo, face_a, midpoint, edge_id)?;
     let n_b = face_outward_normal(topo, face_b, midpoint, edge_id)?;
 
-    // Angle between the outward normals.
     let dot_normals = (n_a.x() * n_b.x() + n_a.y() * n_b.y() + n_a.z() * n_b.z()).clamp(-1.0, 1.0);
     let cross = n_a.cross(n_b);
     let cross_len = (cross.x() * cross.x() + cross.y() * cross.y() + cross.z() * cross.z()).sqrt();
@@ -160,35 +156,10 @@ fn classify_edge(
         return Ok(EdgeClass::Tangent);
     }
 
-    // For a convex edge on a closed solid, a point offset from the
-    // edge midpoint along the *negative* average normal direction should
-    // be inside the solid. Equivalently, the average normal points
-    // outward (away from the material) at a convex edge.
-    //
-    // We verify this by checking that both face normals have a positive
-    // component along n_avg. At a convex edge both normals "fan out",
-    // so n_a · n_avg > 0 and n_b · n_avg > 0. At a concave edge the
-    // normals converge past each other and at least one will have a
-    // negative component.
-    //
-    // Actually: n_a · (n_a + n_b) = 1 + n_a·n_b which is always ≥ 0
-    // when angle_between_normals ≤ π/2, and can still be positive up
-    // to angle = π. This doesn't discriminate.
-    //
-    // Correct approach: use the face centroid. Sample the centroid of
-    // each face and check which side of the edge it's on relative to
-    // the average normal.
-    //
-    // SIMPLEST CORRECT TEST: at a convex edge, the dot product
-    // n_a · n_b is positive when the normals open at less than π/2
-    // (acute convex), zero at right angles, and negative when they
-    // open past π/2. But ALL box edges are convex regardless of this
-    // dot product sign.
-    //
-    // The actual discriminant: sample a third point. Take the centroid
-    // of face_a's outer wire. The vector from edge midpoint to that
-    // centroid should have a NEGATIVE dot with n_b for a convex edge
-    // (the face interior is on the material side, below n_b).
+    // Convexity discriminant: take the centroid of face_a's outer wire.
+    // The vector from edge midpoint to that centroid should have a
+    // NEGATIVE dot with n_b for a convex edge (the face interior is on
+    // the material side, below n_b).
     let centroid_a = face_centroid(topo, face_a)?;
     let to_centroid = Vec3::new(
         centroid_a.x() - midpoint.x(),

--- a/crates/offset/src/assemble.rs
+++ b/crates/offset/src/assemble.rs
@@ -27,15 +27,12 @@ use crate::error::OffsetError;
 pub fn assemble_solid(topo: &mut Topology, data: &OffsetData) -> Result<SolidId, OffsetError> {
     let mut new_faces = Vec::new();
 
-    // Create a face for each successfully offset face that has wire loops.
     for (face_id, offset_face) in &data.offset_faces {
         if offset_face.status == OffsetStatus::Excluded {
             continue;
         }
 
         let Some(wires) = data.face_wires.get(face_id) else {
-            // No wires built for this face — skip with a warning.
-            // In a production build this might log; for now we silently skip.
             continue;
         };
 
@@ -51,13 +48,11 @@ pub fn assemble_solid(topo: &mut Topology, data: &OffsetData) -> Result<SolidId,
         new_faces.push(face_id);
     }
 
-    // Generate wall faces for thick-solid mode (excluded faces).
     if !data.excluded_faces.is_empty() {
         let wall_faces = build_wall_faces(topo, data)?;
         new_faces.extend(wall_faces);
     }
 
-    // Include any joint faces created during Phase 6 (arc joints).
     for &joint_face in &data.joint_faces {
         new_faces.push(joint_face);
     }
@@ -96,12 +91,8 @@ fn build_wall_faces(topo: &mut Topology, data: &OffsetData) -> Result<Vec<FaceId
         for oriented_edge in &wire_edges {
             let edge_id = oriented_edge.edge();
 
-            // Find the adjacent non-excluded face for this edge.
-            // Look through intersections OR use offset face data to compute
-            // the offset position at the original vertices.
-            //
-            // Simple approach: offset each vertex along the face normal by
-            // the offset distance. This works for planar faces.
+            // Offset each vertex along the face normal by the offset
+            // distance. This works for planar faces.
             let edge = topo.edge(edge_id)?;
             let p0_id = if oriented_edge.is_forward() {
                 edge.start()
@@ -117,7 +108,6 @@ fn build_wall_faces(topo: &mut Topology, data: &OffsetData) -> Result<Vec<FaceId
             let p0 = topo.vertex(p0_id)?.point();
             let p1 = topo.vertex(p1_id)?.point();
 
-            // Get the excluded face's outward normal to determine offset direction.
             let excl_face = topo.face(excluded_face_id)?;
             let excl_normal = match excl_face.surface() {
                 FaceSurface::Plane { normal, .. } => {
@@ -145,7 +135,6 @@ fn build_wall_faces(topo: &mut Topology, data: &OffsetData) -> Result<Vec<FaceId
             let q0 = Point3::new(p0.x() + disp.x(), p0.y() + disp.y(), p0.z() + disp.z());
             let q1 = Point3::new(p1.x() + disp.x(), p1.y() + disp.y(), p1.z() + disp.z());
 
-            // Create offset vertices.
             let q0_id = topo.add_vertex(Vertex::new(q0, tol));
             let q1_id = topo.add_vertex(Vertex::new(q1, tol));
 
@@ -185,7 +174,6 @@ fn make_wall_quad(
     let normal = cross * (1.0 / len);
     let d = normal.dot(Vec3::new(p0.x(), p0.y(), p0.z()));
 
-    // Create 4 line edges.
     let e01 = topo.add_edge(Edge::new(p0_id, p1_id, EdgeCurve::Line));
     let e12 = topo.add_edge(Edge::new(p1_id, p2_id, EdgeCurve::Line));
     let e23 = topo.add_edge(Edge::new(p2_id, p3_id, EdgeCurve::Line));

--- a/crates/offset/src/data.rs
+++ b/crates/offset/src/data.rs
@@ -1,4 +1,3 @@
-// Offset pipeline infrastructure — fields populated progressively across phases.
 #![allow(dead_code)]
 //! Central data structures shared across all offset pipeline phases.
 

--- a/crates/offset/src/inter2d.rs
+++ b/crates/offset/src/inter2d.rs
@@ -65,7 +65,6 @@ fn create_edge_from_curve_points(
         return None;
     }
 
-    // Try to fit a circle if we have enough points.
     if points.len() >= 8 {
         if let Some((circle, seam_pt)) = fit_circle_3d(points, tol) {
             let v = find_or_create_vertex(topo, vertex_cache, seam_pt, tol);
@@ -73,7 +72,6 @@ fn create_edge_from_curve_points(
         }
     }
 
-    // Fall back to line edge.
     let p_start = points[0];
     let p_end = points[points.len() - 1];
     let v_start = find_or_create_vertex(topo, vertex_cache, p_start, tol);
@@ -107,13 +105,10 @@ fn fit_circle_3d(points: &[Point3], tol: f64) -> Option<(brepkit_math::curves::C
         return None;
     }
 
-    // Pick 3 well-spaced points.
     let p0 = points[0];
     let p1 = points[n / 3];
     let p2 = points[2 * n / 3];
 
-    // Compute circumcircle of p0, p1, p2 in 3D.
-    // 1. Plane normal from cross product.
     let d1 = Vec3::new(p1.x() - p0.x(), p1.y() - p0.y(), p1.z() - p0.z());
     let d2 = Vec3::new(p2.x() - p0.x(), p2.y() - p0.y(), p2.z() - p0.z());
     let normal = d1.cross(d2);
@@ -127,7 +122,6 @@ fn fit_circle_3d(points: &[Point3], tol: f64) -> Option<(brepkit_math::curves::C
         normal.z() / normal_len,
     );
 
-    // 2. Build local 2D frame in the plane.
     let u_axis = {
         let len = d1.length();
         if len < 1e-15 {
@@ -137,7 +131,6 @@ fn fit_circle_3d(points: &[Point3], tol: f64) -> Option<(brepkit_math::curves::C
     };
     let v_axis = normal.cross(u_axis);
 
-    // 3. Project 3 points to 2D.
     let proj = |p: Point3| -> (f64, f64) {
         let dx = p.x() - p0.x();
         let dy = p.y() - p0.y();
@@ -149,7 +142,7 @@ fn fit_circle_3d(points: &[Point3], tol: f64) -> Option<(brepkit_math::curves::C
     let (bx, by) = proj(p1);
     let (cx_l, cy_l) = proj(p2);
 
-    // 4. Circumcenter in 2D: solve perpendicular bisector intersection.
+    // Circumcenter in 2D: solve perpendicular bisector intersection.
     let d_val = 2.0 * (ax * (by - cy_l) + bx * (cy_l - ay) + cx_l * (ay - by));
     if d_val.abs() < 1e-15 {
         return None;
@@ -165,14 +158,12 @@ fn fit_circle_3d(points: &[Point3], tol: f64) -> Option<(brepkit_math::curves::C
         return None;
     }
 
-    // 5. Lift circumcenter back to 3D.
     let center = Point3::new(
         p0.x() + ux * u_axis.x() + uy * v_axis.x(),
         p0.y() + ux * u_axis.y() + uy * v_axis.y(),
         p0.z() + ux * u_axis.z() + uy * v_axis.z(),
     );
 
-    // 6. Validate: all points should be within tolerance of the circle.
     let max_dev = points
         .iter()
         .map(|p| (dist_sq(*p, center).sqrt() - radius).abs())
@@ -291,7 +282,6 @@ mod tests {
         let mut cache = Vec::new();
         let tol = 1e-7;
 
-        // 32 points on a circle at z=5, radius=2.5
         let n = 32;
         let radius = 2.5;
         let points: Vec<_> = (0..n)

--- a/crates/offset/src/inter3d.rs
+++ b/crates/offset/src/inter3d.rs
@@ -43,7 +43,6 @@ pub fn intersect_faces_3d(
             continue;
         }
 
-        // Both faces must have offset surfaces.
         let (Some(off_a), Some(off_b)) = (
             data.offset_faces.get(&face_a),
             data.offset_faces.get(&face_b),

--- a/crates/offset/src/lib.rs
+++ b/crates/offset/src/lib.rs
@@ -90,33 +90,24 @@ pub fn thick_solid(
 
     let mut data = OffsetData::new(distance, options, exclude.to_vec());
 
-    // Phase 1: edge and vertex classification
     analyse::analyse_edges(topo, solid, &mut data)?;
 
-    // Phase 2: offset surface construction
     offset::build_offset_faces(topo, solid, &mut data)?;
 
-    // Phase 3: 3D face-face intersection
     inter3d::intersect_faces_3d(topo, solid, &mut data)?;
 
-    // Phase 4: 2D PCurve intersection
     inter2d::intersect_pcurves_2d(topo, solid, &mut data)?;
 
-    // Phase 5: edge splitting (uses data from phases 3-4)
-    // Integrated into inter2d for now.
+    // Edge splitting (phase 5) is integrated into inter2d for now.
 
-    // Phase 6: arc joints at convex edges
     if data.options.joint == JointType::Arc {
         arc_joint::build_arc_joints(topo, &mut data)?;
     }
 
-    // Phase 7: wire loop construction
     loops::build_wire_loops(topo, &mut data)?;
 
-    // Phase 8: shell and solid assembly
     let result = assemble::assemble_solid(topo, &data)?;
 
-    // Phase 9: self-intersection removal
     if data.options.remove_self_intersections {
         return self_int::remove_self_intersections(topo, result);
     }

--- a/crates/offset/src/loops.rs
+++ b/crates/offset/src/loops.rs
@@ -71,7 +71,6 @@ fn build_loops_for_face(
     data: &OffsetData,
     face_id: FaceId,
 ) -> Result<Vec<WireId>, OffsetError> {
-    // Collect all intersection edges for this face.
     let mut face_edges: Vec<EdgeId> = Vec::new();
     for intersection in &data.intersections {
         if intersection.face_a != face_id && intersection.face_b != face_id {
@@ -80,7 +79,6 @@ fn build_loops_for_face(
         face_edges.extend_from_slice(&intersection.new_edges);
     }
 
-    // Include boundary edges (thick-solid mode).
     if let Some(boundary) = data.boundary_edges.get(&face_id) {
         face_edges.extend_from_slice(boundary);
     }
@@ -89,17 +87,14 @@ fn build_loops_for_face(
         return Ok(Vec::new());
     }
 
-    // Strategy 1: Circle/seam pattern.
     if let Some(wires) = try_circle_seam_wire(topo, &face_edges)? {
         return Ok(wires);
     }
 
-    // Strategy 2: Direct chain (edges already share vertices).
     if let Some(wires) = try_direct_chain(topo, &face_edges)? {
         return Ok(wires);
     }
 
-    // Strategy 3: Line intersection fallback (box-like faces).
     build_loops_via_line_intersection(topo, data, face_id)
 }
 
@@ -114,7 +109,6 @@ fn try_circle_seam_wire(
     topo: &mut Topology,
     edges: &[EdgeId],
 ) -> Result<Option<Vec<WireId>>, OffsetError> {
-    // Separate circle edges (closed) from non-circle edges.
     let mut circles: Vec<EdgeId> = Vec::new();
     let mut others: Vec<EdgeId> = Vec::new();
     for &eid in edges {
@@ -146,7 +140,6 @@ fn try_circle_seam_wire(
             return Ok(None);
         }
 
-        // Create seam edge connecting the two circle vertices.
         let seam = topo.add_edge(Edge::new(va, vb, EdgeCurve::Line));
 
         // Wire: circle_a(fwd) → seam(fwd) → circle_b(rev) → seam(rev)
@@ -174,7 +167,6 @@ fn try_direct_chain(
     topo: &mut Topology,
     edges: &[EdgeId],
 ) -> Result<Option<Vec<WireId>>, OffsetError> {
-    // Snapshot edge data.
     let edge_info: Vec<(EdgeId, VertexId, VertexId)> = edges
         .iter()
         .map(|&eid| {
@@ -183,7 +175,6 @@ fn try_direct_chain(
         })
         .collect::<Result<Vec<_>, OffsetError>>()?;
 
-    // Build vertex adjacency for non-closed edges.
     let mut adjacency: HashMap<usize, Vec<(usize, usize)>> = HashMap::new();
     for (list_idx, &(_, start, end)) in edge_info.iter().enumerate() {
         if start == end {
@@ -210,7 +201,6 @@ fn try_direct_chain(
         return Ok(None);
     }
 
-    // Walk adjacency to form closed loops.
     let mut visited: HashSet<usize> = HashSet::new();
     let mut all_loops: Vec<Vec<OrientedEdge>> = Vec::new();
 
@@ -440,7 +430,6 @@ fn line_line_closest_point(a: &LineSeg, b: &LineSeg, tol: f64) -> Option<(Point3
 
     let denom = aa * bb - ab * ab;
 
-    // Parallel lines — no unique intersection.
     // Parallel lines — cross product denominator is near-zero.
     if denom.abs() < 1e-20 {
         return None;
@@ -449,7 +438,6 @@ fn line_line_closest_point(a: &LineSeg, b: &LineSeg, tol: f64) -> Option<(Point3
     let t = (ab * bw - bb * aw) / denom;
     let s = (aa * bw - ab * aw) / denom;
 
-    // Points on each line at closest approach.
     let pa = Point3::new(
         a.p0.x() + t * da.0,
         a.p0.y() + t * da.1,
@@ -461,7 +449,6 @@ fn line_line_closest_point(a: &LineSeg, b: &LineSeg, tol: f64) -> Option<(Point3
         b.p0.z() + s * db.2,
     );
 
-    // Check that the lines actually intersect (distance below threshold).
     let dx = pa.x() - pb.x();
     let dy = pa.y() - pb.y();
     let dz = pa.z() - pb.z();

--- a/crates/offset/src/offset.rs
+++ b/crates/offset/src/offset.rs
@@ -34,7 +34,6 @@ pub fn build_offset_faces(
     let faces = topo.shell(shell_id)?.faces().to_vec();
 
     for face_id in faces {
-        // Check if excluded
         if data.excluded_faces.contains(&face_id) {
             let face = topo.face(face_id)?;
             data.offset_faces.insert(

--- a/crates/operations/src/assembly.rs
+++ b/crates/operations/src/assembly.rs
@@ -125,7 +125,6 @@ impl Assembly {
             },
         );
 
-        // Update parent's children list
         if let Some(parent_comp) = self.components.get_mut(&parent) {
             parent_comp.children.push(id);
         }
@@ -194,10 +193,8 @@ impl Assembly {
         let world = parent_transform * comp.transform;
 
         if comp.children.is_empty() {
-            // Leaf node — include in output
             result.push((comp.solid, world));
         } else {
-            // Non-leaf — recurse into children
             for &child_id in &comp.children {
                 self.flatten_recursive(child_id, world, result);
             }
@@ -218,7 +215,6 @@ impl Assembly {
 
         for (solid_id, transform) in self.flatten() {
             let bbox = crate::measure::solid_bounding_box(topo, solid_id)?;
-            // Transform the 8 corners of the bounding box
             let lo = bbox.min;
             let hi = bbox.max;
             let corners = [

--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -22,10 +22,6 @@ use super::classify::polygon_centroid;
 use super::face_polygon;
 use super::types::{FaceSpec, MIN_SOLID_FACES};
 
-// ---------------------------------------------------------------------------
-// Spatial hashing helpers
-// ---------------------------------------------------------------------------
-
 /// Quantize a coordinate to a spatial hash key.
 #[inline]
 #[allow(clippy::cast_possible_truncation)] // coordinate * 1e7 fits in i64
@@ -66,10 +62,6 @@ pub(super) fn vertex_merge_resolution(
         fallback
     }
 }
-
-// ---------------------------------------------------------------------------
-// Solid assembly
-// ---------------------------------------------------------------------------
 
 /// Assemble a solid from a set of planar face polygons with normals.
 ///
@@ -447,12 +439,6 @@ pub(crate) fn assemble_solid_mixed(
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
 }
 
-// ---------------------------------------------------------------------------
-// Degenerate result detection
-// ---------------------------------------------------------------------------
-// Manifold shell building
-// ---------------------------------------------------------------------------
-
 /// Resolve non-manifold edges using manifold pairing.
 ///
 /// For each edge shared by 3+ faces, select the best pair (faces with
@@ -579,10 +565,6 @@ fn build_manifold_shell(
 
     Ok(face_ids.to_vec())
 }
-
-// ---------------------------------------------------------------------------
-// Degenerate result detection
-// ---------------------------------------------------------------------------
 
 /// Validate that a boolean result is not degenerate.
 ///
@@ -759,10 +741,6 @@ pub(super) fn face_components(topo: &Topology, solid: SolidId) -> Vec<Vec<FaceId
     }
     components
 }
-
-// ---------------------------------------------------------------------------
-// Post-assembly edge refinement
-// ---------------------------------------------------------------------------
 
 /// Split long boundary edges at intermediate collinear vertices.
 ///
@@ -973,7 +951,6 @@ pub(super) fn refine_boundary_edges(
         return Ok(());
     }
 
-    // Rebuild faces that have edges needing splits
     for fi in 0..face_ids.len() {
         let fid = face_ids[fi];
         let face = topo.face(fid)?;
@@ -998,7 +975,6 @@ pub(super) fn refine_boundary_edges(
         let is_reversed = face.is_reversed();
         let old_edges: Vec<OrientedEdge> = outer_wire.edges().to_vec();
 
-        // Rebuild the outer wire with split edges
         let mut new_oriented_edges = Vec::new();
         for oe in &old_edges {
             if let Some(intermediates) = edge_splits.get(&oe.edge()) {
@@ -1079,10 +1055,6 @@ pub(super) fn refine_boundary_edges(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Post-assembly boundary edge stitching
-// ---------------------------------------------------------------------------
-
 /// Merge geometrically-coincident boundary edge pairs.
 ///
 /// After boolean assembly, the spatial-hash vertex deduplication may map
@@ -1109,7 +1081,6 @@ pub(super) fn stitch_boundary_edges(
         face_idx: usize,
     }
 
-    // 1. Build edge→face count and collect edge metadata.
     let mut edge_face_count: HashMap<EdgeId, usize> = HashMap::new();
     let mut edge_vertices: HashMap<EdgeId, (VertexId, VertexId)> = HashMap::new();
     // Track which face and wire own each edge for later rewriting.
@@ -1134,7 +1105,6 @@ pub(super) fn stitch_boundary_edges(
         }
     }
 
-    // 2. Collect boundary edges (count == 1) with endpoint positions.
     let mut boundary_edges: Vec<BoundaryEdgeInfo> = Vec::new();
     for (&eid, &count) in &edge_face_count {
         if count != 1 {
@@ -1170,7 +1140,6 @@ pub(super) fn stitch_boundary_edges(
         return Ok(0);
     }
 
-    // 3. Build spatial hash grid of boundary edge midpoints.
     let tol_linear = tol.linear;
     let cell_size = boundary_edges
         .iter()
@@ -1192,7 +1161,6 @@ pub(super) fn stitch_boundary_edges(
         grid.entry((cx, cy, cz)).or_default().push(i);
     }
 
-    // 4. Find matching pairs.
     let mut stitched: HashSet<EdgeId> = HashSet::new();
     // Map: (face_idx, old_edge_id) → replacement_edge_id
     let mut replacements: HashMap<(usize, EdgeId), EdgeId> = HashMap::new();
@@ -1213,7 +1181,6 @@ pub(super) fn stitch_boundary_edges(
         let cy = (mid.y() * inv_cell).floor() as i64;
         let cz = (mid.z() * inv_cell).floor() as i64;
 
-        // Query 3×3×3 neighborhood
         let mut best_match: Option<usize> = None;
         let mut best_dist_sq = f64::INFINITY;
 
@@ -1300,8 +1267,7 @@ pub(super) fn stitch_boundary_edges(
         vertex_remap.len()
     );
 
-    // 5. Apply vertex remaps to ALL edges in affected faces.
-    //    Cascade: if A→B and B→C, then A→C.
+    // Cascade vertex remaps: if A→B and B→C, then A→C.
     let mut resolved_remap: HashMap<VertexId, VertexId> = HashMap::new();
     for (&from, &to) in &vertex_remap {
         let mut target = to;
@@ -1394,10 +1360,6 @@ pub(super) fn stitch_boundary_edges(
     Ok(stitch_count)
 }
 
-// ---------------------------------------------------------------------------
-// Non-manifold edge splitting
-// ---------------------------------------------------------------------------
-
 /// Split non-manifold edges into multiple coincident copies.
 ///
 /// After boolean assembly, some edges may be shared by more than 2 faces.
@@ -1418,7 +1380,6 @@ pub(super) fn split_nonmanifold_edges(
     let mut edge_faces: HashMap<usize, Vec<(usize, bool)>> = HashMap::new();
     for (fi, &fid) in face_ids.iter().enumerate() {
         let face = topo.face(fid)?;
-        // Traverse outer wire and all inner wires.
         for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
             let wire = topo.wire(wid)?;
             for oe in wire.edges() {
@@ -1462,7 +1423,6 @@ pub(super) fn split_nonmanifold_edges(
         let start_pos = topo.vertex(edge_start)?.point();
         let end_pos = topo.vertex(edge_end)?.point();
 
-        // Edge direction vector.
         let edge_dir = Vec3::new(
             end_pos.x() - start_pos.x(),
             end_pos.y() - start_pos.y(),
@@ -1554,7 +1514,6 @@ pub(super) fn split_nonmanifold_edges(
             face_angles.push((fi, is_fwd, angle));
         }
 
-        // Sort by angle.
         face_angles.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal));
 
         // Pair consecutive faces (in angular order) and assign edge copies.
@@ -1585,7 +1544,6 @@ pub(super) fn split_nonmanifold_edges(
         return Ok(());
     }
 
-    // Rebuild face wires with replaced edges.
     let affected_faces: HashSet<usize> = edge_replacements.keys().map(|(fi, _)| *fi).collect();
     for fi in affected_faces {
         let fid = face_ids[fi];
@@ -1619,10 +1577,6 @@ pub(super) fn split_nonmanifold_edges(
 
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Shared-boundary fuse fast path
-// ---------------------------------------------------------------------------
 
 /// Compute a representative normal and d-value for a face surface.
 #[allow(dead_code)]
@@ -1792,10 +1746,6 @@ pub(super) fn try_shared_boundary_fuse(
     Ok(Some(result))
 }
 
-// ---------------------------------------------------------------------------
-// Polygon area helper
-// ---------------------------------------------------------------------------
-
 /// Compute the area of a 3D polygon given its vertices and face normal.
 #[allow(dead_code)]
 pub(super) fn polygon_area_3d(vertices: &[Point3], normal: Vec3) -> f64 {
@@ -1811,10 +1761,6 @@ pub(super) fn polygon_area_3d(vertices: &[Point3], normal: Vec3) -> f64 {
     }
     (area.dot(normal) * 0.5).abs()
 }
-
-// ---------------------------------------------------------------------------
-// Manifold shell reconstruction from face soup
-// ---------------------------------------------------------------------------
 
 /// Build manifold shells from an unordered list of faces.
 ///
@@ -1841,7 +1787,6 @@ pub(super) fn build_manifold_shells(
         });
     }
 
-    // Step 1: Build edge → [(face_index, is_forward)] adjacency map.
     // Only count OUTER wire edges — inner wire edges are internal to the
     // face and don't participate in face-face adjacency for shell building.
     let mut edge_faces: HashMap<usize, Vec<(usize, bool)>> = HashMap::new();
@@ -1873,7 +1818,6 @@ pub(super) fn build_manifold_shells(
         return Ok(topo.add_solid(Solid::new(shell_id, vec![])));
     }
 
-    // Step 2: Build manifold shells via angular face-off selection.
     let mut added: HashSet<usize> = HashSet::new();
     let mut shells: Vec<Vec<FaceId>> = Vec::new();
 
@@ -1887,7 +1831,6 @@ pub(super) fn build_manifold_shells(
         // Track edges within this shell: edge_idx → count of faces using it.
         let mut shell_edge_count: HashMap<usize, u32> = HashMap::new();
 
-        // Initialize with seed face's edges.
         count_face_edges(topo, face_ids[seed_fi], &mut shell_edge_count)?;
 
         let mut queue_idx = 0;
@@ -1896,7 +1839,6 @@ pub(super) fn build_manifold_shells(
             queue_idx += 1;
 
             let face = topo.face(face_ids[current_fi])?;
-            // Collect edges from all wires.
             let mut face_edge_list: Vec<(usize, bool)> = Vec::new();
             // Only traverse outer wire edges for face-face connectivity.
             let wire = topo.wire(face.outer_wire())?;
@@ -1956,7 +1898,7 @@ pub(super) fn build_manifold_shells(
         shells.push(shell_faces.into_iter().map(|fi| face_ids[fi]).collect());
     }
 
-    // Step 3: Build solid — largest shell is outer, rest are inner.
+    // Largest shell is outer, rest are inner.
     if shells.is_empty() {
         return Err(crate::OperationsError::InvalidInput {
             reason: "build_manifold_shells: no shells produced".into(),
@@ -2015,7 +1957,6 @@ fn select_angular_neighbor(
                 reason: format!("edge index {edge_idx} not found"),
             })?;
 
-    // Edge midpoint and tangent direction.
     let edge = topo.edge(edge_id)?;
     let start_pos = topo.vertex(edge.start())?.point();
     let end_pos = topo.vertex(edge.end())?.point();
@@ -2149,7 +2090,6 @@ pub(super) fn register_pcurves(
                 .collect()
         };
 
-        // Iterate all wires (outer + inner).
         let wire_ids: Vec<_> = {
             let f = topo.face(fid)?;
             std::iter::once(f.outer_wire())

--- a/crates/operations/src/boolean/classify.rs
+++ b/crates/operations/src/boolean/classify.rs
@@ -18,14 +18,6 @@ use brepkit_math::vec::{Point2, Point3, Vec3};
 
 use crate::dot_normal_point;
 
-// ---------------------------------------------------------------------------
-// Re-exports from algo (canonical implementation)
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// BVH construction
-// ---------------------------------------------------------------------------
-
 /// Build a BVH over face data for accelerated ray-cast classification.
 ///
 /// Returns `None` when the face count is small enough that linear scan is
@@ -45,10 +37,6 @@ pub(super) fn build_face_bvh(faces: &FaceData) -> Option<Bvh> {
         .collect();
     Some(Bvh::build(&aabbs))
 }
-
-// ---------------------------------------------------------------------------
-// Fragment classification
-// ---------------------------------------------------------------------------
 
 /// Classify a face fragment relative to the opposite solid.
 ///
@@ -188,10 +176,6 @@ pub(super) fn classify_point(
     multiray_classify(centroid, normal, opposite, bvh, tol)
 }
 
-// ---------------------------------------------------------------------------
-// Geometry helpers (inlined)
-// ---------------------------------------------------------------------------
-
 /// Compute `point + dir * t` as a `Point3`.
 #[inline]
 fn point_along_line(pt: &Point3, dir: &Vec3, t: f64) -> Point3 {
@@ -201,10 +185,6 @@ fn point_along_line(pt: &Point3, dir: &Vec3, t: f64) -> Point3 {
         dir.z().mul_add(t, pt.z()),
     )
 }
-
-// ---------------------------------------------------------------------------
-// Ray-casting helpers
-// ---------------------------------------------------------------------------
 
 /// Test a single face against a ray for crossing parity.
 ///
@@ -322,10 +302,6 @@ fn multiray_classify(
         FaceClass::Outside
     }
 }
-
-// ---------------------------------------------------------------------------
-// Geometry helpers
-// ---------------------------------------------------------------------------
 
 /// Compute the centroid of a polygon.
 ///

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -11,10 +11,6 @@ use assembly::validate_boolean_result;
 pub(crate) use assembly::{assemble_solid, assemble_solid_mixed};
 pub use types::{BooleanOp, BooleanOptions, FaceSpec};
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
 // WASM-compatible timer: `std::time::Instant` panics on wasm32 targets.
 #[cfg(not(target_arch = "wasm32"))]
 pub(super) fn timer_now() -> std::time::Instant {
@@ -37,10 +33,6 @@ use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::face::{FaceId, FaceSurface};
 use brepkit_topology::solid::SolidId;
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
 /// Perform a boolean operation on two solids.
 ///
 /// Uses the GFA pipeline as the primary engine, with mesh boolean
@@ -59,7 +51,6 @@ pub fn boolean(
 ) -> Result<SolidId, crate::OperationsError> {
     let tol = brepkit_math::tolerance::Tolerance::new();
 
-    // ── Containment shortcut ─────────────────────────────────────────
     // Detect A⊂B or B⊂A (including A=B) and handle directly.
     // Only applies when BOTH solids have simple analytic classifiers.
     {
@@ -503,7 +494,6 @@ pub fn boolean(
         }
     }
 
-    // ── Broad-phase disjoint intersect ───────────────────────────────
     // If the curvature-aware AABBs of A and B are separated on any axis
     // by more than linear tolerance, the solids provably do not overlap
     // and their intersection is the empty set. Containment shortcuts have
@@ -521,7 +511,6 @@ pub fn boolean(
         }
     }
 
-    // ── GFA pipeline ─────────────────────────────────────────────────
     let algo_op = match op {
         BooleanOp::Fuse => brepkit_algo::bop::BooleanOp::Fuse,
         BooleanOp::Cut => brepkit_algo::bop::BooleanOp::Cut,
@@ -712,7 +701,6 @@ pub fn boolean(
         }
     }
 
-    // ── Multi-region input fallback (Cut only) ───────────────────────
     // When the input solid carries multiple disjoint pieces (a previous
     // cut split a solid into N parts), GFA's pavefiller can't process
     // them together — feeding the whole thing in loses regions. Splitting
@@ -728,7 +716,7 @@ pub fn boolean(
         }
     }
 
-    // ── Mesh boolean fallback (no recursion) ─────────────────────────
+    // Mesh boolean fallback (no recursion).
     let opts = BooleanOptions::default();
     let raw = match mesh_boolean_fallback(topo, op, a, b, opts.deflection, tol, &opts) {
         Ok(raw) => raw,
@@ -768,7 +756,6 @@ pub fn boolean_with_options(
 ) -> Result<SolidId, crate::OperationsError> {
     let result = boolean(topo, op, a, b)?;
     if opts.unify_faces {
-        // Merge co-surface face fragments left by the boolean.
         let unify_opts = brepkit_heal::upgrade::unify_same_domain::UnifyOptions::default();
         if let Err(e) =
             brepkit_heal::upgrade::unify_same_domain::unify_same_domain(topo, result, &unify_opts)
@@ -808,10 +795,6 @@ pub fn compound_cut(
     Ok(result)
 }
 
-// ---------------------------------------------------------------------------
-// Evolution-tracking wrapper
-// ---------------------------------------------------------------------------
-
 /// Perform a boolean operation and return an [`crate::evolution::EvolutionMap`] tracking face
 /// provenance.
 ///
@@ -838,21 +821,14 @@ pub fn boolean_with_evolution(
     input_faces.extend(input_faces_a);
     input_faces.extend(input_faces_b);
 
-    // Run the actual boolean.
     let result = boolean(topo, op, a, b)?;
 
-    // Collect output face normals + centroids.
     let output_faces = collect_face_signatures(topo, result)?;
 
-    // Build the evolution map from geometric face-signature matching.
     let evo = crate::evolution::build_evolution_by_geometry(&input_faces, &output_faces);
 
     Ok((result, evo))
 }
-
-// ---------------------------------------------------------------------------
-// Mesh boolean helpers
-// ---------------------------------------------------------------------------
 
 /// Compute the boolean of two axis-aligned boxes via AABB algebra.
 ///
@@ -3079,10 +3055,6 @@ fn enforce_manifold_shell(
 
     Ok(topo.add_solid(brepkit_topology::solid::Solid::new(outer_id, inner_ids)))
 }
-
-// ---------------------------------------------------------------------------
-// Shared utility functions (relocated from deleted files)
-// ---------------------------------------------------------------------------
 
 /// Sample `n` evenly-spaced points along a closed edge curve.
 ///

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -32,10 +32,6 @@ fn check_result(topo: &Topology, solid: SolidId) -> usize {
     sh.faces().len()
 }
 
-// ── Polygon clipper tests ─────────────────────────────────────────
-
-// ── Disjoint tests ──────────────────────────────────────────────────
-
 #[test]
 fn fuse_disjoint_cubes() {
     let mut topo = Topology::new();
@@ -245,8 +241,6 @@ fn intersect_overlapping_boxes_is_nonempty() {
     );
 }
 
-// ── Diagnostic tests ─────────────────────────────────────────────────
-
 /// Diagnostic: dumps edge sharing state for overlapping box fuse.
 /// Expected to fail until SD face replacement + boundary edge sharing
 /// are complete. Findings: 27 boundary edges (no position duplicates),
@@ -435,8 +429,6 @@ fn gfa_direct_fuse_overlapping_manifold() {
     );
 }
 
-// ── 1D overlapping tests (offset on one axis) ───────────────────────
-
 #[test]
 fn fuse_overlapping_cubes() {
     let mut topo = Topology::new();
@@ -469,8 +461,6 @@ fn cut_overlapping_cubes() {
     let _ = check_result(&topo, result);
     assert_volume_near(&topo, result, 0.5, 0.001);
 }
-
-// ── 3D overlapping tests (offset on all axes) ───────────────────────
 
 #[test]
 fn fuse_overlapping_3d() {
@@ -505,8 +495,6 @@ fn cut_overlapping_3d() {
     assert_volume_near(&topo, result, 0.875, 0.001);
 }
 
-// ── Flush face test ─────────────────────────────────────────────────
-
 #[test]
 fn fuse_flush_face_cubes() {
     let mut topo = Topology::new();
@@ -517,10 +505,6 @@ fn fuse_flush_face_cubes() {
     let _ = check_result(&topo, result);
     assert_volume_near(&topo, result, 2.0, 0.001);
 }
-
-// ── NURBS face data collection test ─────────────────────────
-
-// ── Analytic boolean tests ──────────────────────────────────────────
 
 #[test]
 #[allow(clippy::panic)]
@@ -717,8 +701,6 @@ fn cone_has_circle_edges() {
     }
     assert!(has_circle, "cone should have Circle edges");
 }
-
-// ── Mixed-surface assembly tests ────────────────────
 
 #[test]
 fn assemble_mixed_planar_only() {
@@ -1003,7 +985,6 @@ fn cut_box_by_translated_sphere() {
     let expected = 1000.0 - sph_vol;
     eprintln!("cut volume: {vol:.1} (expected ~{expected:.1})");
 
-    // Count result faces
     let faces = brepkit_topology::explorer::solid_faces(&topo, r).unwrap();
     eprintln!("result has {} faces", faces.len());
 
@@ -1288,7 +1269,6 @@ fn staircase_fuse_with_cylinders() {
         shapes.push(post);
     }
 
-    // Fuse all shapes together sequentially.
     let mut result = shapes[0];
     for &shape in &shapes[1..] {
         result = boolean(&mut topo, BooleanOp::Fuse, result, shape).unwrap();
@@ -1310,7 +1290,6 @@ fn profile_cylinder_cylinder_intersect() {
     let mat = brepkit_math::mat::Mat4::translation(3.0, 0.0, 0.0);
     crate::transform::transform_solid(&mut topo, cyl2, &mat).unwrap();
 
-    // Profile multiple runs
     for i in 0..5 {
         let mut t = Topology::new();
         let c1 = crate::primitives::make_cylinder(&mut t, 5.0, 20.0).unwrap();
@@ -1403,8 +1382,6 @@ fn fuse_overlapping_boxes_validates() {
         report.issues
     );
 }
-
-// ── Shared-boundary fuse ────────────────────────────────────
 
 #[test]
 fn fuse_adjacent_boxes_shared_face() {
@@ -1513,8 +1490,6 @@ fn fuse_adjacent_boxes_3x1_grid() {
     );
 }
 
-// ── Degenerate boolean geometry ────────────────────────────
-
 #[test]
 fn near_tolerance_overlap() {
     // Overlap of exactly the linear tolerance amount
@@ -1537,8 +1512,6 @@ fn boolean_nearly_touching() {
     // Should not panic
     let _result = boolean(&mut topo, BooleanOp::Fuse, a, b);
 }
-
-// ── compound_cut tests ──────────────────────────────────────────────
 
 #[test]
 fn compound_cut_empty_tools_returns_target() {
@@ -2513,8 +2486,6 @@ fn cut_lofted_frustums_octagon_profiles() {
     );
 }
 
-// ── Non-convex face chord clip test ────────────────────────────────────
-//
 // Regression test for the cyrus_beck_clip → polygon_clip_intervals fix.
 // cyrus_beck_clip silently produces wrong results on non-convex (concave)
 // polygons because the Cyrus-Beck algorithm assumes a convex clipping
@@ -2567,8 +2538,6 @@ fn test_boolean_concave_face_chord_clip() {
     assert_volume_near(&topo, result, 2.25, 0.001);
 }
 
-// ── Convex regression test for polygon_clip_intervals ───────────────────
-//
 // Confirms that switching from cyrus_beck_clip to polygon_clip_intervals
 // does not break the common convex-face case. A large box minus a half-
 // overlapping smaller box: expected volume = 8.0 - 0.5 = 7.5.
@@ -2615,8 +2584,6 @@ fn test_boolean_large_scale_vertex_merge() {
     // Expected volume: 100^3 - 50*100*100 = 500_000
     assert_volume_near(&topo, result, 500_000.0, 0.01);
 }
-
-// ── Surface preservation in mesh boolean path ────────────────────
 
 /// Fuse a box and cylinder, then verify the result has positive volume.
 /// Uses the analytic path since face counts are below the mesh boolean threshold.
@@ -2707,8 +2674,6 @@ fn euler_characteristic_box_is_two() {
     let euler = crate::validate::euler_characteristic(&topo, solid).unwrap();
     assert_eq!(euler, 2, "box Euler V-E+F should be 2, got {euler}");
 }
-
-// ── Face explosion regression tests (#270) ──────────────────────
 
 /// Sequential box fuses should not cause face count explosion.
 ///
@@ -3146,8 +3111,6 @@ fn fuse_coincident_rrect_cap_with_frustum() {
     assert_eq!(euler, 2, "should be genus-0");
 }
 
-// ── GFA integration tests for analytic surfaces ────────────────────
-
 #[test]
 fn gfa_box_sphere_cut() {
     let mut topo = Topology::default();
@@ -3228,8 +3191,6 @@ fn gfa_box_cone_intersect() {
         );
     }
 }
-
-// ── D4 gridfinity repro: shelled box + lip fuse ────────────────────
 
 /// Minimal repro of D4 gridfinity non-manifold fuse bug.
 ///
@@ -3394,8 +3355,6 @@ fn d4_shelled_box_fuse_lip() {
     }
 }
 
-// ── Coplanar face tests ──────────────────────────────────────────────
-//
 // "d1a2" scenario: tool B shares an entire face pair with A (identical Z
 // extent [0,1]).  The top and bottom faces of B are coplanar with those
 // of A, so phase_ff_coplanar must produce section edges and the builder
@@ -3427,8 +3386,6 @@ fn coplanar_box_cut_d1a2() {
     // Volume check
     assert_volume_near(&topo, result, 0.75, 0.01);
 }
-
-// ── #696 diagnostic: N-iteration repro ───────────────────────────────
 
 /// Count edges shared by 3+ faces (non-manifold) and edges shared by < 2
 /// faces (boundary) across all wires of a solid's faces. Shared between
@@ -3901,8 +3858,6 @@ fn cut_shelled_target_single_tool_exact_gfa() {
     );
 }
 
-// ── Rounded-rect prisms with true Circle arc corners ────────────────
-//
 // Gridfinity-shaped repros: extruded rounded rectangles (4 planes +
 // 4 tangent quarter-cylinder corners) fused at coplanar interfaces or
 // cut concentrically. Volume oracles are exact closed forms:
@@ -4140,8 +4095,6 @@ fn cut_concentric_rounded_rect_arc_prisms_cavity() {
         "expected 8 analytic cylinder faces (4 outer + 4 cavity), got {cyl}"
     );
 }
-
-// ── Issue #801: cut-then-fuse-back must recover original volume ──────
 
 /// Run `(a − b) ∪ (a ∩ b)` and assert it recovers `vol(a)`, regardless of
 /// fuse operand order. `a` and `b` are boxes placed at `(0,0,0)` and

--- a/crates/operations/src/boolean/types.rs
+++ b/crates/operations/src/boolean/types.rs
@@ -8,10 +8,6 @@ use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::face::{FaceId, FaceSurface};
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
 /// Number of samples used when discretizing closed curves (circles, ellipses)
 /// in the analytic boolean path. All code paths must use this constant so that
 /// band fragments, cap face polygons, and holed-face inner wires share the
@@ -73,10 +69,6 @@ pub(super) const CDT_SNAP_FACTOR: f64 = 100.0;
 /// A cylinder (2 caps + 1 barrel = 3 faces) is the minimal closed solid
 /// produced by boolean operations between boxes and curved primitives.
 pub(super) const MIN_SOLID_FACES: usize = 3;
-
-// ---------------------------------------------------------------------------
-// Public enums
-// ---------------------------------------------------------------------------
 
 /// The type of boolean operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -155,10 +147,6 @@ impl FaceSpec {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Public structs
-// ---------------------------------------------------------------------------
-
 /// Options for boolean operations.
 #[derive(Debug, Clone, Copy)]
 pub struct BooleanOptions {
@@ -205,10 +193,6 @@ impl Default for BooleanOptions {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Internal enums
-// ---------------------------------------------------------------------------
-
 /// Which operand a face fragment originated from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Source {
@@ -216,7 +200,6 @@ pub enum Source {
     B,
 }
 
-// Re-export canonical types from the algo crate.
 pub(super) use brepkit_algo::FaceClass;
 
 /// Result of classifying an intersection curve against a face boundary.
@@ -228,10 +211,6 @@ pub(super) enum CurveClassification {
     /// The entire curve lies outside the face.
     FullyOutside,
 }
-
-// ---------------------------------------------------------------------------
-// Internal structs
-// ---------------------------------------------------------------------------
 
 /// Internal context carrying tolerance-derived thresholds through the boolean
 /// pipeline. Computed once from `BooleanOptions` at the start of a boolean
@@ -325,16 +304,8 @@ pub(super) struct AnalyticFragment {
     pub(super) source_face_id: Option<FaceId>,
 }
 
-// ---------------------------------------------------------------------------
-// Type aliases
-// ---------------------------------------------------------------------------
-
 /// Extracted face data: `(FaceId, vertices, normal, d)`.
 pub(super) type FaceData = Vec<(FaceId, Vec<Point3>, Vec3, f64)>;
-
-// ---------------------------------------------------------------------------
-// Selection truth table
-// ---------------------------------------------------------------------------
 
 /// Determine whether a fragment should be kept and whether to flip its normal.
 ///

--- a/crates/operations/src/chamfer.rs
+++ b/crates/operations/src/chamfer.rs
@@ -18,10 +18,6 @@ use brepkit_topology::vertex::VertexId;
 use crate::boolean::{FaceSpec, assemble_solid_mixed};
 use crate::dot_normal_point;
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
 /// Chamfer one or more edges of a solid.
 ///
 /// Each target edge is replaced by a flat bevel face. The `distance`
@@ -87,10 +83,6 @@ pub fn chamfer_asymmetric(
     chamfer_core(topo, solid, edges, ChamferDistances::Asymmetric { d1, d2 })
 }
 
-// ---------------------------------------------------------------------------
-// Distances helper
-// ---------------------------------------------------------------------------
-
 /// How chamfer distances are assigned to edges.
 enum ChamferDistances {
     /// Same distance on both adjacent faces.
@@ -135,10 +127,6 @@ impl ChamferDistances {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Core implementation
-// ---------------------------------------------------------------------------
-
 #[allow(clippy::too_many_lines)]
 fn chamfer_core(
     topo: &mut Topology,
@@ -148,12 +136,10 @@ fn chamfer_core(
 ) -> Result<SolidId, crate::OperationsError> {
     let tol = Tolerance::new();
 
-    // -- Phase 1: Collect face data --
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
     let shell_face_ids: Vec<FaceId> = shell.faces().to_vec();
 
-    // Build edge→faces map and collect per-face polygon data.
     let mut edge_to_faces: HashMap<usize, Vec<FaceId>> = HashMap::new();
     let mut face_polygons: HashMap<usize, FacePolygon> = HashMap::new();
 
@@ -194,7 +180,7 @@ fn chamfer_core(
         // will be passed through unchanged if they don't contain target edges.
         let normal = match face.surface() {
             FaceSurface::Plane { normal, .. } => *normal,
-            _ => continue, // Skip non-planar faces for polygon data
+            _ => continue,
         };
 
         face_polygons.insert(
@@ -208,7 +194,6 @@ fn chamfer_core(
         );
     }
 
-    // -- Phase 2: Filter to manifold edges, validate --
     // Like fillet, silently skip non-manifold edges (shared by != 2 faces)
     // which commonly occur in boolean operation output.
     let filtered_edges: Vec<EdgeId> = edges
@@ -246,9 +231,6 @@ fn chamfer_core(
         }
     }
 
-    // -- Phase 3: Build modified polygons + collect chamfer face data --
-
-    // For each target edge, we collect the chamfer points from both faces.
     let mut chamfer_data: HashMap<usize, ChamferEdgeData> = HashMap::new();
     let mut result_specs: Vec<FaceSpec> = Vec::new();
 
@@ -475,7 +457,6 @@ fn chamfer_core(
         });
     }
 
-    // -- Phase 4: Build chamfer faces --
     for &edge_id in &filtered_edges {
         let data = chamfer_data.get(&edge_id.index()).ok_or_else(|| {
             crate::OperationsError::InvalidInput {
@@ -494,7 +475,6 @@ fn chamfer_core(
         let f1 = face_list[0];
         let f2 = face_list[1];
 
-        // Retrieve chamfer points: (face, vertex) → Point3
         let c1_start = data.get_point(f1, v_start)?;
         let c1_end = data.get_point(f1, v_end)?;
         let c2_start = data.get_point(f2, v_start)?;
@@ -516,7 +496,6 @@ fn chamfer_core(
                 raw_normal.normalize()?,
             )
         } else {
-            // Reverse winding.
             let flipped = edge_b.cross(edge_a);
             (
                 vec![c1_start, c1_end, c2_end, c2_start],
@@ -533,7 +512,6 @@ fn chamfer_core(
         });
     }
 
-    // -- Phase 4.5: Corner faces --
     // At each original vertex where ALL adjacent edges are chamfered,
     // the trim-plane intersections from each face create a polygonal gap
     // (triangle for box vertices, k-gon for degree-k vertices).
@@ -628,13 +606,8 @@ fn chamfer_core(
         });
     }
 
-    // -- Phase 5: Assemble result solid --
     assemble_solid_mixed(topo, &result_specs, tol)
 }
-
-// ---------------------------------------------------------------------------
-// Internal data structures
-// ---------------------------------------------------------------------------
 
 /// Per-face polygon data collected from the solid.
 struct FacePolygon {
@@ -901,8 +874,6 @@ mod tests {
              (rel_err={rel_err:.2e})"
         );
     }
-
-    // -- Asymmetric chamfer tests --
 
     #[test]
     fn chamfer_asymmetric_single_edge() {

--- a/crates/operations/src/classify.rs
+++ b/crates/operations/src/classify.rs
@@ -22,7 +22,6 @@ use crate::OperationsError;
 use crate::boolean::face_polygon;
 use crate::distance::{point_in_polygon_3d, point_to_face_distance};
 
-// ── Tolerance constants ─────────────────────────────────────────────────
 // Grouped here so they can be tuned together. These are near-zero guards
 // for floating-point arithmetic, NOT geometric tolerance (use `Tolerance`
 // struct for that).
@@ -172,8 +171,6 @@ pub fn classify_point_robust(
     classify_point(topo, solid, point, deflection, tolerance)
 }
 
-// ── Boundary check (analytic, no tessellation) ──────────────────────────
-
 /// Checks if a point is within `tolerance` of any face boundary.
 ///
 /// Uses analytic point-to-surface distance for all surface types.
@@ -193,8 +190,6 @@ fn is_on_boundary(
     }
     Ok(false)
 }
-
-// ── Ray crossing (analytic for analytic faces, tessellation for NURBS) ──
 
 /// Counts the number of times a ray crosses the solid's boundary.
 fn count_ray_crossings(
@@ -504,8 +499,6 @@ fn point_in_uv_boundary(
     point_in_polygon(test, &poly)
 }
 
-// ── Ray-surface intersection roots ──────────────────────────────────────
-
 /// Compute ray-cylinder intersection parameters.
 fn ray_cylinder_roots(
     origin: Point3,
@@ -623,7 +616,6 @@ fn ray_crossings_nurbs(
         return Ok(0);
     }
 
-    // Build UV boundary from face wire vertices.
     let verts = face_polygon(topo, face_id)?;
     if verts.len() < 3 {
         // Full-surface face — every forward hit is a crossing.
@@ -659,8 +651,6 @@ fn ray_crossings_nurbs(
     Ok(crossings)
 }
 
-// ── Winding number (still tessellation-based) ───────────────────────────
-
 /// Computes the generalized winding number of a point relative to a solid.
 ///
 /// Returns `(winding_number, is_on_boundary)`.
@@ -683,7 +673,6 @@ fn compute_winding_number(
         return Ok((0.0, true));
     }
 
-    // Use ray casting: count crossings in a fixed direction.
     let direction = Vec3::new(1.0, 0.3, 0.1); // avoid axis-aligned rays
     let mut crossings = 0u32;
     for &fid in shell.faces() {
@@ -694,8 +683,6 @@ fn compute_winding_number(
     let winding = if crossings % 2 == 1 { 1.0 } else { 0.0 };
     Ok((winding, false))
 }
-
-// ── Math helpers ─────────────────────────────────────────────────────────
 
 /// Compute the normal of a polygon via Newell's method.
 fn polygon_normal(verts: &[Point3]) -> Vec3 {
@@ -915,8 +902,6 @@ mod tests {
         assert_eq!(result, PointClassification::Inside);
     }
 
-    // ── Analytic surface tests ───────────────────────────
-
     #[test]
     fn point_inside_cylinder() {
         let mut topo = Topology::new();
@@ -1003,8 +988,6 @@ mod tests {
         assert_eq!(result, PointClassification::Outside);
     }
 
-    // ── Solver tests ────────────────────────────────────────
-
     #[test]
     fn cubic_three_roots() {
         // (t-1)(t-2)(t-3) = t³ - 6t² + 11t - 6
@@ -1036,8 +1019,6 @@ mod tests {
         assert!((roots[2] - 3.0).abs() < 1e-8);
     }
 
-    // ── Winding number tests ─────────────────────────────
-
     #[test]
     fn winding_point_inside_box() {
         let mut topo = Topology::new();
@@ -1058,8 +1039,6 @@ mod tests {
         assert_eq!(result, PointClassification::Outside);
     }
 
-    // ── Robust classifier tests ──────────────────────────
-
     #[test]
     fn robust_point_inside_box() {
         let mut topo = Topology::new();
@@ -1079,8 +1058,6 @@ mod tests {
             classify_point_robust(&topo, solid, Point3::new(5.0, 5.0, 5.0), 0.1, 1e-6).unwrap();
         assert_eq!(result, PointClassification::Outside);
     }
-
-    // ── Math helper tests ────────────────────────────────
 
     #[test]
     fn quadratic_two_roots() {

--- a/crates/operations/src/compound_ops.rs
+++ b/crates/operations/src/compound_ops.rs
@@ -54,10 +54,8 @@ pub fn fuse_all(
         .map(|&sid| crate::measure::solid_bounding_box(topo, sid))
         .collect::<Result<_, _>>()?;
 
-    // Build disjoint groups: solids whose AABBs overlap go in the same group.
     let groups = partition_overlapping(&bboxes);
 
-    // Process each group: boolean fuse within the group, then merge shells.
     let mut group_results: Vec<SolidId> = Vec::new();
     for group in &groups {
         let group_solids: Vec<SolidId> = group.iter().map(|&i| solids[i]).collect();
@@ -86,7 +84,6 @@ pub fn fuse_all(
         return Ok(group_results[0]);
     }
 
-    // Merge disjoint groups by collecting all faces into a single solid.
     merge_disjoint_solids(topo, &group_results)
 }
 
@@ -238,7 +235,6 @@ mod tests {
         let s1 = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
         let s2 = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
 
-        // Move s2 to (5, 0, 0).
         crate::transform::transform_solid(
             &mut topo,
             s2,

--- a/crates/operations/src/copy.rs
+++ b/crates/operations/src/copy.rs
@@ -15,8 +15,6 @@ use brepkit_topology::solid::{Solid, SolidId};
 use brepkit_topology::vertex::{Vertex, VertexId};
 use brepkit_topology::wire::{OrientedEdge, Wire, WireId};
 
-// ── Snapshot types (read phase) ────────────────────────────────────
-
 struct VertexSnap {
     old_index: usize,
     point: Point3,
@@ -61,8 +59,6 @@ pub fn copy_solid(
     topo: &mut Topology,
     solid_id: SolidId,
 ) -> Result<SolidId, crate::OperationsError> {
-    // ── Read phase: snapshot all data ──────────────────────────────
-
     let solid = topo.solid(solid_id)?;
     let outer_shell_id = solid.outer_shell();
     let inner_shell_ids: Vec<_> = solid.inner_shells().to_vec();
@@ -91,7 +87,6 @@ pub fn copy_solid(
             let inner_wire_indices: Vec<usize> =
                 face.inner_wires().iter().map(|w| w.index()).collect();
 
-            // Snapshot wires.
             for wire_id_val in
                 std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
             {
@@ -112,7 +107,6 @@ pub fn copy_solid(
                     let start_idx = edge.start().index();
                     let end_idx = edge.end().index();
 
-                    // Snapshot vertices.
                     for &vid_idx in &[start_idx, end_idx] {
                         if seen_vertices.insert(vid_idx) {
                             let vid = if vid_idx == start_idx {
@@ -156,9 +150,6 @@ pub fn copy_solid(
         shell_snaps.push(ShellSnap { faces: face_snaps });
     }
 
-    // ── Write phase: allocate new entities ─────────────────────────
-
-    // Pre-allocate topology arenas for the copy.
     topo.reserve(
         vertex_snaps.len(),
         edge_snaps.len(),
@@ -256,7 +247,6 @@ pub fn copy_and_transform_solid(
     }
     let normal_matrix = matrix.inverse()?.transpose();
 
-    // Helper: transform a direction vector by applying the matrix.
     let transform_dir = |dir: Vec3| -> Result<Vec3, crate::OperationsError> {
         let origin = matrix.mul_point(Point3::new(0.0, 0.0, 0.0));
         let tip = matrix.mul_point(Point3::new(dir.x(), dir.y(), dir.z()));
@@ -268,7 +258,7 @@ pub fn copy_and_transform_solid(
         Ok(raw.normalize()?)
     };
 
-    // Helper: transform a plane normal via inverse transpose.
+    // Transform a plane normal via inverse transpose.
     let transform_normal = |n: Vec3| -> Result<Vec3, crate::OperationsError> {
         let transformed = normal_matrix.mul_point(Point3::new(n.x(), n.y(), n.z()));
         let origin = normal_matrix.mul_point(Point3::new(0.0, 0.0, 0.0));
@@ -280,8 +270,7 @@ pub fn copy_and_transform_solid(
         Ok(raw.normalize()?)
     };
 
-    // ── Read phase: snapshot all data (identical to copy_solid) ────
-
+    // Read phase mirrors copy_solid.
     let solid = topo.solid(solid_id)?;
     let outer_shell_id = solid.outer_shell();
     let inner_shell_ids: Vec<_> = solid.inner_shells().to_vec();
@@ -373,9 +362,6 @@ pub fn copy_and_transform_solid(
         shell_snaps.push(ShellSnap { faces: face_snaps });
     }
 
-    // ── Write phase: allocate transformed entities ─────────────────
-
-    // Pre-allocate topology arenas for the copy.
     topo.reserve(
         vertex_snaps.len(),
         edge_snaps.len(),
@@ -388,7 +374,6 @@ pub fn copy_and_transform_solid(
         1,
     );
 
-    // Vertices: apply matrix during allocation.
     let mut vertex_map: HashMap<usize, VertexId> = HashMap::new();
     for vsnap in &vertex_snaps {
         let new_point = matrix.mul_point(vsnap.point);
@@ -396,7 +381,6 @@ pub fn copy_and_transform_solid(
         vertex_map.insert(vsnap.old_index, new_vid);
     }
 
-    // Edges: transform NURBS control points inline.
     let mut edge_map: HashMap<usize, brepkit_topology::edge::EdgeId> = HashMap::new();
     for esnap in &edge_snaps {
         let new_start = vertex_map[&esnap.start_index];
@@ -484,7 +468,7 @@ pub fn copy_and_transform_solid(
         edge_map.insert(esnap.old_index, copied_edge);
     }
 
-    // Wires: no geometry to transform.
+    // Wires carry no geometry to transform.
     let mut wire_map: HashMap<usize, WireId> = HashMap::new();
     for wsnap in &wire_snaps {
         let new_edges: Vec<OrientedEdge> = wsnap
@@ -497,7 +481,6 @@ pub fn copy_and_transform_solid(
         wire_map.insert(wsnap.old_index, topo.add_wire(new_wire));
     }
 
-    // Shells + faces: transform surfaces inline.
     let mut new_shell_ids = Vec::new();
     for ssnap in &shell_snaps {
         let mut new_face_ids = Vec::new();
@@ -613,7 +596,6 @@ pub fn copy_and_transform_solid(
 ///
 /// Returns an error if any topology lookup fails.
 pub fn copy_wire(topo: &mut Topology, wire_id: WireId) -> Result<WireId, crate::OperationsError> {
-    // ── Read phase ─────────────────────────────────────────────────
     let wire = topo.wire(wire_id)?;
     let closed = wire.is_closed();
 
@@ -660,7 +642,6 @@ pub fn copy_wire(topo: &mut Topology, wire_id: WireId) -> Result<WireId, crate::
         });
     }
 
-    // ── Write phase ────────────────────────────────────────────────
     let mut vertex_map: HashMap<usize, VertexId> = HashMap::new();
     for vsnap in &vertex_snaps {
         let new_vid = topo.add_vertex(Vertex::new(vsnap.point, vsnap.tol));
@@ -700,7 +681,6 @@ pub fn copy_wire(topo: &mut Topology, wire_id: WireId) -> Result<WireId, crate::
 ///
 /// Returns an error if any topology lookup fails.
 pub fn copy_face(topo: &mut Topology, face_id: FaceId) -> Result<FaceId, crate::OperationsError> {
-    // ── Read phase ─────────────────────────────────────────────────
     let face = topo.face(face_id)?;
     let surface = face.surface().clone();
     let reversed = face.is_reversed();
@@ -766,7 +746,6 @@ pub fn copy_face(topo: &mut Topology, face_id: FaceId) -> Result<FaceId, crate::
         });
     }
 
-    // ── Write phase ────────────────────────────────────────────────
     topo.reserve(
         vertex_snaps.len(),
         edge_snaps.len(),

--- a/crates/operations/src/defeature.rs
+++ b/crates/operations/src/defeature.rs
@@ -46,7 +46,6 @@ pub fn defeature(
 
     let remove_set: HashSet<usize> = faces_to_remove.iter().map(|f| f.index()).collect();
 
-    // Collect the faces we're keeping.
     let kept_faces: Vec<FaceId> = all_faces
         .iter()
         .filter(|f| !remove_set.contains(&f.index()))
@@ -63,7 +62,6 @@ pub fn defeature(
         });
     }
 
-    // Snapshot the kept faces' geometry.
     let mut result_faces: Vec<(Vec<Point3>, Vec3, f64)> = Vec::new();
 
     for &fid in &kept_faces {
@@ -129,7 +127,6 @@ mod tests {
         let mut topo = Topology::new();
         let solid = make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
 
-        // Get faces of the box
         let solid_data = topo.solid(solid).unwrap();
         let shell = topo.shell(solid_data.outer_shell()).unwrap();
         let faces: Vec<FaceId> = shell.faces().to_vec();

--- a/crates/operations/src/distance.rs
+++ b/crates/operations/src/distance.rs
@@ -65,15 +65,12 @@ pub fn point_to_solid_distance(
     let shell = topo.shell(solid_data.outer_shell())?;
     let face_ids: Vec<FaceId> = shell.faces().to_vec();
 
-    // Build BVH over face AABBs.
     let face_aabbs = build_face_aabbs(topo, &face_ids)?;
     let bvh = Bvh::build(&face_aabbs);
 
-    // Use BVH to find candidate faces in order of proximity.
     let mut best_dist = f64::INFINITY;
     let mut best_point = point;
 
-    // Query BVH for closest face AABB, then iterate candidates.
     let candidates = bvh_distance_candidates(&bvh, &face_aabbs, point);
 
     for idx in candidates {
@@ -122,7 +119,6 @@ pub fn solid_to_solid_distance(
     let mut best_a = Point3::new(0.0, 0.0, 0.0);
     let mut best_b = Point3::new(0.0, 0.0, 0.0);
 
-    // Quick vertex-to-vertex pass.
     for &pa in &verts_a {
         for &pb in &verts_b {
             let dist = (pa - pb).length();
@@ -271,7 +267,6 @@ pub fn point_to_edge(
             point_b: closest,
         })
     } else {
-        // Sample the curve and find closest point
         let (t0, t1) = match edge.curve() {
             brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) => nc.domain(),
             brepkit_topology::edge::EdgeCurve::Circle(c) => {
@@ -440,7 +435,6 @@ fn build_face_aabbs(
 
 /// Get candidate face indices sorted by AABB distance to a point.
 fn bvh_distance_candidates(bvh: &Bvh, aabbs: &[(usize, Aabb3)], point: Point3) -> Vec<usize> {
-    // Start with the closest BVH node and expand.
     // For simplicity, query all faces and sort by AABB distance.
     let mut candidates: Vec<(usize, f64)> = aabbs
         .iter()
@@ -448,9 +442,7 @@ fn bvh_distance_candidates(bvh: &Bvh, aabbs: &[(usize, Aabb3)], point: Point3) -
         .collect();
     candidates.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
-    // Use BVH for pruning if available.
     if let Some(closest_idx) = bvh.query_closest(point) {
-        // Move closest to front if not already.
         if let Some(pos) = candidates.iter().position(|(i, _)| *i == closest_idx) {
             candidates.swap(0, pos);
         }
@@ -516,7 +508,6 @@ fn point_to_polygon_distance(
         return None;
     }
 
-    // Project point onto the plane.
     let signed_dist = normal.dot(Vec3::new(point.x(), point.y(), point.z())) - d;
     let projected = Point3::new(
         (-normal.x()).mul_add(signed_dist, point.x()),
@@ -524,12 +515,10 @@ fn point_to_polygon_distance(
         (-normal.z()).mul_add(signed_dist, point.z()),
     );
 
-    // Check if projected point is inside the polygon.
     if point_in_polygon_3d(&projected, verts, &normal) {
         return Some((signed_dist.abs(), projected));
     }
 
-    // If outside, find closest point on polygon edges.
     let mut best_dist = f64::INFINITY;
     let mut best_point = verts[0];
     let n = verts.len();

--- a/crates/operations/src/draft.rs
+++ b/crates/operations/src/draft.rs
@@ -130,7 +130,6 @@ pub fn draft(
             })
             .collect();
 
-        // Recompute the face plane from the modified vertices.
         if new_verts.len() >= 3 {
             let a = new_verts[1] - new_verts[0];
             let b = new_verts[2] - new_verts[0];
@@ -191,7 +190,6 @@ mod tests {
         let mut topo = Topology::new();
         let cube = make_unit_cube_manifold(&mut topo);
 
-        // Draft the +X face with a 5° angle, pull direction +Z.
         let right_faces = find_faces(&topo, cube, Vec3::new(1.0, 0.0, 0.0));
         assert_eq!(right_faces.len(), 1);
 

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -166,7 +166,6 @@ pub fn split_closed_edge(
     let start_vid = edge.start();
     let curve = edge.curve().clone();
 
-    // Get the parameter domain of the curve.
     let (u0, u1) = match &curve {
         EdgeCurve::NurbsCurve(nc) => nc.domain(),
         EdgeCurve::Circle(_) => (0.0, std::f64::consts::TAU),
@@ -543,34 +542,29 @@ pub fn extrude(
 ) -> Result<SolidId, crate::OperationsError> {
     let tol = Tolerance::new();
 
-    // Validate direction is non-zero.
     if tol.approx_eq(direction.length_squared(), 0.0) {
         return Err(crate::OperationsError::InvalidInput {
             reason: "extrusion direction is zero-length".into(),
         });
     }
 
-    // Validate distance is non-zero.
     if tol.approx_eq(distance, 0.0) {
         return Err(crate::OperationsError::InvalidInput {
             reason: "extrusion distance is zero".into(),
         });
     }
 
-    // Read the input face's data.
     let face_data = topo.face(face)?;
     let mut input_surface = face_data.surface().clone();
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids: Vec<WireId> = face_data.inner_wires().to_vec();
 
-    // Compute offset vector.
     let offset = Vec3::new(
         direction.x() * distance,
         direction.y() * distance,
         direction.z() * distance,
     );
 
-    // --- Process outer wire ---
     let (
         input_verts,
         input_positions,
@@ -606,7 +600,6 @@ pub fn extrude(
 
     let mut all_faces = Vec::with_capacity(n + 2 + inner_wire_ids.len() * 4);
 
-    // --- Bottom face: reversed copy of input wire ---
     // Use the (possibly-split) edges so the bottom cap shares vertices
     // with the side faces, keeping the shell manifold.
     let reversed_bottom_edges: Vec<OrientedEdge> = input_oriented
@@ -618,7 +611,6 @@ pub fn extrude(
         Wire::new(reversed_bottom_edges, true).map_err(crate::OperationsError::Topology)?;
     let bottom_wire_id = topo.add_wire(bottom_wire);
 
-    // --- Process inner wires and create inner wire data ---
     let mut bottom_inner_wire_ids = Vec::with_capacity(inner_wire_ids.len());
     let mut top_inner_wire_ids = Vec::with_capacity(inner_wire_ids.len());
 
@@ -682,7 +674,6 @@ pub fn extrude(
     ));
     all_faces.push(bottom_face);
 
-    // --- Outer side faces ---
     for i in 0..n {
         let next = (i + 1) % n;
 

--- a/crates/operations/src/feature_recognition.rs
+++ b/crates/operations/src/feature_recognition.rs
@@ -39,10 +39,6 @@ use brepkit_topology::solid::SolidId;
 
 use crate::OperationsError;
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 /// Surface classification for a face.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SurfaceClass {
@@ -156,10 +152,6 @@ pub enum Feature {
     },
 }
 
-// ---------------------------------------------------------------------------
-// Main entry point
-// ---------------------------------------------------------------------------
-
 /// Recognize features in a solid.
 ///
 /// Analyzes the solid's face adjacency and geometry to identify
@@ -179,10 +171,8 @@ pub fn recognize_features(
 
     let mut features = Vec::new();
 
-    // Build typed face adjacency graph
     let fag = build_face_adjacency_graph(topo, &face_ids, deflection)?;
 
-    // Detect features using FAG
     detect_chamfers_fag(topo, &fag, &mut features)?;
     detect_fillet_like_fag(&fag, &mut features);
     detect_holes(topo, &fag, &mut features)?;
@@ -192,17 +182,12 @@ pub fn recognize_features(
     Ok(features)
 }
 
-// ---------------------------------------------------------------------------
-// Face adjacency graph construction
-// ---------------------------------------------------------------------------
-
 /// Build a typed face adjacency graph from a set of face IDs.
 fn build_face_adjacency_graph(
     topo: &Topology,
     face_ids: &[FaceId],
     deflection: f64,
 ) -> Result<FaceAdjacencyGraph, OperationsError> {
-    // Build nodes: classify each face surface, compute area.
     let mut nodes = HashMap::new();
     for &fid in face_ids {
         let face = topo.face(fid)?;
@@ -218,7 +203,6 @@ fn build_face_adjacency_graph(
         );
     }
 
-    // Build edge-to-face map, keyed by edge index.
     let mut edge_to_faces: HashMap<usize, (EdgeId, Vec<FaceId>)> = HashMap::new();
     for &fid in face_ids {
         let face = topo.face(fid)?;
@@ -231,7 +215,6 @@ fn build_face_adjacency_graph(
         }
     }
 
-    // Build adjacency with dihedral angles.
     let mut adjacency: HashMap<usize, Vec<(usize, FagEdge)>> = HashMap::new();
     for (eid, faces) in edge_to_faces.values() {
         if faces.len() == 2 {
@@ -291,7 +274,6 @@ fn compute_dihedral_angle(
     face_b: FaceId,
     edge_id: EdgeId,
 ) -> Result<f64, OperationsError> {
-    // Get edge midpoint from vertices.
     let edge = topo.edge(edge_id)?;
     let v_start = topo.vertex(edge.start())?;
     let v_end = topo.vertex(edge.end())?;
@@ -334,10 +316,6 @@ fn face_normal_at(
     Ok(normal)
 }
 
-// ---------------------------------------------------------------------------
-// Chamfer detection (FAG-based)
-// ---------------------------------------------------------------------------
-
 /// Detect chamfer faces using the face adjacency graph.
 ///
 /// A chamfer is a small planar face whose normal is at an intermediate
@@ -371,7 +349,6 @@ fn detect_chamfers_fag(
             continue;
         }
 
-        // Check pairs of neighbors for chamfer geometry.
         for i in 0..neighbors.len() {
             for j in (i + 1)..neighbors.len() {
                 let (ni, _) = &neighbors[i];
@@ -424,10 +401,6 @@ fn get_node_planar_normal(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Fillet-like detection (FAG-based)
-// ---------------------------------------------------------------------------
-
 /// Detect fillet-like faces by small area relative to the average.
 fn detect_fillet_like_fag(fag: &FaceAdjacencyGraph, features: &mut Vec<Feature>) {
     if fag.nodes.is_empty() {
@@ -448,10 +421,6 @@ fn detect_fillet_like_fag(fag: &FaceAdjacencyGraph, features: &mut Vec<Feature>)
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Hole detection
-// ---------------------------------------------------------------------------
 
 /// Detect holes by finding cylindrical faces in the FAG.
 ///
@@ -475,7 +444,6 @@ fn detect_holes(
 
         let diameter = cyl.radius() * 2.0;
 
-        // Check neighbours to determine through vs blind.
         let neighbors = fag
             .adjacency
             .get(&idx)
@@ -498,10 +466,6 @@ fn detect_holes(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Pocket detection (FAG-based)
-// ---------------------------------------------------------------------------
-
 /// Detect pockets using concave-connected components in the FAG.
 ///
 /// A pocket is a set of faces connected by concave edges, with at
@@ -519,12 +483,10 @@ fn detect_pockets_fag(fag: &FaceAdjacencyGraph, features: &mut Vec<Feature>) {
             None => continue,
         };
 
-        // Start from planar faces only.
         if node.surface_class != SurfaceClass::Planar {
             continue;
         }
 
-        // Flood-fill along concave edges.
         let mut component = HashSet::new();
         let mut stack = vec![idx];
 
@@ -571,16 +533,11 @@ fn detect_pockets_fag(fag: &FaceAdjacencyGraph, features: &mut Vec<Feature>) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Pattern detection
-// ---------------------------------------------------------------------------
-
 /// Detect patterns (linear or circular) among already-recognized features.
 ///
 /// Groups holes by similar diameter, then tests whether their centroids
 /// are collinear (linear pattern) or cocircular (circular pattern).
 fn detect_patterns(features: &mut Vec<Feature>) {
-    // Collect hole features with their index and diameter.
     let hole_info: Vec<(usize, f64)> = features
         .iter()
         .enumerate()
@@ -646,10 +603,6 @@ fn group_by_diameter(items: &[(usize, f64)]) -> Vec<Vec<(usize, f64)>> {
     groups
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -692,12 +645,10 @@ mod tests {
         let mut topo = Topology::new();
         let solid = make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
 
-        // Chamfer an edge
         let solid_data = topo.solid(solid).unwrap();
         let shell = topo.shell(solid_data.outer_shell()).unwrap();
         let face_ids: Vec<FaceId> = shell.faces().to_vec();
 
-        // Get edges
         let mut edge_set = HashSet::new();
         for &fid in &face_ids {
             let face = topo.face(fid).unwrap();
@@ -814,7 +765,6 @@ mod tests {
 
     #[test]
     fn classify_surface_variants() {
-        // Plane
         assert_eq!(
             classify_surface(&FaceSurface::Plane {
                 normal: Vec3::new(0.0, 0.0, 1.0),

--- a/crates/operations/src/fill_face.rs
+++ b/crates/operations/src/fill_face.rs
@@ -42,7 +42,6 @@ pub fn fill_coons_patch(
     let top = &curves[2];
     let left = &curves[3];
 
-    // Validate that boundaries connect at corners
     let n_u = bottom.len();
     let n_v = right.len();
 
@@ -66,7 +65,6 @@ pub fn fill_coons_patch(
     let mut control_points = Vec::with_capacity(n_v);
     let mut weights = Vec::with_capacity(n_v);
 
-    // Corner points
     let p00 = bottom[0];
     let p10 = bottom[n_u - 1];
     let p01 = top[0];
@@ -123,7 +121,6 @@ pub fn fill_coons_patch(
         weights,
     )?;
 
-    // Create the face with a boundary wire from corner points
     let corners = [p00, p10, p11, p01];
     let verts: Vec<_> = corners
         .iter()

--- a/crates/operations/src/fillet/g1_chain.rs
+++ b/crates/operations/src/fillet/g1_chain.rs
@@ -28,7 +28,6 @@ pub(super) fn expand_g1_chain(
     let shell = topo.shell(solid_data.outer_shell())?;
     let shell_face_ids: Vec<FaceId> = shell.faces().to_vec();
 
-    // Build edge→faces and vertex→edges maps for the full shell.
     let mut edge_to_faces: HashMap<usize, Vec<FaceId>> = HashMap::new();
     let mut vertex_to_edges: HashMap<usize, Vec<EdgeId>> = HashMap::new();
     let mut edge_ids: HashMap<usize, EdgeId> = HashMap::new();
@@ -62,7 +61,6 @@ pub(super) fn expand_g1_chain(
         edges.dedup_by_key(|e: &mut EdgeId| e.index());
     }
 
-    // Iterative BFS expansion.
     let mut expanded: HashSet<usize> = seed_edges.iter().map(|e| e.index()).collect();
     let mut queue: Vec<EdgeId> = seed_edges.to_vec();
 

--- a/crates/operations/src/fillet/geometry.rs
+++ b/crates/operations/src/fillet/geometry.rs
@@ -163,7 +163,6 @@ pub fn face_surface_normal_at(surface: &FaceSurface, point: Point3) -> Option<Ve
             let radial = dp - cone.axis() * along_axis;
             let radial_n = radial.normalize().ok()?;
             let (sin_a, cos_a) = cone.half_angle().sin_cos();
-            // Normal = radial * sin(half_angle) - axis * cos(half_angle)
             Some(radial_n * sin_a + cone.axis() * (-cos_a))
         }
         FaceSurface::Sphere(sph) => (point - sph.center()).normalize().ok(),

--- a/crates/operations/src/fillet/helpers.rs
+++ b/crates/operations/src/fillet/helpers.rs
@@ -32,8 +32,6 @@ pub(super) fn extract_inner_wire_positions(
     Ok(result)
 }
 
-// ── Internal data structures ───────────────────────────────────────
-
 pub(super) struct FacePolygon {
     pub(super) vertex_ids: Vec<VertexId>,
     pub(super) positions: Vec<Point3>,

--- a/crates/operations/src/fillet/mod.rs
+++ b/crates/operations/src/fillet/mod.rs
@@ -34,7 +34,6 @@ mod rolling_ball;
 #[cfg(test)]
 mod tests;
 
-// Re-export public items.
 pub use g1_chain::fillet_rolling_ball_propagate_g1;
 pub(crate) use geometry::face_surface_normal_at;
 pub use radius_law::FilletRadiusLaw;
@@ -94,7 +93,6 @@ pub fn fillet(
         });
     }
 
-    // Collect face data.
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
     let shell_face_ids: Vec<_> = shell.faces().to_vec();
@@ -198,7 +196,6 @@ pub fn fillet(
         vertex_fillet_endpoints.insert(edge.end().index());
     }
 
-    // Build modified face polygons and fillet faces.
     // Strategy: identical to chamfer but with more offset segments to
     // approximate the circular fillet.
     let mut fillet_data: HashMap<usize, FilletEdgeData> = HashMap::new();
@@ -307,7 +304,6 @@ pub fn fillet(
         });
     }
 
-    // Build fillet faces (planar quads approximating the fillet arc).
     for &edge_id in &filtered_edges {
         let data = fillet_data.get(&edge_id.index()).ok_or_else(|| {
             crate::OperationsError::InvalidInput {
@@ -408,7 +404,6 @@ pub fn fillet_variable(
         });
     }
 
-    // Validate all radii are positive.
     for (_, law) in edge_laws {
         for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
             if law.evaluate(t) <= tol.linear {
@@ -419,7 +414,6 @@ pub fn fillet_variable(
         }
     }
 
-    // Collect face data (same as fillet_rolling_ball).
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
     let shell_face_ids: Vec<_> = shell.faces().to_vec();
@@ -690,7 +684,6 @@ pub fn fillet_variable(
         });
     }
 
-    // Build variable-radius NURBS canal surfaces for each edge.
     let n_samples = 5; // Number of cross-sections along each edge
     let mut fillet_face_indices: Vec<usize> = Vec::new();
 
@@ -716,7 +709,6 @@ pub fn fillet_variable(
             continue;
         };
 
-        // Evaluate surface normals at the edge start point.
         let Some(n1_start) = face_surface_normal_at(surf1, p_start) else {
             continue;
         };
@@ -762,7 +754,6 @@ pub fn fillet_variable(
             let tan = geometry::sample_edge_tangent(&edge_curve, p_start, p_end, t);
             let local_dir = tan.normalize().unwrap_or(edge_dir);
 
-            // Evaluate surface normals at this sample point.
             let ln1 = face_surface_normal_at(surf1, p).unwrap_or(n1_start);
             let ln2 = face_surface_normal_at(surf2, p).unwrap_or(n2_start);
 
@@ -857,7 +848,6 @@ pub fn fillet_variable(
         )
         .map_err(crate::OperationsError::Math)?;
 
-        // Boundary vertices for the canal surface.
         let c1s = grid[0][0];
         let c2s = grid[0][2];
         let c1e = grid[n_v - 1][0];

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -103,8 +103,6 @@ fn fillet_no_edges_error() {
     assert!(fillet(&mut topo, cube, &[], 0.1).is_err());
 }
 
-// ── Variable-radius fillet tests ────────────────
-
 #[test]
 fn radius_law_constant() {
     let law = FilletRadiusLaw::Constant(0.5);
@@ -213,8 +211,6 @@ fn fillet_has_positive_volume() {
         "filleted cube should have significant volume, got {vol}"
     );
 }
-
-// ── Rolling-ball fillet tests ──────────────────────────
 
 #[test]
 fn rolling_ball_fillet_single_edge() {
@@ -450,8 +446,6 @@ fn rolling_ball_fillet_error_cases() {
     assert!(fillet_rolling_ball(&mut topo, cube, &[edges[0]], -0.1).is_err());
     assert!(fillet_rolling_ball(&mut topo, cube, &[], 0.1).is_err());
 }
-
-// ── Vertex blend tests ───────────────────────────────
 
 #[test]
 fn vertex_blend_all_edges_box() {
@@ -1200,12 +1194,10 @@ fn fillet_on_fillet_box() {
     let solid = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
     let edges = solid_edge_ids(&topo, solid);
 
-    // First fillet: all 12 edges with small radius
     let result1 = fillet_rolling_ball(&mut topo, solid, &edges, 0.1).unwrap();
     let vol1 = crate::measure::solid_volume(&topo, result1, 0.01).unwrap();
     assert!(vol1 > 0.0, "first fillet should produce positive volume");
 
-    // Get edges from the filleted solid for second fillet
     let edges2 = solid_edge_ids(&topo, result1);
     assert!(
         !edges2.is_empty(),

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -101,17 +101,13 @@ pub fn heal_solid(
     solid: SolidId,
     tolerance: f64,
 ) -> Result<HealingReport, crate::OperationsError> {
-    // Pass 1: fix wire connectivity (must run before vertex merging).
+    // Must run before vertex merging.
     let wire_gaps_closed = close_wire_gaps(topo, solid, tolerance)?;
-    // Pass 2: merge near-coincident vertices.
     let vertices_merged = merge_coincident_vertices(topo, solid, tolerance)?;
-    // Pass 3: remove degenerate edges.
     let degenerate_edges_removed = remove_degenerate_edges(topo, solid, tolerance)?;
-    // Pass 4: remove small faces.
     let small_faces_removed = remove_small_faces(topo, solid, tolerance)?;
-    // Pass 5: remove duplicate faces.
     let duplicate_faces_removed = remove_duplicate_faces(topo, solid, tolerance)?;
-    // Pass 6: fix face orientations (run last, after topology is clean).
+    // Run last, after topology is clean.
     let orientations_fixed = fix_face_orientations(topo, solid)?;
 
     Ok(HealingReport {
@@ -147,12 +143,10 @@ pub fn merge_coincident_vertices(
     };
     let tol_sq = tol * tol;
 
-    // Collect all vertex positions.
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
     let face_ids: Vec<_> = shell.faces().to_vec();
 
-    // Gather all unique vertex IDs and their positions.
     let mut vertex_ids: Vec<VertexId> = Vec::new();
     let mut positions: Vec<Point3> = Vec::new();
     let mut seen = std::collections::HashSet::new();
@@ -198,7 +192,6 @@ pub fn merge_coincident_vertices(
         return Ok(0);
     }
 
-    // Apply merges: update edge start/end vertices.
     let mut edge_ids = Vec::new();
     for &fid in &face_ids {
         let face = topo.face(fid)?;
@@ -281,7 +274,6 @@ pub fn remove_degenerate_edges(
             let len_sq = (end_pos - start_pos).length_squared();
 
             if len_sq < tol_sq && edge.start() != edge.end() {
-                // Degenerate edge — skip it
                 any_removed = true;
                 removed_count += 1;
             } else {
@@ -300,7 +292,6 @@ pub fn remove_degenerate_edges(
             if face.outer_wire() == wire_id {
                 face.set_outer_wire(new_wire_id);
             } else {
-                // Check inner wires
                 let iw = face.inner_wires().to_vec();
                 for (i, &iw_id) in iw.iter().enumerate() {
                     if iw_id == wire_id {
@@ -436,7 +427,6 @@ pub fn fix_face_orientations(
     let shell = topo.shell(solid_data.outer_shell())?;
     let face_ids: Vec<_> = shell.faces().to_vec();
 
-    // Compute center of mass (approximate) from all face centroids.
     let mut center = Vec3::new(0.0, 0.0, 0.0);
     let mut total_faces: usize = 0;
 
@@ -472,7 +462,6 @@ pub fn fix_face_orientations(
         center.z() * inv_faces,
     );
 
-    // For each planar face, check if the normal points away from center.
     let mut fixed_count = 0;
     let mut faces_to_flip = Vec::new();
 
@@ -514,7 +503,6 @@ pub fn fix_face_orientations(
         }
     }
 
-    // Apply flips (only planar faces can be flipped).
     for (fid, normal, d) in faces_to_flip {
         let face = topo.face_mut(fid)?;
         face.set_surface(FaceSurface::Plane {
@@ -558,7 +546,6 @@ pub fn close_wire_gaps(
     for &fid in &face_ids {
         let face = topo.face(fid)?;
 
-        // Check all wires (outer + inner).
         let wire_ids: Vec<_> = std::iter::once(face.outer_wire())
             .chain(face.inner_wires().iter().copied())
             .collect();
@@ -572,8 +559,6 @@ pub fn close_wire_gaps(
                 continue;
             }
 
-            // For each pair of consecutive edges, check if end of edge i
-            // matches start of edge i+1.
             let mut merge_pairs: Vec<(VertexId, VertexId)> = Vec::new();
 
             for i in 0..n_edges {
@@ -582,14 +567,12 @@ pub fn close_wire_gaps(
                 let edge_i = topo.edge(edges_list[i].edge())?;
                 let edge_next = topo.edge(edges_list[next_i].edge())?;
 
-                // End vertex of current edge (accounting for orientation).
                 let end_vid = if edges_list[i].is_forward() {
                     edge_i.end()
                 } else {
                     edge_i.start()
                 };
 
-                // Start vertex of next edge (accounting for orientation).
                 let start_vid = if edges_list[next_i].is_forward() {
                     edge_next.start()
                 } else {

--- a/crates/operations/src/helix.rs
+++ b/crates/operations/src/helix.rs
@@ -116,7 +116,6 @@ pub fn make_helix_curve(
     let mut control_points = Vec::with_capacity(2 * total_segs + 1);
     let mut weights = Vec::with_capacity(2 * total_segs + 1);
 
-    // Starting point.
     let start = helix_point(origin, axis, u_dir, v_dir, radius, 0.0, 0.0);
     control_points.push(start);
     weights.push(1.0);
@@ -143,7 +142,6 @@ pub fn make_helix_curve(
         weights.push(1.0);
     }
 
-    // Build knot vector for degree 2.
     let n = control_points.len();
     let degree = 2;
     let mut knots = Vec::with_capacity(n + degree + 1);
@@ -236,7 +234,6 @@ mod tests {
         )
         .unwrap();
 
-        // Degree 2 curve.
         assert_eq!(curve.degree(), 2);
 
         // Should have enough control points for 8 segments.

--- a/crates/operations/src/lib.rs
+++ b/crates/operations/src/lib.rs
@@ -21,7 +21,6 @@
 
 use brepkit_math::vec::{Point3, Vec3};
 
-// ── Core: shape creation ─────────────────────────────────────────
 pub mod extrude;
 pub mod helix;
 pub mod loft;
@@ -31,29 +30,24 @@ pub mod projection;
 pub mod revolve;
 pub mod sweep;
 
-// ── Transform: spatial operations ────────────────────────────────
 pub mod copy;
 pub mod mirror;
 pub mod pattern;
 pub mod transform;
 
-// ── Boolean: set operations ──────────────────────────────────────
 pub mod boolean;
 pub mod mesh_boolean;
 
-// ── Blend: edge smoothing ────────────────────────────────────────
 pub mod blend_ops;
 pub mod chamfer;
 pub mod fillet;
 
-// ── Offset: wall thickness ───────────────────────────────────────
 pub mod offset_face;
 pub mod offset_solid;
 pub mod offset_trim;
 pub mod offset_v2;
 pub mod offset_wire;
 
-// ── Surface & solid modification ─────────────────────────────────
 pub mod draft;
 pub mod fill_face;
 pub mod section;
@@ -61,13 +55,11 @@ pub mod shell_op;
 pub mod split;
 pub mod thicken;
 
-// ── Repair: shape fixing ─────────────────────────────────────────
 pub mod defeature;
 pub mod heal;
 pub mod sew;
 pub mod untrim;
 
-// ── Analysis: interrogation ──────────────────────────────────────
 pub mod classify;
 pub mod distance;
 pub mod feature_recognition;
@@ -75,10 +67,8 @@ pub mod measure;
 pub mod query;
 pub mod validate;
 
-// ── Tessellation: mesh generation ────────────────────────────────
 pub mod tessellate;
 
-// ── Infrastructure ───────────────────────────────────────────────
 pub mod assembly;
 pub mod compound_ops;
 pub mod evolution;

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -123,7 +123,6 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
         return Ok(curved_solid);
     }
 
-    // Collect vertex positions for each profile.
     let mut profile_verts: Vec<Vec<Point3>> = Vec::with_capacity(profiles.len());
     for &fid in profiles {
         let face = topo.face(fid)?;
@@ -161,7 +160,6 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
     let num_profiles = profile_verts.len();
     let num_sections = num_profiles - 1;
 
-    // Create all vertices.
     let ring_verts: Vec<Vec<brepkit_topology::vertex::VertexId>> = profile_verts
         .iter()
         .map(|verts| {
@@ -172,7 +170,6 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
         })
         .collect();
 
-    // Create profile edges for each ring.
     let ring_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> = ring_verts
         .iter()
         .map(|ring| {
@@ -185,7 +182,6 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
         })
         .collect();
 
-    // Create connecting edges between adjacent profiles.
     let connect_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> = (0..num_sections)
         .map(|s| {
             (0..n)
@@ -284,7 +280,6 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
         all_faces.push(fid);
     }
 
-    // Assemble.
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
@@ -933,7 +928,6 @@ pub fn loft_smooth(
         return loft(topo, profiles);
     }
 
-    // Collect vertex positions for each profile.
     let mut profile_verts: Vec<Vec<Point3>> = Vec::with_capacity(profiles.len());
     for &fid in profiles {
         let face = topo.face(fid)?;
@@ -949,7 +943,6 @@ pub fn loft_smooth(
         profile_verts.push(verts);
     }
 
-    // Resample all profiles to the maximum vertex count.
     let n = profile_verts.iter().map(Vec::len).max().unwrap_or(0);
     if n < 3 {
         return Err(crate::OperationsError::InvalidInput {
@@ -967,7 +960,6 @@ pub fn loft_smooth(
 
     let num_profiles = profile_verts.len();
 
-    // Create all vertices.
     let ring_verts: Vec<Vec<brepkit_topology::vertex::VertexId>> = profile_verts
         .iter()
         .map(|verts| {
@@ -978,7 +970,6 @@ pub fn loft_smooth(
         })
         .collect();
 
-    // Create profile edges for each ring.
     let ring_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> = ring_verts
         .iter()
         .map(|ring| {
@@ -1028,11 +1019,9 @@ pub fn loft_smooth(
             .map(|k| vec![profile_verts[k][i], profile_verts[k][next_i]])
             .collect();
 
-        // Interpolate a NURBS surface through the grid.
         let surface =
             interpolate_surface(&grid, degree_u, degree_v).map_err(crate::OperationsError::Math)?;
 
-        // Create the boundary wire for this side face.
         // The wire goes around the edge of the NURBS patch:
         // bottom edge → right rail → top edge (reversed) → left rail (reversed)
         let last = num_profiles - 1;
@@ -1091,7 +1080,6 @@ pub fn loft_smooth(
         all_faces.push(fid);
     }
 
-    // Assemble.
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
@@ -1227,7 +1215,6 @@ mod tests {
         let mut topo = Topology::new();
         let square = make_square_at(&mut topo, 1.0, 0.0);
 
-        // Create a triangle profile.
         let tol_val = 1e-7;
         let v0 = topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 1.0), tol_val));
         let v1 = topo.add_vertex(Vertex::new(Point3::new(1.0, 0.0, 1.0), tol_val));
@@ -1317,8 +1304,6 @@ mod tests {
             "CW-wound loft should produce positive volume, got {vol}"
         );
     }
-
-    // ── Smooth NURBS loft tests ──────────────────────────
 
     #[test]
     fn loft_smooth_two_profiles_delegates() {

--- a/crates/operations/src/measure/mod.rs
+++ b/crates/operations/src/measure/mod.rs
@@ -12,8 +12,6 @@ pub use bounding_box::solid_bounding_box;
 pub use edge_length::{edge_length, face_perimeter, wire_length};
 pub use volume::{solid_center_of_mass, solid_volume, solid_volume_from_faces};
 
-// ── Tests ─────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::panic)]
@@ -25,12 +23,9 @@ mod tests {
 
     use super::*;
 
-    // ── Helper: assert relative error within tolerance ────────────
-    //
     // For analytic primitives (box, cylinder, sphere, cone, torus) we
     // expect 1e-8 relative error. For NURBS-involving operations
     // (fillet, boolean, tessellation-based) we accept 1e-4.
-
     fn assert_rel(actual: f64, expected: f64, rel_tol: f64, label: &str) {
         let rel_err = if expected.abs() < 1e-15 {
             actual.abs()
@@ -87,8 +82,6 @@ mod tests {
             aabb.max.z()
         );
     }
-
-    // ── Bounding box ─────────────────────────────────────────────
 
     #[test]
     fn unit_cube_bounding_box() {
@@ -153,8 +146,6 @@ mod tests {
         assert!(aabb.min.z() <= -3.0 + 1e-6, "min.z={}", aabb.min.z());
         assert!(aabb.max.z() >= 3.0 - 1e-6, "max.z={}", aabb.max.z());
     }
-
-    // ── Volume: analytic primitives (1e-8 tolerance) ─────────────
 
     #[test]
     fn unit_cube_volume() {
@@ -260,8 +251,6 @@ mod tests {
         assert_rel(vol, expected, 1e-10, "torus R=10 r=3 volume");
     }
 
-    // ── Volume: tessellation-based (1e-4 tolerance) ──────────────
-
     /// Ellipsoid via non-uniform scale of a unit sphere.
     /// V = (4/3)*pi*a*b*c where a,b,c are the semi-axes.
     ///
@@ -335,8 +324,6 @@ mod tests {
         assert_rel(vol, 24.0, 1e-8, "extruded 2x3x4 box volume");
     }
 
-    // ── Volume: operations that involve NURBS (1e-4 tolerance) ───
-
     /// Fillet on one edge of a 20^3 box.
     ///
     /// A rolling-ball fillet of radius r on one edge of length L removes
@@ -365,8 +352,6 @@ mod tests {
         let expected = 8000.0 - (1.0 - PI / 4.0) * 4.0 * 20.0;
         assert_rel(vol, expected, 0.01, "fillet r=2 on 20^3 box, one edge");
     }
-
-    // ── Surface area ─────────────────────────────────────────────
 
     #[test]
     fn unit_cube_surface_area() {
@@ -431,8 +416,6 @@ mod tests {
         assert_rel(area, expected, 1e-4, "sphere r=5 surface area");
     }
 
-    // ── Center of mass ───────────────────────────────────────────
-
     #[test]
     fn unit_cube_center_of_mass() {
         let mut topo = Topology::new();
@@ -485,8 +468,6 @@ mod tests {
         assert_rel(com.y(), 1.5, 1e-8, "rect box CoM y");
         assert_rel(com.z(), 2.0, 1e-8, "rect box CoM z");
     }
-
-    // ── Edge & wire lengths ──────────────────────────────────────
 
     #[test]
     fn edge_length_unit_cube() {
@@ -569,8 +550,6 @@ mod tests {
         assert_rel(len, 16.0, 1e-8, "3x5 rectangle perimeter");
     }
 
-    // ── Boolean volume ───────────────────────────────────────────
-
     /// Boolean cut must reduce volume: cut(box, cylinder) < box volume.
     ///
     /// Regression test for the cylinder band classification bug.
@@ -607,8 +586,6 @@ mod tests {
         );
         assert_rel(cut_vol, expected, 0.02, "cut(box, cylinder) volume");
     }
-
-    // ── Edge case: degenerate and boundary inputs ────────────────
 
     /// Volume and AABB of a very thin box (one dimension near-zero).
     /// 10 * 10 * 0.001 -> V = 0.1, SA = 2(100 + 0.01 + 0.01) = 200.04.
@@ -688,8 +665,6 @@ mod tests {
         assert_rel(vol, expected, 1e-8, "near-pointed frustum volume");
     }
 
-    // ── Composition: measure after operations ────────────────────
-
     /// Volume after transform: uniform scale by 2 triples each dimension.
     /// Unit cube -> 2x2x2 cube -> V = 8.
     #[test]
@@ -734,8 +709,6 @@ mod tests {
         assert_rel(vol_before, 60.0, 1e-8, "box volume before rotation");
         assert_rel(vol_after, 60.0, 1e-8, "box volume after rotation");
     }
-
-    // ── Error path validation ────────────────────────────────────
 
     /// Cone total surface area = pi*r*l + pi*r^2 (lateral + base cap).
     /// r=1, h=1: slant l=sqrt(2), lateral = pi*1*sqrt(2) = pi*sqrt(2) ~ 4.4429.

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -29,7 +29,6 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     let solid_data = topo.solid(solid).ok()?;
     let shell = topo.shell(solid_data.outer_shell()).ok()?;
 
-    // Classify all faces by surface type.
     let mut sphere_r: Option<f64> = None;
     let mut cyl: Option<(Point3, Vec3, f64)> = None; // (origin, axis, radius)
     let mut cone_params: Option<(Point3, Vec3)> = None; // (apex, axis)
@@ -75,10 +74,8 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         }
     }
 
-    // -- Sphere: all faces are sphere faces (e.g. two hemispheres) --
     if let Some(r) = sphere_r {
         if cyl.is_none() && cone_params.is_none() && torus_params.is_none() && planes.is_empty() {
-            // Verify actual vertex distances match the stored radius.
             // A non-uniform scale transforms vertices but leaves the sphere
             // surface radius unchanged, making the analytic formula wrong.
             let sphere_faces: Vec<_> = shell.faces().to_vec();
@@ -117,8 +114,6 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         }
     }
 
-    // -- Cylinder: 1 cylindrical face + planar caps --
-    //
     // A pure cylinder has exactly 1 cylindrical face and 2 planar caps.
     // If there are more than 2 planes the solid is compound (e.g. a box
     // with a drilled hole has 1 cylindrical hole-wall + 6 box faces).
@@ -141,8 +136,6 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         }
     }
 
-    // -- Cone / frustum: 1 conical face + planar caps --
-    //
     // Cap radii are read directly from the Circle3D edges of the cap faces,
     // bypassing the ConicalSurface parameterization entirely. Heights are
     // derived from the circle centers projected onto the cone axis.
@@ -183,7 +176,6 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         }
     }
 
-    // -- Torus: 1 toroidal face, no planar caps --
     if let Some((r_major, r_minor)) = torus_params {
         if cyl.is_none() && cone_params.is_none() && sphere_r.is_none() && planes.is_empty() {
             return Some(2.0 * PI * PI * r_major * r_minor * r_minor);
@@ -393,7 +385,6 @@ fn analytic_cylinder_signed_volume(
         }
     };
 
-    // Collect boundary vertex (u,v) parameters on the cylinder.
     let wire = topo.wire(face.outer_wire())?;
     let mut u_vals = Vec::new();
     let mut v_vals = Vec::new();
@@ -428,7 +419,6 @@ fn analytic_cylinder_signed_volume(
         }
     }
 
-    // Determine v-range (axial).
     let v_min = v_vals.iter().copied().fold(f64::INFINITY, f64::min);
     let v_max = v_vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
     let h = v_max - v_min;
@@ -932,7 +922,6 @@ pub fn solid_volume_from_faces(
             break;
         }
 
-        // Check all edges are lines.
         let mut pts = Vec::with_capacity(3);
         for oe in edges {
             let edge = topo.edge(oe.edge())?;

--- a/crates/operations/src/mesh_boolean.rs
+++ b/crates/operations/src/mesh_boolean.rs
@@ -19,10 +19,6 @@ use crate::OperationsError;
 use crate::boolean::BooleanOp;
 use crate::tessellate::TriangleMesh;
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
 /// Result of a mesh boolean operation.
 #[derive(Debug, Clone)]
 pub struct MeshBooleanResult {
@@ -123,10 +119,6 @@ pub fn mesh_boolean_with_metadata(
     Ok(MeshBooleanResult { mesh })
 }
 
-// ---------------------------------------------------------------------------
-// Step 1: BVH broad-phase
-// ---------------------------------------------------------------------------
-
 /// Build a BVH over a mesh's triangles, returning the BVH and per-triangle AABBs.
 fn build_triangle_bvh(mesh: &TriangleMesh) -> (Bvh, Vec<Aabb3>) {
     let tri_count = mesh.indices.len() / 3;
@@ -160,10 +152,6 @@ fn find_intersecting_pairs(mesh_a: &TriangleMesh, bvh_b: &Bvh) -> Vec<(usize, us
 
     pairs
 }
-
-// ---------------------------------------------------------------------------
-// Step 2: Triangle-triangle intersection
-// ---------------------------------------------------------------------------
 
 /// An intersection segment between two triangles.
 #[derive(Debug, Clone)]
@@ -643,10 +631,6 @@ fn triangle_centroid(v0: Point3, v1: Point3, v2: Point3) -> Point3 {
     )
 }
 
-// ---------------------------------------------------------------------------
-// Step 3: Split meshes by intersection edges
-// ---------------------------------------------------------------------------
-
 /// A triangle mesh that has been split by intersection segments.
 #[derive(Debug, Clone)]
 struct SplitMesh {
@@ -695,13 +679,11 @@ fn split_mesh_by_intersections(
         let i2 = mesh.indices[i * 3 + 2] as usize;
 
         if let Some(segments) = tri_segments.get(&i) {
-            // This triangle needs splitting.
             let v0 = mesh.positions[i0];
             let v1 = mesh.positions[i1];
             let v2 = mesh.positions[i2];
             let n0 = mesh.normals[i0];
 
-            // Collect all unique intersection points on this triangle.
             let mut insert_pts: Vec<Point3> = Vec::new();
             for &(p0, p1) in segments {
                 maybe_add_unique(&mut insert_pts, p0, tolerance);
@@ -732,7 +714,6 @@ fn split_mesh_by_intersections(
                 drop_collinear_midpoints(&mut insert_pts, tolerance);
             }
 
-            // Split the triangle by inserting these points.
             let sub_tris = split_triangle_by_points(v0, v1, v2, &insert_pts, tolerance);
 
             for (sv0, sv1, sv2) in sub_tris {
@@ -747,7 +728,6 @@ fn split_mesh_by_intersections(
                 triangles.push([base, base + 1, base + 2]);
             }
         } else {
-            // No intersection: keep the triangle as-is.
             #[allow(clippy::cast_possible_truncation)]
             {
                 triangles.push([i0 as u32, i1 as u32, i2 as u32]);
@@ -994,10 +974,6 @@ fn dist_sq(a: Point3, b: Point3) -> f64 {
     d.dot(d)
 }
 
-// ---------------------------------------------------------------------------
-// Step 4: Classification
-// ---------------------------------------------------------------------------
-
 /// Classify each triangle in a split mesh as inside or outside the other mesh.
 ///
 /// Uses generalized winding number: a triangle's centroid is inside the other
@@ -1061,10 +1037,6 @@ pub(crate) fn winding_number_at_point(point: Point3, mesh: &TriangleMesh) -> f64
     total_solid_angle / (4.0 * std::f64::consts::PI)
 }
 
-// ---------------------------------------------------------------------------
-// Step 5: Assembly
-// ---------------------------------------------------------------------------
-
 /// Assemble the result mesh from classified sub-triangles.
 ///
 /// Selection logic:
@@ -1082,7 +1054,6 @@ fn assemble_result(
     let mut normals = Vec::new();
     let mut indices = Vec::new();
 
-    // Process mesh A triangles.
     for (i, tri) in split_a.triangles.iter().enumerate() {
         let inside_b = classify_a.get(i).copied().unwrap_or(false);
         let keep = match op {
@@ -1102,7 +1073,6 @@ fn assemble_result(
         }
     }
 
-    // Process mesh B triangles.
     for (i, tri) in split_b.triangles.iter().enumerate() {
         let inside_a = classify_b.get(i).copied().unwrap_or(false);
         let (keep, flip) = match op {
@@ -1144,7 +1114,6 @@ fn append_triangle(
     let base = positions.len() as u32;
 
     if flip {
-        // Reverse winding order and negate normals.
         for &idx in tri.iter().rev() {
             let i = idx as usize;
             positions.push(src_positions[i]);
@@ -1163,10 +1132,6 @@ fn append_triangle(
     indices.push(base + 2);
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 /// Extract the three vertices of a triangle from a mesh.
 fn get_triangle(mesh: &TriangleMesh, tri_idx: usize) -> (Point3, Point3, Point3) {
     let base = tri_idx * 3;
@@ -1175,10 +1140,6 @@ fn get_triangle(mesh: &TriangleMesh, tri_idx: usize) -> (Point3, Point3, Point3)
     let i2 = mesh.indices[base + 2] as usize;
     (mesh.positions[i0], mesh.positions[i1], mesh.positions[i2])
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -1189,7 +1150,6 @@ mod tests {
     /// Create a tetrahedron mesh centered at a point.
     fn tetrahedron_mesh(center: Point3, size: f64) -> TriangleMesh {
         let s = size;
-        // Regular tetrahedron vertices.
         let v0 = Point3::new(center.x() + s, center.y() + s, center.z() + s);
         let v1 = Point3::new(center.x() + s, center.y() - s, center.z() - s);
         let v2 = Point3::new(center.x() - s, center.y() + s, center.z() - s);
@@ -1197,7 +1157,6 @@ mod tests {
 
         let positions = [v0, v1, v2, v3];
 
-        // Compute face normals for each face.
         let faces = [(0u32, 2, 1), (0, 1, 3), (0, 3, 2), (1, 2, 3)];
         let mut out_positions = Vec::new();
         let mut out_normals = Vec::new();
@@ -1239,7 +1198,6 @@ mod tests {
         let cy = center.y();
         let cz = center.z();
 
-        // 8 corner vertices.
         let verts = [
             Point3::new(cx - s, cy - s, cz - s), // 0
             Point3::new(cx + s, cy - s, cz - s), // 1

--- a/crates/operations/src/mirror.rs
+++ b/crates/operations/src/mirror.rs
@@ -35,10 +35,8 @@ pub fn mirror(
 ) -> Result<SolidId, crate::OperationsError> {
     let normal = plane_normal.normalize()?;
 
-    // First, copy the solid (we need a new independent copy).
     let new_solid = crate::copy::copy_solid(topo, solid)?;
 
-    // Build the reflection matrix.
     // For a plane through point P with normal n:
     //   Reflect(x) = x - 2 * ((x - P) · n) * n
     // This is equivalent to: translate(-P), reflect through origin, translate(P).
@@ -102,7 +100,6 @@ mod tests {
         let mut topo = Topology::new();
         let solid = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
 
-        // Mirror across YZ plane (x=0).
         let mirrored = mirror(
             &mut topo,
             solid,
@@ -111,7 +108,6 @@ mod tests {
         )
         .unwrap();
 
-        // The mirrored solid should have the same volume.
         let vol_orig = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
         let vol_mirror = crate::measure::solid_volume(&topo, mirrored, 0.1).unwrap();
         let tol = Tolerance::loose();
@@ -155,7 +151,6 @@ mod tests {
         )
         .unwrap();
 
-        // Should be a different solid ID.
         assert_ne!(
             solid.index(),
             mirrored.index(),

--- a/crates/operations/src/offset_face.rs
+++ b/crates/operations/src/offset_face.rs
@@ -37,7 +37,6 @@ pub fn offset_face(
 ) -> Result<FaceId, OperationsError> {
     let tol = Tolerance::new();
     if distance.abs() < tol.linear {
-        // Zero offset: just copy the face.
         return copy_face(topo, face_id);
     }
 
@@ -75,10 +74,8 @@ fn offset_planar_face(
     d: f64,
     distance: f64,
 ) -> Result<FaceId, OperationsError> {
-    // New plane: same normal, shifted d.
     let new_d = d + distance;
 
-    // Offset all vertices in the wires.
     let offset_vec = Vec3::new(
         normal.x() * distance,
         normal.y() * distance,
@@ -119,10 +116,9 @@ fn offset_nurbs_face(
     distance: f64,
     samples: usize,
 ) -> Result<FaceId, OperationsError> {
-    let n = samples.max(4); // Minimum 4×4 grid.
+    let n = samples.max(4);
     let tol = Tolerance::new();
 
-    // Pass 1: Evaluate curvature at a coarse grid to identify high-curvature regions.
     let coarse = n.max(4);
     #[allow(clippy::cast_precision_loss)]
     let coarse_div = (coarse - 1) as f64;
@@ -157,10 +153,6 @@ fn offset_nurbs_face(
         }
     }
 
-    // Pass 2: Build adaptive parameter grid. For each coarse cell, decide
-    // the local subdivision level based on curvature × |distance|.
-    // High curvature × distance → more samples (up to 4× coarse density).
-    //
     // The 0.25 factor sets the refinement sensitivity: a cell is refined when
     // its local `curvature * |distance|` exceeds 25% of the surface-wide
     // maximum `max_curvature * |distance|`. This ensures at least the top
@@ -170,22 +162,18 @@ fn offset_nurbs_face(
     let mut u_params: Vec<f64> = Vec::new();
     let mut v_params: Vec<f64> = Vec::new();
 
-    // Collect u-parameters: for each coarse interval, subdivide if needed.
     #[allow(clippy::cast_precision_loss)]
     for i in 0..coarse {
         let u0 = i as f64 / coarse_div;
         u_params.push(u0);
 
         if i + 1 < coarse {
-            // Check if any cell in this u-row has high curvature.
             let row_max = curvatures[i].iter().copied().fold(0.0_f64, f64::max);
             let cell_metric = row_max * distance.abs();
             if threshold > 1e-12 && cell_metric > threshold {
-                // Add midpoints for this interval.
                 let u1 = (i + 1) as f64 / coarse_div;
                 let mid = 0.5 * (u0 + u1);
                 u_params.push(mid);
-                // If very high curvature, add quarter-points too.
                 if cell_metric > threshold * 3.0 {
                     u_params.push(0.25_f64.mul_add(u1 - u0, u0));
                     u_params.push(0.75_f64.mul_add(u1 - u0, u0));
@@ -193,12 +181,10 @@ fn offset_nurbs_face(
             }
         }
     }
-    // Ensure endpoint.
     if u_params.last().is_none_or(|&u| (u - 1.0).abs() > 1e-15) {
         u_params.push(1.0);
     }
 
-    // Collect v-parameters similarly.
     #[allow(clippy::cast_precision_loss)]
     for j in 0..coarse {
         let v0 = j as f64 / coarse_div;
@@ -222,13 +208,11 @@ fn offset_nurbs_face(
         v_params.push(1.0);
     }
 
-    // Sort and deduplicate parameter lists.
     u_params.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     u_params.dedup_by(|a, b| (*a - *b).abs() < 1e-15);
     v_params.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     v_params.dedup_by(|a, b| (*a - *b).abs() < 1e-15);
 
-    // Sample the surface and offset each point along the normal.
     let nu = u_params.len();
     let nv = v_params.len();
     let mut offset_grid: Vec<Vec<Point3>> = Vec::with_capacity(nu);
@@ -253,7 +237,6 @@ fn offset_nurbs_face(
         offset_grid.push(row);
     }
 
-    // Fit a new NURBS surface through the offset points.
     let degree = nurbs.degree_u().min(nurbs.degree_v()).min(3);
     let raw_offset = interpolate_surface(&offset_grid, degree, degree).map_err(|e| {
         OperationsError::InvalidInput {
@@ -281,12 +264,10 @@ fn offset_nurbs_face(
         }
     };
 
-    // Copy the wire topology from the original face, offsetting vertices.
     let face = topo.face(face_id)?;
     let outer_wire = face.outer_wire();
     let inner_wires: Vec<_> = face.inner_wires().to_vec();
 
-    // Offset wire vertices along the NURBS normal at their positions.
     let new_outer = offset_wire_along_nurbs(topo, outer_wire, nurbs, distance)?;
 
     let mut new_inner = Vec::new();
@@ -329,7 +310,6 @@ fn offset_cylinder_face(
         brepkit_math::surfaces::CylindricalSurface::new(cyl.origin(), cyl.axis(), new_radius)
             .map_err(OperationsError::Math)?;
 
-    // Offset wire vertices radially outward from the cylinder axis.
     let radial_offset = |pt: Point3| -> Point3 {
         let to_axis = Vec3::new(
             pt.x() - cyl.origin().x(),
@@ -384,7 +364,6 @@ fn offset_sphere_face(
     let new_sphere = brepkit_math::surfaces::SphericalSurface::new(sphere.center(), new_radius)
         .map_err(OperationsError::Math)?;
 
-    // Offset vertices radially from sphere center.
     let radial_offset = |pt: Point3| -> Point3 {
         let to_center = pt - sphere.center();
         if let Ok(dir) = to_center.normalize() {
@@ -437,7 +416,6 @@ fn offset_cone_face(
         brepkit_math::surfaces::ConicalSurface::new(new_apex, cone.axis(), cone.half_angle())
             .map_err(OperationsError::Math)?;
 
-    // Offset wire vertices along the cone's radial direction.
     let radial_offset = |pt: Point3| -> Point3 {
         let to_apex = Vec3::new(
             pt.x() - cone.apex().x(),
@@ -495,7 +473,6 @@ fn offset_torus_face(
     )
     .map_err(OperationsError::Math)?;
 
-    // Offset wire vertices radially from the torus center, in the tube direction.
     let z_axis = torus.z_axis();
     let center = torus.center();
     let radial_offset = |pt: Point3| -> Point3 {
@@ -899,8 +876,6 @@ mod tests {
         );
     }
 
-    // ── NURBS face helpers ────────────────────────────────────────────────────
-
     /// Build a flat bilinear NURBS face on the XY plane (z = `z_height`).
     ///
     /// Degree-1 in both u and v, 2×2 control points, clamped knot vectors.
@@ -949,8 +924,6 @@ mod tests {
 
         topo.add_face(Face::new(wid, vec![], FaceSurface::Nurbs(nurbs)))
     }
-
-    // ── NURBS face offset tests ───────────────────────────────────────────────
 
     #[test]
     fn offset_nurbs_face_outward_produces_nurbs_surface() {

--- a/crates/operations/src/offset_solid.rs
+++ b/crates/operations/src/offset_solid.rs
@@ -51,7 +51,6 @@ pub fn offset_solid(
     let shell = topo.shell(solid_data.outer_shell())?;
     let face_ids: Vec<FaceId> = shell.faces().to_vec();
 
-    // Check if all faces are planar.
     let all_planar = face_ids.iter().all(|&fid| {
         topo.face(fid)
             .map(|f| matches!(f.surface(), FaceSurface::Plane { .. }))
@@ -62,7 +61,6 @@ pub fn offset_solid(
         return offset_solid_general(topo, solid, &face_ids, distance, tol);
     }
 
-    // Collect face normals and plane equations.
     let mut face_normals: std::collections::BTreeMap<usize, (Vec3, f64)> =
         std::collections::BTreeMap::new();
     let mut vertex_faces: std::collections::BTreeMap<usize, Vec<usize>> =
@@ -81,7 +79,6 @@ pub fn offset_solid(
 
         face_normals.insert(fid.index(), (normal, d));
 
-        // Track which faces each vertex belongs to.
         let wire = topo.wire(face.outer_wire())?;
         for oe in wire.edges() {
             let edge = topo.edge(oe.edge())?;
@@ -96,7 +93,6 @@ pub fn offset_solid(
         }
     }
 
-    // Deduplicate face lists for each vertex.
     for faces in vertex_faces.values_mut() {
         faces.sort_unstable();
         faces.dedup();
@@ -147,7 +143,6 @@ pub fn offset_solid(
         }
     }
 
-    // Build offset faces using the computed vertex positions.
     let mut offset_faces: Vec<(Vec<Point3>, Vec3, f64)> = Vec::new();
 
     for &fid in &face_ids {
@@ -432,7 +427,6 @@ mod tests {
     ///
     /// Sphere offset goes through tessellation path (NURBS faces).
     /// With 32 segments, expect ~5% error from tessellation approximation.
-    /// Previously used 15% tolerance — tightened to 5%.
     #[test]
     fn offset_sphere_outward() {
         let mut topo = Topology::new();

--- a/crates/operations/src/offset_trim.rs
+++ b/crates/operations/src/offset_trim.rs
@@ -40,7 +40,9 @@ const MAX_INVALID_FRACTION: f64 = 0.5;
 /// by more than `tolerance * DISTANCE_TOLERANCE_FACTOR` are flagged.
 const DISTANCE_TOLERANCE_FACTOR: f64 = 10.0;
 
-/// Relative tolerance for the fallback distance check.
+/// Relative tolerance for the fallback distance check. Kept tight because
+/// the SSI-based primary path handles the cases that would otherwise need a
+/// looser bound.
 const RELATIVE_DISTANCE_TOL: f64 = 0.02;
 
 /// Detect and remove self-intersections in an offset NURBS surface.

--- a/crates/operations/src/offset_trim.rs
+++ b/crates/operations/src/offset_trim.rs
@@ -40,9 +40,7 @@ const MAX_INVALID_FRACTION: f64 = 0.5;
 /// by more than `tolerance * DISTANCE_TOLERANCE_FACTOR` are flagged.
 const DISTANCE_TOLERANCE_FACTOR: f64 = 10.0;
 
-/// Relative tolerance for the fallback distance check. Tightened from
-/// 0.15 to 0.02 — the SSI-based primary path handles the cases that
-/// formerly needed the loose 15% tolerance.
+/// Relative tolerance for the fallback distance check.
 const RELATIVE_DISTANCE_TOL: f64 = 0.02;
 
 /// Detect and remove self-intersections in an offset NURBS surface.
@@ -70,14 +68,12 @@ pub fn trim_offset_self_intersections(
     offset_distance: f64,
     tolerance: f64,
 ) -> Result<NurbsSurface, OperationsError> {
-    // ── Primary path: SSI-based detection ──────────────────────────────
     if let Ok(ssi_curves) = detect_self_intersection(offset, SSI_GRID, tolerance) {
         if !ssi_curves.is_empty() {
             return trim_via_ssi(original, offset, offset_distance, tolerance, &ssi_curves);
         }
     }
 
-    // ── Fallback path: sampling-based detection ────────────────────────
     trim_via_sampling(original, offset, offset_distance, tolerance)
 }
 
@@ -120,7 +116,6 @@ fn trim_via_ssi(
         if ssi.params_a.is_empty() {
             continue;
         }
-        // Check midpoint of each sheet.
         let mid_idx = ssi.params_a.len() / 2;
         let (ua, va) = ssi.params_a[mid_idx];
         let (ub, vb) = ssi.params_b[mid_idx];
@@ -157,7 +152,6 @@ fn trim_via_ssi(
         for j in 0..n {
             let v = lerp(v_min, v_max, j as f64 / (n - 1) as f64);
 
-            // Check if this sample is near any invalid parameter point.
             let near_invalid = invalid_params
                 .iter()
                 .any(|&(iu, iv)| ((u - iu).powi(2) + (v - iv).powi(2)).sqrt() < proximity);
@@ -180,7 +174,6 @@ fn trim_via_ssi(
         mask.push(row);
     }
 
-    // Count invalid samples.
     let total = n * n;
     let invalid_count = mask
         .iter()
@@ -213,11 +206,9 @@ fn trim_via_sampling(
     offset_distance: f64,
     tolerance: f64,
 ) -> Result<NurbsSurface, OperationsError> {
-    // Step 1: Detection — sample the offset surface and check distances.
     let validity_mask =
         detect_self_intersections_sampling(original, offset, offset_distance, tolerance);
 
-    // Count invalid samples.
     let total = validity_mask.len() * validity_mask[0].len();
     let invalid_count = validity_mask
         .iter()
@@ -225,12 +216,10 @@ fn trim_via_sampling(
         .filter(|&&v| !v)
         .count();
 
-    // If no self-intersections detected, return the offset unchanged.
     if invalid_count == 0 {
         return Ok(offset.clone());
     }
 
-    // If too much of the surface is invalid, return an error.
     #[allow(clippy::cast_precision_loss)]
     let invalid_fraction = invalid_count as f64 / total as f64;
     if invalid_fraction > MAX_INVALID_FRACTION {
@@ -244,10 +233,8 @@ fn trim_via_sampling(
         });
     }
 
-    // Step 2: Localization — refine the validity mask with normal checking.
     let refined_mask = refine_validity_mask(original, offset, offset_distance, tolerance);
 
-    // Recount after refinement.
     let refined_total = refined_mask.len() * refined_mask[0].len();
     let refined_invalid = refined_mask
         .iter()
@@ -267,7 +254,6 @@ fn trim_via_sampling(
         });
     }
 
-    // Step 3: Trimming — refit the surface using only valid samples.
     refit_valid_region(offset, &refined_mask)
 }
 
@@ -452,7 +438,6 @@ fn refit_valid_region(
         grid.push(row);
     }
 
-    // Fit a new surface through the valid sample grid.
     let degree = offset.degree_u().min(offset.degree_v()).clamp(1, 3);
     let degree = degree.min(refit_n - 1);
 

--- a/crates/operations/src/offset_wire.rs
+++ b/crates/operations/src/offset_wire.rs
@@ -85,7 +85,6 @@ pub fn offset_wire_with_join(
         });
     }
 
-    // Get face normal.
     let face = topo.face(face_id)?;
     let face_normal = match face.surface() {
         FaceSurface::Plane { normal, .. } => *normal,
@@ -96,7 +95,6 @@ pub fn offset_wire_with_join(
         }
     };
 
-    // Get ordered vertices of the face's outer wire.
     let verts = face_polygon(topo, face_id)?;
     let n = verts.len();
     if n < 3 {
@@ -205,7 +203,6 @@ fn build_intersection_wire(
         }
     }
 
-    // Build the offset wire.
     let vert_ids: Vec<_> = offset_verts
         .iter()
         .map(|&p| topo.add_vertex(Vertex::new(p, tol.linear)))
@@ -313,7 +310,6 @@ fn build_arc_wire(
         }
     }
 
-    // Build edges with shared vertex IDs.
     let mut oriented_edges = Vec::with_capacity(2 * n);
 
     for i in 0..n {
@@ -406,7 +402,6 @@ fn build_chamfer_wire(
         }
     }
 
-    // Build edges with shared vertex IDs.
     let mut oriented_edges = Vec::with_capacity(2 * n);
 
     for i in 0..n {

--- a/crates/operations/src/pattern.rs
+++ b/crates/operations/src/pattern.rs
@@ -98,7 +98,6 @@ pub fn circular_pattern(
         #[allow(clippy::cast_precision_loss)]
         let angle = angle_step * (i as f64);
 
-        // Build rotation matrix around the axis.
         let matrix = rotation_matrix(axis, angle);
         transform_solid(topo, copy, &matrix)?;
         solids.push(copy);
@@ -186,7 +185,7 @@ pub fn grid_pattern(
 fn rotation_matrix(axis: Vec3, angle: f64) -> Mat4 {
     let cos_a = angle.cos();
     let sin_a = angle.sin();
-    let omc = 1.0 - cos_a; // one minus cos
+    let omc = 1.0 - cos_a;
     let ax = axis.x();
     let ay = axis.y();
     let az = axis.z();
@@ -234,7 +233,6 @@ mod tests {
         let comp = topo.compound(compound).unwrap();
         assert_eq!(comp.solids().len(), 3, "should have 3 copies");
 
-        // Verify each copy has the right volume.
         let tol = Tolerance::loose();
         for &sid in comp.solids() {
             let vol = crate::measure::solid_volume(&topo, sid, 0.1).unwrap();

--- a/crates/operations/src/pipe.rs
+++ b/crates/operations/src/pipe.rs
@@ -47,7 +47,6 @@ pub fn pipe(
 ) -> Result<SolidId, crate::OperationsError> {
     let tol = Tolerance::new();
 
-    // Validate path.
     if path.control_points().len() < 2 {
         return Err(crate::OperationsError::InvalidInput {
             reason: "pipe path must have at least 2 control points".into(),
@@ -66,7 +65,6 @@ pub fn pipe(
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids: Vec<brepkit_topology::wire::WireId> = face_data.inner_wires().to_vec();
 
-    // Collect profile vertices.
     let input_wire = topo.wire(input_wire_id)?;
     let input_oriented: Vec<_> = input_wire.edges().to_vec();
     let n = input_oriented.len();
@@ -91,19 +89,15 @@ pub fn pipe(
         input_normal = -input_normal;
     }
 
-    // Compute profile centroid.
     let centroid = crate::winding::polygon_centroid(&input_verts);
 
-    // Compute scaling factors from guide curve.
     let num_segments = (path.control_points().len() * 2).max(4);
     let scale_factors = compute_scale_factors(path, guide, num_segments, tol)?;
 
-    // Compute frames along the path (reusing sweep's frame logic).
     let initial_tangent = path_tangent_0;
     let initial_up = orthogonalize(input_normal, initial_tangent);
     let initial_right = initial_tangent.cross(initial_up);
 
-    // Build ring vertices with scaling.
     let mut ring_verts: Vec<Vec<brepkit_topology::vertex::VertexId>> =
         Vec::with_capacity(num_segments + 1);
 
@@ -208,7 +202,6 @@ pub fn pipe(
         });
     }
 
-    // Build edges and faces (same topology as regular sweep).
     let mut ring_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> =
         Vec::with_capacity(num_segments + 1);
     for ring in &ring_verts {
@@ -237,7 +230,6 @@ pub fn pipe(
 
     let mut all_faces = Vec::with_capacity(num_segments * n + 2);
 
-    // Start cap.
     let start_reversed: Vec<OrientedEdge> = (0..n)
         .rev()
         .map(|i| OrientedEdge::new(ring_edges[0][i], false))
@@ -265,7 +257,6 @@ pub fn pipe(
     ));
     all_faces.push(start_face);
 
-    // Side faces.
     for seg in 0..num_segments {
         for i in 0..n {
             let next_i = (i + 1) % n;
@@ -301,7 +292,6 @@ pub fn pipe(
         }
     }
 
-    // Inner side faces for pipe.
     for ipd in &inner_pipe_data {
         for seg in 0..num_segments {
             for i in 0..ipd.n {
@@ -342,7 +332,6 @@ pub fn pipe(
         }
     }
 
-    // End cap with inner wire holes.
     let end_edges: Vec<OrientedEdge> = (0..n)
         .map(|i| OrientedEdge::new(ring_edges[num_segments][i], true))
         .collect();
@@ -387,7 +376,6 @@ fn compute_scale_factors(
     tol: Tolerance,
 ) -> Result<Vec<f64>, crate::OperationsError> {
     let Some(guide) = guide else {
-        // No guide: uniform scale of 1.0.
         return Ok(vec![1.0; num_segments + 1]);
     };
 

--- a/crates/operations/src/primitives.rs
+++ b/crates/operations/src/primitives.rs
@@ -20,8 +20,6 @@ use brepkit_topology::solid::{Solid, SolidId};
 use brepkit_topology::vertex::Vertex;
 use brepkit_topology::wire::{OrientedEdge, Wire};
 
-// ── Box ────────────────────────────────────────────────────────────
-
 /// Create a box solid with one corner at the origin.
 ///
 /// The box extends from `(0, 0, 0)` to `(dx, dy, dz)`.
@@ -44,7 +42,6 @@ pub fn make_box(
         });
     }
 
-    // 8 vertices: corner at origin, extending to (dx, dy, dz)
     let v = [
         topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 0.0), tol.linear)),
         topo.add_vertex(Vertex::new(Point3::new(dx, 0.0, 0.0), tol.linear)),
@@ -56,7 +53,6 @@ pub fn make_box(
         topo.add_vertex(Vertex::new(Point3::new(0.0, dy, dz), tol.linear)),
     ];
 
-    // 12 edges (shared between faces)
     // Bottom ring (z=0)
     let eb0 = topo.add_edge(Edge::new(v[0], v[1], EdgeCurve::Line));
     let eb1 = topo.add_edge(Edge::new(v[1], v[2], EdgeCurve::Line));
@@ -134,8 +130,6 @@ pub fn make_box(
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
 }
 
-// ── Cylinder ───────────────────────────────────────────────────────
-
 /// Create a cylinder solid with its axis along +Z, base at the origin.
 ///
 /// The cylinder extends from `z = 0` to `z = height`.
@@ -165,7 +159,6 @@ pub fn make_cylinder(
     // Cylinder base at z=0, top at z=height.
     // (brepjs drill and placement code assumes this convention.)
 
-    // Analytic cylindrical surface
     let cyl_surface = brepkit_math::surfaces::CylindricalSurface::new(
         Point3::new(0.0, 0.0, 0.0),
         Vec3::new(0.0, 0.0, 1.0),
@@ -245,8 +238,6 @@ pub fn make_cylinder(
     let shell_id = topo.add_shell(shell);
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
 }
-
-// ── Cone ───────────────────────────────────────────────────────────
 
 /// Create a cone solid with its base at the origin, axis along +Z.
 ///
@@ -461,8 +452,6 @@ pub fn make_cone(
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
 }
 
-// ── Sphere ─────────────────────────────────────────────────────────
-
 /// Create a sphere solid centered at the origin.
 ///
 /// Built as a single spherical face with a degenerate boundary wire,
@@ -555,8 +544,6 @@ pub fn make_sphere(
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
 }
 
-// ── Torus ──────────────────────────────────────────────────────────
-
 /// Create a torus solid centered at the origin in the XY plane.
 ///
 /// Built as a single `ToroidalSurface` face with exact analytic geometry,
@@ -637,8 +624,6 @@ pub fn make_torus(
     let shell_id = topo.add_shell(shell);
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
 }
-
-// ── Helpers ────────────────────────────────────────────────────────
 
 /// Build a trapezoid face in the XZ plane (y=0) for cone profiles.
 ///
@@ -724,8 +709,6 @@ fn make_rect_xz_face(
     Ok(topo.add_face(Face::new(wid, vec![], FaceSurface::Plane { normal, d })))
 }
 
-// ── Convex hull ───────────────────────────────────────────────────
-
 /// Create a solid from the 3D convex hull of a point cloud.
 ///
 /// Uses the Quickhull algorithm to compute the convex hull, then
@@ -747,14 +730,12 @@ pub fn make_convex_hull(
 
     let tol = Tolerance::new();
 
-    // Create vertices in the topology arena.
     let vertex_ids: Vec<_> = hull
         .vertices
         .iter()
         .map(|p| topo.add_vertex(Vertex::new(*p, tol.linear)))
         .collect();
 
-    // Create faces from hull triangles, sharing edges between adjacent faces.
     // Each undirected edge (min_vertex, max_vertex) is created once; the second
     // face that references it uses reverse orientation.
     let mut edge_map: HashMap<(usize, usize), brepkit_topology::edge::EdgeId> = HashMap::new();
@@ -781,7 +762,6 @@ pub fn make_convex_hull(
         let wire = Wire::new(oriented_edges, true).map_err(crate::OperationsError::Topology)?;
         let wid = topo.add_wire(wire);
 
-        // Compute face plane from triangle vertices.
         let pa = hull.vertices[a];
         let pb = hull.vertices[b];
         let pc = hull.vertices[c];
@@ -865,8 +845,6 @@ mod tests {
     use super::*;
     use crate::test_helpers::{assert_euler_genus0, assert_volume_near, euler_characteristic};
 
-    // ── Box tests ──────────────────────────────────────────────────
-
     #[test]
     fn make_box_unit_cube() {
         let mut topo = Topology::new();
@@ -876,7 +854,6 @@ mod tests {
         let sh = topo.shell(s.outer_shell()).unwrap();
         assert_eq!(sh.faces().len(), 6, "box should have 6 faces");
 
-        // Verify volume
         let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
         assert!(
             (vol - 1.0).abs() < 1e-10,
@@ -950,8 +927,6 @@ mod tests {
             .expect("box should be manifold");
     }
 
-    // ── Cylinder tests ─────────────────────────────────────────────
-
     #[test]
     fn make_cylinder_basic() {
         let mut topo = Topology::new();
@@ -992,8 +967,6 @@ mod tests {
         assert!(make_cylinder(&mut topo, 1.0, 0.0).is_err());
     }
 
-    // ── Cone tests ─────────────────────────────────────────────────
-
     #[test]
     fn make_cone_frustum() {
         let mut topo = Topology::new();
@@ -1033,8 +1006,6 @@ mod tests {
         let mut topo = Topology::new();
         assert!(make_cone(&mut topo, -1.0, 1.0, 1.0).is_err());
     }
-
-    // ── Sphere tests ───────────────────────────────────────────────
 
     #[test]
     fn make_sphere_basic() {
@@ -1108,8 +1079,6 @@ mod tests {
         assert!(make_sphere(&mut topo, 1.0, 2).is_err());
     }
 
-    // ── Torus tests ────────────────────────────────────────────────
-
     #[test]
     fn make_torus_basic() {
         let mut topo = Topology::new();
@@ -1156,8 +1125,6 @@ mod tests {
         assert!(make_torus(&mut topo, 0.0, 1.0, 8).is_err());
         assert!(make_torus(&mut topo, 3.0, 0.0, 8).is_err());
     }
-
-    // ── Periodic surface / singular point tests ─────────────────────
 
     #[test]
     fn cylinder_seam_continuity() {
@@ -1241,8 +1208,6 @@ mod tests {
         assert!(has_apex, "cone should have apex vertex at (0,0,3)");
     }
 
-    // ── Degenerate geometry tests ──────────────────────────────
-
     #[test]
     fn make_box_very_thin() {
         // Thin plate: dx=1e-4, dy=1, dz=1
@@ -1284,8 +1249,6 @@ mod tests {
             rel_error * 100.0
         );
     }
-
-    // ── Convex hull tests ─────────────────────────────────────────
 
     #[test]
     fn convex_hull_unit_cube() {

--- a/crates/operations/src/revolve.rs
+++ b/crates/operations/src/revolve.rs
@@ -182,8 +182,6 @@ pub fn revolve(
 ) -> Result<SolidId, crate::OperationsError> {
     let tol = Tolerance::new();
 
-    // --- Validation ---
-
     if tol.approx_eq(axis_direction.length_squared(), 0.0) {
         return Err(crate::OperationsError::InvalidInput {
             reason: "revolve axis direction is zero-length".into(),
@@ -200,7 +198,6 @@ pub fn revolve(
     let is_full = angle_radians >= 2.0f64.mul_add(PI, -tol.angular);
     let angle = if is_full { 2.0 * PI } else { angle_radians };
 
-    // Read input face.
     let face_data = topo.face(face)?;
     let mut input_normal = match face_data.surface() {
         FaceSurface::Plane { normal, .. } => *normal,
@@ -237,12 +234,8 @@ pub fn revolve(
         }
     }
 
-    // --- Arc segmentation ---
-
     let (num_segs, seg_angle) = arc_segmentation(angle);
     let num_boundaries = if is_full { num_segs } else { num_segs + 1 };
-
-    // --- Revolve a single wire, returning ring data ---
 
     let revolve_wire = |topo: &mut Topology,
                         wire_id: brepkit_topology::wire::WireId|
@@ -278,7 +271,6 @@ pub fn revolve(
             })
             .collect::<Result<_, _>>()?;
 
-        // Create rotated vertices.
         let mut ring_verts: Vec<Vec<VertexId>> = Vec::with_capacity(num_boundaries);
         ring_verts.push(input_verts.clone());
 
@@ -295,7 +287,6 @@ pub fn revolve(
             ring_verts.push(ring);
         }
 
-        // Create arc edges.
         let mut arc_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> = Vec::with_capacity(num_segs);
 
         for seg in 0..num_segs {
@@ -314,7 +305,6 @@ pub fn revolve(
             arc_edges.push(seg_edges);
         }
 
-        // Create ring edges.
         let input_edge_ids: Vec<_> = input_oriented
             .iter()
             .map(brepkit_topology::wire::OrientedEdge::edge)
@@ -343,11 +333,7 @@ pub fn revolve(
         })
     };
 
-    // --- Revolve outer wire ---
-
     let outer = revolve_wire(topo, input_wire_id)?;
-
-    // --- Revolve inner wires ---
 
     let mut inner_data: Vec<WireRevolveData> = Vec::new();
     for &iw_id in &inner_wire_ids {
@@ -362,8 +348,6 @@ pub fn revolve(
                 .map(brepkit_topology::vertex::Vertex::point)
         })
         .collect::<Result<_, _>>()?;
-
-    // --- Build faces ---
 
     let mut all_faces = Vec::new();
 
@@ -549,7 +533,6 @@ pub fn revolve(
         all_faces.push(fid);
     }
 
-    // Assemble shell and solid.
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
     let solid = topo.add_solid(Solid::new(shell_id, vec![]));

--- a/crates/operations/src/section.rs
+++ b/crates/operations/src/section.rs
@@ -70,11 +70,9 @@ pub fn section(
 ) -> Result<Section, crate::OperationsError> {
     let tol = Tolerance::new();
 
-    // Normalize the cutting plane normal.
     let normal = plane_normal.normalize()?;
     let d = dot_normal_point(normal, plane_point);
 
-    // Collect all intersection segments from all shells (outer + inner).
     let solid_data = topo.solid(solid)?;
     let all_shell_ids: Vec<_> = std::iter::once(solid_data.outer_shell())
         .chain(solid_data.inner_shells().iter().copied())
@@ -106,7 +104,6 @@ pub fn section(
                 }
             }
             FaceSurface::Nurbs(nurbs) => {
-                // Use surface-plane intersection to find crossing points.
                 let intersection_curves =
                     brepkit_math::nurbs::intersection::intersect_plane_nurbs(nurbs, normal, d, 50)?;
                 for curve in &intersection_curves {
@@ -159,7 +156,6 @@ pub fn section(
         return Ok(Section { faces: Vec::new() });
     }
 
-    // Assemble segments into closed wires.
     let mut wires = assemble_wires(topo, &segments, normal, d, tol)?;
 
     // Fallback: if crossing-based segments didn't form closed wires,
@@ -333,7 +329,6 @@ fn extract_coplanar_boundary(
     // floating-point precision differences across platforms (e.g. WASM).
     let coplanar_tol = tol.linear * 100.0;
 
-    // Identify coplanar face indices.
     let mut coplanar_faces = Vec::new();
     for &fid in face_ids {
         let verts = face_polygon(topo, fid)?;
@@ -369,7 +364,6 @@ fn extract_coplanar_boundary(
         if qa <= qb { (qa, qb) } else { (qb, qa) }
     };
 
-    // Count edge occurrences and store the actual points.
     let mut edge_counts: HashMap<EdgeKey, (Point3, Point3, usize)> = HashMap::new();
 
     for &fid in &coplanar_faces {
@@ -414,7 +408,6 @@ fn intersect_planar_face_with_plane(
         return None;
     }
 
-    // Classify each vertex relative to the cutting plane.
     let dists: Vec<f64> = verts
         .iter()
         .map(|v| dot_normal_point(cut_normal, *v) - cut_d)
@@ -428,7 +421,6 @@ fn intersect_planar_face_with_plane(
         return None;
     }
 
-    // Collect intersection points where edges cross the plane.
     let mut crossings = Vec::new();
 
     for i in 0..n {
@@ -436,7 +428,6 @@ fn intersect_planar_face_with_plane(
         let di = dists[i];
         let dj = dists[j];
 
-        // Check if vertex is on the plane.
         if di.abs() < tol.linear {
             crossings.push(verts[i]);
             continue;
@@ -456,7 +447,6 @@ fn intersect_planar_face_with_plane(
         }
     }
 
-    // Deduplicate nearby crossings.
     let mut unique = Vec::new();
     for p in &crossings {
         if !unique
@@ -489,7 +479,6 @@ fn assemble_wires(
         return Ok(vec![]);
     }
 
-    // Convert segments to a mutable list for chaining.
     let mut remaining: Vec<(Point3, Point3)> = segments.to_vec();
     let mut wires = Vec::new();
 
@@ -504,18 +493,15 @@ fn assemble_wires(
     let chain_tol = tol.linear * 1000.0;
 
     while !remaining.is_empty() {
-        // Start a new chain with the first remaining segment.
         let first = remaining.remove(0);
         let mut chain: Vec<Point3> = vec![first.0, first.1];
 
-        // Iteratively find the closest segment that connects to the chain end.
         let mut changed = true;
         while changed {
             changed = false;
             let chain_end = chain[chain.len() - 1];
             let threshold_sq = chain_tol * chain_tol;
 
-            // Find the closest matching segment endpoint.
             let mut best_idx = None;
             let mut best_dist = threshold_sq;
             let mut best_forward = true;
@@ -544,7 +530,6 @@ fn assemble_wires(
             }
         }
 
-        // Check if the chain forms a closed loop.
         if chain.len() < 3 {
             continue;
         }
@@ -554,16 +539,13 @@ fn assemble_wires(
         let closed = (start - end).length_squared() < chain_tol * chain_tol;
 
         if !closed {
-            // Not a closed wire — skip (partial section).
             continue;
         }
 
-        // Remove the duplicate closing point if present.
         if chain.len() > 3 {
             chain.pop();
         }
 
-        // Build topology: vertices, edges, wire.
         let n = chain.len();
         let vert_ids: Vec<_> = chain
             .iter()

--- a/crates/operations/src/sew.rs
+++ b/crates/operations/src/sew.rs
@@ -51,7 +51,6 @@ pub fn sew_faces(
         Tolerance::new().linear
     };
 
-    // Phase 1: Snapshot all face geometry.
     let mut face_snapshots: Vec<FaceSnapshot> = Vec::with_capacity(faces.len());
 
     for &fid in faces {
@@ -77,7 +76,6 @@ pub fn sew_faces(
         });
     }
 
-    // Phase 2: Merge coincident vertices using spatial hash.
     let resolution = 1.0 / tol;
     let mut vertex_map: HashMap<(i64, i64, i64), VertexId> = HashMap::new();
 
@@ -93,7 +91,6 @@ pub fn sew_faces(
                 .or_insert_with(|| topo.add_vertex(Vertex::new(p, tol)))
         };
 
-    // Phase 3: Create merged edges and rebuild faces.
     let mut edge_map: HashMap<(usize, usize), EdgeId> = HashMap::new();
     let mut new_face_ids: Vec<FaceId> = Vec::with_capacity(face_snapshots.len());
 
@@ -131,7 +128,6 @@ pub fn sew_faces(
         new_face_ids.push(face_id);
     }
 
-    // Phase 4: Assemble into shell and solid.
     let shell = Shell::new(new_face_ids).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
@@ -248,7 +244,6 @@ mod tests {
 
         let solid = sew_faces(&mut topo, &[f0, f1], 1e-6).unwrap();
 
-        // Count unique edges across both faces.
         let s = topo.solid(solid).unwrap();
         let sh = topo.shell(s.outer_shell()).unwrap();
 
@@ -274,7 +269,6 @@ mod tests {
     fn sew_six_cube_faces() {
         let mut topo = Topology::new();
 
-        // Create 6 loose faces of a unit cube.
         let bottom = make_loose_quad(
             &mut topo,
             Point3::new(0.0, 0.0, 0.0),

--- a/crates/operations/src/shell_op.rs
+++ b/crates/operations/src/shell_op.rs
@@ -150,7 +150,6 @@ pub fn shell(
 
     let open_set: HashSet<usize> = open_faces.iter().map(|f| f.index()).collect();
 
-    // Validate open_faces belong to the solid.
     let solid_face_set: HashSet<usize> = all_face_ids.iter().map(|f| f.index()).collect();
     for &of in open_faces {
         if !solid_face_set.contains(&of.index()) {
@@ -184,7 +183,6 @@ pub fn shell(
         )
     };
 
-    // Collect (normal, is_open) for each face at each vertex.
     let mut vertex_normals: HashMap<(i64, i64, i64), Vec<(Vec3, bool)>> = HashMap::new();
 
     for &(fid, ref verts) in &face_verts {
@@ -257,8 +255,7 @@ pub fn shell(
         inner_pos.insert(key, inner);
     }
 
-    // ─── Phase 3: Outer faces (non-open, kept as-is) ──────────────────────
-
+    // Outer faces: the non-open faces kept as-is.
     for &(fid, ref verts) in &face_verts {
         if open_set.contains(&fid.index()) {
             continue;
@@ -320,7 +317,7 @@ pub fn shell(
         }
         let face = topo.face(fid)?;
 
-        // Map outer vertices to inner positions (reversed winding for inward normal).
+        // Reversed winding gives the inner face an inward-pointing normal.
         let inner_verts: Vec<Point3> = outer_verts
             .iter()
             .map(|v| inner_pos.get(&quantize_pt(*v)).copied().unwrap_or(*v))
@@ -433,7 +430,6 @@ pub fn shell(
 
     let solid = assemble_solid_mixed(topo, &result_specs, tol)?;
 
-    // Find boundary edges (edges used by exactly 1 face).
     let edge_face_map = brepkit_topology::explorer::edge_to_face_map(topo, solid)?;
     let mut boundary_edge_ids: Vec<brepkit_topology::edge::EdgeId> = Vec::new();
     for (&edge_idx, faces) in &edge_face_map {
@@ -455,12 +451,10 @@ pub fn shell(
     for &eid in &boundary_edge_ids {
         let face_id = edge_face_map[&eid.index()][0];
         let face = topo.face(face_id)?;
-        // Find orientation of this edge in its face's wire.
         let wire = topo.wire(face.outer_wire())?;
         let mut found = false;
         for oe in wire.edges() {
             if oe.edge() == eid {
-                // Rim face uses opposite orientation.
                 boundary_oriented.push(brepkit_topology::wire::OrientedEdge::new(
                     eid,
                     !oe.is_forward(),
@@ -470,7 +464,6 @@ pub fn shell(
             }
         }
         if !found {
-            // Check inner wires too.
             for &iw_id in face.inner_wires() {
                 let iw = topo.wire(iw_id)?;
                 for oe in iw.edges() {
@@ -494,7 +487,6 @@ pub fn shell(
         }
     }
 
-    // Sort boundary edges into connected loops.
     let loops = sort_edges_into_loops(topo, &boundary_oriented)?;
 
     if loops.len() < 2 {
@@ -504,7 +496,6 @@ pub fn shell(
     }
 
     // Classify loops: the outer loop has larger average distance from centroid.
-    // Compute centroid of all boundary vertices.
     let mut centroid = Vec3::new(0.0, 0.0, 0.0);
     let mut vert_count = 0.0;
     let mut rim_z = 0.0_f64;
@@ -520,7 +511,6 @@ pub fn shell(
         rim_z /= vert_count;
     }
 
-    // Compute average radial distance for each loop.
     let mut loop_radii: Vec<(usize, f64)> = Vec::new();
     for (i, lp) in loops.iter().enumerate() {
         let mut avg_r = 0.0;
@@ -586,7 +576,6 @@ pub fn shell(
     );
     let rim_face_id = topo.add_face(rim_face);
 
-    // Add the rim face to the shell.
     let solid_data = topo.solid(solid)?;
     let shell_id = solid_data.outer_shell();
     let shell = topo.shell(shell_id)?;
@@ -613,7 +602,6 @@ fn sort_edges_into_loops(
         return Ok(Vec::new());
     }
 
-    // Build start_vertex → edge index map.
     let mut start_map: HashMap<usize, Vec<usize>> = HashMap::new();
     let mut edge_endpoints: Vec<(VertexId, VertexId)> = Vec::new();
     for (i, oe) in edges.iter().enumerate() {
@@ -647,7 +635,6 @@ fn sort_edges_into_loops(
                 break; // Loop closed.
             }
 
-            // Find next edge starting at end_vid.
             let mut found = false;
             if let Some(candidates) = start_map.get(&end_vid) {
                 for &idx in candidates {
@@ -711,7 +698,6 @@ mod tests {
         let mut topo = Topology::new();
         let cube = make_unit_cube_manifold(&mut topo);
 
-        // Shell with no open faces: creates a solid shell.
         let result = shell(&mut topo, cube, 0.1, &[]).unwrap();
 
         let s = topo.solid(result).unwrap();
@@ -726,7 +712,6 @@ mod tests {
         let mut topo = Topology::new();
         let cube = make_unit_cube_manifold(&mut topo);
 
-        // Find the top face (+Z normal).
         let top_faces = find_faces_by_normal(&topo, cube, Vec3::new(0.0, 0.0, 1.0));
         assert_eq!(top_faces.len(), 1, "should find exactly one +Z face");
 
@@ -785,7 +770,6 @@ mod tests {
         let mut topo = Topology::new();
         let cube = make_unit_cube_manifold(&mut topo);
 
-        // Find both +Z and -Z faces
         let top = find_faces_by_normal(&topo, cube, Vec3::new(0.0, 0.0, 1.0));
         let bot = find_faces_by_normal(&topo, cube, Vec3::new(0.0, 0.0, -1.0));
         let mut open_faces = top;
@@ -820,7 +804,6 @@ mod tests {
         // Use a simple box (no rounded corners) to isolate shell behavior.
         let box_solid = make_box(&mut topo, w, d, h).unwrap();
 
-        // Count faces after extrude.
         let box_shell_data = topo
             .shell(topo.solid(box_solid).unwrap().outer_shell())
             .unwrap();
@@ -828,7 +811,6 @@ mod tests {
         eprintln!("[diag] Box extrude face count: {extrude_face_count}");
         assert_eq!(extrude_face_count, 6);
 
-        // Find top face and shell.
         let top_faces = find_faces_by_normal(&topo, box_solid, Vec3::new(0.0, 0.0, 1.0));
         assert_eq!(top_faces.len(), 1, "should find exactly one top face");
 
@@ -841,7 +823,6 @@ mod tests {
         // 5 outer + 5 inner + 1 annular rim = 11
         assert_eq!(shell_face_count, 11, "box shell should have 11 faces");
 
-        // Verify original box volume first.
         let box_vol = crate::measure::solid_volume(&topo, box_solid, 0.01).unwrap();
         let expected_box_vol = w * d * h;
         eprintln!("[diag] Box volume: {box_vol:.2}, expected: {expected_box_vol:.2}");
@@ -852,7 +833,6 @@ mod tests {
         let pct = (vol - expected_vol).abs() / expected_vol;
         eprintln!("[diag] Shell volume: {vol:.2}, expected: {expected_vol:.2}, diff: {pct:.4}");
 
-        // Also count face surface types.
         for &fid in sh.faces() {
             let f = topo.face(fid).unwrap();
             let kind = match f.surface() {
@@ -989,7 +969,6 @@ mod tests {
         let result = crate::validate::validate_solid(&topo, shelled);
         eprintln!("[gf-exact] Validation: {result:?}");
 
-        // After unify_faces
         let removed = crate::heal::unify_faces(&mut topo, shelled).unwrap();
         let sh3 = topo
             .shell(topo.solid(shelled).unwrap().outer_shell())
@@ -1086,11 +1065,9 @@ mod tests {
         let face = Face::new(wire_id, vec![], FaceSurface::Plane { normal, d: 0.0 });
         let face_id = topo.add_face(face);
 
-        // Extrude up.
         let solid =
             crate::extrude::extrude(&mut topo, face_id, Vec3::new(0.0, 0.0, 1.0), h).unwrap();
 
-        // Count faces after extrude.
         let sh = topo
             .shell(topo.solid(solid).unwrap().outer_shell())
             .unwrap();
@@ -1099,7 +1076,6 @@ mod tests {
         // Expected: 2 caps + 8 sides (4 planar + 4 cylindrical) = 10
         assert_eq!(extrude_fc, 10, "extruded rounded rect should have 10 faces");
 
-        // Count face types.
         let mut plane_count = 0;
         let mut cyl_count = 0;
         for &fid in sh.faces() {
@@ -1114,7 +1090,6 @@ mod tests {
         assert_eq!(plane_count, 6, "4 flat sides + 2 caps = 6 planar");
         assert_eq!(cyl_count, 4, "4 corner cylinders");
 
-        // Volume check after extrude (before shell).
         // Expected: A = w*d - 4*r^2*(1-pi/4), V = A*h
         let expected_area = w * d - 4.0 * r * r * (1.0 - std::f64::consts::FRAC_PI_4);
         let expected_vol = expected_area * h;
@@ -1129,7 +1104,6 @@ mod tests {
             "extrude volume error {rel_err:.6} exceeds 0.1%"
         );
 
-        // Find top face(s) and shell.
         let top = find_faces_by_normal(&topo, solid, Vec3::new(0.0, 0.0, 1.0));
         assert_eq!(top.len(), 1, "one top face");
 
@@ -1140,7 +1114,6 @@ mod tests {
         let shell_fc = sh2.faces().len();
         eprintln!("[rounded] Shell faces: {shell_fc}");
 
-        // Count surface types in shell.
         let mut sp = 0;
         let mut sc = 0;
         for &fid in sh2.faces() {
@@ -1164,7 +1137,6 @@ mod tests {
         }
         eprintln!("[rounded] Shell: {sp} planar, {sc} cylinder");
 
-        // Diagnostic: inspect the rim face (last face) in detail.
         {
             let rim_fid = *sh2.faces().last().unwrap();
             let rim_f = topo.face(rim_fid).unwrap();
@@ -1221,7 +1193,6 @@ mod tests {
             }
         }
 
-        // Check face reversal state.
         for &fid in sh2.faces() {
             let f = topo.face(fid).unwrap();
             let kind = match f.surface() {
@@ -1237,7 +1208,6 @@ mod tests {
         let vol = crate::measure::solid_volume(&topo, shelled, 0.01).unwrap();
         eprintln!("[rounded] Shell volume: {vol:.2}");
 
-        // Check Euler characteristic.
         let result = crate::validate::validate_solid(&topo, shelled);
         eprintln!("[rounded] Validation: {result:?}");
     }
@@ -1330,11 +1300,9 @@ mod tests {
         );
         let face_id = topo.add_face(face);
 
-        // Extrude upward
         let solid =
             crate::extrude::extrude(&mut topo, face_id, Vec3::new(0.0, 0.0, 1.0), h).unwrap();
 
-        // Shell: remove top face
         let top = find_faces_by_normal(&topo, solid, Vec3::new(0.0, 0.0, 1.0));
         assert_eq!(top.len(), 1, "one top face");
 

--- a/crates/operations/src/sketch.rs
+++ b/crates/operations/src/sketch.rs
@@ -115,7 +115,6 @@ impl Sketch {
     ) -> Result<SolveResult, SketchError> {
         let mut sys = GcsSystem::new();
 
-        // Add points
         let point_ids: Vec<PointId> = self
             .points
             .iter()
@@ -146,7 +145,6 @@ impl Sketch {
             Ok(lid)
         };
 
-        // Convert constraints
         for c in &self.constraints {
             match c {
                 Constraint::Coincident(a, b) => {
@@ -189,7 +187,6 @@ impl Sketch {
 
         let result = sys.solve(max_iterations, tolerance)?;
 
-        // Write solved positions back
         for (i, pid) in point_ids.iter().enumerate() {
             if let Some(data) = sys.point(*pid) {
                 self.points[i].x = data.x;

--- a/crates/operations/src/split.rs
+++ b/crates/operations/src/split.rs
@@ -48,7 +48,6 @@ pub fn split(
     let normal = plane_normal.normalize()?;
     let d = dot_normal_point(normal, plane_point);
 
-    // Collect face data.
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
     let face_ids: Vec<brepkit_topology::face::FaceId> = shell.faces().to_vec();
@@ -66,7 +65,6 @@ pub fn split(
             .map(|v| dot_normal_point(normal, *v) - d)
             .collect();
 
-        // Classify: all positive, all negative, or mixed.
         let all_pos = dists.iter().all(|&di| di > -tol.linear);
         let all_neg = dists.iter().all(|&di| di < tol.linear);
 
@@ -122,7 +120,6 @@ pub fn split(
         });
     }
 
-    // Build cap faces from crossing points.
     let cap = build_cap_polygon(&cap_points, normal, d, tol);
 
     if let Some((cap_verts, cap_normal, cap_d)) = cap {
@@ -167,7 +164,6 @@ fn clip_polygon(
         let di = dists[i];
         let dj = dists[j];
 
-        // Classify current vertex.
         if di >= -tol.linear {
             pos_verts.push(verts[i]);
         }
@@ -175,7 +171,6 @@ fn clip_polygon(
             neg_verts.push(verts[i]);
         }
 
-        // Check for edge crossing.
         if (di > tol.linear && dj < -tol.linear) || (di < -tol.linear && dj > tol.linear) {
             let t = di / (di - dj);
             let pi = verts[i];
@@ -203,7 +198,6 @@ fn build_cap_polygon(
     d: f64,
     tol: Tolerance,
 ) -> Option<(Vec<Point3>, Vec3, f64)> {
-    // Deduplicate points.
     let mut unique = Vec::new();
     for p in points {
         if !unique
@@ -218,7 +212,6 @@ fn build_cap_polygon(
         return None;
     }
 
-    // Compute centroid.
     #[allow(clippy::cast_precision_loss)]
     let inv_n = 1.0 / unique.len() as f64;
     let (cx, cy, cz) = unique.iter().fold((0.0, 0.0, 0.0), |(ax, ay, az), p| {
@@ -226,7 +219,6 @@ fn build_cap_polygon(
     });
     let centroid = Point3::new(cx * inv_n, cy * inv_n, cz * inv_n);
 
-    // Build a local 2D coordinate system on the plane.
     let candidate = if normal.x().abs() < 0.9 {
         Vec3::new(1.0, 0.0, 0.0)
     } else {
@@ -240,7 +232,6 @@ fn build_cap_polygon(
     let u_axis = Vec3::new(u_axis.x() / u_len, u_axis.y() / u_len, u_axis.z() / u_len);
     let v_axis = normal.cross(u_axis);
 
-    // Sort points by angle around centroid.
     let mut angles: Vec<(f64, usize)> = unique
         .iter()
         .enumerate()
@@ -282,7 +273,6 @@ mod tests {
         )
         .unwrap();
 
-        // Each half should have positive volume.
         let vol_pos = crate::measure::solid_volume(&topo, result.positive, 0.1).unwrap();
         let vol_neg = crate::measure::solid_volume(&topo, result.negative, 0.1).unwrap();
 
@@ -295,7 +285,6 @@ mod tests {
             "negative half should have volume, got {vol_neg}"
         );
 
-        // Together they should approximately equal the original volume.
         let tol = Tolerance::loose();
         let total = vol_pos + vol_neg;
         assert!(

--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -198,7 +198,6 @@ fn sweep_wire_through_frames(
         })
         .collect::<Result<_, _>>()?;
 
-    // Create ring vertices by transforming through frames.
     let mut ring_verts: Vec<Vec<VertexId>> = Vec::with_capacity(num_segments + 1);
     for frame in frames {
         let ring: Vec<VertexId> = positions
@@ -223,7 +222,6 @@ fn sweep_wire_through_frames(
         ring_verts.push(ring_verts[0].clone());
     }
 
-    // Create ring edges (profile edges within each ring).
     let real_ring_count = if is_closed {
         ring_verts.len() - 1
     } else {
@@ -244,7 +242,6 @@ fn sweep_wire_through_frames(
         ring_edges.push(ring_edges[0].clone());
     }
 
-    // Create path edges (between consecutive rings).
     let mut path_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> = Vec::with_capacity(num_segments);
     for seg in 0..num_segments {
         let edges: Vec<_> = (0..n)
@@ -363,8 +360,6 @@ pub fn sweep(
 ) -> Result<SolidId, crate::OperationsError> {
     let tol = Tolerance::new();
 
-    // --- Validation ---
-
     if path.control_points().len() < 2 {
         return Err(crate::OperationsError::InvalidInput {
             reason: "sweep path must have at least 2 control points".into(),
@@ -383,7 +378,6 @@ pub fn sweep(
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids: Vec<brepkit_topology::wire::WireId> = face_data.inner_wires().to_vec();
 
-    // Detect closed vs degenerate paths.
     let start_end_coincide = tol.approx_eq(
         (path.evaluate(1.0) - path.evaluate(0.0)).length_squared(),
         0.0,
@@ -403,7 +397,6 @@ pub fn sweep(
         false
     };
 
-    // Collect profile vertices and positions.
     let input_wire = topo.wire(input_wire_id)?;
     let original_oriented: Vec<_> = input_wire.edges().to_vec();
 
@@ -448,10 +441,7 @@ pub fn sweep(
         input_normal = -input_normal;
     }
 
-    // Compute profile centroid.
     let centroid = crate::winding::polygon_centroid(&input_positions);
-
-    // --- Compute frames along the path ---
 
     let num_segments = (path.control_points().len() * 2).max(4);
 
@@ -467,12 +457,9 @@ pub fn sweep(
     let initial_up = frames[0].up;
     let initial_tangent = frames[0].tangent;
 
-    // --- Create ring vertices ---
-    //
     // ring_verts[k][i] = vertex at path sample k, profile vertex i.
     // For closed paths, frames has num_segments entries; we append a copy
     // of the first ring so indexing ring_verts[num_segments] works unchanged.
-
     let mut ring_verts: Vec<Vec<VertexId>> = Vec::with_capacity(num_segments + 1);
 
     for frame in &frames {
@@ -499,10 +486,7 @@ pub fn sweep(
         ring_verts.push(ring_verts[0].clone());
     }
 
-    // --- Create profile edges within each ring ---
-    //
     // ring_edges[k][i] = edge from ring_verts[k][i] to ring_verts[k][(i+1)%n].
-
     let real_ring_count = if is_closed {
         num_segments
     } else {
@@ -524,10 +508,7 @@ pub fn sweep(
         ring_edges.push(ring_edges[0].clone());
     }
 
-    // --- Create path edges between consecutive rings ---
-    //
     // path_edges[seg][i] = edge from ring_verts[seg][i] to ring_verts[seg+1][i].
-
     let mut path_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> = Vec::with_capacity(num_segments);
     for seg in 0..num_segments {
         let edges: Vec<_> = (0..n)
@@ -541,8 +522,6 @@ pub fn sweep(
             .collect();
         path_edges.push(edges);
     }
-
-    // --- Sweep inner wires ---
 
     let mut inner_swept: Vec<SweptWireData> = Vec::new();
     for &iw_id in &inner_wire_ids {
@@ -558,8 +537,6 @@ pub fn sweep(
             is_closed,
         )?);
     }
-
-    // --- Build faces ---
 
     let mut all_faces = Vec::with_capacity(num_segments * n + if is_closed { 0 } else { 2 });
 
@@ -594,7 +571,6 @@ pub fn sweep(
         for i in 0..n {
             let next_i = (i + 1) % n;
 
-            // Compute side normal from edge direction and path direction.
             let p0 = topo.vertex(ring_verts[seg][i])?.point();
             let p1 = topo.vertex(ring_verts[seg][next_i])?.point();
             let p_next = topo.vertex(ring_verts[seg + 1][i])?.point();
@@ -630,7 +606,6 @@ pub fn sweep(
         }
     }
 
-    // Inner side faces.
     for iwd in &inner_swept {
         let inner_faces = build_inner_side_faces(topo, iwd, num_segments)?;
         all_faces.extend(inner_faces);
@@ -661,7 +636,6 @@ pub fn sweep(
         all_faces.push(end_face);
     }
 
-    // Assemble shell and solid.
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
     let solid = topo.add_solid(Solid::new(shell_id, vec![]));
@@ -729,7 +703,6 @@ pub fn sweep_smooth(
         false
     };
 
-    // Collect profile vertices.
     let input_wire = topo.wire(input_wire_id)?;
     let original_oriented: Vec<_> = input_wire.edges().to_vec();
 
@@ -768,7 +741,6 @@ pub fn sweep_smooth(
         input_normal = -input_normal;
     }
 
-    // Compute centroid and frames.
     let centroid = crate::winding::polygon_centroid(&input_positions);
 
     let num_segments = (path.control_points().len() * 2).max(4);
@@ -817,7 +789,6 @@ pub fn sweep_smooth(
         .map(|&p| topo.add_vertex(Vertex::new(p, tol.linear)))
         .collect();
 
-    // Create profile edges for first and last rings.
     let first_ring_edges: Vec<_> = (0..n)
         .map(|i| {
             let next = (i + 1) % n;
@@ -831,7 +802,6 @@ pub fn sweep_smooth(
         })
         .collect();
 
-    // Sweep inner wires for smooth variant.
     let mut inner_swept_smooth: Vec<SweptWireData> = Vec::new();
     for &iw_id in &inner_wire_ids_smooth {
         inner_swept_smooth.push(sweep_wire_through_frames(
@@ -849,7 +819,6 @@ pub fn sweep_smooth(
 
     let mut all_faces = Vec::with_capacity(n + 2);
 
-    // Start cap with inner wire holes.
     let start_reversed: Vec<OrientedEdge> = (0..n)
         .rev()
         .map(|i| OrientedEdge::new(first_ring_edges[i], false))
@@ -883,7 +852,6 @@ pub fn sweep_smooth(
         let surface =
             interpolate_surface(&grid, degree_u, degree_v).map_err(crate::OperationsError::Math)?;
 
-        // Rail edges from first to last ring.
         let e_left_rail = topo.add_edge(Edge::new(first_ring[i], last_ring[i], EdgeCurve::Line));
         let e_right_rail = topo.add_edge(Edge::new(
             first_ring[next_i],
@@ -906,13 +874,11 @@ pub fn sweep_smooth(
         all_faces.push(topo.add_face(Face::new(side_wire_id, vec![], FaceSurface::Nurbs(surface))));
     }
 
-    // Inner side faces for smooth variant.
     for iwd in &inner_swept_smooth {
         let inner_faces = build_inner_side_faces(topo, iwd, num_segments)?;
         all_faces.extend(inner_faces);
     }
 
-    // End cap with inner wire holes.
     let end_edges: Vec<OrientedEdge> = (0..n)
         .map(|i| OrientedEdge::new(last_ring_edges[i], true))
         .collect();
@@ -1192,7 +1158,6 @@ pub fn sweep_with_options(
     let initial_up = frames[0].up;
     let initial_tangent = frames[0].tangent;
 
-    // Create ring vertices with optional scaling
     let mut ring_verts: Vec<Vec<VertexId>> = Vec::with_capacity(num_segments + 1);
 
     for (k, frame) in frames.iter().enumerate() {
@@ -1250,8 +1215,7 @@ pub fn sweep_with_options(
         path_edges.push(edges);
     }
 
-    // Sweep inner wires for options variant.
-    // Note: closed paths are delegated to sweep() earlier, so is_closed is always false here.
+    // Closed paths are delegated to sweep() earlier, so is_closed is always false here.
     let mut inner_swept_opts: Vec<SweptWireData> = Vec::new();
     for &iw_id in &inner_wire_ids_opts {
         inner_swept_opts.push(sweep_wire_through_frames(
@@ -1269,7 +1233,6 @@ pub fn sweep_with_options(
 
     let mut all_faces = Vec::with_capacity(num_segments * n + 2);
 
-    // Start cap with inner wire holes.
     let start_reversed_edges: Vec<OrientedEdge> = (0..n)
         .rev()
         .map(|i| OrientedEdge::new(ring_edges[0][i], false))
@@ -1290,7 +1253,6 @@ pub fn sweep_with_options(
     ));
     all_faces.push(start_face);
 
-    // Side faces
     for seg in 0..num_segments {
         for i in 0..n {
             let next_i = (i + 1) % n;
@@ -1329,13 +1291,11 @@ pub fn sweep_with_options(
         }
     }
 
-    // Inner side faces for options variant.
     for iwd in &inner_swept_opts {
         let inner_faces = build_inner_side_faces(topo, iwd, num_segments)?;
         all_faces.extend(inner_faces);
     }
 
-    // End cap with inner wire holes.
     let end_edges: Vec<OrientedEdge> = (0..n)
         .map(|i| OrientedEdge::new(ring_edges[num_segments][i], true))
         .collect();
@@ -1380,19 +1340,16 @@ fn detect_kinks(path: &NurbsCurve) -> Vec<f64> {
     let knots = path.knots();
     let (u_min, u_max) = path.domain();
 
-    // Collect unique internal knot values and their multiplicities.
     let mut kinks = Vec::new();
     let mut i = 0;
     while i < knots.len() {
         let u = knots[i];
 
-        // Skip endpoint knots.
         if u <= u_min + KNOT_EPS || u >= u_max - KNOT_EPS {
             i += 1;
             continue;
         }
 
-        // Count multiplicity.
         let mut mult = 1;
         while i + mult < knots.len() && (knots[i + mult] - u).abs() < KNOT_EPS {
             mult += 1;
@@ -1452,7 +1409,6 @@ fn sweep_miter(
         "sweep_miter should only be called when the path has kinks"
     );
 
-    // Validate profile.
     let face_data = topo.face(profile)?;
     let mut input_normal = match face_data.surface() {
         FaceSurface::Plane { normal, .. } => *normal,
@@ -1465,7 +1421,6 @@ fn sweep_miter(
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids: Vec<brepkit_topology::wire::WireId> = face_data.inner_wires().to_vec();
 
-    // Collect and prepare profile vertices.
     let input_wire = topo.wire(input_wire_id)?;
     let original_oriented: Vec<_> = input_wire.edges().to_vec();
     if original_oriented.is_empty() {
@@ -1521,8 +1476,6 @@ fn sweep_miter(
     }
     sub_paths.push(remaining);
 
-    // For each sub-path, compute frames and build the ring vertices.
-    // We'll collect all faces across all segments plus miter faces.
     let mut all_faces: Vec<FaceId> = Vec::new();
 
     // Track the ring vertices at the end of each segment / start of the next
@@ -1534,7 +1487,6 @@ fn sweep_miter(
         let is_first = seg_idx == 0;
         let is_last = seg_idx == sub_paths.len() - 1;
 
-        // Compute the tangent at the start of this sub-path.
         let sub_tangent_0 = sub_path.tangent(sub_path.domain().0)?;
         let up_hint = orthogonalize(input_normal, sub_tangent_0);
 
@@ -1544,7 +1496,6 @@ fn sweep_miter(
             (sub_path.control_points().len() * 2).max(4)
         };
 
-        // Compute frames for this sub-path.
         let sub_frames = match options.contact_mode {
             SweepContactMode::RotationMinimizing => {
                 compute_frames(sub_path, num_segments, up_hint, false)?
@@ -1667,7 +1618,6 @@ fn sweep_miter(
                 })
                 .collect();
 
-            // Create miter ring edges.
             let miter_ring_edges: Vec<brepkit_topology::edge::EdgeId> = (0..n)
                 .map(|i| {
                     let next = (i + 1) % n;
@@ -1683,7 +1633,6 @@ fn sweep_miter(
                 }
             })?;
 
-            // Side faces connecting prev_end_ring to miter_ring.
             let prev_to_miter_path_edges: Vec<brepkit_topology::edge::EdgeId> = (0..n)
                 .map(|i| topo.add_edge(Edge::new(prev_ring[i], miter_ring[i], EdgeCurve::Line)))
                 .collect();
@@ -1761,7 +1710,6 @@ fn sweep_miter(
             }
         }
 
-        // Create path edges.
         let mut path_edges: Vec<Vec<brepkit_topology::edge::EdgeId>> =
             Vec::with_capacity(num_segments);
         for seg in 0..num_segments {
@@ -1777,7 +1725,6 @@ fn sweep_miter(
             path_edges.push(edges);
         }
 
-        // Sweep inner wires for this segment.
         let mut inner_swept: Vec<SweptWireData> = Vec::new();
         for &iw_id in &inner_wire_ids {
             inner_swept.push(sweep_wire_through_frames(
@@ -1816,7 +1763,6 @@ fn sweep_miter(
             )));
         }
 
-        // Side faces.
         for seg in 0..num_segments {
             for i in 0..n {
                 let next_i = (i + 1) % n;
@@ -1854,7 +1800,6 @@ fn sweep_miter(
             }
         }
 
-        // Inner side faces.
         for iwd in &inner_swept {
             let inner_faces = build_inner_side_faces(topo, iwd, num_segments)?;
             all_faces.extend(inner_faces);
@@ -1889,7 +1834,6 @@ fn sweep_miter(
         prev_end_ring_edges = Some(ring_edges[num_segments].clone());
     }
 
-    // Assemble shell and solid.
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
     Ok(topo.add_solid(Solid::new(shell_id, vec![])))
@@ -2507,7 +2451,6 @@ mod tests {
         let face = crate::primitives::make_box(&mut topo, 0.5, 0.5, 0.01).unwrap();
         let solid = topo.solid(face).unwrap();
         let shell = topo.shell(solid.outer_shell()).unwrap();
-        // Use a face from the box as profile
         let profile = shell.faces()[0];
 
         let path = NurbsCurve::new(
@@ -2544,7 +2487,6 @@ mod tests {
 
         let result = sweep_with_options(&mut topo, profile, &path, &options).unwrap();
 
-        // The result should be a tapered solid
         let vol = crate::measure::solid_volume(&topo, result, 0.5).unwrap();
         assert!(vol > 0.0, "tapered sweep should have positive volume");
     }

--- a/crates/operations/src/tessellate/edge_sampling.rs
+++ b/crates/operations/src/tessellate/edge_sampling.rs
@@ -421,7 +421,6 @@ pub(super) fn sample_wire_positions(
         }
     }
 
-    // Remove closing duplicate.
     if positions.len() > 2 {
         if let (Some(first), Some(last)) = (positions.first(), positions.last()) {
             if (*last - *first).length() < tol {

--- a/crates/operations/src/tessellate/face.rs
+++ b/crates/operations/src/tessellate/face.rs
@@ -57,7 +57,6 @@ pub fn tessellate_with_uvs_a(
     let mut result = match face_data.surface() {
         FaceSurface::Plane { normal, .. } => {
             let mesh = tessellate_planar(topo, face_data, *normal, deflection, angular_tol)?;
-            // For planar faces, project onto plane axes to get UVs.
             let (u_axis, v_axis) = plane_axes(*normal);
             let origin = if mesh.positions.is_empty() {
                 brepkit_math::vec::Point3::new(0.0, 0.0, 0.0)

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -362,7 +362,6 @@ pub(super) fn weld_boundary_vertices(
         return;
     }
 
-    // Build half-edge set to find boundary edges.
     let mut half_edges: DetHashMap<(u32, u32), usize> = DetHashMap::default();
     for tri in mesh.indices.chunks_exact(3) {
         let (i0, i1, i2) = (tri[0], tri[1], tri[2]);

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -40,7 +40,6 @@ pub(super) fn tessellate_revolution_band_shared(
         return Ok(false);
     }
 
-    // Angle (u) projection and outward-normal closures for the surface.
     let (project, surf_normal): (ProjectFn, NormalFn) = match face_data.surface() {
         FaceSurface::Cylinder(c) => {
             let (c1, c2) = (c.clone(), c.clone());
@@ -171,7 +170,6 @@ pub(super) fn tessellate_nonplanar_cdt(
     use brepkit_math::vec::Point2;
     use brepkit_topology::edge::EdgeId;
 
-    // Step 1: Collect boundary points in wire-traversal order with global IDs.
     let wire = topo.wire(face_data.outer_wire())?;
     let tol_dup = 1e-10;
 
@@ -228,7 +226,6 @@ pub(super) fn tessellate_nonplanar_cdt(
         }
     }
 
-    // Remove closing duplicate.
     if boundary_3d.len() > 2 {
         if let (Some(&(_, first_gid, _, _)), Some(&(_, last_gid, _, _))) =
             (boundary_3d.first(), boundary_3d.last())
@@ -250,18 +247,15 @@ pub(super) fn tessellate_nonplanar_cdt(
         });
     }
 
-    // Step 2: Project boundary 3D points to (u,v) parameter space.
     let mut boundary_uv: Vec<(f64, f64)> = boundary_3d
         .iter()
         .map(|(pt, _, edge_id_local, _)| {
-            // Try PCurve lookup first.
             if let Some(pcurve) = topo.pcurves().get(*edge_id_local, face_id) {
                 let uv = project_via_pcurve(pcurve, *pt, face_data.surface());
                 if let Some(uv) = uv {
                     return Ok(uv);
                 }
             }
-            // Fall back to surface projection.
             project_to_surface_uv(face_data.surface(), *pt)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -412,7 +406,6 @@ pub(super) fn tessellate_nonplanar_cdt(
     );
     let mut cdt = Cdt::with_capacity(bounds, n_boundary);
 
-    // Step 3: Insert boundary points into CDT.
     let mut cdt_to_global: Vec<Option<u32>> = vec![None; 3]; // 3 super-triangle verts
 
     let boundary_pts: Vec<Point2> = boundary_uv
@@ -430,7 +423,6 @@ pub(super) fn tessellate_nonplanar_cdt(
         cdt_to_global[cdt_idx] = Some(boundary_3d[i].1);
     }
 
-    // Step 4: Insert boundary constraints.
     for i in 0..n_boundary {
         let v0 = boundary_cdt_ids[i];
         let v1 = boundary_cdt_ids[(i + 1) % n_boundary];
@@ -438,7 +430,6 @@ pub(super) fn tessellate_nonplanar_cdt(
             .map_err(crate::OperationsError::Math)?;
     }
 
-    // Step 5: Generate interior sample points.
     let du = u_max - u_min;
     let dv = v_max - v_min;
     if du > 1e-15 && dv > 1e-15 {
@@ -467,13 +458,11 @@ pub(super) fn tessellate_nonplanar_cdt(
         }
     }
 
-    // Step 6: Remove triangles outside the boundary polygon.
     let boundary_pairs: Vec<(usize, usize)> = (0..n_boundary)
         .map(|i| (boundary_cdt_ids[i], boundary_cdt_ids[(i + 1) % n_boundary]))
         .collect();
     cdt.remove_exterior(&boundary_pairs);
 
-    // Step 7: Assign global IDs to interior CDT vertices and emit triangles.
     let cdt_verts = cdt.vertices();
     let triangles = cdt.triangles();
 
@@ -499,7 +488,6 @@ pub(super) fn tessellate_nonplanar_cdt(
         }
     }
 
-    // Emit triangles.
     for (i0, i1, i2) in triangles {
         if i0 < 3 || i1 < 3 || i2 < 3 {
             continue; // Skip super-triangle vertices
@@ -694,7 +682,6 @@ pub(super) fn tessellate_nonplanar_snap(
 
     let mut local_to_global: Vec<u32> = Vec::with_capacity(face_mesh.positions.len());
 
-    // Collect all edge points for this face to use as snap targets.
     let wire = topo.wire(face_data.outer_wire())?;
     let mut snap_targets: Vec<(Point3, u32)> = Vec::new();
     for oe in wire.edges() {

--- a/crates/operations/src/tessellate/planar.rs
+++ b/crates/operations/src/tessellate/planar.rs
@@ -31,7 +31,6 @@ pub(super) fn tessellate_analytic_with_boundary(
     // a common reversal pass for all face types after this function returns.
     let wire = topo.wire(face_data.outer_wire())?;
 
-    // Collect boundary vertices in order, projecting to UV with seam unwrapping.
     let mut uv_pts: Vec<(f64, f64)> = Vec::new();
     let mut positions_3d: Vec<Point3> = Vec::new();
 
@@ -75,7 +74,6 @@ pub(super) fn tessellate_analytic_with_boundary(
         }
     }
 
-    // CDT-triangulate the UV boundary polygon.
     let uv_p2: Vec<brepkit_math::vec::Point2> = uv_pts
         .iter()
         .map(|&(u, v)| brepkit_math::vec::Point2::new(u, v))
@@ -108,13 +106,11 @@ pub(super) fn tessellate_analytic_with_boundary(
         }
     }
 
-    // Remove exterior triangles.
     cdt.remove_exterior(&boundary_segs);
 
     let tris = cdt.triangles();
     let cdt_verts = cdt.vertices();
 
-    // Build mesh: compute 3D positions on the cylinder surface.
     let mut positions = Vec::with_capacity(cdt_verts.len());
     let mut normals_out = Vec::with_capacity(cdt_verts.len());
     let mut uvs = Vec::with_capacity(cdt_verts.len());
@@ -183,7 +179,6 @@ pub(super) fn tessellate_analytic(
     let u_periodic = (u_range.1 - u_range.0 - std::f64::consts::TAU).abs()
         < brepkit_math::tolerance::Tolerance::new().linear;
 
-    // Build (nu+1) x (nv+1) vertex grid.
     let mut grid = vec![0u32; (nu + 1) * (nv + 1)];
     for iv in 0..=nv {
         let v = v_range.0 + (v_range.1 - v_range.0) * (iv as f64) / (nv as f64);
@@ -437,7 +432,6 @@ pub(super) fn tessellate_planar(
             indices,
         })
     } else {
-        // CDT path for faces with holes.
         tessellate_planar_with_holes(topo, face_data, &positions, normal, deflection, angular_tol)
     }
 }
@@ -492,7 +486,6 @@ fn tessellate_planar_with_holes(
     use brepkit_math::cdt::Cdt;
     use brepkit_math::vec::Point2;
 
-    // Collect all positions: outer + inner wires.
     let mut all_positions: Vec<Point3> = outer_positions.to_vec();
     let outer_count = all_positions.len();
     let mut inner_wire_ranges: Vec<(usize, usize)> = Vec::new();
@@ -520,7 +513,6 @@ fn tessellate_planar_with_holes(
         .insert_points_hilbert(&pts2d)
         .map_err(crate::OperationsError::Math)?;
 
-    // Insert outer boundary constraints.
     let mut all_constraints: Vec<(usize, usize)> = Vec::new();
     for i in 0..outer_count {
         let j = (i + 1) % outer_count;
@@ -533,7 +525,6 @@ fn tessellate_planar_with_holes(
         }
     }
 
-    // Insert inner wire constraints (holes).
     for &(start, end) in &inner_wire_ranges {
         let count = end - start;
         for i in 0..count {
@@ -548,7 +539,6 @@ fn tessellate_planar_with_holes(
         }
     }
 
-    // Remove exterior triangles (using only outer boundary constraints).
     let outer_constraints: Vec<(usize, usize)> = (0..outer_count)
         .filter_map(|i| {
             let j = (i + 1) % outer_count;
@@ -559,8 +549,7 @@ fn tessellate_planar_with_holes(
         .collect();
     cdt.remove_exterior(&outer_constraints);
 
-    // Remove hole interiors by seeding from each hole's centroid.
-    // Build a set of all constraint edges for flood-fill stopping.
+    // Constraint edges drive the flood-fill stop condition below.
     let constraint_set: DetHashSet<(usize, usize)> = all_constraints
         .iter()
         .flat_map(|&(a, b)| {
@@ -578,11 +567,9 @@ fn tessellate_planar_with_holes(
         let hole_poly: Vec<Point2> = (start..end).map(|i| pts2d[i]).collect();
         let seed = find_interior_seed(&hole_poly);
 
-        // Flood-fill remove from the seed, stopping at constraints.
         let _removed = cdt.flood_remove_from_point(seed, &constraint_set);
     }
 
-    // Extract triangles and build mesh.
     let cdt_triangles = cdt.triangles();
     let cdt_verts = cdt.vertices();
     let num_tris = cdt_triangles.len();
@@ -596,14 +583,12 @@ fn tessellate_planar_with_holes(
         vi_to_orig.entry(cdt_vi).or_insert(orig_idx);
     }
 
-    // Map CDT point indices -> output mesh indices.
     let mut cdt_to_mesh: DetHashMap<usize, u32> = DetHashMap::default();
     for &(v0, v1, v2) in &cdt_triangles {
         for &vi in &[v0, v1, v2] {
             if let std::collections::hash_map::Entry::Vacant(e) = cdt_to_mesh.entry(vi) {
                 #[allow(clippy::cast_possible_truncation)]
                 let mesh_idx = positions_out.len() as u32;
-                // Find the original 3D point for this CDT vertex.
                 if let Some(&orig_idx) = vi_to_orig.get(&vi) {
                     positions_out.push(all_positions[orig_idx]);
                 } else {

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -145,13 +145,12 @@ fn tessellate_solid_core(
 ) -> Result<(TriangleMesh, Option<Vec<u32>>, usize), crate::OperationsError> {
     use brepkit_topology::explorer;
 
-    // Phase 1: Collect all faces and build edge->face adjacency.
     let all_faces = explorer::solid_faces(topo, solid)?;
     let edge_face_map = explorer::edge_to_face_map(topo, solid)?;
 
-    // Phase 2: Tessellate each unique edge once. The map is a std `HashMap`,
-    // so sort its keys into ID order before use — keeping all downstream
-    // iteration deterministic regardless of insertion-order hashing.
+    // The map is a std `HashMap`, so sort its keys into ID order before use —
+    // keeping all downstream iteration deterministic regardless of
+    // insertion-order hashing.
     let mut edge_indices: Vec<usize> = edge_face_map.keys().copied().collect();
     edge_indices.sort_unstable();
     #[cfg(not(target_arch = "wasm32"))]
@@ -203,7 +202,8 @@ fn tessellate_solid_core(
         map
     };
 
-    // Phase 2b: Synchronize circle edge samples with face grid density.
+    // Synchronize circle edge samples with face grid density so a face's rim
+    // points line up with its own analytic grid columns.
     {
         for &face_id in &all_faces {
             let face_data = topo.face(face_id)?;
@@ -266,7 +266,6 @@ fn tessellate_solid_core(
         }
     }
 
-    // Phase 3: Build merged mesh with shared edge vertices.
     let mut merged = TriangleMesh::default();
     let mut point_to_global: DetHashMap<(i64, i64, i64), u32> = DetHashMap::default();
     let mut edge_global_indices: DetHashMap<usize, Vec<u32>> = DetHashMap::default();
@@ -287,7 +286,6 @@ fn tessellate_solid_core(
         edge_global_indices.insert(edge_idx, global_ids);
     }
 
-    // Phase 3b: Circle edge refinement.
     {
         let tol_linear = brepkit_math::tolerance::Tolerance::new().linear;
         let refine_tol = tol_linear * 10.0;
@@ -376,7 +374,6 @@ fn tessellate_solid_core(
         }
     }
 
-    // Phase 4: Tessellate each face using its boundary edge vertices.
     // When tracking, `tri_faces` runs parallel to the mesh triangles:
     // tri_faces[t] is the index (into `all_faces`) of the face that produced
     // triangle t. The ungrouped caller skips this bookkeeping entirely.
@@ -395,7 +392,6 @@ fn tessellate_solid_core(
     #[allow(clippy::items_after_statements)]
     type CdtResult = Result<Vec<(usize, usize, usize)>, crate::OperationsError>;
 
-    // Phase 4a: Collect CDT jobs for large planar faces with holes.
     let mut cdt_jobs: Vec<CdtJob> = Vec::new();
     let mut other_face_indices: Vec<usize> = Vec::new();
 
@@ -478,7 +474,6 @@ fn tessellate_solid_core(
         other_face_indices.push(fi);
     }
 
-    // Phase 4b: Run CDTs in parallel for large planar faces.
     #[cfg(not(target_arch = "wasm32"))]
     let cdt_results: Vec<CdtResult> = if cdt_jobs.len() >= 2 {
         use rayon::prelude::*;
@@ -498,7 +493,6 @@ fn tessellate_solid_core(
         .map(|job| run_planar_cdt(&job.pts2d, job.outer_count, &job.inner_wire_ranges))
         .collect();
 
-    // Phase 4c: Merge CDT results into the shared mesh (sequential).
     for (job, result) in cdt_jobs.iter().zip(cdt_results) {
         let tris = result?;
 
@@ -533,7 +527,6 @@ fn tessellate_solid_core(
         }
     }
 
-    // Phase 4d: Process remaining faces sequentially.
     for &fi in &other_face_indices {
         if let Err(e) = tessellate_face_with_shared_edges(
             topo,
@@ -554,7 +547,6 @@ fn tessellate_solid_core(
         }
     }
 
-    // Phase 5: Surface-aware vertex normals.
     let n_verts = merged.positions.len();
     let tri_count = merged.indices.len() / 3;
 
@@ -640,10 +632,9 @@ fn tessellate_solid_core(
         }
     }
 
-    // Phase 6: Weld boundary vertices.
     weld_boundary_vertices(&mut merged, deflection, tri_faces.as_mut());
 
-    // Phase 7: Drop coincident/cancelling triangles left by booleans that
+    // Drop coincident/cancelling triangles left by booleans that
     // produced overlapping coplanar faces (issue #696). Keyed on quantized
     // positions so position-coincident triangles with distinct vertex IDs
     // are still caught.

--- a/crates/operations/src/test_helpers.rs
+++ b/crates/operations/src/test_helpers.rs
@@ -12,8 +12,6 @@ use brepkit_topology::explorer;
 use brepkit_topology::face::FaceId;
 use brepkit_topology::solid::SolidId;
 
-// ── Volume / area assertions ──────────────────────────────────────
-
 /// Assert that a solid's volume is within `rel_tol` of `expected`.
 ///
 /// When `expected` is near zero (< 1e-15), `rel_tol` is treated as an
@@ -61,8 +59,6 @@ pub fn assert_area_near(topo: &Topology, face: FaceId, expected: f64, rel_tol: f
     );
 }
 
-// ── Point assertions ──────────────────────────────────────────────
-
 /// Assert that two points are within `abs_tol` of each other.
 ///
 /// # Panics
@@ -85,8 +81,6 @@ pub fn assert_point_near(actual: Point3, expected: Point3, abs_tol: f64) {
         expected.z(),
     );
 }
-
-// ── Topological invariant assertions ──────────────────────────────
 
 /// Compute the Euler characteristic V - E + F for a solid.
 ///
@@ -133,8 +127,6 @@ pub fn assert_manifold(topo: &Topology, solid: SolidId) {
         .expect("solid should be manifold");
 }
 
-// ── Boolean conservation ──────────────────────────────────────────
-
 /// Assert the inclusion-exclusion principle: V(A) + V(B) = V(A∪B) + V(A∩B).
 ///
 /// This is a fundamental conservation law for boolean operations.
@@ -165,8 +157,6 @@ pub fn assert_volume_conservation(
         rel_tol * 100.0,
     );
 }
-
-// ── CW profile assertions ──────────────────────────────────────
 
 /// Assert that a CW-wound profile produces a solid with the expected volume.
 ///

--- a/crates/operations/src/thicken.rs
+++ b/crates/operations/src/thicken.rs
@@ -52,7 +52,6 @@ fn face_normal(surface: &FaceSurface) -> Result<Vec3, crate::OperationsError> {
     match surface {
         FaceSurface::Plane { normal, .. } => Ok(*normal),
         FaceSurface::Nurbs(nurbs) => {
-            // Evaluate at the surface center.
             nurbs
                 .normal(0.5, 0.5)
                 .map_err(|e| crate::OperationsError::InvalidInput {
@@ -124,7 +123,6 @@ mod tests {
 
         let mut topo = Topology::new();
 
-        // Build a flat NURBS face.
         let surface = NurbsSurface::new(
             1,
             1,

--- a/crates/operations/src/transform.rs
+++ b/crates/operations/src/transform.rs
@@ -88,7 +88,6 @@ pub fn transform_solid(
                 let ref_point = topo.vertex(ref_vid)?.point();
                 let new_d = new_normal.dot(Vec3::new(ref_point.x(), ref_point.y(), ref_point.z()));
 
-                // Now mutate the face.
                 let face_mut = topo.face_mut(fid)?;
                 face_mut.set_surface(FaceSurface::Plane {
                     normal: new_normal,
@@ -920,8 +919,6 @@ mod tests {
         assert!(has_neg_z, "should have -Z normal after Z rotation");
     }
 
-    // ── Analytic surface transform helpers ───────────────────────────────────
-
     /// Build a minimal solid containing a single face with the given surface.
     ///
     /// The wire is a unit square in XY; only the face surface type varies.
@@ -964,8 +961,6 @@ mod tests {
         let shell_id = topo.add_shell(shell);
         topo.add_solid(Solid::new(shell_id, vec![]))
     }
-
-    // ── Cylinder surface transform ────────────────────────────────────────────
 
     #[test]
     fn translate_cylinder_face_updates_origin() {
@@ -1052,8 +1047,6 @@ mod tests {
         assert!(found, "cylinder face not found after rotation");
     }
 
-    // ── Cone surface transform ────────────────────────────────────────────────
-
     #[test]
     fn translate_cone_face_updates_apex() {
         use brepkit_math::surfaces::ConicalSurface;
@@ -1101,8 +1094,6 @@ mod tests {
         assert!(found, "cone face not found after transform");
     }
 
-    // ── Sphere surface transform ──────────────────────────────────────────────
-
     #[test]
     fn translate_sphere_face_updates_center() {
         use brepkit_math::surfaces::SphericalSurface;
@@ -1142,8 +1133,6 @@ mod tests {
         }
         assert!(found, "sphere face not found after transform");
     }
-
-    // ── Torus surface transform ───────────────────────────────────────────────
 
     #[test]
     fn translate_torus_face_updates_center() {
@@ -1188,8 +1177,6 @@ mod tests {
         }
         assert!(found, "torus face not found after transform");
     }
-
-    // ── transform_direction degenerate case ───────────────────────────────────
 
     #[test]
     fn transform_direction_zero_vector_is_error() {

--- a/crates/operations/src/untrim.rs
+++ b/crates/operations/src/untrim.rs
@@ -63,13 +63,10 @@ pub fn untrim_face(
     samples_per_curve: usize,
     interior_samples: usize,
 ) -> Result<NurbsSurface, OperationsError> {
-    // Step 1: Collect all trim boundary points into a single polyline loop.
     let trim_loop = collect_trim_loop(trim_curves, samples_per_curve)?;
 
-    // Step 2: Compute the bounding box in parameter space.
     let (u_min, u_max, v_min, v_max) = param_bounding_box(&trim_loop)?;
 
-    // Step 3: Build a regular grid inside the trim loop.
     let n = interior_samples.max(4);
     #[allow(clippy::cast_precision_loss)]
     let n_f = (n - 1) as f64;
@@ -91,7 +88,6 @@ pub fn untrim_face(
             let pt = if point_in_trim_loop(uv, &trim_loop) {
                 surface.evaluate(u, v)
             } else {
-                // Project to the nearest boundary point and evaluate there.
                 let closest = closest_point_on_polyline(uv, &trim_loop);
                 surface.evaluate(closest.x(), closest.y())
             };
@@ -100,7 +96,6 @@ pub fn untrim_face(
         grid.push(row);
     }
 
-    // Step 4: Fit a new NURBS surface through the grid.
     let degree = surface.degree_u().min(surface.degree_v()).clamp(1, 3);
     let grid_rows = grid.len();
     let grid_cols = grid[0].len();
@@ -149,7 +144,6 @@ pub fn untrim_topology_face(
         }
     };
 
-    // Collect PCurves for all edges on this face.
     let pcurve_entries = topo.pcurves().pcurves_for_face(face);
     if pcurve_entries.is_empty() {
         return Err(OperationsError::InvalidInput {
@@ -157,7 +151,6 @@ pub fn untrim_topology_face(
         });
     }
 
-    // Sample each PCurve into a TrimCurve polyline.
     let n_samples = samples_per_curve.max(2);
     let trim_curves: Vec<TrimCurve> = pcurve_entries
         .iter()
@@ -284,7 +277,6 @@ fn closest_point_on_polyline(point: Point2, polyline: &[Point2]) -> Point2 {
         let a = polyline[i];
         let b = polyline[j];
 
-        // Project point onto segment [a, b].
         let ab_x = b.x() - a.x();
         let ab_y = b.y() - a.y();
         let len_sq = ab_x.mul_add(ab_x, ab_y * ab_y);

--- a/crates/operations/src/validate.rs
+++ b/crates/operations/src/validate.rs
@@ -165,7 +165,6 @@ pub fn validate_solid_with_options(
     // geometry, above 1000 makes the check meaningless.
     let scale = options.tolerance_scale.clamp(0.1, 1000.0);
 
-    // 1. Entity counts and Euler characteristic.
     let (f, e, v) = explorer::solid_entity_counts(topo, solid)?;
 
     // Euler-Poincaré formula for a cell complex with inner loops:
@@ -173,8 +172,6 @@ pub fn validate_solid_with_options(
     // where g is the genus and L is the total number of inner wire loops
     // across all faces. For a genus-0 solid with no holes: V-E+F = 2.
     // With L inner wires: V-E+F = 2 + L.
-    //
-    // Count total inner wires across all faces.
     let mut total_inner_loops: i64 = 0;
     let faces = explorer::solid_faces(topo, solid)?;
     for fid in &faces {
@@ -201,7 +198,6 @@ pub fn validate_solid_with_options(
         });
     }
 
-    // 2 & 3. Edge sharing: each edge should be in exactly 2 faces.
     let edge_map = explorer::edge_to_face_map(topo, solid)?;
     let mut boundary_edges = 0;
     let mut non_manifold_edges = 0;
@@ -244,8 +240,6 @@ pub fn validate_solid_with_options(
         });
     }
 
-    // 4. Degenerate faces.
-    //
     // Only faces on a planar surface bounded entirely by straight edges
     // require ≥3 unique vertices. Faces with curved edges (Circle,
     // Ellipse, NURBS) or non-planar surfaces (Cylinder, Sphere, Torus,
@@ -274,7 +268,6 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 5. Face normal consistency.
     let scaled_tol = Tolerance {
         linear: tol.linear * scale,
         angular: tol.angular * scale,
@@ -296,7 +289,6 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 6. Wire closure: every wire must form a closed loop.
     for fid in &faces {
         let face = topo.face(*fid)?;
         let wire_ids: Vec<_> = std::iter::once(face.outer_wire())
@@ -318,8 +310,6 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 7. Degenerate face area: faces with near-zero polygon area are likely slivers.
-    //
     // Only meaningful for faces bounded entirely by straight edges.
     // The polygon area formula uses vertex positions, which is
     // meaningless when edges are curved (e.g. a cylinder cap has
@@ -342,7 +332,6 @@ pub fn validate_solid_with_options(
 
         let wire = topo.wire(face.outer_wire())?;
 
-        // Collect wire vertex positions.
         let mut positions = Vec::new();
         for oe in wire.edges() {
             let edge = topo.edge(oe.edge())?;
@@ -350,8 +339,6 @@ pub fn validate_solid_with_options(
             positions.push(topo.vertex(vid)?.point());
         }
 
-        // Compute face area using the shoelace formula generalized to 3D
-        // (sum of cross products of consecutive edge vectors from centroid).
         if positions.len() >= 3 {
             let area = polygon_area_3d(&positions);
             if area < area_tol_sq {
@@ -366,8 +353,8 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 8. Zero-length edges: edges with coincident start/end vertices
-    // (but not intentionally closed edges like circles).
+    // Skip intentionally closed edges (like circles) when checking for
+    // coincident start/end vertices.
     let all_edges = explorer::solid_edges(topo, solid)?;
     for eid in &all_edges {
         let edge = topo.edge(*eid)?;
@@ -391,7 +378,6 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 9. Empty wires.
     for fid in &faces {
         let face = topo.face(*fid)?;
         let wire_ids: Vec<_> = std::iter::once(face.outer_wire())
@@ -413,7 +399,7 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 10. Shell connectivity: all faces should be reachable from any face.
+    // Shell connectivity: all faces should be reachable from any face.
     // For genus-0 solids (sphere-like), all faces must be in one connected
     // component. Higher-genus solids (e.g. hollow revolves creating a torus)
     // can legitimately have multiple face-connected components (inner/outer
@@ -427,7 +413,6 @@ pub fn validate_solid_with_options(
         queue.push_back(faces[0]);
 
         while let Some(current) = queue.pop_front() {
-            // Find all faces that share an edge with current
             for adj_faces in edge_map.values() {
                 if adj_faces.iter().any(|f| f.index() == current.index()) {
                     for neighbor in adj_faces {
@@ -451,7 +436,6 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 11. Redundant faces in shell.
     {
         let mut face_counts = std::collections::HashMap::new();
         for fid in &faces {
@@ -467,7 +451,6 @@ pub fn validate_solid_with_options(
         }
     }
 
-    // 12. Edge vertex consistency: edge vertices must belong to the solid.
     let vertex_set: std::collections::HashSet<usize> = {
         let verts = explorer::solid_vertices(topo, solid)?;
         verts.iter().map(|v| v.index()).collect()
@@ -552,7 +535,6 @@ pub fn validate_solid_relaxed_with_options(
 
     let faces = explorer::solid_faces(topo, solid)?;
 
-    // Degenerate faces (planar + straight edges only) — Warning in relaxed.
     for fid in &faces {
         let face_data = topo.face(*fid)?;
         let is_planar = matches!(
@@ -575,7 +557,6 @@ pub fn validate_solid_relaxed_with_options(
         }
     }
 
-    // Face normal consistency (planar faces).
     let scaled_tol = Tolerance {
         linear: tol.linear * scale,
         angular: tol.angular * scale,
@@ -626,7 +607,6 @@ pub fn validate_solid_relaxed_with_options(
         }
     }
 
-    // Degenerate face area (planar + straight edges only).
     let area_tol_sq = scaled_tol.linear * scaled_tol.linear;
     for fid in &faces {
         let face = topo.face(*fid)?;
@@ -688,7 +668,6 @@ pub fn validate_solid_relaxed_with_options(
         }
     }
 
-    // Empty wires.
     for fid in &faces {
         let face = topo.face(*fid)?;
         let wire_ids: Vec<_> = std::iter::once(face.outer_wire())
@@ -710,7 +689,6 @@ pub fn validate_solid_relaxed_with_options(
         }
     }
 
-    // Redundant faces.
     {
         let mut face_counts = std::collections::HashMap::new();
         for fid in &faces {
@@ -726,7 +704,6 @@ pub fn validate_solid_relaxed_with_options(
         }
     }
 
-    // Edge vertex consistency.
     let vertex_set: std::collections::HashSet<usize> = {
         let verts = explorer::solid_vertices(topo, solid)?;
         verts.iter().map(|v| v.index()).collect()
@@ -858,7 +835,7 @@ mod tests {
         let shell_id = topo.solid(solid).unwrap().outer_shell();
         let shell = topo.shell(shell_id).unwrap();
         let mut faces: Vec<_> = shell.faces().to_vec();
-        faces.pop(); // Remove last face
+        faces.pop();
 
         let open_shell = brepkit_topology::shell::Shell::new(faces).unwrap();
         *topo.shell_mut(shell_id).unwrap() = open_shell;
@@ -1063,8 +1040,6 @@ mod tests {
         );
     }
 
-    // ── Wire closure validation ──────────────────────
-
     #[test]
     fn wire_closure_check_on_valid_box() {
         let mut topo = Topology::new();
@@ -1082,8 +1057,6 @@ mod tests {
             "valid box should have no wire issues: {wire_issues:?}"
         );
     }
-
-    // ── Degenerate face area ─────────────────────────
 
     #[test]
     fn polygon_area_unit_square() {
@@ -1142,7 +1115,7 @@ mod tests {
         let shell_id = topo.solid(solid).unwrap().outer_shell();
         let shell = topo.shell(shell_id).unwrap();
         let mut faces: Vec<_> = shell.faces().to_vec();
-        let extra_face = faces[0]; // duplicate first face
+        let extra_face = faces[0];
         faces.push(extra_face);
 
         let new_shell = brepkit_topology::shell::Shell::new(faces).unwrap();
@@ -1231,10 +1204,6 @@ mod tests {
         }
     }
 
-    // ── repair_solid ─────────────────────────────────
-
-    // ── Zero-length edge detection ─────────────────────
-
     #[test]
     fn validate_detects_zero_length_edge() {
         let mut topo = Topology::new();
@@ -1260,8 +1229,6 @@ mod tests {
         );
     }
 
-    // ── Disconnected shell detection ───────────────────
-
     #[test]
     fn validate_connected_shell_passes() {
         let mut topo = Topology::new();
@@ -1278,8 +1245,6 @@ mod tests {
             report.issues
         );
     }
-
-    // ── Redundant face detection ───────────────────────
 
     #[test]
     fn validate_detects_redundant_face() {
@@ -1307,8 +1272,6 @@ mod tests {
             report.issues
         );
     }
-
-    // ── Boolean result validation ──────────────────────
 
     #[test]
     fn boolean_fuse_result_validates() {
@@ -1446,8 +1409,6 @@ mod tests {
         );
     }
 
-    // ── repair_solid ─────────────────────────────────
-
     #[test]
     fn repair_clean_box() {
         let mut topo = Topology::new();
@@ -1485,8 +1446,6 @@ mod tests {
         // Should not crash; may or may not be valid depending on cylinder topology
         let _ = report.is_valid_after();
     }
-
-    // ── Relaxed validation ────────────────────────────
 
     #[test]
     fn relaxed_valid_box() {
@@ -1621,8 +1580,6 @@ mod tests {
             "should warn about open wire"
         );
     }
-
-    // ── ValidationOptions tolerance tuning ──────────────
 
     #[test]
     fn validation_options_default() {

--- a/crates/sketch/src/gcs/qr.rs
+++ b/crates/sketch/src/gcs/qr.rs
@@ -66,7 +66,6 @@ impl QrResult {
                 }
             }
 
-            // Swap columns if needed
             if best_col != step {
                 for i in 0..m {
                     data.swap(i * n + step, i * n + best_col);
@@ -210,7 +209,6 @@ impl QrResult {
             z[i] = s / rii;
         }
 
-        // Unpermute
         let mut x = vec![0.0; self.n];
         for (i, &pi) in self.perm.iter().enumerate() {
             x[pi] = z[i];

--- a/crates/sketch/src/gcs/solver.rs
+++ b/crates/sketch/src/gcs/solver.rs
@@ -101,7 +101,6 @@ where
             };
         }
 
-        // Compute J*g
         let mut jg = vec![0.0; num_residuals];
         for i in 0..num_residuals {
             for j in 0..n {
@@ -117,15 +116,12 @@ where
 
         let h_sd: Vec<f64> = g.iter().map(|&v| -alpha * v).collect();
 
-        // DogLeg blending
         let h = dogleg_step(&h_gn, &h_sd, delta);
         let h_norm = h.iter().map(|&v| v * v).sum::<f64>().sqrt();
 
-        // Trial point
         let trial: Vec<f64> = params.iter().zip(h.iter()).map(|(&p, &d)| p + d).collect();
         let r_trial = residual_fn(&trial);
 
-        // Compute reduction ratio
         let cost_current: f64 = r.iter().map(|&v| v * v).sum::<f64>() * 0.5;
         let cost_trial: f64 = r_trial.iter().map(|&v| v * v).sum::<f64>() * 0.5;
         let actual_reduction = cost_current - cost_trial;
@@ -159,12 +155,10 @@ where
             delta = (delta / 4.0).max(delta_min);
         }
 
-        // Accept or reject step
         if rho > 0.0 {
             params.copy_from_slice(&trial);
         }
 
-        // Check if step is too small to make progress
         if h_norm < 1e-15 * (1.0 + param_norm) {
             let final_r = residual_fn(params);
             let final_max = final_r.iter().fold(0.0_f64, |a, &b| a.max(b.abs()));

--- a/crates/sketch/src/gcs/system.rs
+++ b/crates/sketch/src/gcs/system.rs
@@ -74,8 +74,6 @@ impl GcsSystem {
         }
     }
 
-    // ── Entity CRUD ─────────────────────────────────────────────────
-
     /// Add a point. Returns its handle.
     pub fn add_point(&mut self, data: PointData) -> PointId {
         self.dirty = true;
@@ -101,25 +99,21 @@ impl GcsSystem {
     /// circle, or constraint. Returns `SketchError::InvalidHandle` if the handle
     /// is stale or invalid.
     pub fn remove_point(&mut self, id: PointId) -> Result<PointData, SketchError> {
-        // Check lines
         for (_, line) in self.lines.iter() {
             if line.p1 == id || line.p2 == id {
                 return Err(SketchError::EntityInUse);
             }
         }
-        // Check circles
         for (_, circle) in self.circles.iter() {
             if circle.center == id {
                 return Err(SketchError::EntityInUse);
             }
         }
-        // Check arcs
         for (_, arc) in self.arcs.iter() {
             if arc.center == id || arc.start == id || arc.end == id {
                 return Err(SketchError::EntityInUse);
             }
         }
-        // Check constraints
         for (_, entry) in self.constraints.iter() {
             if constraint_references_point(&entry.constraint, id) {
                 return Err(SketchError::EntityInUse);
@@ -250,9 +244,7 @@ impl GcsSystem {
     /// Returns `SketchError::EntityInUse` if the arc is referenced by a constraint.
     /// Returns `SketchError::InvalidHandle` if the handle is stale or invalid.
     pub fn remove_arc(&mut self, id: ArcId) -> Result<ArcData, SketchError> {
-        // Check no user constraints reference this arc
         for (cid, entry) in self.constraints.iter() {
-            // Skip the arc's own internal constraint
             if self.arc_internal_constraints.get(&id) == Some(&cid) {
                 continue;
             }
@@ -261,7 +253,6 @@ impl GcsSystem {
             }
         }
 
-        // Remove internal constraint
         if let Some(cid) = self.arc_internal_constraints.remove(&id) {
             self.constraints.remove(cid);
         }
@@ -280,8 +271,6 @@ impl GcsSystem {
     pub fn arcs(&self) -> impl Iterator<Item = (ArcId, &ArcData)> {
         self.arcs.iter()
     }
-
-    // ── Constraint CRUD ─────────────────────────────────────────────
 
     /// Add a constraint. Validates that all referenced entities exist.
     ///
@@ -339,8 +328,6 @@ impl GcsSystem {
         self.circles.len()
     }
 
-    // ── Solve ───────────────────────────────────────────────────────
-
     /// Solve the constraint system.
     ///
     /// Modifies entity positions in-place to satisfy all constraints.
@@ -380,12 +367,10 @@ impl GcsSystem {
             });
         }
 
-        // Extract params
         let mut params = self.extract_params();
         let param_index = self.param_index.clone();
         let param_map = self.param_map.clone();
 
-        // Collect constraints for closures
         let constraints: Vec<Constraint> = self
             .constraints
             .iter()
@@ -428,7 +413,6 @@ impl GcsSystem {
             tolerance,
         );
 
-        // Write back solved params
         self.write_params(&params);
 
         Ok(result)
@@ -489,8 +473,6 @@ impl GcsSystem {
         self.circles.iter()
     }
 
-    // ── Internal ────────────────────────────────────────────────────
-
     /// Rebuild parameter map if dirty.
     fn rebuild_if_dirty(&mut self) {
         if !self.dirty {
@@ -499,7 +481,6 @@ impl GcsSystem {
         self.param_map.clear();
         self.param_index.clear();
 
-        // Free point params
         for (id, data) in self.points.iter() {
             if !data.fixed {
                 let idx = self.param_map.len();
@@ -511,7 +492,6 @@ impl GcsSystem {
             }
         }
 
-        // Circle radius params
         for (id, _) in self.circles.iter() {
             let idx = self.param_map.len();
             self.param_map.push(ParamRef::CircleRadius(id));
@@ -1039,26 +1019,21 @@ mod tests {
         let top = sys.add_line(p2, p3).unwrap();
         let left = sys.add_line(p3, p0).unwrap();
 
-        // Pin origin
         sys.add_constraint(Constraint::FixX(p0, 0.0)).unwrap();
         sys.add_constraint(Constraint::FixY(p0, 0.0)).unwrap();
 
-        // Bottom: horizontal, length 30
         sys.add_constraint(Constraint::Horizontal(bottom)).unwrap();
         sys.add_constraint(Constraint::Distance(p0, p1, 30.0))
             .unwrap();
 
-        // Right: vertical, length 20
         sys.add_constraint(Constraint::Vertical(right)).unwrap();
         sys.add_constraint(Constraint::Distance(p1, p2, 20.0))
             .unwrap();
 
-        // Top: horizontal, length 30
         sys.add_constraint(Constraint::Horizontal(top)).unwrap();
         sys.add_constraint(Constraint::Distance(p2, p3, 30.0))
             .unwrap();
 
-        // Left: vertical, length 20
         sys.add_constraint(Constraint::Vertical(left)).unwrap();
         sys.add_constraint(Constraint::Distance(p3, p0, 20.0))
             .unwrap();

--- a/crates/topology/src/adjacency.rs
+++ b/crates/topology/src/adjacency.rs
@@ -59,7 +59,6 @@ impl AdjacencyIndex {
     pub fn build_from_faces(topo: &Topology, faces: &[FaceId]) -> Result<Self, TopologyError> {
         let mut edge_faces: HashMap<EdgeId, SmallVec<[FaceId; 2]>> = HashMap::new();
 
-        // Walk all faces -> wires -> oriented edges to build edge_faces map.
         for &face_id in faces {
             let face = topo.face(face_id)?;
             // Collect all wire IDs (outer + inner) to avoid borrow issues.
@@ -77,12 +76,10 @@ impl AdjacencyIndex {
             }
         }
 
-        // Classify edges and build face neighbors.
         let mut non_manifold_edges = Vec::new();
         let mut boundary_edges = Vec::new();
         let mut face_neighbors: HashMap<FaceId, SmallVec<[FaceId; 6]>> = HashMap::new();
 
-        // Pre-populate face_neighbors with empty vecs for all faces.
         for &face_id in faces {
             face_neighbors.entry(face_id).or_default();
         }
@@ -102,7 +99,6 @@ impl AdjacencyIndex {
             }
         }
 
-        // Deduplicate neighbor lists (a face pair may share multiple edges).
         for neighbors in face_neighbors.values_mut() {
             neighbors.sort_unstable_by_key(|id| id.index());
             neighbors.dedup();
@@ -223,10 +219,8 @@ mod tests {
         let v3 = topo.add_vertex(Vertex::new(Point3::new(0.5, -1.0, 0.0), 1e-7));
         let v4 = topo.add_vertex(Vertex::new(Point3::new(0.5, 0.0, 1.0), 1e-7));
 
-        // Shared edge
         let e01 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
 
-        // Face 1: v0-v1-v2
         let e12 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
         let e20 = topo.add_edge(Edge::new(v2, v0, EdgeCurve::Line));
         let w1 = topo.add_wire(
@@ -249,7 +243,6 @@ mod tests {
             },
         ));
 
-        // Face 2: v0-v1-v3
         let e13 = topo.add_edge(Edge::new(v1, v3, EdgeCurve::Line));
         let e30 = topo.add_edge(Edge::new(v3, v0, EdgeCurve::Line));
         let w2 = topo.add_wire(
@@ -272,7 +265,6 @@ mod tests {
             },
         ));
 
-        // Face 3: v0-v1-v4
         let e14 = topo.add_edge(Edge::new(v1, v4, EdgeCurve::Line));
         let e40 = topo.add_edge(Edge::new(v4, v0, EdgeCurve::Line));
         let w3 = topo.add_wire(
@@ -328,7 +320,6 @@ mod tests {
         let topo = Topology::new();
         let adj = AdjacencyIndex::build_from_faces(&topo, &[]).unwrap();
 
-        // Create a dummy edge ID that isn't in the index.
         let mut dummy: Arena<Edge> = Arena::new();
         let fake_eid = dummy.alloc(Edge::new(
             {

--- a/crates/topology/src/compsolid.rs
+++ b/crates/topology/src/compsolid.rs
@@ -74,7 +74,6 @@ mod tests {
     fn compsolid_in_arena() {
         let mut topo = Topology::new();
 
-        // Create two minimal solids (just for ID purposes)
         let _v = topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 0.0), 1e-7));
 
         let cs = CompSolid::new(vec![], vec![]);

--- a/crates/topology/src/explorer.rs
+++ b/crates/topology/src/explorer.rs
@@ -331,13 +331,10 @@ mod tests {
         let faces = solid_faces(&topo, cube).unwrap();
         let map = edge_to_face_map(&topo, cube).unwrap();
 
-        // Find adjacent faces of the first face.
         let neighbors = adjacent_faces(&topo, faces[0], &map).unwrap();
 
-        // Each face of a cube is adjacent to 4 other faces.
         assert_eq!(neighbors.len(), 4, "cube face should have 4 adjacent faces");
 
-        // Check that each neighbor shares exactly 1 edge with face[0].
         for &neighbor in &neighbors {
             let shared = shared_edges(&topo, faces[0], neighbor).unwrap();
             assert_eq!(
@@ -356,7 +353,6 @@ mod tests {
         let faces = solid_faces(&topo, cube).unwrap();
         let wires = face_wires(&topo, faces[0]).unwrap();
 
-        // No inner wires on a cube face.
         assert_eq!(wires.len(), 1, "cube face should have 1 wire (outer only)");
     }
 }

--- a/crates/topology/src/pcurve.rs
+++ b/crates/topology/src/pcurve.rs
@@ -220,7 +220,6 @@ mod tests {
 
     #[test]
     fn pcurve_evaluate() {
-        // Line direction is normalized, so (1,0) stays (1,0)
         let line = Line2D::new(Point2::new(0.0, 0.0), Vec2::new(1.0, 0.0)).unwrap();
         let pcurve = PCurve::new(Curve2D::Line(line), 0.0, 1.0);
 

--- a/crates/topology/src/topology.rs
+++ b/crates/topology/src/topology.rs
@@ -144,8 +144,6 @@ impl Topology {
         self.solids.reserve(solids);
     }
 
-    // ── Single-entity lookup (by ID → Result) ─────────────────────
-
     arena_get!(vertex, vertices, Vertex, VertexId, VertexNotFound);
     arena_get_mut!(vertex_mut, vertices, Vertex, VertexId, VertexNotFound);
 
@@ -187,8 +185,6 @@ impl Topology {
         CompSolidId,
         CompSolidNotFound
     );
-
-    // ── Allocation + arena access + count + index reconstruction ──
 
     arena_api!(
         add = add_vertex,
@@ -270,8 +266,6 @@ impl Topology {
         Id = CompSolidId
     );
 
-    // ── Empty-result sentinel ─────────────────────────────────────
-
     /// Allocates an empty-result solid: a solid backed by a faceless
     /// [`Shell::empty`].
     ///
@@ -299,8 +293,6 @@ impl Topology {
         })
     }
 
-    // ── PCurve registry ───────────────────────────────────────────
-
     /// Returns a shared reference to the pcurve registry.
     #[must_use]
     pub fn pcurves(&self) -> &PCurveRegistry {
@@ -311,8 +303,6 @@ impl Topology {
     pub fn pcurves_mut(&mut self) -> &mut PCurveRegistry {
         &mut self.pcurves
     }
-
-    // ── Adjacency ─────────────────────────────────────────────────
 
     /// Builds an adjacency index for the given solid.
     ///
@@ -348,11 +338,9 @@ mod tests {
 
         let snapshot = topo.clone();
 
-        // Add more entities after the snapshot
         topo.add_vertex(Vertex::new(Point3::new(4.0, 5.0, 6.0), 1e-7));
         assert_eq!(topo.num_vertices(), 2);
 
-        // Snapshot still has exactly 1 vertex
         assert_eq!(snapshot.num_vertices(), 1);
         let v = snapshot.vertex(vid).unwrap();
         assert!((v.point().x() - 1.0).abs() < f64::EPSILON);
@@ -365,10 +353,8 @@ mod tests {
 
         let snapshot = topo.clone();
 
-        // Mutate after snapshot
         topo.add_vertex(Vertex::new(Point3::new(9.0, 9.0, 9.0), 1e-7));
 
-        // Restore from snapshot
         topo = snapshot;
         assert_eq!(topo.num_vertices(), 1);
         let v = topo.vertex(vid).unwrap();
@@ -418,7 +404,6 @@ mod tests {
         let v = topo.vertex(vid).unwrap();
         assert!((v.point().x() - 1.0).abs() < f64::EPSILON);
 
-        // New allocations still work after reserve.
         let vid2 = topo.add_vertex(Vertex::new(Point3::new(4.0, 5.0, 6.0), 1e-7));
         assert_eq!(topo.num_vertices(), 2);
         let v2 = topo.vertex(vid2).unwrap();

--- a/crates/topology/src/validation.rs
+++ b/crates/topology/src/validation.rs
@@ -62,7 +62,6 @@ pub fn validate_wire_closed(wire: &Wire, topo: &Topology) -> Result<(), Topology
         }
     }
 
-    // Check last -> first closure.
     if let (Some(last), Some(first)) = (oriented.last(), oriented.first()) {
         let last_edge = topo.edge(last.edge())?;
         let first_edge = topo.edge(first.edge())?;
@@ -113,10 +112,8 @@ pub fn validate_shell_manifold(shell: &Shell, topo: &Topology) -> Result<(), Top
     for &face_id in shell.faces() {
         let face = topo.face(face_id)?;
 
-        // Outer wire.
         count_wire_edges(face.outer_wire(), topo, &mut edge_counts)?;
 
-        // Inner wires (holes).
         for &inner_wire_id in face.inner_wires() {
             count_wire_edges(inner_wire_id, topo, &mut edge_counts)?;
         }
@@ -336,10 +333,8 @@ mod tests {
         let v3 = topo.add_vertex(crate::vertex::Vertex::new(Point3::new(1.0, 1.0, 0.0), 1e-7));
         let v4 = topo.add_vertex(crate::vertex::Vertex::new(Point3::new(0.5, 0.5, 1.0), 1e-7));
 
-        // Shared edge between all three faces.
         let shared = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
 
-        // Face 1: v0-v1-v2
         let e_a = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
         let e_b = topo.add_edge(Edge::new(v2, v0, EdgeCurve::Line));
         let w0 = topo.add_wire(
@@ -354,7 +349,6 @@ mod tests {
             .unwrap(),
         );
 
-        // Face 2: v0-v1-v3
         let e_c = topo.add_edge(Edge::new(v1, v3, EdgeCurve::Line));
         let e_d = topo.add_edge(Edge::new(v3, v0, EdgeCurve::Line));
         let w1 = topo.add_wire(


### PR DESCRIPTION
## What

Removes ~2,000 lines of redundant step-narration comments across the workspace. The project convention (CLAUDE.md "Code Comments") is to default to **no** comments and keep one only when it explains a non-obvious WHY. Rapid iteration had accumulated a large backlog of comments that merely restate the code below them.

Examples of what was removed:
- Step-narration: `// Collect all unique edge IDs.`, `// Apply.`, `// Build the AABB.`
- Section-header banners that just name the next block
- Change-narration / before-after / tombstones: `// Now mutate the face`, `// Previously used 15% tolerance`, `// relocated from deleted files`

## What was deliberately **kept**

- Every `///` / `//!` doc block (`missing_docs` is `-D warnings` in CI — deleting these would fail the build)
- Every WHY-bearing comment: math derivations (NURBS Book / quadrature refs, Jacobians), geometric invariants, tolerance & numerical-stability rationale, "Instead of X we do Y because…" tradeoff notes, borrow-checker snapshot notes, `# Errors`/`# Panics`/`# Safety` sections, and TODOs with concrete triggers

## Safety

This is **strictly comment-only**. The diff is ~1,990 deletions / ~50 insertions; every non-blank insertion is a code line that had a trailing comment stripped (verified byte-identical to its pre-image). No logic line changed.

Per-crate removal (approx): operations ~860, blend 233, algo 192, heal 195, io ~122, math 70, sketch 33, check 28, topology ~26, offset ~70, geometry 8.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Audited every added non-comment line to confirm no behavior change