### PR TITLE
docs: remove third-party kernel references from comments

### DIFF
--- a/crates/algo/src/builder/assemble.rs
+++ b/crates/algo/src/builder/assemble.rs
@@ -1,6 +1,6 @@
 //! Assemble selected faces into shells and solids.
 //!
-//! Delegates to [`builder_solid::build_solid`] for OCCT-style 4-phase
+//! Delegates to [`builder_solid::build_solid`] for 4-phase
 //! shell assembly with edge connectivity, dihedral angle selection,
 //! and Growth/Hole classification.
 
@@ -12,8 +12,8 @@ use crate::error::AlgoError;
 
 /// Assemble selected faces into a solid.
 ///
-/// Delegates to [`builder_solid::build_solid`], which implements an
-/// OCCT-style BuilderSolid assembly:
+/// Delegates to [`builder_solid::build_solid`], which implements the
+/// BuilderSolid assembly:
 /// 1. Build shells via edge-connectivity flood-fill (with dihedral
 ///    angle selection at non-manifold edges)
 /// 2. Classify shells as Growth/Hole via signed volume

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1,4 +1,4 @@
-//! BuilderSolid — OCCT-style 4-phase shell assembly.
+//! BuilderSolid — 4-phase shell assembly.
 //!
 //! Takes BOP-selected faces and assembles them into manifold shells,
 //! classifies shells as Growth/Hole, and nests holes inside growth shells.
