### PR TITLE
fix(sweep): densify long spine spans so non-square sweeps don't overshoot

### DIFF
--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -341,6 +341,62 @@ fn build_inner_cap_wires(
     Ok(wires)
 }
 
+/// Insert interior points into a polyline so no gap exceeds a small multiple
+/// of the typical (median) sample spacing.
+///
+/// A single global interpolating NURBS fit through unevenly-spaced points
+/// overshoots wildly where a long, sparsely-sampled span (e.g. a long straight
+/// spine edge sampled only at its endpoints) sits between densely-sampled
+/// high-curvature corners — chord-length parameterization does not prevent this
+/// when one span is orders of magnitude longer than its neighbours. Bounding
+/// the max gap keeps the fit well-conditioned. The threshold is derived from
+/// the median gap, so it is scale-invariant; interior insertion per segment is
+/// capped to avoid blow-up on pathological inputs.
+#[must_use]
+pub fn densify_path_points(points: &[Point3]) -> Vec<Point3> {
+    const GAP_RATIO: f64 = 4.0;
+    const MAX_INSERT_PER_SEGMENT: usize = 256;
+
+    if points.len() < 3 {
+        return points.to_vec();
+    }
+
+    let mut gaps: Vec<f64> = points
+        .windows(2)
+        .map(|w| (w[1] - w[0]).length())
+        .filter(|d| *d > 1e-12)
+        .collect();
+    if gaps.is_empty() {
+        return points.to_vec();
+    }
+    gaps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median = gaps[gaps.len() / 2];
+    let max_gap = median * GAP_RATIO;
+    if max_gap <= 0.0 {
+        return points.to_vec();
+    }
+
+    let mut out: Vec<Point3> = Vec::with_capacity(points.len());
+    for w in points.windows(2) {
+        let (a, b) = (w[0], w[1]);
+        out.push(a);
+        let seg = (b - a).length();
+        if seg > max_gap {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let steps = ((seg / max_gap).ceil() as usize).min(MAX_INSERT_PER_SEGMENT);
+            for s in 1..steps {
+                #[allow(clippy::cast_precision_loss)]
+                let f = (s as f64) / (steps as f64);
+                out.push(a + (b - a) * f);
+            }
+        }
+    }
+    if let Some(&last) = points.last() {
+        out.push(last);
+    }
+    out
+}
+
 /// Sweep a face along a path curve to produce a solid.
 ///
 /// Creates a solid by moving a planar profile along a NURBS curve, with the

--- a/crates/operations/src/sweep/tests.rs
+++ b/crates/operations/src/sweep/tests.rs
@@ -1030,3 +1030,90 @@ fn sweep_miter_fallback_smooth_on_no_kinks() {
         "straight-path miter fallback should produce volume ~5.0, got {vol}"
     );
 }
+
+// ── densify_path_points (rectLipSweep non-square overshoot regression) ──
+
+/// Sample a rounded-rectangle boundary the way `sweepAlongEdges` does: line
+/// edges contribute only endpoints; corner arcs contribute interior samples.
+/// This reproduces the under-sampled long-edge condition that made the global
+/// interpolating path fit overshoot on non-square spines.
+fn sparse_rounded_rect(half_x: f64, half_y: f64, r: f64) -> Vec<Point3> {
+    let (cx, cy) = (half_x - r, half_y - r);
+    let hp = std::f64::consts::FRAC_PI_2;
+    let corners = [
+        (cx, -cy, -hp, 0.0),
+        (cx, cy, 0.0, hp),
+        (-cx, cy, hp, std::f64::consts::PI),
+        (-cx, -cy, std::f64::consts::PI, 3.0 * hp),
+    ];
+    let mut pts: Vec<Point3> = Vec::new();
+    let push = |p: Point3, pts: &mut Vec<Point3>| {
+        if pts.last().is_none_or(|l: &Point3| (*l - p).length() > 1e-7) {
+            pts.push(p);
+        }
+    };
+    for &(ccx, ccy, a0, a1) in &corners {
+        for k in 0..=8 {
+            let a = a0 + (a1 - a0) * f64::from(k) / 8.0;
+            push(
+                Point3::new(ccx + r * a.cos(), ccy + r * a.sin(), 0.0),
+                &mut pts,
+            );
+        }
+    }
+    if let Some(first) = pts.first().copied() {
+        push(first, &mut pts);
+    }
+    pts
+}
+
+fn path_x_extent(path: &NurbsCurve) -> (f64, f64) {
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for k in 0..=400 {
+        let x = path.evaluate(f64::from(k) / 400.0).x();
+        lo = lo.min(x);
+        hi = hi.max(x);
+    }
+    (lo, hi)
+}
+
+#[test]
+fn densify_fixes_nonsquare_spine_overshoot() {
+    use brepkit_math::nurbs::fitting::interpolate;
+
+    // 42 x 126 rounded rect → half 21 x 63, r 3.75. Long edges (~118mm) are
+    // sampled only at endpoints, so the raw fit overshoots far past x = ±21.
+    let pts = sparse_rounded_rect(21.0, 63.0, 3.75);
+
+    let raw = interpolate(&pts, 3).unwrap();
+    let (_, raw_hi) = path_x_extent(&raw);
+    assert!(
+        raw_hi > 50.0,
+        "expected the un-densified fit to overshoot (got x_max {raw_hi}); \
+         if this no longer overshoots the regression guard is moot"
+    );
+
+    let dense = densify_path_points(&pts);
+    let fixed = interpolate(&dense, 3).unwrap();
+    let (fixed_lo, fixed_hi) = path_x_extent(&fixed);
+    assert!(
+        fixed_hi < 22.0 && fixed_lo > -22.0,
+        "densified fit must stay near the true ±21 bound, got x[{fixed_lo:.2},{fixed_hi:.2}]"
+    );
+}
+
+#[test]
+fn densify_leaves_uniform_polyline_unchanged() {
+    // Evenly spaced points: no gap exceeds the median multiple, so no inserts.
+    let pts: Vec<Point3> = (0..10)
+        .map(|i| Point3::new(f64::from(i), 0.0, 0.0))
+        .collect();
+    assert_eq!(densify_path_points(&pts).len(), pts.len());
+}
+
+#[test]
+fn densify_short_input_is_identity() {
+    let pts = vec![Point3::new(0.0, 0.0, 0.0), Point3::new(10.0, 0.0, 0.0)];
+    assert_eq!(densify_path_points(&pts), pts);
+}

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -960,6 +960,12 @@ impl BrepKernel {
             .into());
         }
 
