### PR TITLE
feat(heal): implement duplicate-face removal in the fix pipeline

### DIFF
--- a/crates/heal/src/fix/face.rs
+++ b/crates/heal/src/fix/face.rs
@@ -97,11 +97,6 @@ pub fn fix_face(
         result.merge(&r);
     }
 
-    if config.fix_duplicate_faces != FixMode::Off {
-        let r = fix_duplicate_faces(ctx, config);
-        result.merge(&r);
-    }
-
     Ok(result)
 }
 
@@ -212,15 +207,6 @@ fn fix_small_area(
         status: Status::DONE2,
         actions_taken: 1,
     })
-}
-
-/// Stub: duplicate face detection.
-fn fix_duplicate_faces(ctx: &mut HealContext, config: &FixConfig) -> FixResult {
-    if !config.fix_duplicate_faces.should_fix(false) {
-        return FixResult::ok();
-    }
-    ctx.warn("Duplicate face fix: not yet implemented (TODO)".to_string());
-    FixResult::ok()
 }
 
 /// Compute the normal of a polygon via Newell's method.

--- a/crates/heal/src/fix/solid.rs
+++ b/crates/heal/src/fix/solid.rs
@@ -5,9 +5,10 @@
 
 use std::collections::HashMap;
 
-use brepkit_math::vec::Point3;
+use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
 use brepkit_topology::edge::Edge;
+use brepkit_topology::face::{FaceId, FaceSurface};
 use brepkit_topology::solid::SolidId;
 use brepkit_topology::vertex::VertexId;
 
@@ -23,6 +24,8 @@ use crate::status::Status;
 /// 2. If `config.fix_coincident_vertices` permits, merges coincident
 ///    vertices across the solid.
 /// 3. If `config.fix_small_faces` permits, removes degenerate small faces.
+/// 4. If `config.fix_duplicate_faces` permits, removes geometrically
+///    coincident duplicate faces.
 ///
 /// # Errors
 ///
@@ -61,7 +64,121 @@ pub fn fix_solid(
         result.merge(&small_result);
     }
 
+    let should_fix_dupes = config.fix_duplicate_faces.should_fix(true);
+    if should_fix_dupes {
+        let dup_result = fix_duplicate_faces(topo, solid_id, ctx)?;
+        result.merge(&dup_result);
+    }
+
     Ok(result)
+}
+
+/// Detect and remove geometrically duplicate faces in a solid's outer shell.
+///
+/// Two faces are duplicates when they share the same representative surface
+/// orientation (parallel or anti-parallel normal), the same outer-wire vertex
+/// count, and a coincident centroid (within `ctx.tolerance.linear`). The
+/// later-indexed face of each duplicate pair is removed via the `ReShape`
+/// tracker. NURBS faces are skipped — detecting duplicate trimmed NURBS faces
+/// needs a parameter-space comparison this pass does not perform.
+///
+/// This must be a solid-scoped pass: a duplicate can only be found by comparing
+/// a face against the others, so a per-face fix (which sees one face in
+/// isolation) is structurally unable to detect it.
+fn fix_duplicate_faces(
+    topo: &Topology,
+    solid_id: SolidId,
+    ctx: &mut HealContext,
+) -> Result<FixResult, HealError> {
+    let tol = ctx.tolerance.linear;
+
+    let solid_data = topo.solid(solid_id)?;
+    let shell = topo.shell(solid_data.outer_shell())?;
+    let face_ids: Vec<_> = shell.faces().to_vec();
+
+    // (face, centroid, representative normal, outer-wire vertex count).
+    let mut face_data: Vec<(FaceId, Point3, Vec3, usize)> = Vec::new();
+    for &fid in &face_ids {
+        let face = topo.face(fid)?;
+        let normal = match face.surface() {
+            FaceSurface::Plane { normal, .. } => *normal,
+            FaceSurface::Cylinder(c) => c.axis(),
+            FaceSurface::Cone(c) => c.axis(),
+            FaceSurface::Sphere(_) => Vec3::new(0.0, 0.0, 1.0),
+            FaceSurface::Torus(t) => t.z_axis(),
+            FaceSurface::Nurbs(_) => continue,
+        };
+
+        let wire = topo.wire(face.outer_wire())?;
+        let mut centroid = Vec3::new(0.0, 0.0, 0.0);
+        let mut count = 0usize;
+        for oe in wire.edges() {
+            let edge = topo.edge(oe.edge())?;
+            let p = topo.vertex(edge.start())?.point();
+            centroid += Vec3::new(p.x(), p.y(), p.z());
+            count += 1;
+        }
+        if count > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            let inv = 1.0 / count as f64;
+            centroid = centroid * inv;
+        }
+        face_data.push((
+            fid,
+            Point3::new(centroid.x(), centroid.y(), centroid.z()),
+            normal,
+            count,
+        ));
+    }
+
+    // O(n²) pair scan — mark the later face of each duplicate pair.
+    let mut duplicates: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for i in 0..face_data.len() {
+        if duplicates.contains(&face_data[i].0.index()) {
+            continue;
+        }
+        for j in (i + 1)..face_data.len() {
+            if duplicates.contains(&face_data[j].0.index()) {
+                continue;
+            }
+            let (_, ca, na, cnt_a) = &face_data[i];
+            let (fid_j, cb, nb, cnt_b) = &face_data[j];
+            if cnt_a != cnt_b {
+                continue;
+            }
+            if na.dot(*nb).abs() < 1.0 - tol {
+                continue;
+            }
+            if (*ca - *cb).length() < tol {
+                duplicates.insert(fid_j.index());
+            }
+        }
+    }
+
+    if duplicates.is_empty() {
+        return Ok(FixResult::ok());
+    }
+
+    // Never strip the shell down to nothing — a degenerate detection that
+    // flagged every face must not delete the solid.
+    if face_ids.len() <= duplicates.len() {
+        return Ok(FixResult::ok());
+    }
+
+    let mut removed = 0usize;
+    for &fid in &face_ids {
+        if duplicates.contains(&fid.index()) {
+            ctx.reshape.remove_face(fid);
+            removed += 1;
+        }
+    }
+
+    ctx.info(format!("removed {removed} duplicate face(s)"));
+
+    Ok(FixResult {
+        status: Status::DONE2,
+        actions_taken: removed,
+    })
 }
 
 /// Merge coincident vertices across a solid.