@@ -132,9 +132,8 @@ fn perform_shapes_to_avoid(
         let edge_map = build_edge_face_map(topo, faces)?;
         let mut to_remove: HashSet<FaceId> = HashSet::new();
 
-        // Only remove faces where EVERY edge is free (≤1 face).
-        // This is less aggressive than OCCT's approach (which removes any
-        // face with any free edge) to avoid stripping valid multi-region faces.
+        // Only remove faces where EVERY edge is free (≤1 face). Removing a
+        // face with *any* free edge would strip valid multi-region faces.
         for &fid in faces.iter() {
             let face_keys = face_edge_keys(topo, fid)?;
             if face_keys.is_empty() {
@@ -271,8 +270,6 @@ fn perform_loops(topo: &Topology, faces: &[FaceId]) -> Result<Vec<Vec<FaceId>>, 
 /// At an edge shared by 3+ faces, selects the face with the smallest
 /// positive dihedral angle relative to the current face. This implements
 /// clockwise face traversal around the edge.
-///
-/// Reference: OCCT `BOPTools_AlgoTools::GetFaceOff` + `AngleWithRef`.
 pub fn get_face_off(
     topo: &Topology,
     edge_start: Point3,
@@ -348,7 +345,6 @@ pub fn get_face_off(
 /// Signed angle between two direction vectors using a reference axis.
 ///
 /// Returns the angle from `d1` to `d2` measured around `d_ref`.
-/// Port of OCCT's `AngleWithRef`.
 fn angle_with_ref(d1: Vec3, d2: Vec3, d_ref: Vec3) -> f64 {
     let cross = d1.cross(d2);
     let sin_val = cross.length();

--- a/crates/algo/src/builder/split_types.rs
+++ b/crates/algo/src/builder/split_types.rs
@@ -79,7 +79,7 @@ pub struct SectionEdge {
     /// Pave block ID from the GFA arena. When two faces share the same
     /// FF section curve, their section edges have the same pave_block_id.
     /// Used by `build_topology_face` to share the topology edge entity
-    /// across faces (OCCT TShape-sharing for cross-face edges).
+    /// across faces (shared edge identity for cross-face edges).
     pub pave_block_id: Option<usize>,
 }
 

--- a/crates/algo/src/pave_filler/force_interf_ee.rs
+++ b/crates/algo/src/pave_filler/force_interf_ee.rs
@@ -3,7 +3,7 @@
 //!
 //! Runs after `make_blocks` (which splits PaveBlocks at extra paves),
 //! iterating leaf PaveBlocks to find pairs with matching 3D endpoints
-//! and compatible curve geometry. This follows OCCT's `ForceInterfEE` pattern.
+//! and compatible curve geometry.
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/blend/src/blend_func.rs
+++ b/crates/blend/src/blend_func.rs
@@ -11,7 +11,7 @@
 //!
 //! # Blend types
 //!
-//! - [`ConstRadBlend`] — constant-radius fillet (OCCT `BlendFunc_ConstRad`)
+//! - [`ConstRadBlend`] — constant-radius fillet
 //! - [`EvolRadBlend`] — variable-radius fillet using a [`RadiusLaw`]
 //! - [`ChamferBlend`] — two-distance chamfer
 //! - [`ChamferAngleBlend`] — distance-angle chamfer
@@ -125,7 +125,7 @@ pub fn project_normal_to_section(normal: Vec3, nplan: Vec3) -> Vec3 {
 
 /// Constant-radius fillet blend function.
 ///
-/// Implements the OCCT `BlendFunc_ConstRad` constraint system:
+/// Constraint system:
 /// - `f1 = nplan · (midpoint - guide)` (planarity)
 /// - `f2..f4 = (P1 + R·npn1) - (P2 + R·npn2)` (equidistance)
 #[derive(Debug, Clone)]
@@ -178,7 +178,7 @@ impl ConstRadBlend {
 
     /// Compute the Jacobian for a given radius (shared with `EvolRadBlend`).
     ///
-    /// First-order Jacobian ignoring `∂npn/∂u` terms (standard OCCT approach).
+    /// First-order Jacobian ignoring `∂npn/∂u` terms.
     fn jacobian_with_radius(
         r: f64,
         surf1: &dyn ParametricSurface,

--- a/crates/heal/src/construct/convert_surface.rs
+++ b/crates/heal/src/construct/convert_surface.rs
@@ -206,8 +206,7 @@ pub fn cone_to_nurbs(
 ///
 /// The poles (`v = ±π/2`) are degenerate in the parameterization
 /// (multiple `u` values map to the same point), as is standard for
-/// tensor-product spheres. This matches OCCT's `Geom_SphericalSurface`
-/// behavior.
+/// tensor-product spheres.
 ///
 /// # Errors
 ///

--- a/crates/heal/src/custom/convert_to_bspline.rs
+++ b/crates/heal/src/custom/convert_to_bspline.rs
@@ -1,6 +1,5 @@
 //! Convert analytic geometry to B-spline representation.
 //!
-//! Equivalent to OCCT's `BRepBuilderAPI_NurbsConvert` / `ShapeCustom::ConvertToBSpline`.
 //! Replaces every analytic surface (Plane, Cylinder, Cone, Sphere, Torus) with a
 //! NURBS surface and every analytic curve (Line, Circle, Ellipse) with a NURBS
 //! curve.

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -60,7 +60,7 @@ pub fn maybe_split_closed_wire(
 /// Internal variant that lets the caller opt in to passing closed circle /
 /// ellipse / NURBS-recognized-as-circle edges through unsplit. The basic
 /// extrude path uses this so the side face can be built as a true analytic
-/// cylinder (matching OCCT's exact π·r²·h), while sweep / complexExtrude /
+/// cylinder (matching the exact π·r²·h), while sweep / complexExtrude /
 /// twist still split — they apply per-edge profiles that don't work on a
 /// single closed-curve edge.
 pub(crate) fn maybe_split_closed_wire_with(
@@ -392,7 +392,7 @@ fn side_face_surface(
             // brepjs (and other callers) often construct circles as rational
             // quadratic NURBS via `makeCircleEdge`. Extruding those as ruled
             // NURBS surfaces leaves a ~0.12% volume deficit vs the exact
-            // π·r²·h answer that OCCT returns. Recognize the NURBS as a
+            // π·r²·h answer. Recognize the NURBS as a
             // circle and use a true `Cylinder` surface for the side face
             // when possible — the recognition is geometrically exact for
             // the rational-quadratic circle construction.
@@ -1414,7 +1414,7 @@ mod tests {
 
     /// Extruding a face with a NURBS curve edge that is geometrically a
     /// circular arc should produce a `Cylinder` side face (not a ruled
-    /// NURBS surface). This matches the OCCT-equivalent behavior: brepjs
+    /// NURBS surface). brepjs
     /// constructs circles as rational-quadratic NURBS, and extruding those
     /// as NURBS leaves a small but persistent volume deficit. Recognizing
     /// the curve as a circle and using the exact analytic cylinder surface

--- a/crates/operations/src/heal.rs
+++ b/crates/operations/src/heal.rs
@@ -1658,9 +1658,9 @@ fn order_edges_into_loops(
 ///
 /// Returns the number of faces and edges that were converted.
 ///
-/// Equivalent to OCCT's `BRepBuilderAPI_NurbsConvert`. Stored pcurves are
-/// dropped on conversion — see `brepkit_heal::custom::convert_to_bspline` for
-/// the full rationale.
+/// Converts every analytic surface and curve to a NURBS representation.
+/// Stored pcurves are dropped on conversion — see
+/// `brepkit_heal::custom::convert_to_bspline` for the full rationale.
 ///
 /// # Errors
 ///

--- a/crates/operations/src/section.rs
+++ b/crates/operations/src/section.rs
@@ -196,8 +196,7 @@ pub fn section(
 /// A wire is "inner" when it sits inside another wire (in the section plane) and
 /// is not itself inside any wire that's already inside another. Two-level nesting
 /// (holes within holes within holes) is collapsed into the outermost containment;
-/// CAD sections don't typically produce deeper nesting and OCCT treats them the
-/// same way.
+/// CAD sections don't typically produce deeper nesting.
 fn group_wires_by_containment(
     topo: &Topology,
     wires: &[WireId],
@@ -485,7 +484,7 @@ fn assemble_wires(
     // Chaining tolerance must be tight enough to keep separate loops apart
     // (e.g., the outer perimeter and the inner hole of a hollow shape) while
     // still tolerating the small endpoint drift produced by tessellated NURBS
-    // intersections. `tol.linear * 1000` (≈ 1e-4) is OCCT-compatible for both.
+    // intersections. `tol.linear * 1000` (≈ 1e-4) balances both.
     //
     // Earlier this defaulted to 50% of the average segment length, which for
     // a hollow 20×20 box section was ≈ 15 — wildly generous, bridging the

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -276,8 +276,8 @@ fn tessellate_plain_cylinder_watertight() {
 
 /// Regression for issue #696: dovetail-style fuse where a small tongue protrudes
 /// into two adjacent slabs. The downstream consumer (gridfinity-layout-tool)
-/// adds a TONGUE_PROTRUSION specifically to avoid coplanar fuse residue under
-/// OCCT, but brepkit's pipeline produced non-manifold tessellation output. This
+/// adds a TONGUE_PROTRUSION specifically to avoid coplanar fuse residue, but
+/// brepkit's pipeline produced non-manifold tessellation output. This
 /// minimal case exercises the same topological pattern.
 #[test]
 fn tessellate_dovetail_fuse_manifold_issue_696() {

--- a/crates/wasm/src/bindings/heal.rs
+++ b/crates/wasm/src/bindings/heal.rs
@@ -106,9 +106,9 @@ impl BrepKernel {
     /// already in the model are left untouched. Returns the number of entities
     /// converted.
     ///
-    /// Equivalent to OCCT's `BRepBuilderAPI_NurbsConvert`. Stored pcurves are
-    /// dropped during conversion — callers that depend on pcurves should
-    /// recompute them afterwards.
+    /// Converts every analytic surface and curve to a NURBS representation.
+    /// Stored pcurves are dropped during conversion — callers that depend on
+    /// pcurves should recompute them afterwards.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## What

Several doc and inline comments named a third-party CAD kernel's internal classes/methods to describe what brepkit's own code does. Project policy is not to reference external kernels in code or comments. This PR rewords them to describe the behavior directly.

Examples:
- `BuilderSolid — X-style 4-phase shell assembly` → `BuilderSolid — 4-phase shell assembly`
- `Implements the X \`BlendFunc_ConstRad\` constraint system:` → `Constraint system:`
- `Equivalent to X's \`BRepBuilderAPI_NurbsConvert\`. Stored pcurves are dropped…` → `Converts every analytic surface and curve to a NURBS representation. Stored pcurves are dropped…`
- `Reference: X \`BOPTools_AlgoTools::GetFaceOff\`` → removed (the function's own doc already describes it)

## Scope & safety

22 comments across 12 files (algo `builder/`+`pave_filler/`, blend, heal, operations `section`/`extrude`/`heal`, wasm bindings). Comment-only:
- No doc block deleted — only the kernel-naming sentence/clause was removed or reworded, so every documented item keeps its doc (`missing_docs` is `-D warnings` in CI).
- No code changed.

## Verification
- `rg -ni 'occt|opencascade'` → no matches remain
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean