### PR TITLE
chore(rust): upgrade pinned toolchain 1.94.0 → 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
-# rust-toolchain.toml pins the exact Rust version (1.94.0) and includes
+# rust-toolchain.toml pins the exact Rust version (1.96.0) and includes
 # rustfmt, clippy, and the wasm32 target. Rustup auto-detects it, so most
 # jobs don't need dtolnay/rust-toolchain.
 

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -109,10 +109,7 @@ pub fn build_wire_loops_with_winding(
     let mut used = vec![false; edges.len()];
     let mut loops = Vec::new();
 
-    loop {
-        let Some(start_idx) = used.iter().position(|u| !u) else {
-            break;
-        };
+    while let Some(start_idx) = used.iter().position(|u| !u) {
         used[start_idx] = true;
 
         let start_vertex = quantize_uv_periodic(edges[start_idx].start_uv, tol, u_period, v_period);

--- a/crates/algo/src/pave_filler/phase_ef.rs
+++ b/crates/algo/src/pave_filler/phase_ef.rs
@@ -326,7 +326,7 @@ fn check_edge_face_pairs(
 
                 arena.face_info_mut(fid).vertices_in.insert(vertex_id);
 
-                log::debug!("EF: edge {eid:?} crosses face {fid:?} at t={t:.6}",);
+                log::debug!("EF: edge {eid:?} crosses face {fid:?} at t={t:.6}");
             }
         }
     }

--- a/crates/algo/src/pave_filler/phase_vv.rs
+++ b/crates/algo/src/pave_filler/phase_vv.rs
@@ -62,7 +62,7 @@ pub fn perform(
 
                 arena.merge_vertices(va, vb);
 
-                log::debug!("VV: vertices {va:?} and {vb:?} coincide (dist={dist:.2e})",);
+                log::debug!("VV: vertices {va:?} and {vb:?} coincide (dist={dist:.2e})");
             }
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain to the latest stable.

- `rust-toolchain.toml`: `1.94.0` → **`1.96.0`** (+ matching `ci.yml` comment).
- **MSRV unchanged** at `1.85` (edition-2024 floor); the CI MSRV job still pins 1.85.0.

## New 1.96 clippy lints fixed (under `-D warnings`, all in `brepkit-algo`)

- `while_let_loop` — `wire_builder` `loop {}` + let-else-break rewritten as `while let`.
- `unnecessary_trailing_comma` ×2 — trailing comma removed from two `log::debug!` calls.

## Verification (on 1.96.0)

- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — all pass (incl. the long boolean suite)
- `cargo build -p brepkit-wasm --target wasm32-unknown-unknown` — builds
- `cargo +1.85.1 check -p brepkit-algo` — MSRV still compiles