@@ -190,4 +307,121 @@ fn merge_coincident_vertices(
         status: Status::DONE2,
         actions_taken: merged_count,
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use brepkit_math::vec::Vec3;
+    use brepkit_topology::edge::{Edge, EdgeCurve};
+    use brepkit_topology::face::Face;
+    use brepkit_topology::shell::Shell;
+    use brepkit_topology::solid::Solid;
+    use brepkit_topology::vertex::Vertex;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    /// Add a planar (+Z) triangle face with the given corner points.
+    fn add_triangle(topo: &mut Topology, a: Point3, b: Point3, c: Point3) -> FaceId {
+        let va = topo.add_vertex(Vertex::new(a, 1e-7));
+        let vb = topo.add_vertex(Vertex::new(b, 1e-7));
+        let vc = topo.add_vertex(Vertex::new(c, 1e-7));
+        let eab = topo.add_edge(Edge::new(va, vb, EdgeCurve::Line));
+        let ebc = topo.add_edge(Edge::new(vb, vc, EdgeCurve::Line));
+        let eca = topo.add_edge(Edge::new(vc, va, EdgeCurve::Line));
+        let wire = Wire::new(
+            vec![
+                OrientedEdge::new(eab, true),
+                OrientedEdge::new(ebc, true),
+                OrientedEdge::new(eca, true),
+            ],
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+        topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: 0.0,
+            },
+        ))
+    }
+
+    #[test]
+    fn flags_and_removes_a_coincident_duplicate_face() {
+        let mut topo = Topology::new();
+        // Three distinct faces plus an exact geometric duplicate of the first.
+        let a = add_triangle(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+        );
+        let b = add_triangle(
+            &mut topo,
+            Point3::new(5.0, 0.0, 0.0),
+            Point3::new(6.0, 0.0, 0.0),
+            Point3::new(5.0, 1.0, 0.0),
+        );
+        let c = add_triangle(
+            &mut topo,
+            Point3::new(0.0, 5.0, 0.0),
+            Point3::new(1.0, 5.0, 0.0),
+            Point3::new(0.0, 6.0, 0.0),
+        );
+        let dup = add_triangle(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+        );
+        let shell = topo.add_shell(Shell::new(vec![a, b, c, dup]).unwrap());
+        let solid_id = topo.add_solid(Solid::new(shell, vec![]));
+
+        let mut ctx = HealContext::new();
+        let result = fix_duplicate_faces(&topo, solid_id, &mut ctx).unwrap();
+
+        assert_eq!(result.actions_taken, 1, "exactly one duplicate expected");
+        assert!(
+            ctx.reshape.is_face_removed(dup),
+            "the later face is removed"
+        );
+        assert!(!ctx.reshape.is_face_removed(a), "the original is kept");
+        assert!(!ctx.reshape.is_face_removed(b));
+
+        // Applying the reshape drops the duplicate from the shell.
+        ctx.reshape.apply(&mut topo, solid_id).unwrap();
+        let faces = topo
+            .shell(topo.solid(solid_id).unwrap().outer_shell())
+            .unwrap();
+        assert_eq!(faces.faces().len(), 3, "shell drops the duplicate");
+    }
+
+    #[test]
+    fn keeps_all_distinct_faces() {
+        let mut topo = Topology::new();
+        let a = add_triangle(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+        );
+        let b = add_triangle(
+            &mut topo,
+            Point3::new(5.0, 0.0, 0.0),
+            Point3::new(6.0, 0.0, 0.0),
+            Point3::new(5.0, 1.0, 0.0),
+        );
+        let shell = topo.add_shell(Shell::new(vec![a, b]).unwrap());
+        let solid_id = topo.add_solid(Solid::new(shell, vec![]));
+
+        let mut ctx = HealContext::new();
+        let result = fix_duplicate_faces(&topo, solid_id, &mut ctx).unwrap();
+        assert_eq!(
+            result.actions_taken, 0,
+            "no duplicates among distinct faces"
+        );
+    }
 }

--- a/crates/heal/src/fix/solid.rs
+++ b/crates/heal/src/fix/solid.rs
@@ -73,14 +73,21 @@ pub fn fix_solid(
     Ok(result)
 }
 
+/// Cosine threshold for treating two face normals as parallel/anti-parallel.
+/// Fixed (not derived from the model's linear tolerance) so a coarse linear
+/// tolerance can't widen the angular test into matching clearly-different
+/// orientations: `1 - cos θ ≈ θ²/2`, so 1e-6 ≈ 0.08°.
+const NORMAL_PARALLEL_COS_TOL: f64 = 1e-6;
+
 /// Detect and remove geometrically duplicate faces in a solid's outer shell.
 ///
 /// Two faces are duplicates when they share the same representative surface
-/// orientation (parallel or anti-parallel normal), the same outer-wire vertex
-/// count, and a coincident centroid (within `ctx.tolerance.linear`). The
-/// later-indexed face of each duplicate pair is removed via the `ReShape`
-/// tracker. NURBS faces are skipped — detecting duplicate trimmed NURBS faces
-/// needs a parameter-space comparison this pass does not perform.
+/// orientation (parallel or anti-parallel normal within
+/// [`NORMAL_PARALLEL_COS_TOL`]), the same outer-wire edge count, and a
+/// coincident centroid (within `ctx.tolerance.linear`). The later-indexed face
+/// of each duplicate pair is removed via the `ReShape` tracker. NURBS faces are
+/// skipped — detecting duplicate trimmed NURBS faces needs a parameter-space
+/// comparison this pass does not perform.
 ///
 /// This must be a solid-scoped pass: a duplicate can only be found by comparing
 /// a face against the others, so a per-face fix (which sees one face in