+        // Densify long, sparsely-sampled spans (e.g. long straight spine edges
+        // sampled only at endpoints) so the global interpolating fit below does
+        // not overshoot at adjacent high-curvature corners (e.g. non-square
+        // rounded-rect spines).
+        let points = brepkit_operations::sweep::densify_path_points(&points);
+
         // Fit an interpolating NURBS curve through the points.
         let degree = std::cmp::min(3, points.len() - 1);
         let path_curve = brepkit_math::nurbs::fitting::interpolate(&points, degree)?;


### PR DESCRIPTION
## Summary

`sweepAlongEdges` produced catastrophically wrong geometry for **non-square** swept profiles: a 42×126 gridfinity lip spine ballooned to **x = ±104** instead of ±21 (a 5× blow-out). The square case was always fine, which masked the bug. This was the open `gridfinity.rectLipSweep` parity gap in brepjs.

## Root cause

`sweepAlongEdges` samples points along the spine wire and fits a **single global interpolating NURBS** through them — but it samples **line edges only at their endpoints**. On a non-square rounded-rect spine, a long (~118 mm) straight edge becomes one under-constrained span sitting between densely-sampled tight corner arcs (r = 3.75). A global C2 interpolation through points whose spacing varies ~160× overshoots wildly at the high-curvature corners. Chord-length parameterization (already used) does not prevent this. Square spines are unaffected because every edge is short and well-constrained.

Diagnosis isolated the fault to the **path fit**, not the frame transport: a path-only bounds check (no sweep) showed the fitted NURBS itself reaching x = ±104. The rotation-minimizing frame logic was exonerated.

## Fix

`densify_path_points` (in `operations::sweep`): insert interior points so no gap exceeds a small multiple (4×) of the **median** sample spacing — scale-invariant, with per-segment insertion capped at 256 to avoid blow-up on pathological inputs. Called in `sweepAlongEdges` before `interpolate`.

After the fix the fitted path stays within ±21 and the swept lip is geometrically correct (`x[-22.28,22.28] y[-64.28,64.28] z[-1.52,2.88] vol 2254`), matching the square lip (vol 2256).

## Verification

- New regression test `densify_fixes_nonsquare_spine_overshoot` (asserts the raw fit overshoots and the densified fit stays near ±21), plus identity/uniform-input guards.
- Full `brepkit-operations` suite green (682 passed, 0 failed); clippy clean.
- **End-to-end**: built the wasm, swapped it into brepjs, and ran the real `sweepSketch`(withContact) path — the 42×126 lip no longer balloons (xMax 22.28, correct 4.4 mm height).

## Note

Fixing the sweep uncovered a *separate* downstream issue: fusing the corrected non-square lip onto its hollow box drops the lip (coincident contact-ring, the known GFA same-domain/overlap theme) — the square case fuses fine. That is a distinct GFA boolean gap, tracked separately; this PR resolves the documented sweep overshoot.