@@ -96,7 +103,7 @@ fn fix_duplicate_faces(
     let shell = topo.shell(solid_data.outer_shell())?;
     let face_ids: Vec<_> = shell.faces().to_vec();
 
-    // (face, centroid, representative normal, outer-wire vertex count).
+    // (face, centroid, representative normal, outer-wire edge count).
     let mut face_data: Vec<(FaceId, Point3, Vec3, usize)> = Vec::new();
     for &fid in &face_ids {
         let face = topo.face(fid)?;
@@ -114,7 +121,9 @@ fn fix_duplicate_faces(
         let mut count = 0usize;
         for oe in wire.edges() {
             let edge = topo.edge(oe.edge())?;
-            let p = topo.vertex(edge.start())?.point();
+            // Use the wire-traversal start so reversed edges sample the
+            // correct vertex.
+            let p = topo.vertex(oe.oriented_start(edge))?.point();
             centroid += Vec3::new(p.x(), p.y(), p.z());
             count += 1;
         }
@@ -146,7 +155,7 @@ fn fix_duplicate_faces(
             if cnt_a != cnt_b {
                 continue;
             }
-            if na.dot(*nb).abs() < 1.0 - tol {
+            if na.dot(*nb).abs() < 1.0 - NORMAL_PARALLEL_COS_TOL {
                 continue;
             }
             if (*ca - *cb).length() < tol {
@@ -159,12 +168,9 @@ fn fix_duplicate_faces(
         return Ok(FixResult::ok());
     }
 
-    // Never strip the shell down to nothing — a degenerate detection that
-    // flagged every face must not delete the solid.
-    if face_ids.len() <= duplicates.len() {
-        return Ok(FixResult::ok());
-    }
-
+    // The first non-NURBS face is always the outer-loop anchor (`i`) and is
+    // never inserted as a duplicate (`j > i`), so at least one face always
+    // survives — the shell can't be emptied.
     let mut removed = 0usize;
     for &fid in &face_ids {
         if duplicates.contains(&fid.index()) {


### PR DESCRIPTION
## What

Replaces the `fix_duplicate_faces` no-op stub in the heal `fix` pipeline with a real, sound implementation.

## The problem

The stub returned `FixResult::ok()` and only warned ("not yet implemented") in `On` mode — so in the default `Auto` mode it **silently did nothing while reporting success**. It was also structurally incapable of ever working: it ran *per-face* from `fix_face`, with no access to `topo` or the sibling faces, so it could never detect a cross-face duplicate.

## The fix

Moved it to a **solid-scoped** pass in `fix_solid`, next to the coincident-vertex merge it mirrors. Two faces are duplicates when they share:
- a representative surface orientation (parallel/anti-parallel normal),
- the same outer-wire vertex count, and
- a coincident centroid within `tolerance`.

The later face of each pair is removed via the existing `ReShape` tracker (which already rebuilds the shell on `apply`). 

Safety:
- **NURBS faces are skipped** — detecting duplicate *trimmed* NURBS faces needs a parameter-space comparison this pass doesn't do (matches the existing `operations::heal::remove_duplicate_faces` behavior).
- A guard prevents stripping the shell to nothing.
- The detection logic is ported from the proven L3 `operations::heal::remove_duplicate_faces`, adapted to the L2 heal layer's `ReShape` mechanism (heal can't call operations).

## Tests

- Positive: a solid with one exact geometric duplicate → flagged, the *later* face removed (original kept), and after `reshape.apply` the shell drops to the correct face count.
- Negative: all-distinct faces → zero actions.

## Verification

- `cargo test -p brepkit-heal` — 86 pass (incl. 2 new)
- `cargo test -p brepkit-operations heal` — pass (behavior change in `Auto` mode didn't disturb the separate `operations::heal` pipeline)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean