### PR TITLE
chore(rust): raise MSRV to 1.88, refresh deps, adopt let-chains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,15 @@ jobs:
           files: lcov.info
 
   msrv:
-    name: MSRV (1.85)
+    name: MSRV (1.88)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # Override rust-toolchain.toml to test the declared minimum version
+      # Override rust-toolchain.toml to test the declared minimum version.
+      # Action SHA stays pinned; the Rust version is set explicitly below.
       - uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
+        with:
+          toolchain: "1.88.0"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "git+https://github.com/andymai/brepkit.git"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.dependencies]
 # Math

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -694,10 +694,10 @@ fn normalize_face_wires(topo: &mut Topology, fid: FaceId) {
 
     // Only the inner-wire *list* changes when empties were dropped; the face
     // already points at the (in-place updated) outer and surviving wires.
-    if kept_inner_wids.len() != inner_wids.len() {
-        if let Ok(f) = topo.face_mut(fid) {
-            *f.inner_wires_mut() = kept_inner_wids;
-        }
+    if kept_inner_wids.len() != inner_wids.len()
+        && let Ok(f) = topo.face_mut(fid)
+    {
+        *f.inner_wires_mut() = kept_inner_wids;
     }
 }
 
@@ -860,10 +860,10 @@ fn remove_zero_length_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Res
         let mut new_inner_ids = Vec::new();
         for inner_oes in &inner_oes_list {
             let kept = strip(inner_oes);
-            if is_rebuildable_loop(topo, &kept) {
-                if let Ok(w) = brepkit_topology::wire::Wire::new(kept, true) {
-                    new_inner_ids.push(topo.add_wire(w));
-                }
+            if is_rebuildable_loop(topo, &kept)
+                && let Ok(w) = brepkit_topology::wire::Wire::new(kept, true)
+            {
+                new_inner_ids.push(topo.add_wire(w));
             }
         }
         let mut new_face = Face::new(new_outer_id, new_inner_ids, surface);

--- a/crates/algo/src/builder/face_splitter/conversion.rs
+++ b/crates/algo/src/builder/face_splitter/conversion.rs
@@ -21,10 +21,10 @@ pub fn collect_wire_points(
     };
     let mut pts = Vec::new();
     for oe in wire.edges() {
-        if let Ok(edge) = topo.edge(oe.edge()) {
-            if let Ok(v) = topo.vertex(edge.start()) {
-                pts.push(v.point());
-            }
+        if let Ok(edge) = topo.edge(oe.edge())
+            && let Ok(v) = topo.vertex(edge.start())
+        {
+            pts.push(v.point());
         }
     }
     pts

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -427,8 +427,10 @@ pub fn split_face_2d(
     // into stacked bands, not discs. Requires seam-anchored circles (see
     // the seam-anchor pre-pass in fill_images_faces); falls through to the
     // generic paths when preconditions don't hold.
-    if u_periodic && !is_plane && original_inner_wires.is_empty() {
-        if let Some(bands) = split_periodic_face_into_bands(
+    if u_periodic
+        && !is_plane
+        && original_inner_wires.is_empty()
+        && let Some(bands) = split_periodic_face_into_bands(
             &surface,
             &boundary_edges,
             sections,
@@ -436,9 +438,9 @@ pub fn split_face_2d(
             reversed,
             face_id,
             tol.linear,
-        ) {
-            return bands;
-        }
+        )
+    {
+        return bands;
     }
 
     // Internal section edge shortcut: when section edges form closed loops
@@ -539,11 +541,11 @@ pub fn split_face_2d(
         let seam_u = {
             let mut su = 0.0_f64;
             for edge in &boundary_edges {
-                if matches!(edge.curve_3d, EdgeCurve::Line) {
-                    if let Some((u, _)) = surface.project_point(edge.start_3d) {
-                        su = u;
-                        break;
-                    }
+                if matches!(edge.curve_3d, EdgeCurve::Line)
+                    && let Some((u, _)) = surface.project_point(edge.start_3d)
+                {
+                    su = u;
+                    break;
                 }
             }
             su
@@ -554,10 +556,10 @@ pub fn split_face_2d(
             if (edge.start_3d - edge.end_3d).length() < 1e-10 {
                 // Closed edge: find the 3D point at u = seam_u + pi on the surface.
                 // Project the boundary vertex to get v, then evaluate surface at (anti_u, v).
-                if let Some((_, v)) = surface.project_point(edge.start_3d) {
-                    if let Some(anti_pt) = surface.evaluate(anti_u, v) {
-                        split_pts_3d.push(anti_pt);
-                    }
+                if let Some((_, v)) = surface.project_point(edge.start_3d)
+                    && let Some(anti_pt) = surface.evaluate(anti_u, v)
+                {
+                    split_pts_3d.push(anti_pt);
                 }
             }
         }
@@ -722,36 +724,37 @@ pub fn split_face_2d(
     // build_surface_info), so quantized junction keys would never match.
     // Remap every endpoint u into the continuous window that starts after
     // the largest angular gap.
-    if !u_periodic && !is_plane {
-        if let (Some(u_period), _) = super::pcurve_compute::surface_periods(&surface) {
-            let mut us: Vec<f64> = all_edges
-                .iter()
-                .flat_map(|e| [e.start_uv.x(), e.end_uv.x()])
-                .map(|u| u.rem_euclid(u_period))
-                .collect();
-            us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            if us.len() >= 2 {
-                let mut gap_start = us[us.len() - 1];
-                let mut max_gap = u_period - (us[us.len() - 1] - us[0]);
-                for w in us.windows(2) {
-                    if w[1] - w[0] > max_gap {
-                        max_gap = w[1] - w[0];
-                        gap_start = w[0];
-                    }
+    if !u_periodic
+        && !is_plane
+        && let (Some(u_period), _) = super::pcurve_compute::surface_periods(&surface)
+    {
+        let mut us: Vec<f64> = all_edges
+            .iter()
+            .flat_map(|e| [e.start_uv.x(), e.end_uv.x()])
+            .map(|u| u.rem_euclid(u_period))
+            .collect();
+        us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        if us.len() >= 2 {
+            let mut gap_start = us[us.len() - 1];
+            let mut max_gap = u_period - (us[us.len() - 1] - us[0]);
+            for w in us.windows(2) {
+                if w[1] - w[0] > max_gap {
+                    max_gap = w[1] - w[0];
+                    gap_start = w[0];
                 }
-                if max_gap > 0.05 {
-                    let lo = gap_start + max_gap;
-                    for e in &mut all_edges {
-                        let remap = |uv: Point2| -> Point2 {
-                            let mut d = (uv.x() - lo).rem_euclid(u_period);
-                            if d > u_period - 1e-6 {
-                                d = 0.0;
-                            }
-                            Point2::new(lo + d, uv.y())
-                        };
-                        e.start_uv = remap(e.start_uv);
-                        e.end_uv = remap(e.end_uv);
-                    }
+            }
+            if max_gap > 0.05 {
+                let lo = gap_start + max_gap;
+                for e in &mut all_edges {
+                    let remap = |uv: Point2| -> Point2 {
+                        let mut d = (uv.x() - lo).rem_euclid(u_period);
+                        if d > u_period - 1e-6 {
+                            d = 0.0;
+                        }
+                        Point2::new(lo + d, uv.y())
+                    };
+                    e.start_uv = remap(e.start_uv);
+                    e.end_uv = remap(e.end_uv);
                 }
             }
         }
@@ -793,16 +796,16 @@ pub fn split_face_2d(
     // section's endpoint mid-way on the other, 3 regions): it merges everything
     // into one loop, or splits on only one section. Prefer the direct geometric
     // construction whenever it yields more regions than the wire builder did.
-    if sections.len() >= 2 && is_plane && !holes_integrated {
-        if let Some(ref boundary) = boundary_edges_backup {
-            if let Some(result) = try_split_crossing_plane_face(
-                &surface, boundary, sections, rank, reversed, face_id, frame, tol,
-            ) {
-                if result.len() > loops.len() {
-                    return result;
-                }
-            }
-        }
+    if sections.len() >= 2
+        && is_plane
+        && !holes_integrated
+        && let Some(ref boundary) = boundary_edges_backup
+        && let Some(result) = try_split_crossing_plane_face(
+            &surface, boundary, sections, rank, reversed, face_id, frame, tol,
+        )
+        && result.len() > loops.len()
+    {
+        return result;
     }
 
     // Classify each loop as outer (positive area) or hole (negative).
@@ -913,10 +916,8 @@ pub fn split_face_2d(
                     break;
                 }
             }
-            if !assigned {
-                if let Some(sf) = sub_faces.first_mut() {
-                    sf.inner_wires.push(hole);
-                }
+            if !assigned && let Some(sf) = sub_faces.first_mut() {
+                sf.inner_wires.push(hole);
             }
         }
     }
@@ -999,23 +1000,23 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
     // strip at constant v) need the interior UV offset toward the pole.
     // The outer wire of a sphere cap maps to a horizontal line in UV,
     // producing a near-zero-area polygon whose centroid lies on the boundary.
-    if let FaceSurface::Sphere(_) = &sub_face.surface {
-        if !pts_2d.is_empty() {
-            let v_min = pts_2d.iter().map(|p| p.y()).fold(f64::INFINITY, f64::min);
-            let v_max = pts_2d
-                .iter()
-                .map(|p| p.y())
-                .fold(f64::NEG_INFINITY, f64::max);
-            if (v_max - v_min) < 0.1 {
-                let v_boundary = (v_min + v_max) * 0.5;
-                let v_pole = if v_boundary >= 0.0 {
-                    std::f64::consts::FRAC_PI_2
-                } else {
-                    -std::f64::consts::FRAC_PI_2
-                };
-                let u_center = pts_2d.iter().map(|p| p.x()).sum::<f64>() / pts_2d.len() as f64;
-                interior_uv = Point2::new(u_center, (v_boundary + v_pole) * 0.5);
-            }
+    if let FaceSurface::Sphere(_) = &sub_face.surface
+        && !pts_2d.is_empty()
+    {
+        let v_min = pts_2d.iter().map(|p| p.y()).fold(f64::INFINITY, f64::min);
+        let v_max = pts_2d
+            .iter()
+            .map(|p| p.y())
+            .fold(f64::NEG_INFINITY, f64::max);
+        if (v_max - v_min) < 0.1 {
+            let v_boundary = (v_min + v_max) * 0.5;
+            let v_pole = if v_boundary >= 0.0 {
+                std::f64::consts::FRAC_PI_2
+            } else {
+                -std::f64::consts::FRAC_PI_2
+            };
+            let u_center = pts_2d.iter().map(|p| p.x()).sum::<f64>() / pts_2d.len() as f64;
+            interior_uv = Point2::new(u_center, (v_boundary + v_pole) * 0.5);
         }
     }
 

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -780,10 +780,10 @@ pub(super) fn split_face_with_internal_loops(
             })
             .collect();
         // Verify hole is closed.
-        if let (Some(first), Some(last)) = (hole.first(), hole.last()) {
-            if (last.end_3d - first.start_3d).length() < tol_3d * 100.0 {
-                all_holes.push(hole);
-            }
+        if let (Some(first), Some(last)) = (hole.first(), hole.last())
+            && (last.end_3d - first.start_3d).length() < tol_3d * 100.0
+        {
+            all_holes.push(hole);
         }
     }
 

--- a/crates/algo/src/builder/fill_images.rs
+++ b/crates/algo/src/builder/fill_images.rs
@@ -27,10 +27,10 @@ pub fn fill_edge_images(arena: &GfaArena) -> HashMap<EdgeId, Vec<EdgeId>> {
         let mut split_with_param: Vec<(f64, EdgeId)> = Vec::new();
 
         for leaf_id in leaves {
-            if let Some(pb) = arena.pave_blocks.get(leaf_id) {
-                if let Some(se) = pb.split_edge {
-                    split_with_param.push((pb.start.parameter, se));
-                }
+            if let Some(pb) = arena.pave_blocks.get(leaf_id)
+                && let Some(se) = pb.split_edge
+            {
+                split_with_param.push((pb.start.parameter, se));
             }
         }
 

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -73,15 +73,14 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
         };
         let mut map = HashMap::new();
         for (_, cb) in arena.common_blocks.iter() {
-            if let Some(edge_id) = cb.split_edge {
-                if let Ok(edge) = topo.edge(edge_id) {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        let qs = qpt(sv.point());
-                        let qe = qpt(ev.point());
-                        let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
-                        map.insert(key, edge_id);
-                    }
-                }
+            if let Some(edge_id) = cb.split_edge
+                && let Ok(edge) = topo.edge(edge_id)
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+            {
+                let qs = qpt(sv.point());
+                let qe = qpt(ev.point());
+                let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
+                map.insert(key, edge_id);
             }
         }
         map
@@ -179,18 +178,18 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
         let mut vid_faces: HashMap<usize, (Point3, std::collections::HashSet<usize>)> =
             HashMap::new();
         for (&face_id, &_rank) in face_ranks {
-            if let Ok(face) = topo.face(face_id) {
-                if let Ok(wire) = topo.wire(face.outer_wire()) {
-                    for oe in wire.edges() {
-                        if let Ok(edge) = topo.edge(oe.edge()) {
-                            for &vid in &[edge.start(), edge.end()] {
-                                let rv = arena.resolve_vertex(vid);
-                                if let Ok(v) = topo.vertex(rv) {
-                                    let entry = vid_faces.entry(rv.index()).or_insert_with(|| {
-                                        (v.point(), std::collections::HashSet::new())
-                                    });
-                                    entry.1.insert(face_id.index());
-                                }
+            if let Ok(face) = topo.face(face_id)
+                && let Ok(wire) = topo.wire(face.outer_wire())
+            {
+                for oe in wire.edges() {
+                    if let Ok(edge) = topo.edge(oe.edge()) {
+                        for &vid in &[edge.start(), edge.end()] {
+                            let rv = arena.resolve_vertex(vid);
+                            if let Ok(v) = topo.vertex(rv) {
+                                let entry = vid_faces.entry(rv.index()).or_insert_with(|| {
+                                    (v.point(), std::collections::HashSet::new())
+                                });
+                                entry.1.insert(face_id.index());
                             }
                         }
                     }
@@ -538,17 +537,18 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
                     new_oes.push(*oe);
                 }
             }
-            if any_changed && new_oes.len() >= 3 {
-                if let Ok(new_wire) = Wire::new(new_oes, true) {
-                    let wid = topo.add_wire(new_wire);
-                    let new_face = if is_reversed {
-                        Face::new_reversed(wid, vec![], surface)
-                    } else {
-                        Face::new(wid, vec![], surface)
-                    };
-                    if let Ok(face) = topo.face_mut(sf.face_id) {
-                        *face = new_face;
-                    }
+            if any_changed
+                && new_oes.len() >= 3
+                && let Ok(new_wire) = Wire::new(new_oes, true)
+            {
+                let wid = topo.add_wire(new_wire);
+                let new_face = if is_reversed {
+                    Face::new_reversed(wid, vec![], surface)
+                } else {
+                    Face::new(wid, vec![], surface)
+                };
+                if let Ok(face) = topo.face_mut(sf.face_id) {
+                    *face = new_face;
                 }
             }
         }
@@ -844,10 +844,10 @@ fn rebuild_face_with_cb_edges(
                 let qs = qpt(sv.point());
                 let qe = qpt(ev.point());
                 let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
-                if let Some(&cb_edge) = cb_qpair_edges.get(&key) {
-                    if cb_edge != oe.edge() {
-                        return true;
-                    }
+                if let Some(&cb_edge) = cb_qpair_edges.get(&key)
+                    && cb_edge != oe.edge()
+                {
+                    return true;
                 }
                 if vv_vertex_seed
                     .get(&qs)
@@ -933,10 +933,10 @@ fn rebuild_face_with_cb_edges(
         let cb_start_qs: HashMap<brepkit_topology::edge::EdgeId, (i64, i64, i64)> = {
             let mut m = HashMap::new();
             for &eid in cb_qpair_edges.values() {
-                if let Ok(e) = topo.edge(eid) {
-                    if let Ok(v) = topo.vertex(e.start()) {
-                        m.insert(eid, qpt(v.point()));
-                    }
+                if let Ok(e) = topo.edge(eid)
+                    && let Ok(v) = topo.vertex(e.start())
+                {
+                    m.insert(eid, qpt(v.point()));
                 }
             }
             m
@@ -953,18 +953,18 @@ fn rebuild_face_with_cb_edges(
 
             // (1) CB edge replacement
             let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
-            if let Some(&cb_edge) = cb_qpair_edges.get(&key) {
-                if cb_edge != eid {
-                    let oriented_start_q = if fwd { qs } else { qe };
-                    // If we can't look up the CB edge's start position,
-                    // preserve the original orientation rather than
-                    // guessing `false`.
-                    let new_fwd = cb_start_qs
-                        .get(&cb_edge)
-                        .map_or(fwd, |&cs| cs == oriented_start_q);
-                    oes.push(OrientedEdge::new(cb_edge, new_fwd));
-                    continue;
-                }
+            if let Some(&cb_edge) = cb_qpair_edges.get(&key)
+                && cb_edge != eid
+            {
+                let oriented_start_q = if fwd { qs } else { qe };
+                // If we can't look up the CB edge's start position,
+                // preserve the original orientation rather than
+                // guessing `false`.
+                let new_fwd = cb_start_qs
+                    .get(&cb_edge)
+                    .map_or(fwd, |&cs| cs == oriented_start_q);
+                oes.push(OrientedEdge::new(cb_edge, new_fwd));
+                continue;
             }
 
             // (2) Vertex canonicalization via VV seed
@@ -1154,10 +1154,10 @@ fn build_section_map(topo: &Topology, arena: &GfaArena) -> HashMap<FaceId, Vec<S
         // strictly inside the disc; drop those on or outside its boundary.
         let cap_disc = cap_disc_circle(topo, face_id);
         for &pb_id in &fi.pave_blocks_in {
-            if let Some(circle) = &cap_disc {
-                if !pb_strictly_inside_circle(topo, arena, pb_id, circle) {
-                    continue;
-                }
+            if let Some(circle) = &cap_disc
+                && !pb_strictly_inside_circle(topo, arena, pb_id, circle)
+            {
+                continue;
             }
             map.entry(face_id)
                 .or_default()
@@ -1990,58 +1990,58 @@ fn resolve_edge_vertices(
         let pb_id = arena.pave_blocks.id_from_index(pb_idx);
         let is_cb = pb_id.is_some_and(|id| arena.pb_to_cb.contains_key(&id));
         let pb = pb_id.and_then(|id| arena.pave_blocks.get(id));
-        if let Some(pb) = pb {
-            if let (true, Some(split_edge)) = (is_cb, pb.split_edge) {
-                // Use the split edge's actual vertices — these are the topology
-                // entities created by MakeSplitEdges and shared via CommonBlocks.
-                if let Ok(se) = topo.edge(split_edge) {
-                    let se_start = se.start();
-                    let se_end = se.end();
+        if let Some(pb) = pb
+            && let (true, Some(split_edge)) = (is_cb, pb.split_edge)
+        {
+            // Use the split edge's actual vertices — these are the topology
+            // entities created by MakeSplitEdges and shared via CommonBlocks.
+            if let Ok(se) = topo.edge(split_edge) {
+                let se_start = se.start();
+                let se_end = se.end();
 
-                    // Verify position match (section edges can be forward or reversed)
-                    let start_pos = topo
-                        .vertex(se_start)
-                        .ok()
-                        .map(brepkit_topology::vertex::Vertex::point);
-                    let end_pos = topo
-                        .vertex(se_end)
-                        .ok()
-                        .map(brepkit_topology::vertex::Vertex::point);
+                // Verify position match (section edges can be forward or reversed)
+                let start_pos = topo
+                    .vertex(se_start)
+                    .ok()
+                    .map(brepkit_topology::vertex::Vertex::point);
+                let end_pos = topo
+                    .vertex(se_end)
+                    .ok()
+                    .map(brepkit_topology::vertex::Vertex::point);
 
-                    if let (Some(sp), Some(ep)) = (start_pos, end_pos) {
-                        let fwd_match = (sp - edge.start_3d).length() < tol.linear
-                            && (ep - edge.end_3d).length() < tol.linear;
-                        let rev_match = (sp - edge.end_3d).length() < tol.linear
-                            && (ep - edge.start_3d).length() < tol.linear;
+                if let (Some(sp), Some(ep)) = (start_pos, end_pos) {
+                    let fwd_match = (sp - edge.start_3d).length() < tol.linear
+                        && (ep - edge.end_3d).length() < tol.linear;
+                    let rev_match = (sp - edge.end_3d).length() < tol.linear
+                        && (ep - edge.start_3d).length() < tol.linear;
 
-                        if fwd_match {
-                            let qs = quantize(edge.start_3d);
-                            let qe = quantize(edge.end_3d);
-                            // Use fresh vertex from cache/registry if available
-                            // (from rank pool or CB pre-pass). Fall back to
-                            // the split_edge's actual vertex only if no fresh
-                            // vertex exists. This prevents topology connections
-                            // between the GFA result and the PaveFiller's
-                            // intermediate split edges.
-                            let vs = *cache
-                                .entry(qs)
-                                .or_insert_with(|| *pb_registry.entry(qs).or_insert(se_start));
-                            let ve = *cache
-                                .entry(qe)
-                                .or_insert_with(|| *pb_registry.entry(qe).or_insert(se_end));
-                            return (vs, ve);
-                        }
-                        if rev_match {
-                            let qs = quantize(edge.start_3d);
-                            let qe = quantize(edge.end_3d);
-                            let vs = *cache
-                                .entry(qs)
-                                .or_insert_with(|| *pb_registry.entry(qs).or_insert(se_end));
-                            let ve = *cache
-                                .entry(qe)
-                                .or_insert_with(|| *pb_registry.entry(qe).or_insert(se_start));
-                            return (vs, ve);
-                        }
+                    if fwd_match {
+                        let qs = quantize(edge.start_3d);
+                        let qe = quantize(edge.end_3d);
+                        // Use fresh vertex from cache/registry if available
+                        // (from rank pool or CB pre-pass). Fall back to
+                        // the split_edge's actual vertex only if no fresh
+                        // vertex exists. This prevents topology connections
+                        // between the GFA result and the PaveFiller's
+                        // intermediate split edges.
+                        let vs = *cache
+                            .entry(qs)
+                            .or_insert_with(|| *pb_registry.entry(qs).or_insert(se_start));
+                        let ve = *cache
+                            .entry(qe)
+                            .or_insert_with(|| *pb_registry.entry(qe).or_insert(se_end));
+                        return (vs, ve);
+                    }
+                    if rev_match {
+                        let qs = quantize(edge.start_3d);
+                        let qe = quantize(edge.end_3d);
+                        let vs = *cache
+                            .entry(qs)
+                            .or_insert_with(|| *pb_registry.entry(qs).or_insert(se_end));
+                        let ve = *cache
+                            .entry(qe)
+                            .or_insert_with(|| *pb_registry.entry(qe).or_insert(se_start));
+                        return (vs, ve);
                     }
                 }
             }

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -352,14 +352,12 @@ fn sample_face_interior(
                 }
             }
         }
-        if let Some(mid) = closed_mid {
-            if v_max - v_min > tol.linear {
-                if let Some((u, _)) = face.surface().project_point(mid) {
-                    if let Some(pt) = face.surface().evaluate(u, 0.5 * (v_min + v_max)) {
-                        return Ok(pt);
-                    }
-                }
-            }
+        if let Some(mid) = closed_mid
+            && v_max - v_min > tol.linear
+            && let Some((u, _)) = face.surface().project_point(mid)
+            && let Some(pt) = face.surface().evaluate(u, 0.5 * (v_min + v_max))
+        {
+            return Ok(pt);
         }
     }
 
@@ -522,10 +520,10 @@ fn sample_face_interior(
     let interior_pt = mid_pt + offset;
 
     // Project back onto the surface to ensure the point is on-surface
-    if let Some((u, v)) = surface.project_point(interior_pt) {
-        if let Some(on_surface) = surface.evaluate(u, v) {
-            return Ok(on_surface);
-        }
+    if let Some((u, v)) = surface.project_point(interior_pt)
+        && let Some(on_surface) = surface.evaluate(u, v)
+    {
+        return Ok(on_surface);
     }
 
     // Planes have no UV projection, but the inward offset is already in-plane,

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -111,10 +111,10 @@ pub fn detect_same_domain<S: BuildHasher>(
     // Key = edge set, Value = list of sub-face indices with that set.
     let mut groups: HashMap<EdgeSet, Vec<usize>> = HashMap::new();
     for (idx, edge_set) in edge_sets.iter().enumerate() {
-        if let Some(es) = edge_set {
-            if !es.is_empty() {
-                groups.entry(es.clone()).or_default().push(idx);
-            }
+        if let Some(es) = edge_set
+            && !es.is_empty()
+        {
+            groups.entry(es.clone()).or_default().push(idx);
         }
     }
 

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -250,14 +250,13 @@ pub fn remove_pendant_sections(
         for incident in vmap.values() {
             let mut srcs = incident.iter().map(|&i| edges[i].source_edge_idx);
             let first = srcs.next().flatten();
-            if let Some(src) = first {
-                if incident
+            if let Some(src) = first
+                && incident
                     .iter()
                     .all(|&i| edges[i].source_edge_idx == Some(src))
-                {
-                    pendant_src = Some(src);
-                    break;
-                }
+            {
+                pendant_src = Some(src);
+                break;
             }
         }
 

--- a/crates/algo/src/classifier/analytic.rs
+++ b/crates/algo/src/classifier/analytic.rs
@@ -491,17 +491,22 @@ pub fn try_build_analytic_classifier(
     }
 
     // Cylinder + plane caps.
-    if has_cylinder && has_planar && !has_sphere {
-        if let Some(c) = try_build_cylinder_classifier(topo, shell.faces(), cylinder_info?, &tol) {
-            return Some(c);
-        }
+    if has_cylinder
+        && has_planar
+        && !has_sphere
+        && let Some(c) = try_build_cylinder_classifier(topo, shell.faces(), cylinder_info?, &tol)
+    {
+        return Some(c);
     }
 
     // Cone + plane caps.
-    if has_cone && has_planar && !has_sphere && !has_cylinder {
-        if let Some(c) = try_build_cone_classifier(topo, shell.faces(), cone_info?, &tol) {
-            return Some(c);
-        }
+    if has_cone
+        && has_planar
+        && !has_sphere
+        && !has_cylinder
+        && let Some(c) = try_build_cone_classifier(topo, shell.faces(), cone_info?, &tol)
+    {
+        return Some(c);
     }
 
     // Mixed plane+cone/cylinder: try ConvexAnalytic.
@@ -525,10 +530,10 @@ fn try_build_planar_classifier(
     tol: &Tolerance,
 ) -> Option<AnalyticClassifier> {
     // Try axis-aligned box (exactly 6 faces).
-    if faces.len() == 6 {
-        if let Some(c) = try_build_box_classifier(topo, faces, tol) {
-            return Some(c);
-        }
+    if faces.len() == 6
+        && let Some(c) = try_build_box_classifier(topo, faces, tol)
+    {
+        return Some(c);
     }
 
     // Try convex polyhedron.

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -168,10 +168,10 @@ fn wire_polygon(
     // Drop the duplicated closing point.
     if verts.len() >= 2 {
         let first_pt = verts[0];
-        if let Some(last) = verts.last() {
-            if (*last - first_pt).length() < join_tol {
-                verts.pop();
-            }
+        if let Some(last) = verts.last()
+            && (*last - first_pt).length() < join_tol
+        {
+            verts.pop();
         }
     }
     Ok(verts)

--- a/crates/algo/src/ds/arena.rs
+++ b/crates/algo/src/ds/arena.rs
@@ -157,10 +157,10 @@ impl GfaArena {
     /// Add a face reference to an existing CommonBlock.
     #[allow(dead_code)] // Used by upcoming ForceInterfEE
     pub fn add_face_to_cb(&mut self, cb: CommonBlockId, face: FaceId) {
-        if let Some(cb) = self.common_blocks.get_mut(cb) {
-            if !cb.faces.contains(&face) {
-                cb.faces.push(face);
-            }
+        if let Some(cb) = self.common_blocks.get_mut(cb)
+            && !cb.faces.contains(&face)
+        {
+            cb.faces.push(face);
         }
     }
 }

--- a/crates/algo/src/pave_filler/helpers.rs
+++ b/crates/algo/src/pave_filler/helpers.rs
@@ -27,10 +27,10 @@ pub(super) fn find_nearby_pave_vertex(
             if let Some(pb) = arena.pave_blocks.get(pb_id) {
                 for vid in [pb.start.vertex, pb.end.vertex] {
                     let resolved = arena.resolve_vertex(vid);
-                    if let Ok(v) = topo.vertex(resolved) {
-                        if (v.point() - point).length() <= tol.linear {
-                            return Some(resolved);
-                        }
+                    if let Ok(v) = topo.vertex(resolved)
+                        && (v.point() - point).length() <= tol.linear
+                    {
+                        return Some(resolved);
                     }
                 }
             }

--- a/crates/algo/src/pave_filler/link_existing.rs
+++ b/crates/algo/src/pave_filler/link_existing.rs
@@ -107,15 +107,14 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
             let key = if qs <= qe { (qs, qe) } else { (qe, qs) };
             boundary_index.entry(key).or_default().push(pb_id);
 
-            if sv == ev {
-                if let Ok(edge) = topo.edge(pb.original_edge) {
-                    if let EdgeCurve::Circle(c) = edge.curve() {
-                        closed_index
-                            .entry(circle_key(c, qpt, scale))
-                            .or_default()
-                            .push(pb_id);
-                    }
-                }
+            if sv == ev
+                && let Ok(edge) = topo.edge(pb.original_edge)
+                && let EdgeCurve::Circle(c) = edge.curve()
+            {
+                closed_index
+                    .entry(circle_key(c, qpt, scale))
+                    .or_default()
+                    .push(pb_id);
             }
         }
     }
@@ -184,22 +183,22 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
             // the seam vertex, which is arbitrary, so coincident circles
             // with different seams never share a key. Match on quantized
             // circle geometry instead.
-            if !linked_this && sv == ev {
-                if let EdgeCurve::Circle(c) = &section_curve {
-                    if let Some(candidates) = closed_index.get(&circle_key(c, qpt, scale)) {
-                        for &boundary_pb_id in candidates {
-                            if try_link(
-                                topo,
-                                tol,
-                                arena,
-                                section_pb_id,
-                                &section_curve,
-                                boundary_pb_id,
-                            ) {
-                                linked += 1;
-                                break;
-                            }
-                        }
+            if !linked_this
+                && sv == ev
+                && let EdgeCurve::Circle(c) = &section_curve
+                && let Some(candidates) = closed_index.get(&circle_key(c, qpt, scale))
+            {
+                for &boundary_pb_id in candidates {
+                    if try_link(
+                        topo,
+                        tol,
+                        arena,
+                        section_pb_id,
+                        &section_curve,
+                        boundary_pb_id,
+                    ) {
+                        linked += 1;
+                        break;
                     }
                 }
             }

--- a/crates/algo/src/pave_filler/make_split_edges.rs
+++ b/crates/algo/src/pave_filler/make_split_edges.rs
@@ -46,10 +46,10 @@ pub fn perform(topo: &mut Topology, arena: &mut GfaArena) -> Result<(), AlgoErro
             if !processed_cbs.insert(cb_id) {
                 // CB already processed — reuse its split edge
                 let split_edge = arena.common_blocks.get(cb_id).and_then(|cb| cb.split_edge);
-                if let Some(edge_id) = split_edge {
-                    if let Some(pb) = arena.pave_blocks.get_mut(pb_id) {
-                        pb.split_edge = Some(edge_id);
-                    }
+                if let Some(edge_id) = split_edge
+                    && let Some(pb) = arena.pave_blocks.get_mut(pb_id)
+                {
+                    pb.split_edge = Some(edge_id);
                 }
                 continue;
             }

--- a/crates/algo/src/pave_filler/phase_ee.rs
+++ b/crates/algo/src/pave_filler/phase_ee.rs
@@ -179,13 +179,12 @@ fn find_edge_edge_crossings(
     // (which return no crossings above), the overlap is handled by VE paves
     // at arc endpoints plus ForceInterfEE common blocks — sampling here
     // would emit a spurious crossing at every sample pair along the arc.
-    if let (EdgeCurve::Circle(ca), EdgeCurve::Circle(cb)) = (edge_a.curve(), edge_b.curve()) {
-        if (ca.radius() - cb.radius()).abs() < tol.linear
-            && (ca.center() - cb.center()).length() < tol.linear
-            && ca.normal().dot(cb.normal()).abs() > 1.0 - tol.angular
-        {
-            return Ok(Vec::new());
-        }
+    if let (EdgeCurve::Circle(ca), EdgeCurve::Circle(cb)) = (edge_a.curve(), edge_b.curve())
+        && (ca.radius() - cb.radius()).abs() < tol.linear
+        && (ca.center() - cb.center()).length() < tol.linear
+        && ca.normal().dot(cb.normal()).abs() > 1.0 - tol.angular
+    {
+        return Ok(Vec::new());
     }
 
     let n: usize = 32;
@@ -235,17 +234,17 @@ fn find_edge_edge_crossings(
                 [&pts_a[i], &pts_a[i + 1]],
                 [&pts_b[j], &pts_b[j + 1]],
                 tol.linear,
-            ) {
-                if domain_a.contains(&t_a) && domain_b.contains(&t_b) {
-                    // Deduplicate: skip if too close to existing crossing
-                    let is_dup = crossings
-                        .iter()
-                        .any(|&(ct_a, ct_b, _): &(f64, f64, Point3)| {
-                            (t_a - ct_a).abs() < 1e-6 && (t_b - ct_b).abs() < 1e-6
-                        });
-                    if !is_dup {
-                        crossings.push((t_a, t_b, pt));
-                    }
+            ) && domain_a.contains(&t_a)
+                && domain_b.contains(&t_b)
+            {
+                // Deduplicate: skip if too close to existing crossing
+                let is_dup = crossings
+                    .iter()
+                    .any(|&(ct_a, ct_b, _): &(f64, f64, Point3)| {
+                        (t_a - ct_a).abs() < 1e-6 && (t_b - ct_b).abs() < 1e-6
+                    });
+                if !is_dup {
+                    crossings.push((t_a, t_b, pt));
                 }
             }
         }

--- a/crates/algo/src/pave_filler/phase_ef.rs
+++ b/crates/algo/src/pave_filler/phase_ef.rs
@@ -157,12 +157,11 @@ fn build_face_containment(
     // The last edge's end vertex coincides with the first edge's start
     // vertex on a closed wire; drop the duplicate so the closing polygon
     // segment isn't degenerate.
-    if outer_points.len() >= 2 {
-        if let (Some(&first), Some(&last)) = (outer_points.first(), outer_points.last()) {
-            if (last - first).length() <= tol.linear {
-                outer_points.pop();
-            }
-        }
+    if outer_points.len() >= 2
+        && let (Some(&first), Some(&last)) = (outer_points.first(), outer_points.last())
+        && (last - first).length() <= tol.linear
+    {
+        outer_points.pop();
     }
     all_points.extend_from_slice(&outer_points);
 

--- a/crates/algo/src/pave_filler/phase_ff_coplanar.rs
+++ b/crates/algo/src/pave_filler/phase_ff_coplanar.rs
@@ -265,11 +265,11 @@ fn process_coplanar_pair(
     for &(b_eid, p2d_start, p2d_end, _, _) in &edges_b {
         let start_edge = which_boundary_edge(p2d_start, &edges_a, tol.linear);
         let end_edge = which_boundary_edge(p2d_end, &edges_a, tol.linear);
-        if let (Some(si), Some(ei)) = (start_edge, end_edge) {
-            if si == ei {
-                let a_eid = edges_a[si].0;
-                create_coplanar_common_block(arena, a_eid, b_eid, tol.linear);
-            }
+        if let (Some(si), Some(ei)) = (start_edge, end_edge)
+            && si == ei
+        {
+            let a_eid = edges_a[si].0;
+            create_coplanar_common_block(arena, a_eid, b_eid, tol.linear);
         }
     }
 
@@ -369,10 +369,10 @@ fn should_create_section_edge(
     // crossing edges that enter and exit the target boundary.
     let start_edge_idx = which_boundary_edge(p2d_start, target_edges, tol);
     let end_edge_idx = which_boundary_edge(p2d_end, target_edges, tol);
-    if let (Some(si), Some(ei)) = (start_edge_idx, end_edge_idx) {
-        if si == ei {
-            return false; // Both endpoints on the same target edge — shared boundary
-        }
+    if let (Some(si), Some(ei)) = (start_edge_idx, end_edge_idx)
+        && si == ei
+    {
+        return false; // Both endpoints on the same target edge — shared boundary
     }
 
     let mid = Point2::new(

--- a/crates/algo/src/pave_filler/phase_vf.rs
+++ b/crates/algo/src/pave_filler/phase_vf.rs
@@ -120,12 +120,12 @@ fn check_vertex_face_pairs(
                     }
                 }
                 _ => {
-                    if let Some((u, v)) = surface.project_point(pos) {
-                        if let Some(surf_pt) = surface.evaluate(u, v) {
-                            let dist = (pos - surf_pt).length();
-                            if dist <= combined_tol {
-                                record_vf(arena, resolved_vid, fid, (u, v));
-                            }
+                    if let Some((u, v)) = surface.project_point(pos)
+                        && let Some(surf_pt) = surface.evaluate(u, v)
+                    {
+                        let dist = (pos - surf_pt).length();
+                        if dist <= combined_tol {
+                            record_vf(arena, resolved_vid, fid, (u, v));
                         }
                     }
                 }

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -806,38 +806,38 @@ fn trace_builder_overlapping_box_fuse() {
 
     // Dump edges for sub-faces with out-of-bounds interior points
     for (i, sf) in sub_faces.iter().enumerate() {
-        if let Some(pt) = sf.interior_point {
-            if pt.x() > 1.6 || pt.x() < -0.1 || pt.y() > 1.1 || pt.z() > 1.1 {
-                eprintln!(
-                    "  OUT-OF-BOUNDS SF[{i}]: ipt=({:.3},{:.3},{:.3})",
-                    pt.x(),
-                    pt.y(),
-                    pt.z()
-                );
-                if let Ok(face) = topo.face(sf.face_id) {
-                    if let Ok(wire) = topo.wire(face.outer_wire()) {
-                        for (ei, oe) in wire.edges().iter().enumerate() {
-                            if let Ok(edge) = topo.edge(oe.edge()) {
-                                let sp = topo
-                                    .vertex(edge.start())
-                                    .map(brepkit_topology::vertex::Vertex::point)
-                                    .ok();
-                                let ep = topo
-                                    .vertex(edge.end())
-                                    .map(brepkit_topology::vertex::Vertex::point)
-                                    .ok();
-                                if let (Some(s), Some(e)) = (sp, ep) {
-                                    eprintln!(
-                                        "    E[{ei}]: ({:.4},{:.4},{:.4})->({:.4},{:.4},{:.4})",
-                                        s.x(),
-                                        s.y(),
-                                        s.z(),
-                                        e.x(),
-                                        e.y(),
-                                        e.z()
-                                    );
-                                }
-                            }
+        if let Some(pt) = sf.interior_point
+            && (pt.x() > 1.6 || pt.x() < -0.1 || pt.y() > 1.1 || pt.z() > 1.1)
+        {
+            eprintln!(
+                "  OUT-OF-BOUNDS SF[{i}]: ipt=({:.3},{:.3},{:.3})",
+                pt.x(),
+                pt.y(),
+                pt.z()
+            );
+            if let Ok(face) = topo.face(sf.face_id)
+                && let Ok(wire) = topo.wire(face.outer_wire())
+            {
+                for (ei, oe) in wire.edges().iter().enumerate() {
+                    if let Ok(edge) = topo.edge(oe.edge()) {
+                        let sp = topo
+                            .vertex(edge.start())
+                            .map(brepkit_topology::vertex::Vertex::point)
+                            .ok();
+                        let ep = topo
+                            .vertex(edge.end())
+                            .map(brepkit_topology::vertex::Vertex::point)
+                            .ok();
+                        if let (Some(s), Some(e)) = (sp, ep) {
+                            eprintln!(
+                                "    E[{ei}]: ({:.4},{:.4},{:.4})->({:.4},{:.4},{:.4})",
+                                s.x(),
+                                s.y(),
+                                s.z(),
+                                e.x(),
+                                e.y(),
+                                e.z()
+                            );
                         }
                     }
                 }
@@ -1032,22 +1032,21 @@ fn trace_builder_z_axis_overlap() {
         );
 
         // Dump edges for faces with unexpected edge counts
-        if n_edges != 4 {
-            if let Ok(face) = topo.face(sf.face_id) {
-                if let Ok(wire) = topo.wire(face.outer_wire()) {
-                    for (ei, oe) in wire.edges().iter().enumerate() {
-                        if let Ok(edge) = topo.edge(oe.edge()) {
-                            let sp = topo
-                                .vertex(edge.start())
-                                .map(brepkit_topology::vertex::Vertex::point)
-                                .ok();
-                            let ep = topo
-                                .vertex(edge.end())
-                                .map(brepkit_topology::vertex::Vertex::point)
-                                .ok();
-                            eprintln!("    E[{ei}]: {sp:?} -> {ep:?} fwd={}", oe.is_forward());
-                        }
-                    }
+        if n_edges != 4
+            && let Ok(face) = topo.face(sf.face_id)
+            && let Ok(wire) = topo.wire(face.outer_wire())
+        {
+            for (ei, oe) in wire.edges().iter().enumerate() {
+                if let Ok(edge) = topo.edge(oe.edge()) {
+                    let sp = topo
+                        .vertex(edge.start())
+                        .map(brepkit_topology::vertex::Vertex::point)
+                        .ok();
+                    let ep = topo
+                        .vertex(edge.end())
+                        .map(brepkit_topology::vertex::Vertex::point)
+                        .ok();
+                    eprintln!("    E[{ei}]: {sp:?} -> {ep:?} fwd={}", oe.is_forward());
                 }
             }
         }
@@ -1110,18 +1109,18 @@ fn gfa_fuse_z_axis_overlapping_manifold_boxes() {
     eprintln!("{e} edges, {v} verts, euler={euler}, {non_manifold} non-manifold");
 
     for (&eid, &count) in &edge_face_count {
-        if count != 2 {
-            if let Ok(e) = topo.edge(eid) {
-                let sp = topo
-                    .vertex(e.start())
-                    .map(brepkit_topology::vertex::Vertex::point)
-                    .ok();
-                let ep = topo
-                    .vertex(e.end())
-                    .map(brepkit_topology::vertex::Vertex::point)
-                    .ok();
-                eprintln!("  NM edge {eid:?}: count={count} {sp:?} -> {ep:?}");
-            }
+        if count != 2
+            && let Ok(e) = topo.edge(eid)
+        {
+            let sp = topo
+                .vertex(e.start())
+                .map(brepkit_topology::vertex::Vertex::point)
+                .ok();
+            let ep = topo
+                .vertex(e.end())
+                .map(brepkit_topology::vertex::Vertex::point)
+                .ok();
+            eprintln!("  NM edge {eid:?}: count={count} {sp:?} -> {ep:?}");
         }
     }
 
@@ -1457,10 +1456,10 @@ fn gfa_cut_box_cylinder_coplanar_caps_produces_valid_topology() {
     )> = Vec::new();
     for &eid in edge_use_count.keys() {
         let edge = topo.edge(eid).unwrap();
-        if edge.start() == edge.end() {
-            if let EdgeCurve::Circle(c) = edge.curve() {
-                full_circles.push((eid, c.clone()));
-            }
+        if edge.start() == edge.end()
+            && let EdgeCurve::Circle(c) = edge.curve()
+        {
+            full_circles.push((eid, c.clone()));
         }
     }
     for i in 0..full_circles.len() {

--- a/crates/blend/src/corner.rs
+++ b/crates/blend/src/corner.rs
@@ -161,16 +161,16 @@ fn contact_section_at_vertex<'a>(
         return Option::None;
     }
 
-    if let Ok(first_edge) = topo.edge(edges[0]) {
-        if first_edge.start() == vertex_id {
-            return stripe.sections.first();
-        }
+    if let Ok(first_edge) = topo.edge(edges[0])
+        && first_edge.start() == vertex_id
+    {
+        return stripe.sections.first();
     }
 
-    if let Ok(last_edge) = topo.edge(edges[edges.len() - 1]) {
-        if last_edge.end() == vertex_id {
-            return stripe.sections.last();
-        }
+    if let Ok(last_edge) = topo.edge(edges[edges.len() - 1])
+        && last_edge.end() == vertex_id
+    {
+        return stripe.sections.last();
     }
 
     let vpos = topo.vertex(vertex_id).ok()?.point();

--- a/crates/check/src/distance/mod.rs
+++ b/crates/check/src/distance/mod.rs
@@ -72,13 +72,12 @@ pub fn point_to_solid(
         da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    if let Some(closest_idx) = bvh.query_closest(point) {
-        if let Some(pos) = candidates
+    if let Some(closest_idx) = bvh.query_closest(point)
+        && let Some(pos) = candidates
             .iter()
             .position(|&i| face_aabbs[i].0 == closest_idx)
-        {
-            candidates.swap(0, pos);
-        }
+    {
+        candidates.swap(0, pos);
     }
 
     for idx in candidates {
@@ -88,11 +87,11 @@ pub fn point_to_solid(
         }
         let face_idx = face_aabbs[idx].0;
         let fid = face_ids[face_idx];
-        if let Ok(Some((dist, closest))) = point_to_face(topo, point, fid) {
-            if dist < best_dist {
-                best_dist = dist;
-                best_point = closest;
-            }
+        if let Ok(Some((dist, closest))) = point_to_face(topo, point, fid)
+            && dist < best_dist
+        {
+            best_dist = dist;
+            best_point = closest;
         }
     }
 
@@ -212,12 +211,12 @@ pub fn solid_to_solid(
             if aabb.distance_squared_to_point(pa) > best_dist * best_dist {
                 continue;
             }
-            if let Ok(Some((dist, closest))) = point_to_face(topo, pa, faces_b[idx]) {
-                if dist < best_dist {
-                    best_dist = dist;
-                    best_a = pa;
-                    best_b = closest;
-                }
+            if let Ok(Some((dist, closest))) = point_to_face(topo, pa, faces_b[idx])
+                && dist < best_dist
+            {
+                best_dist = dist;
+                best_a = pa;
+                best_b = closest;
             }
         }
     }
@@ -235,12 +234,12 @@ pub fn solid_to_solid(
             if aabb.distance_squared_to_point(pb) > best_dist * best_dist {
                 continue;
             }
-            if let Ok(Some((dist, closest))) = point_to_face(topo, pb, faces_a[idx]) {
-                if dist < best_dist {
-                    best_dist = dist;
-                    best_b = pb;
-                    best_a = closest;
-                }
+            if let Ok(Some((dist, closest))) = point_to_face(topo, pb, faces_a[idx])
+                && dist < best_dist
+            {
+                best_dist = dist;
+                best_b = pb;
+                best_a = closest;
             }
         }
     }

--- a/crates/geometry/src/convert/recognize_curve.rs
+++ b/crates/geometry/src/convert/recognize_curve.rs
@@ -200,11 +200,11 @@ fn try_recognize_circle(samples: &[Point3], tolerance: f64) -> Option<(Point3, V
         for pt in samples.iter().skip(i + 1) {
             let v2 = *pt - p0;
             let n = v1.cross(v2);
-            if n.length() > tolerance {
-                if let Ok(normalized) = n.normalize() {
-                    normal = Some(normalized);
-                    break 'outer;
-                }
+            if n.length() > tolerance
+                && let Ok(normalized) = n.normalize()
+            {
+                normal = Some(normalized);
+                break 'outer;
             }
         }
     }
@@ -340,11 +340,11 @@ fn try_recognize_ellipse(
         for pt in samples.iter().skip(i + 1) {
             let v2 = *pt - p0;
             let n = v1.cross(v2);
-            if n.length() > tolerance {
-                if let Ok(normalized) = n.normalize() {
-                    normal = Some(normalized);
-                    break 'outer;
-                }
+            if n.length() > tolerance
+                && let Ok(normalized) = n.normalize()
+            {
+                normal = Some(normalized);
+                break 'outer;
             }
         }
     }
@@ -502,11 +502,11 @@ fn try_recognize_hyperbola(
         for pt in samples.iter().skip(i + 1) {
             let v2 = *pt - p0;
             let n = v1.cross(v2);
-            if n.length() > tolerance {
-                if let Ok(normalized) = n.normalize() {
-                    normal = Some(normalized);
-                    break 'outer;
-                }
+            if n.length() > tolerance
+                && let Ok(normalized) = n.normalize()
+            {
+                normal = Some(normalized);
+                break 'outer;
             }
         }
     }
@@ -660,11 +660,11 @@ fn try_recognize_parabola(samples: &[Point3], tolerance: f64) -> Option<(Point3,
         for pt in samples.iter().skip(i + 1) {
             let v2 = *pt - p0;
             let n = v1.cross(v2);
-            if n.length() > tolerance {
-                if let Ok(normalized) = n.normalize() {
-                    normal = Some(normalized);
-                    break 'outer;
-                }
+            if n.length() > tolerance
+                && let Ok(normalized) = n.normalize()
+            {
+                normal = Some(normalized);
+                break 'outer;
             }
         }
     }

--- a/crates/geometry/src/convert/recognize_surface.rs
+++ b/crates/geometry/src/convert/recognize_surface.rs
@@ -133,11 +133,11 @@ fn try_recognize_plane(surface: &NurbsSurface, tolerance: f64) -> Option<(Vec3, 
         for pt in all_pts.iter().skip(i + 1) {
             let v2 = *pt - p0;
             let n = v1.cross(v2);
-            if n.length() > tolerance {
-                if let Ok(normalized) = n.normalize() {
-                    normal = Some(normalized);
-                    break 'outer;
-                }
+            if n.length() > tolerance
+                && let Ok(normalized) = n.normalize()
+            {
+                normal = Some(normalized);
+                break 'outer;
             }
         }
     }
@@ -614,11 +614,11 @@ fn try_recognize_torus(surface: &NurbsSurface, tolerance: f64) -> Option<(Point3
         for j in (i + 1)..n_rows {
             let v2 = cps[j][0] - p0;
             let cross = v1.cross(v2);
-            if cross.length() > tolerance {
-                if let Ok(normalized) = cross.normalize() {
-                    axis = Some(normalized);
-                    break 'outer;
-                }
+            if cross.length() > tolerance
+                && let Ok(normalized) = cross.normalize()
+            {
+                axis = Some(normalized);
+                break 'outer;
             }
         }
     }

--- a/crates/heal/src/analysis/shell.rs
+++ b/crates/heal/src/analysis/shell.rs
@@ -156,12 +156,12 @@ fn count_connected_components(faces: &[FaceId], edge_uses: &HashMap<usize, EdgeU
     let mut parent: Vec<usize> = (0..n).collect();
 
     for eu in edge_uses.values() {
-        if eu.faces.len() >= 2 {
-            if let Some(&idx_a) = face_to_idx.get(&eu.faces[0].0.index()) {
-                for &(fid, _) in &eu.faces[1..] {
-                    if let Some(&idx_b) = face_to_idx.get(&fid.index()) {
-                        union(&mut parent, idx_a, idx_b);
-                    }
+        if eu.faces.len() >= 2
+            && let Some(&idx_a) = face_to_idx.get(&eu.faces[0].0.index())
+        {
+            for &(fid, _) in &eu.faces[1..] {
+                if let Some(&idx_b) = face_to_idx.get(&fid.index()) {
+                    union(&mut parent, idx_a, idx_b);
                 }
             }
         }

--- a/crates/heal/src/fix/wire.rs
+++ b/crates/heal/src/fix/wire.rs
@@ -111,11 +111,11 @@ fn fix_wire_impl(
         result.merge(&r);
     }
 
-    if config.fix_lacking != FixMode::Off {
-        if let Some(fid) = face_id {
-            let r = fix_lacking(topo, wire_id, fid, ctx, config)?;
-            result.merge(&r);
-        }
+    if config.fix_lacking != FixMode::Off
+        && let Some(fid) = face_id
+    {
+        let r = fix_lacking(topo, wire_id, fid, ctx, config)?;
+        result.merge(&r);
     }
 
     if config.fix_notched != FixMode::Off {
@@ -128,11 +128,11 @@ fn fix_wire_impl(
         result.merge(&r);
     }
 
-    if config.fix_missing_seam != FixMode::Off {
-        if let Some(fid) = face_id {
-            let r = fix_missing_seam(topo, wire_id, fid, ctx, config)?;
-            result.merge(&r);
-        }
+    if config.fix_missing_seam != FixMode::Off
+        && let Some(fid) = face_id
+    {
+        let r = fix_missing_seam(topo, wire_id, fid, ctx, config)?;
+        result.merge(&r);
     }
 
     Ok(result)

--- a/crates/heal/src/upgrade/collapse_collinear_vertices.rs
+++ b/crates/heal/src/upgrade/collapse_collinear_vertices.rs
@@ -315,10 +315,10 @@ fn find_line_edge(
         if !((s == a && e == b) || (s == b && e == a)) {
             continue;
         }
-        if let Ok(edge) = topo.edge(eid) {
-            if matches!(edge.curve(), EdgeCurve::Line) {
-                return Some(eid);
-            }
+        if let Ok(edge) = topo.edge(eid)
+            && matches!(edge.curve(), EdgeCurve::Line)
+        {
+            return Some(eid);
         }
     }
     None

--- a/crates/io/src/gltf/reader.rs
+++ b/crates/io/src/gltf/reader.rs
@@ -120,18 +120,16 @@ pub fn read_glb(data: &[u8]) -> Result<TriangleMesh, crate::IoError> {
             }
         }
 
-        if let Some(norm_idx) = prim.normal_accessor {
-            if let Some(accessor) = accessors.get(norm_idx) {
-                if let Some(view) = buffer_views.get(accessor.buffer_view) {
-                    if let Ok(norm_data) = safe_slice(bin, view.byte_offset, view.byte_length) {
-                        for chunk in norm_data.chunks_exact(12) {
-                            let x = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-                            let y = f32::from_le_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]);
-                            let z = f32::from_le_bytes([chunk[8], chunk[9], chunk[10], chunk[11]]);
-                            normals.push(Vec3::new(f64::from(x), f64::from(y), f64::from(z)));
-                        }
-                    }
-                }
+        if let Some(norm_idx) = prim.normal_accessor
+            && let Some(accessor) = accessors.get(norm_idx)
+            && let Some(view) = buffer_views.get(accessor.buffer_view)
+            && let Ok(norm_data) = safe_slice(bin, view.byte_offset, view.byte_length)
+        {
+            for chunk in norm_data.chunks_exact(12) {
+                let x = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                let y = f32::from_le_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]);
+                let z = f32::from_le_bytes([chunk[8], chunk[9], chunk[10], chunk[11]]);
+                normals.push(Vec3::new(f64::from(x), f64::from(y), f64::from(z)));
             }
         }
 

--- a/crates/io/src/iges/reader.rs
+++ b/crates/io/src/iges/reader.rs
@@ -146,10 +146,10 @@ fn build_topology(topo: &mut Topology, entities: &[IgesEntity]) -> Result<Vec<So
     let mut face_ids = Vec::new();
 
     for entity in entities {
-        if entity.entity_type == 108 {
-            if let Ok(face_id) = build_plane_face(topo, &entity.params) {
-                face_ids.push(face_id);
-            }
+        if entity.entity_type == 108
+            && let Ok(face_id) = build_plane_face(topo, &entity.params)
+        {
+            face_ids.push(face_id);
         }
         // Entity types 110 (line), 126 (NURBS curve), 128 (NURBS surface)
         // are skipped — they would be referenced by higher-level entities.

--- a/crates/io/src/step/reader.rs
+++ b/crates/io/src/step/reader.rs
@@ -69,21 +69,21 @@ fn parse_step_entities(input: &str) -> Result<HashMap<u64, StepEntity>, IoError>
             let id_part = stmt[..eq_pos].trim();
             let rest = stmt[eq_pos + 1..].trim();
 
-            if let Some(id) = parse_entity_id(id_part) {
-                if let Some(paren_pos) = rest.find('(') {
-                    let entity_type = rest[..paren_pos].trim().to_uppercase();
-                    // Attrs = everything after the entity opening paren.
-                    // E.g., for `TYPE('', (1.0, 2.0))`, attrs = `'', (1.0, 2.0))`
-                    let attrs = rest[paren_pos + 1..].trim();
+            if let Some(id) = parse_entity_id(id_part)
+                && let Some(paren_pos) = rest.find('(')
+            {
+                let entity_type = rest[..paren_pos].trim().to_uppercase();
+                // Attrs = everything after the entity opening paren.
+                // E.g., for `TYPE('', (1.0, 2.0))`, attrs = `'', (1.0, 2.0))`
+                let attrs = rest[paren_pos + 1..].trim();
 
-                    entities.insert(
-                        id,
-                        StepEntity {
-                            entity_type,
-                            attrs: attrs.to_string(),
-                        },
-                    );
-                }
+                entities.insert(
+                    id,
+                    StepEntity {
+                        entity_type,
+                        attrs: attrs.to_string(),
+                    },
+                );
             }
         }
     }
@@ -611,10 +611,10 @@ fn parse_refs(attrs: &str) -> Vec<u64> {
             while i < bytes.len() && bytes[i].is_ascii_digit() {
                 i += 1;
             }
-            if i > start {
-                if let Ok(num) = attrs[start..i].parse::<u64>() {
-                    refs.push(num);
-                }
+            if i > start
+                && let Ok(num) = attrs[start..i].parse::<u64>()
+            {
+                refs.push(num);
             }
         } else {
             i += 1;
@@ -625,11 +625,11 @@ fn parse_refs(attrs: &str) -> Vec<u64> {
 
 /// Extract `#NNN` references from the first parenthesized list in attrs.
 fn parse_list_refs(attrs: &str) -> Vec<u64> {
-    if let Some(start) = attrs.find('(') {
-        if let Some(end) = attrs[start..].find(')') {
-            let inner = &attrs[start + 1..start + end];
-            return parse_refs(inner);
-        }
+    if let Some(start) = attrs.find('(')
+        && let Some(end) = attrs[start..].find(')')
+    {
+        let inner = &attrs[start + 1..start + end];
+        return parse_refs(inner);
     }
     Vec::new()
 }
@@ -640,14 +640,14 @@ fn parse_list_refs(attrs: &str) -> Vec<u64> {
 fn parse_floats(attrs: &str) -> Vec<f64> {
     let mut result = Vec::new();
     // Try nested parentheses first.
-    if let Some(start) = attrs.find('(') {
-        if let Some(end) = attrs[start..].find(')') {
-            let inner = &attrs[start + 1..start + end];
-            for part in inner.split(',') {
-                let trimmed = part.trim();
-                if let Ok(v) = trimmed.parse::<f64>() {
-                    result.push(v);
-                }
+    if let Some(start) = attrs.find('(')
+        && let Some(end) = attrs[start..].find(')')
+    {
+        let inner = &attrs[start + 1..start + end];
+        for part in inner.split(',') {
+            let trimmed = part.trim();
+            if let Ok(v) = trimmed.parse::<f64>() {
+                result.push(v);
             }
         }
     }

--- a/crates/io/src/threemf/reader.rs
+++ b/crates/io/src/threemf/reader.rs
@@ -182,7 +182,7 @@ fn parse_triangle_attributes(
 
 /// Build a [`TriangleMesh`] from indexed vertices, computing per-vertex normals.
 fn build_mesh(vertices: &[Point3], indices: &[u32]) -> Result<TriangleMesh, IoError> {
-    if indices.len() % 3 != 0 {
+    if !indices.len().is_multiple_of(3) {
         return Err(IoError::ParseError {
             reason: format!(
                 "triangle indices count {} is not a multiple of 3",

--- a/crates/math/src/cdt/mod.rs
+++ b/crates/math/src/cdt/mod.rs
@@ -419,10 +419,10 @@ impl Cdt {
                     continue; // Don't cross constraint edges.
                 }
 
-                if let Some(adj) = self.triangles[ti].adj[local] {
-                    if !self.triangles[adj].removed {
-                        stack.push(adj);
-                    }
+                if let Some(adj) = self.triangles[ti].adj[local]
+                    && !self.triangles[adj].removed
+                {
+                    stack.push(adj);
                 }
             }
         }
@@ -484,10 +484,10 @@ impl Cdt {
                 if constraints.contains(&edge_key) {
                     continue;
                 }
-                if let Some(adj) = self.triangles[ti].adj[local] {
-                    if !self.triangles[adj].removed {
-                        stack.push(adj);
-                    }
+                if let Some(adj) = self.triangles[ti].adj[local]
+                    && !self.triangles[adj].removed
+                {
+                    stack.push(adj);
                 }
             }
         }
@@ -572,12 +572,11 @@ impl Cdt {
                         continue;
                     }
 
-                    if let Some(adj) = tri.adj[local] {
-                        if let Some(&adj_idx) = tri_to_idx.get(&adj) {
-                            if !visited[adj_idx] {
-                                stack.push(adj);
-                            }
-                        }
+                    if let Some(adj) = tri.adj[local]
+                        && let Some(&adj_idx) = tri_to_idx.get(&adj)
+                        && !visited[adj_idx]
+                    {
+                        stack.push(adj);
                     }
                 }
             }

--- a/crates/math/src/nurbs/bezier_clip.rs
+++ b/crates/math/src/nurbs/bezier_clip.rs
@@ -455,20 +455,17 @@ fn bezier_clip_recurse(
     // Early overlap detection: if both fat lines are degenerate (near-zero
     // thickness), the curves are collinear. Check for overlap immediately
     // instead of subdividing 2^30 times.
-    if depth <= 2 {
-        if let Some((_, _, d_min_a, d_max_a, _)) = fat_line(cps_a) {
-            if (d_max_a - d_min_a) < DEGENERATE_FAT_LINE {
-                if let Some((_, _, d_min_b, d_max_b, _)) = fat_line(cps_b) {
-                    if (d_max_b - d_min_b) < DEGENERATE_FAT_LINE {
-                        // Both curves are essentially straight lines — check overlap.
-                        if check_overlap(
-                            seg_a, seg_b, u_a_lo, u_a_hi, u_b_lo, u_b_hi, tolerance, overlaps,
-                        ) {
-                            return;
-                        }
-                    }
-                }
-            }
+    if depth <= 2
+        && let Some((_, _, d_min_a, d_max_a, _)) = fat_line(cps_a)
+        && (d_max_a - d_min_a) < DEGENERATE_FAT_LINE
+        && let Some((_, _, d_min_b, d_max_b, _)) = fat_line(cps_b)
+        && (d_max_b - d_min_b) < DEGENERATE_FAT_LINE
+    {
+        // Both curves are essentially straight lines — check overlap.
+        if check_overlap(
+            seg_a, seg_b, u_a_lo, u_a_hi, u_b_lo, u_b_hi, tolerance, overlaps,
+        ) {
+            return;
         }
     }
 
@@ -774,11 +771,12 @@ fn merge_duplicate_hits(hits: &mut Vec<CurveCurveHit>, tolerance: f64) {
     merged.push(hits[0]);
 
     for hit in hits.iter().skip(1) {
-        if let Some(last) = merged.last() {
-            if (hit.u1 - last.u1).abs() < tolerance && (hit.u2 - last.u2).abs() < tolerance {
-                // Duplicate — skip it.
-                continue;
-            }
+        if let Some(last) = merged.last()
+            && (hit.u1 - last.u1).abs() < tolerance
+            && (hit.u2 - last.u2).abs() < tolerance
+        {
+            // Duplicate — skip it.
+            continue;
         }
         merged.push(*hit);
     }

--- a/crates/math/src/nurbs/intersection/surface_marching.rs
+++ b/crates/math/src/nurbs/intersection/surface_marching.rs
@@ -467,11 +467,12 @@ fn perturbation_tangent(
         if let Some(refined) = refine_ssi_point(s1, s2, u1p, v1p, u2, v2, 1e-8) {
             let d = refined.point - point.point;
             let dist = d.length();
-            if dist > best_dist && dist > 1e-12 {
-                if let Ok(normalized) = d.normalize() {
-                    best_dist = dist;
-                    best_dir = Some(normalized);
-                }
+            if dist > best_dist
+                && dist > 1e-12
+                && let Ok(normalized) = d.normalize()
+            {
+                best_dist = dist;
+                best_dir = Some(normalized);
             }
         }
     }
@@ -963,10 +964,10 @@ pub(super) fn near_existing_segment(
     for seg in segments {
         if seg.len() < 2 {
             // Single-point segment: fallback to point distance.
-            if let Some(p) = seg.first() {
-                if (p.point - point.point).length() < dist {
-                    return true;
-                }
+            if let Some(p) = seg.first()
+                && (p.point - point.point).length() < dist
+            {
+                return true;
             }
             continue;
         }

--- a/crates/math/src/nurbs/intersection/surface_seeding.rs
+++ b/crates/math/src/nurbs/intersection/surface_seeding.rs
@@ -713,15 +713,15 @@ pub(super) fn find_ssi_seeds_grid(
     for &(u1, v1, p1) in &pts1 {
         for &(u2, v2, p2) in &pts2 {
             let dist = (p1 - p2).length();
-            if dist < threshold {
-                if let Some(refined) = refine_ssi_point(s1, s2, u1, v1, u2, v2, tolerance) {
-                    // 100x dedup: multiple grid samples may converge to the same intersection
-                    let dup = seeds.iter().any(|s: &IntersectionPoint| {
-                        (s.point - refined.point).length() < tolerance * 100.0
-                    });
-                    if !dup {
-                        seeds.push(refined);
-                    }
+            if dist < threshold
+                && let Some(refined) = refine_ssi_point(s1, s2, u1, v1, u2, v2, tolerance)
+            {
+                // 100x dedup: multiple grid samples may converge to the same intersection
+                let dup = seeds.iter().any(|s: &IntersectionPoint| {
+                    (s.point - refined.point).length() < tolerance * 100.0
+                });
+                if !dup {
+                    seeds.push(refined);
                 }
             }
         }

--- a/crates/math/src/polygon2d.rs
+++ b/crates/math/src/polygon2d.rs
@@ -56,16 +56,16 @@ pub fn sutherland_hodgman_clip(subject: &[Point2], clip: &[Point2]) -> Vec<Point
             let prev_inside = cross_2d(edge_start, edge_end, previous) >= 0.0;
 
             if curr_inside {
-                if !prev_inside {
-                    if let Some(p) = line_intersect_2d(previous, current, edge_start, edge_end) {
-                        output.push(p);
-                    }
-                }
-                output.push(current);
-            } else if prev_inside {
-                if let Some(p) = line_intersect_2d(previous, current, edge_start, edge_end) {
+                if !prev_inside
+                    && let Some(p) = line_intersect_2d(previous, current, edge_start, edge_end)
+                {
                     output.push(p);
                 }
+                output.push(current);
+            } else if prev_inside
+                && let Some(p) = line_intersect_2d(previous, current, edge_start, edge_end)
+            {
+                output.push(p);
             }
         }
     }

--- a/crates/math/tests/ssi_robustness.rs
+++ b/crates/math/tests/ssi_robustness.rs
@@ -296,14 +296,14 @@ fn plane_sphere_tangent() {
 
     // Tangent plane: either empty (degenerate zero-radius circle rejected)
     // or a circle with radius ~0.
-    if !results.is_empty() {
-        if let ExactIntersectionCurve::Circle(c) = &results[0] {
-            assert!(
-                c.radius() < 1e-6,
-                "tangent circle radius should be ~0, got {}",
-                c.radius()
-            );
-        }
+    if !results.is_empty()
+        && let ExactIntersectionCurve::Circle(c) = &results[0]
+    {
+        assert!(
+            c.radius() < 1e-6,
+            "tangent circle radius should be ~0, got {}",
+            c.radius()
+        );
     }
 }
 

--- a/crates/offset/src/inter2d.rs
+++ b/crates/offset/src/inter2d.rs
@@ -65,11 +65,11 @@ fn create_edge_from_curve_points(
         return None;
     }
 
-    if points.len() >= 8 {
-        if let Some((circle, seam_pt)) = fit_circle_3d(points, tol) {
-            let v = find_or_create_vertex(topo, vertex_cache, seam_pt, tol);
-            return Some(topo.add_edge(Edge::new(v, v, EdgeCurve::Circle(circle))));
-        }
+    if points.len() >= 8
+        && let Some((circle, seam_pt)) = fit_circle_3d(points, tol)
+    {
+        let v = find_or_create_vertex(topo, vertex_cache, seam_pt, tol);
+        return Some(topo.add_edge(Edge::new(v, v, EdgeCurve::Circle(circle))));
     }
 
     let p_start = points[0];

--- a/crates/offset/src/loops.rs
+++ b/crates/offset/src/loops.rs
@@ -291,15 +291,15 @@ fn build_loops_via_line_intersection(
         }
     }
 
-    if let Some(boundary) = data.boundary_edges.get(&face_id) {
-        if let Some(offset_face) = data.offset_faces.get(&face_id) {
-            for &eid in boundary {
-                let edge = topo.edge(eid)?;
-                let orig_p0 = topo.vertex(edge.start())?.point();
-                let orig_p1 = topo.vertex(edge.end())?.point();
-                let (p0, p1) = project_boundary_edge(orig_p0, orig_p1, &offset_face.surface);
-                line_segs.push(LineSeg { p0, p1 });
-            }
+    if let Some(boundary) = data.boundary_edges.get(&face_id)
+        && let Some(offset_face) = data.offset_faces.get(&face_id)
+    {
+        for &eid in boundary {
+            let edge = topo.edge(eid)?;
+            let orig_p0 = topo.vertex(edge.start())?.point();
+            let orig_p1 = topo.vertex(edge.end())?.point();
+            let (p0, p1) = project_boundary_edge(orig_p0, orig_p1, &offset_face.surface);
+            line_segs.push(LineSeg { p0, p1 });
         }
     }
 

--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -767,10 +767,10 @@ pub(super) fn refine_boundary_edges(
             for oe in wire.edges() {
                 let eid = oe.edge();
                 *edge_face_count.entry(eid).or_default() += 1;
-                if let std::collections::hash_map::Entry::Vacant(e) = edge_vertices.entry(eid) {
-                    if let Ok(edge) = topo.edge(eid) {
-                        e.insert((edge.start(), edge.end()));
-                    }
+                if let std::collections::hash_map::Entry::Vacant(e) = edge_vertices.entry(eid)
+                    && let Ok(edge) = topo.edge(eid)
+                {
+                    e.insert((edge.start(), edge.end()));
                 }
             }
         }
@@ -794,12 +794,11 @@ pub(super) fn refine_boundary_edges(
     for &(start, end) in edge_vertices.values() {
         for &vid in &[start, end] {
             let in_pre = precomputed_positions.is_some_and(|p| p.contains_key(&vid));
-            if !in_pre {
-                if let std::collections::hash_map::Entry::Vacant(e) = extra_positions.entry(vid) {
-                    if let Ok(v) = topo.vertex(vid) {
-                        e.insert(v.point());
-                    }
-                }
+            if !in_pre
+                && let std::collections::hash_map::Entry::Vacant(e) = extra_positions.entry(vid)
+                && let Ok(v) = topo.vertex(vid)
+            {
+                e.insert(v.point());
             }
         }
     }
@@ -1095,10 +1094,10 @@ pub(super) fn stitch_boundary_edges(
             for oe in wire.edges() {
                 let eid = oe.edge();
                 *edge_face_count.entry(eid).or_default() += 1;
-                if let std::collections::hash_map::Entry::Vacant(e) = edge_vertices.entry(eid) {
-                    if let Ok(edge) = topo.edge(eid) {
-                        e.insert((edge.start(), edge.end()));
-                    }
+                if let std::collections::hash_map::Entry::Vacant(e) = edge_vertices.entry(eid)
+                    && let Ok(edge) = topo.edge(eid)
+                {
+                    e.insert((edge.start(), edge.end()));
                 }
                 edge_owner.entry(eid).or_insert((fi, outer_wire_id));
             }
@@ -1482,12 +1481,12 @@ pub(super) fn split_nonmanifold_edges(
                     let mut sum = Vec3::new(0.0, 0.0, 0.0);
                     let mut count = 0usize;
                     for oe in wire.edges() {
-                        if let Ok(e) = topo.edge(oe.edge()) {
-                            if let Ok(vx) = topo.vertex(e.start()) {
-                                let p = vx.point();
-                                sum = Vec3::new(sum.x() + p.x(), sum.y() + p.y(), sum.z() + p.z());
-                                count += 1;
-                            }
+                        if let Ok(e) = topo.edge(oe.edge())
+                            && let Ok(vx) = topo.vertex(e.start())
+                        {
+                            let p = vx.point();
+                            sum = Vec3::new(sum.x() + p.x(), sum.y() + p.y(), sum.z() + p.z());
+                            count += 1;
                         }
                     }
                     if count == 0 {
@@ -1913,10 +1912,10 @@ pub(super) fn build_manifold_shells(
 
     let mut inner_ids = Vec::new();
     for inner_faces in &shells[1..] {
-        if !inner_faces.is_empty() {
-            if let Ok(inner_shell) = Shell::new(inner_faces.clone()) {
-                inner_ids.push(topo.add_shell(inner_shell));
-            }
+        if !inner_faces.is_empty()
+            && let Ok(inner_shell) = Shell::new(inner_faces.clone())
+        {
+            inner_ids.push(topo.add_shell(inner_shell));
         }
     }
 

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -220,19 +220,21 @@ pub fn boolean(
         // GFA's no-intersection assembly drops fully-contained cone/torus
         // tools; the cavity is exactly the tool's reversed shell, so construct
         // it here for any simple tool whose vertices are all strictly inside.
-        if op == BooleanOp::Cut && b_in_a && !a_in_b {
-            if let Some(classifier) = ca.as_ref() {
-                let tool_simple = topo
-                    .solid(b)
-                    .map(|s| s.inner_shells().is_empty())
-                    .unwrap_or(false);
-                if tool_simple && solid_strictly_inside(topo, b, classifier, tol) {
-                    if let Ok(result) = build_contained_cut_hollow(topo, a, b) {
-                        if validate_boolean_result(topo, result).is_ok() {
-                            return Ok(result);
-                        }
-                    }
-                }
+        if op == BooleanOp::Cut
+            && b_in_a
+            && !a_in_b
+            && let Some(classifier) = ca.as_ref()
+        {
+            let tool_simple = topo
+                .solid(b)
+                .map(|s| s.inner_shells().is_empty())
+                .unwrap_or(false);
+            if tool_simple
+                && solid_strictly_inside(topo, b, classifier, tol)
+                && let Ok(result) = build_contained_cut_hollow(topo, a, b)
+                && validate_boolean_result(topo, result).is_ok()
+            {
+                return Ok(result);
             }
         }
         if (b_in_a || a_in_b) && op != BooleanOp::Cut {
@@ -339,8 +341,8 @@ pub fn boolean(
                 (Some(sa), Some(sb)) => (sa - sb).abs() < tol.linear,
                 _ => false,
             };
-            if let (true, Some(slope)) = (same_axis_dir && same_apex && same_half_angle, slope_a) {
-                if let Some(result) = coaxial_cone_shortcut(
+            if let (true, Some(slope)) = (same_axis_dir && same_apex && same_half_angle, slope_a)
+                && let Some(result) = coaxial_cone_shortcut(
                     topo,
                     op,
                     *oa,
@@ -349,9 +351,9 @@ pub fn boolean(
                     (*za_min, *za_max),
                     (*zb_min, *zb_max),
                     tol,
-                )? {
-                    return Ok(result);
-                }
+                )?
+            {
+                return Ok(result);
             }
         }
 
@@ -370,11 +372,9 @@ pub fn boolean(
                 max: b_max,
             }),
         ) = (ca.as_ref(), cb.as_ref())
+            && let Some(result) = box_pair_shortcut(topo, op, *a_min, *a_max, *b_min, *b_max, tol)?
         {
-            if let Some(result) = box_pair_shortcut(topo, op, *a_min, *a_max, *b_min, *b_max, tol)?
-            {
-                return Ok(result);
-            }
+            return Ok(result);
         }
 
         // Box-sphere intersect shortcut: when one input classifies as an
@@ -448,12 +448,11 @@ pub fn boolean(
         ) = (ca.as_ref(), cb.as_ref())
         {
             let coincident = (*ca_center - *cb_center).length() < tol.linear;
-            if coincident {
-                if let Some(result) =
+            if coincident
+                && let Some(result) =
                     concentric_sphere_shortcut(topo, op, a, b, *ca_center, *ra, *rb, tol)?
-                {
-                    return Ok(result);
-                }
+            {
+                return Ok(result);
             }
         }
 
@@ -484,12 +483,14 @@ pub fn boolean(
             // sweep is symmetric about the central plane).
             let coaxial = aa.dot(*ab).abs() > 1.0 - tol.angular;
             let same_major = (maj_a - maj_b).abs() < tol.linear;
-            if coincident && coaxial && same_major {
-                if let Some(result) = coaxial_torus_shortcut(
+            if coincident
+                && coaxial
+                && same_major
+                && let Some(result) = coaxial_torus_shortcut(
                     topo, op, a, b, *ca_center, *aa, *maj_a, *min_a, *min_b, tol,
-                )? {
-                    return Ok(result);
-                }
+                )?
+            {
+                return Ok(result);
             }
         }
     }
@@ -504,10 +505,10 @@ pub fn boolean(
     if op == BooleanOp::Intersect {
         let bb_a = crate::measure::solid_bounding_box(topo, a).ok();
         let bb_b = crate::measure::solid_bounding_box(topo, b).ok();
-        if let Some((a_box, b_box)) = bb_a.zip(bb_b) {
-            if aabbs_separated(&a_box, &b_box, tol.linear) {
-                return Ok(topo.add_empty_solid());
-            }
+        if let Some((a_box, b_box)) = bb_a.zip(bb_b)
+            && aabbs_separated(&a_box, &b_box, tol.linear)
+        {
+            return Ok(topo.add_empty_solid());
         }
     }
 
@@ -709,10 +710,11 @@ pub fn boolean(
     // more complex interaction semantics so we leave those to mesh.
     if op == BooleanOp::Cut {
         let components = crate::boolean::assembly::face_components(topo, a);
-        if components.len() >= 2 && components_are_disjoint_pieces(topo, &components) {
-            if let Ok(result) = cut_multi_region_input(topo, a, b, components.len()) {
-                return Ok(result);
-            }
+        if components.len() >= 2
+            && components_are_disjoint_pieces(topo, &components)
+            && let Ok(result) = cut_multi_region_input(topo, a, b, components.len())
+        {
+            return Ok(result);
         }
     }
 
@@ -1961,12 +1963,12 @@ fn infer_planar_triangle_flags(
     let mut planes: Vec<(brepkit_math::vec::Vec3, f64)> = Vec::new();
     if let Ok(face_ids) = brepkit_topology::explorer::solid_faces(topo, solid) {
         for fid in face_ids {
-            if let Ok(face) = topo.face(fid) {
-                if let brepkit_topology::face::FaceSurface::Plane { normal, d } = face.surface() {
-                    let len = normal.dot(*normal).sqrt();
-                    if len > tol.linear {
-                        planes.push((*normal * (1.0 / len), *d / len));
-                    }
+            if let Ok(face) = topo.face(fid)
+                && let brepkit_topology::face::FaceSurface::Plane { normal, d } = face.surface()
+            {
+                let len = normal.dot(*normal).sqrt();
+                if len > tol.linear {
+                    planes.push((*normal * (1.0 / len), *d / len));
                 }
             }
         }
@@ -3046,10 +3048,11 @@ fn enforce_manifold_shell(
     let outer_id = topo.add_shell(outer);
     let mut inner_ids = Vec::new();
     for (i, faces) in shells.iter().enumerate() {
-        if i != best_idx && !faces.is_empty() {
-            if let Ok(inner) = brepkit_topology::shell::Shell::new(faces.clone()) {
-                inner_ids.push(topo.add_shell(inner));
-            }
+        if i != best_idx
+            && !faces.is_empty()
+            && let Ok(inner) = brepkit_topology::shell::Shell::new(faces.clone())
+        {
+            inner_ids.push(topo.add_shell(inner));
         }
     }
 

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1950,10 +1950,10 @@ fn fuse_ring_inside_shelled_box() {
         sh.faces()
             .iter()
             .filter(|&&fid| {
-                if let Ok(f) = topo.face(fid) {
-                    if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = f.surface() {
-                        return tol.approx_eq(normal.z(), 1.0);
-                    }
+                if let Ok(f) = topo.face(fid)
+                    && let brepkit_topology::face::FaceSurface::Plane { normal, .. } = f.surface()
+                {
+                    return tol.approx_eq(normal.z(), 1.0);
                 }
                 false
             })
@@ -2022,10 +2022,10 @@ fn fuse_ring_inside_shelled_cylinder() {
         sh.faces()
             .iter()
             .filter(|&&fid| {
-                if let Ok(f) = topo.face(fid) {
-                    if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = f.surface() {
-                        return tol.approx_eq(normal.z(), 1.0);
-                    }
+                if let Ok(f) = topo.face(fid)
+                    && let brepkit_topology::face::FaceSurface::Plane { normal, .. } = f.surface()
+                {
+                    return tol.approx_eq(normal.z(), 1.0);
                 }
                 false
             })
@@ -2088,10 +2088,10 @@ fn fuse_ring_overlapping_shelled_box_height() {
         sh.faces()
             .iter()
             .filter(|&&fid| {
-                if let Ok(f) = topo.face(fid) {
-                    if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = f.surface() {
-                        return tol.approx_eq(normal.z(), 1.0);
-                    }
+                if let Ok(f) = topo.face(fid)
+                    && let brepkit_topology::face::FaceSurface::Plane { normal, .. } = f.surface()
+                {
+                    return tol.approx_eq(normal.z(), 1.0);
                 }
                 false
             })

--- a/crates/operations/src/chamfer.rs
+++ b/crates/operations/src/chamfer.rs
@@ -102,14 +102,14 @@ impl ChamferDistances {
         match self {
             Self::Symmetric(d) => *d,
             Self::Asymmetric { d1, d2 } => {
-                if let Some(faces) = edge_to_faces.get(&edge_index) {
-                    if faces.len() == 2 {
-                        if faces[0] == face_id {
-                            return *d1;
-                        }
-                        if faces[1] == face_id {
-                            return *d2;
-                        }
+                if let Some(faces) = edge_to_faces.get(&edge_index)
+                    && faces.len() == 2
+                {
+                    if faces[0] == face_id {
+                        return *d1;
+                    }
+                    if faces[1] == face_id {
+                        return *d2;
                     }
                 }
                 // Fallback (shouldn't happen for filtered manifold edges).

--- a/crates/operations/src/classify.rs
+++ b/crates/operations/src/classify.rs
@@ -182,10 +182,10 @@ fn is_on_boundary(
 ) -> Result<bool, OperationsError> {
     let tol = Tolerance::new();
     for &fid in faces {
-        if let Some((dist, _)) = point_to_face_distance(topo, point, fid, tol)? {
-            if dist < tolerance {
-                return Ok(true);
-            }
+        if let Some((dist, _)) = point_to_face_distance(topo, point, fid, tol)?
+            && dist < tolerance
+        {
+            return Ok(true);
         }
     }
     Ok(false)

--- a/crates/operations/src/distance.rs
+++ b/crates/operations/src/distance.rs
@@ -80,11 +80,11 @@ pub fn point_to_solid_distance(
             continue;
         }
 
-        if let Some((dist, closest)) = point_to_face_distance(topo, point, fid, tol)? {
-            if dist < best_dist {
-                best_dist = dist;
-                best_point = closest;
-            }
+        if let Some((dist, closest)) = point_to_face_distance(topo, point, fid, tol)?
+            && dist < best_dist
+        {
+            best_dist = dist;
+            best_point = closest;
         }
     }
 
@@ -144,12 +144,12 @@ pub fn solid_to_solid_distance(
             if aabb_dist_sq > best_dist * best_dist {
                 continue;
             }
-            if let Some((dist, closest)) = point_to_face_distance(topo, pa, faces_b[idx], tol)? {
-                if dist < best_dist {
-                    best_dist = dist;
-                    best_a = pa;
-                    best_b = closest;
-                }
+            if let Some((dist, closest)) = point_to_face_distance(topo, pa, faces_b[idx], tol)?
+                && dist < best_dist
+            {
+                best_dist = dist;
+                best_a = pa;
+                best_b = closest;
             }
         }
     }
@@ -168,12 +168,12 @@ pub fn solid_to_solid_distance(
             if aabb_dist_sq > best_dist * best_dist {
                 continue;
             }
-            if let Some((dist, closest)) = point_to_face_distance(topo, pb, faces_a[idx], tol)? {
-                if dist < best_dist {
-                    best_dist = dist;
-                    best_a = closest;
-                    best_b = pb;
-                }
+            if let Some((dist, closest)) = point_to_face_distance(topo, pb, faces_a[idx], tol)?
+                && dist < best_dist
+            {
+                best_dist = dist;
+                best_a = closest;
+                best_b = pb;
             }
         }
     }
@@ -442,10 +442,10 @@ fn bvh_distance_candidates(bvh: &Bvh, aabbs: &[(usize, Aabb3)], point: Point3) -
         .collect();
     candidates.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
-    if let Some(closest_idx) = bvh.query_closest(point) {
-        if let Some(pos) = candidates.iter().position(|(i, _)| *i == closest_idx) {
-            candidates.swap(0, pos);
-        }
+    if let Some(closest_idx) = bvh.query_closest(point)
+        && let Some(pos) = candidates.iter().position(|(i, _)| *i == closest_idx)
+    {
+        candidates.swap(0, pos);
     }
 
     candidates.into_iter().map(|(i, _)| i).collect()

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -587,15 +587,14 @@ pub fn extrude(
 
     // If the outer wire is CW, the stored face normal opposes the actual outward
     // direction. Negate it so cap normals are derived correctly.
-    if outer_is_cw {
-        if let FaceSurface::Plane {
+    if outer_is_cw
+        && let FaceSurface::Plane {
             ref mut normal,
             ref mut d,
         } = input_surface
-        {
-            *normal = -*normal;
-            *d = -*d;
-        }
+    {
+        *normal = -*normal;
+        *d = -*d;
     }
 
     let mut all_faces = Vec::with_capacity(n + 2 + inner_wire_ids.len() * 4);

--- a/crates/operations/src/feature_recognition.rs
+++ b/crates/operations/src/feature_recognition.rs
@@ -521,14 +521,14 @@ fn detect_pockets_fag(fag: &FaceAdjacencyGraph, features: &mut Vec<Feature>) {
             }
         }
 
-        if let Some(floor_face) = floor {
-            if walls.len() >= 2 {
-                features.push(Feature::Pocket {
-                    floor: floor_face,
-                    walls,
-                });
-                visited.extend(&component);
-            }
+        if let Some(floor_face) = floor
+            && walls.len() >= 2
+        {
+            features.push(Feature::Pocket {
+                floor: floor_face,
+                walls,
+            });
+            visited.extend(&component);
         }
     }
 }

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -518,20 +518,20 @@ pub fn fillet_rolling_ball(
     let mut vertex_fillet_adjacency: HashMap<usize, Vec<(usize, usize, usize)>> = HashMap::new();
     for &edge_id in &filtered_edges {
         let edge = topo.edge(edge_id)?;
-        if let Some(faces) = edge_to_faces.get(&edge_id.index()) {
-            if faces.len() >= 2 {
-                let f1 = faces[0].index();
-                let f2 = faces[1].index();
-                let (fa, fb) = if f1 < f2 { (f1, f2) } else { (f2, f1) };
-                vertex_fillet_adjacency
-                    .entry(edge.start().index())
-                    .or_default()
-                    .push((edge_id.index(), fa, fb));
-                vertex_fillet_adjacency
-                    .entry(edge.end().index())
-                    .or_default()
-                    .push((edge_id.index(), fa, fb));
-            }
+        if let Some(faces) = edge_to_faces.get(&edge_id.index())
+            && faces.len() >= 2
+        {
+            let f1 = faces[0].index();
+            let f2 = faces[1].index();
+            let (fa, fb) = if f1 < f2 { (f1, f2) } else { (f2, f1) };
+            vertex_fillet_adjacency
+                .entry(edge.start().index())
+                .or_default()
+                .push((edge_id.index(), fa, fb));
+            vertex_fillet_adjacency
+                .entry(edge.end().index())
+                .or_default()
+                .push((edge_id.index(), fa, fb));
         }
     }
     let mut g1_chain_vertices: HashSet<usize> = HashSet::new();
@@ -974,24 +974,24 @@ pub fn fillet_rolling_ball(
                             trimmed_verts.push(pos);
                         }
                         // Preserve the unfilleted "after" edge at a setback corner.
-                        if setback_map.contains_key(&(ei, vi)) {
-                            if let Ok(dir) = (next_pos - pos).normalize() {
-                                let p = pos + dir * radius;
-                                trimmed_verts.push(p);
-                                corner_preserved.entry(vi).or_insert(p);
-                            }
+                        if setback_map.contains_key(&(ei, vi))
+                            && let Ok(dir) = (next_pos - pos).normalize()
+                        {
+                            let p = pos + dir * radius;
+                            trimmed_verts.push(p);
+                            corner_preserved.entry(vi).or_insert(p);
                         }
                     }
                     (false, true, _) => {
                         // The "after" edge is filleted — use its specific contact.
                         let ei = wire_edge_ids[i].index();
                         // Preserve the unfilleted "before" edge at a setback corner.
-                        if setback_map.contains_key(&(ei, vi)) {
-                            if let Ok(dir) = (prev_pos - pos).normalize() {
-                                let p = pos + dir * radius;
-                                trimmed_verts.push(p);
-                                corner_preserved.entry(vi).or_insert(p);
-                            }
+                        if setback_map.contains_key(&(ei, vi))
+                            && let Ok(dir) = (prev_pos - pos).normalize()
+                        {
+                            let p = pos + dir * radius;
+                            trimmed_verts.push(p);
+                            corner_preserved.entry(vi).or_insert(p);
                         }
                         if let Some(&pt) = fillet_contact_map.get(&(vi, ei, fi)) {
                             trimmed_verts.push(pt);
@@ -1119,12 +1119,12 @@ pub fn fillet_rolling_ball(
                     }
                     // The "after" edge is the unfilleted edge at this corner.
                     // If the filleted edge was set back here, preserve it.
-                    if setback_map.contains_key(&(ei, vi)) {
-                        if let Ok(dir) = (next_pos - pos).normalize() {
-                            let p = pos + dir * radius;
-                            new_verts.push(p);
-                            corner_preserved.entry(vi).or_insert(p);
-                        }
+                    if setback_map.contains_key(&(ei, vi))
+                        && let Ok(dir) = (next_pos - pos).normalize()
+                    {
+                        let p = pos + dir * radius;
+                        new_verts.push(p);
+                        corner_preserved.entry(vi).or_insert(p);
                     }
                 }
                 (false, true, _) => {
@@ -1132,12 +1132,12 @@ pub fn fillet_rolling_ball(
                     // The "before" edge is the unfilleted edge at this corner.
                     // If the filleted edge was set back here, preserve it by
                     // emitting a trim point on it *before* the fillet contact.
-                    if setback_map.contains_key(&(ei, vi)) {
-                        if let Ok(dir) = (prev_pos - pos).normalize() {
-                            let p = pos + dir * radius;
-                            new_verts.push(p);
-                            corner_preserved.entry(vi).or_insert(p);
-                        }
+                    if setback_map.contains_key(&(ei, vi))
+                        && let Ok(dir) = (prev_pos - pos).normalize()
+                    {
+                        let p = pos + dir * radius;
+                        new_verts.push(p);
+                        corner_preserved.entry(vi).or_insert(p);
                     }
                     if let Some(&pt) = fillet_contact_map.get(&(vi, ei, fi)) {
                         new_verts.push(pt);
@@ -1529,63 +1529,63 @@ pub fn fillet_rolling_ball(
         // (still sharp) unfilleted edge with nothing to share it.
         if fillet_count == 2 {
             let mut built = false;
-            if let (Some(&p_pt), Some(v_pos)) = (corner_preserved.get(&vi), original_vertex) {
-                if blend_points.len() == 3 {
-                    // Sphere centre: corner offset inward by R along each distinct
-                    // contact-face normal. Convex corners subtract Σnormals;
-                    // concave corners add (same rule as the 3-edge path below).
-                    let mut face_normals: Vec<Vec3> = Vec::new();
-                    for &(face_idx, _) in contacts {
-                        if let Some(poly) = face_polygons.get(&face_idx) {
-                            let n = poly.normal;
-                            if !face_normals.iter().any(|e| (*e - n).length() < 1e-10) {
-                                face_normals.push(n);
-                            }
+            if let (Some(&p_pt), Some(v_pos)) = (corner_preserved.get(&vi), original_vertex)
+                && blend_points.len() == 3
+            {
+                // Sphere centre: corner offset inward by R along each distinct
+                // contact-face normal. Convex corners subtract Σnormals;
+                // concave corners add (same rule as the 3-edge path below).
+                let mut face_normals: Vec<Vec3> = Vec::new();
+                for &(face_idx, _) in contacts {
+                    if let Some(poly) = face_polygons.get(&face_idx) {
+                        let n = poly.normal;
+                        if !face_normals.iter().any(|e| (*e - n).length() < 1e-10) {
+                            face_normals.push(n);
                         }
                     }
-                    let normal_sum = face_normals.iter().fold(Vec3::new(0.0, 0.0, 0.0), |a, n| {
-                        Vec3::new(a.x() + n.x(), a.y() + n.y(), a.z() + n.z())
-                    });
-                    let fillet_edges = vertex_fillet_edges
-                        .get(&vi)
-                        .map(Vec::as_slice)
-                        .unwrap_or(&[]);
-                    let is_concave = corner_is_concave(topo, vi, fillet_edges, normal_sum);
-                    let offset_sign = if is_concave { 1.0 } else { -1.0 };
-                    let sphere_center = Point3::new(
-                        v_pos.x() + offset_sign * radius * normal_sum.x(),
-                        v_pos.y() + offset_sign * radius * normal_sum.y(),
-                        v_pos.z() + offset_sign * radius * normal_sum.z(),
-                    );
+                }
+                let normal_sum = face_normals.iter().fold(Vec3::new(0.0, 0.0, 0.0), |a, n| {
+                    Vec3::new(a.x() + n.x(), a.y() + n.y(), a.z() + n.z())
+                });
+                let fillet_edges = vertex_fillet_edges
+                    .get(&vi)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+                let is_concave = corner_is_concave(topo, vi, fillet_edges, normal_sum);
+                let offset_sign = if is_concave { 1.0 } else { -1.0 };
+                let sphere_center = Point3::new(
+                    v_pos.x() + offset_sign * radius * normal_sum.x(),
+                    v_pos.y() + offset_sign * radius * normal_sum.y(),
+                    v_pos.z() + offset_sign * radius * normal_sum.z(),
+                );
 
-                    // `far` (D) is the contact on the two edges' shared face —
-                    // the point farthest from P. The other two connect to P.
-                    let far_idx = (0..3)
-                        .max_by(|&a, &b| {
-                            (blend_points[a] - p_pt)
-                                .length()
-                                .partial_cmp(&(blend_points[b] - p_pt).length())
-                                .unwrap_or(std::cmp::Ordering::Equal)
-                        })
-                        .unwrap_or(0);
-                    let far = blend_points[far_idx];
-                    let near: Vec<Point3> = (0..3)
-                        .filter(|&i| i != far_idx)
-                        .map(|i| blend_points[i])
-                        .collect();
+                // `far` (D) is the contact on the two edges' shared face —
+                // the point farthest from P. The other two connect to P.
+                let far_idx = (0..3)
+                    .max_by(|&a, &b| {
+                        (blend_points[a] - p_pt)
+                            .length()
+                            .partial_cmp(&(blend_points[b] - p_pt).length())
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    })
+                    .unwrap_or(0);
+                let far = blend_points[far_idx];
+                let near: Vec<Point3> = (0..3)
+                    .filter(|&i| i != far_idx)
+                    .map(|i| blend_points[i])
+                    .collect();
 
-                    if let Some(spec) = build_two_edge_corner_patch(
-                        p_pt,
-                        near[0],
-                        far,
-                        near[1],
-                        sphere_center,
-                        v_pos,
-                        is_concave,
-                    ) {
-                        all_specs.push(spec);
-                        built = true;
-                    }
+                if let Some(spec) = build_two_edge_corner_patch(
+                    p_pt,
+                    near[0],
+                    far,
+                    near[1],
+                    sphere_center,
+                    v_pos,
+                    is_concave,
+                ) {
+                    all_specs.push(spec);
+                    built = true;
                 }
             }
             if !built {
@@ -1639,178 +1639,178 @@ pub fn fillet_rolling_ball(
         // The fillet sphere at a vertex corner is tangent to each adjacent
         // face.  Its center lies at the original vertex offset inward by R
         // along each face normal: center = vertex - R * Σ(face_normals).
-        if ordered_points.len() == 3 {
-            if let Some(v_pos) = original_vertex {
-                // Collect distinct face normals from the contacts at this vertex.
-                let mut face_normals: Vec<Vec3> = Vec::new();
-                for &(face_idx, _) in contacts {
-                    if let Some(poly) = face_polygons.get(&face_idx) {
-                        let n = poly.normal;
-                        let already = face_normals.iter().any(|existing| {
-                            (existing.x() - n.x()).abs() < 1e-10
-                                && (existing.y() - n.y()).abs() < 1e-10
-                                && (existing.z() - n.z()).abs() < 1e-10
-                        });
-                        if !already {
-                            face_normals.push(n);
-                        }
+        if ordered_points.len() == 3
+            && let Some(v_pos) = original_vertex
+        {
+            // Collect distinct face normals from the contacts at this vertex.
+            let mut face_normals: Vec<Vec3> = Vec::new();
+            for &(face_idx, _) in contacts {
+                if let Some(poly) = face_polygons.get(&face_idx) {
+                    let n = poly.normal;
+                    let already = face_normals.iter().any(|existing| {
+                        (existing.x() - n.x()).abs() < 1e-10
+                            && (existing.y() - n.y()).abs() < 1e-10
+                            && (existing.z() - n.z()).abs() < 1e-10
+                    });
+                    if !already {
+                        face_normals.push(n);
                     }
                 }
+            }
 
-                // Sphere center: vertex offset inward by R along each face normal.
-                let normal_sum = face_normals
-                    .iter()
-                    .fold(Vec3::new(0.0, 0.0, 0.0), |acc, n| {
-                        Vec3::new(acc.x() + n.x(), acc.y() + n.y(), acc.z() + n.z())
-                    });
+            // Sphere center: vertex offset inward by R along each face normal.
+            let normal_sum = face_normals
+                .iter()
+                .fold(Vec3::new(0.0, 0.0, 0.0), |acc, n| {
+                    Vec3::new(acc.x() + n.x(), acc.y() + n.y(), acc.z() + n.z())
+                });
 
-                // Determine whether this vertex corner is convex or concave.
-                // For a convex corner the face normals (outward) and edge
-                // tangents (pointing away from vertex, i.e. inward) point in
-                // opposite directions: normal_sum · avg_tangent < 0.
-                // For concave corners they align: dot > 0.
-                let is_concave = if let Some(fillet_edges) = vertex_fillet_edges.get(&vi) {
-                    if fillet_edges.len() >= 3 {
-                        let mut tangent_sum = Vec3::new(0.0, 0.0, 0.0);
-                        let mut count = 0;
-                        for &eid in fillet_edges {
-                            if let Ok(edge) = topo.edge(eid) {
-                                let e_start = edge.start();
-                                let e_end = edge.end();
-                                let curve = edge.curve().clone();
-                                let p_s = topo.vertex(e_start)?.point();
-                                let p_e = topo.vertex(e_end)?.point();
-                                let (t_param, sign) = if e_start.index() == vi {
-                                    let (t0, _) = curve.domain_with_endpoints(p_s, p_e);
-                                    (t0, 1.0)
-                                } else {
-                                    let (_, t1) = curve.domain_with_endpoints(p_s, p_e);
-                                    (t1, -1.0)
-                                };
-                                let tan = curve.tangent_with_endpoints(t_param, p_s, p_e);
-                                if let Ok(n) = (tan * sign).normalize() {
-                                    tangent_sum = Vec3::new(
-                                        tangent_sum.x() + n.x(),
-                                        tangent_sum.y() + n.y(),
-                                        tangent_sum.z() + n.z(),
-                                    );
-                                    count += 1;
-                                }
+            // Determine whether this vertex corner is convex or concave.
+            // For a convex corner the face normals (outward) and edge
+            // tangents (pointing away from vertex, i.e. inward) point in
+            // opposite directions: normal_sum · avg_tangent < 0.
+            // For concave corners they align: dot > 0.
+            let is_concave = if let Some(fillet_edges) = vertex_fillet_edges.get(&vi) {
+                if fillet_edges.len() >= 3 {
+                    let mut tangent_sum = Vec3::new(0.0, 0.0, 0.0);
+                    let mut count = 0;
+                    for &eid in fillet_edges {
+                        if let Ok(edge) = topo.edge(eid) {
+                            let e_start = edge.start();
+                            let e_end = edge.end();
+                            let curve = edge.curve().clone();
+                            let p_s = topo.vertex(e_start)?.point();
+                            let p_e = topo.vertex(e_end)?.point();
+                            let (t_param, sign) = if e_start.index() == vi {
+                                let (t0, _) = curve.domain_with_endpoints(p_s, p_e);
+                                (t0, 1.0)
+                            } else {
+                                let (_, t1) = curve.domain_with_endpoints(p_s, p_e);
+                                (t1, -1.0)
+                            };
+                            let tan = curve.tangent_with_endpoints(t_param, p_s, p_e);
+                            if let Ok(n) = (tan * sign).normalize() {
+                                tangent_sum = Vec3::new(
+                                    tangent_sum.x() + n.x(),
+                                    tangent_sum.y() + n.y(),
+                                    tangent_sum.z() + n.z(),
+                                );
+                                count += 1;
                             }
                         }
-                        count >= 3 && normal_sum.dot(tangent_sum) > 0.0
-                    } else {
-                        false
                     }
+                    count >= 3 && normal_sum.dot(tangent_sum) > 0.0
                 } else {
                     false
-                };
+                }
+            } else {
+                false
+            };
 
-                // For outward-pointing face normals on a convex corner, "inward"
-                // means subtracting. For concave corners the offset direction
-                // is reversed (we add instead of subtract).
-                let offset_sign = if is_concave { 1.0 } else { -1.0 };
-                let sphere_center = Point3::new(
-                    v_pos.x() + offset_sign * radius * normal_sum.x(),
-                    v_pos.y() + offset_sign * radius * normal_sum.y(),
-                    v_pos.z() + offset_sign * radius * normal_sum.z(),
+            // For outward-pointing face normals on a convex corner, "inward"
+            // means subtracting. For concave corners the offset direction
+            // is reversed (we add instead of subtract).
+            let offset_sign = if is_concave { 1.0 } else { -1.0 };
+            let sphere_center = Point3::new(
+                v_pos.x() + offset_sign * radius * normal_sum.x(),
+                v_pos.y() + offset_sign * radius * normal_sum.y(),
+                v_pos.z() + offset_sign * radius * normal_sum.z(),
+            );
+
+            let p0 = ordered_points[0];
+            let p1 = ordered_points[1];
+            let p2 = ordered_points[2];
+
+            // Helper: compute the tangent-intersection control point and
+            // weight for a rational quadratic Bézier circular arc from a to b
+            // on the sphere.  The middle CP sits at distance r/cos(θ/2) from
+            // center (the tangent intersection), and the weight is cos(θ/2).
+            let arc_mid_and_weight = |a: Point3, b: Point3| -> Option<(Point3, f64)> {
+                let va = (a - sphere_center).normalize().ok()?;
+                let vb = (b - sphere_center).normalize().ok()?;
+                let r_actual = (a - sphere_center).length();
+                let sum = va + vb;
+                let len = sum.length();
+                if len < 1e-15 {
+                    return None;
+                }
+                let dir = Vec3::new(sum.x() / len, sum.y() / len, sum.z() / len);
+                let cos_half = len / 2.0; // cos(θ/2) for unit vectors
+                let r_ctrl = r_actual / cos_half;
+                let cp = Point3::new(
+                    sphere_center.x() + dir.x() * r_ctrl,
+                    sphere_center.y() + dir.y() * r_ctrl,
+                    sphere_center.z() + dir.z() * r_ctrl,
+                );
+                Some((cp, cos_half))
+            };
+
+            // Compute per-edge arc midpoints and weights.
+            if let (Some((m01, w01)), Some((m12, w12)), Some((m20, w20))) = (
+                arc_mid_and_weight(p0, p1),
+                arc_mid_and_weight(p1, p2),
+                arc_mid_and_weight(p2, p0),
+            ) {
+                // Interior control point: a single degree-(2,2) rational
+                // patch over a wide spherical triangle sags inward at its
+                // centre if the interior control point sits on the sphere.
+                // Place it instead at the intersection of the three corner
+                // tangent planes (the apex of the tangent cone), pushed out
+                // along the average radial direction.  For an orthogonal
+                // (box) corner this lands at center + r·Σdir (overshoot √3),
+                // and the rational blend then tracks the sphere within a few
+                // percent of R — inside the corner-blend deviation budget.
+                let r_actual = (p0 - sphere_center).length();
+                let dir0 = (p0 - sphere_center) * (1.0 / r_actual);
+                let dir1 = (p1 - sphere_center) * (1.0 / r_actual);
+                let dir2 = (p2 - sphere_center) * (1.0 / r_actual);
+                let radial_sum = dir0 + dir1 + dir2;
+                let apex = Point3::new(
+                    sphere_center.x() + radial_sum.x() * r_actual,
+                    sphere_center.y() + radial_sum.y() * r_actual,
+                    sphere_center.z() + radial_sum.z() * r_actual,
                 );
 
-                let p0 = ordered_points[0];
-                let p1 = ordered_points[1];
-                let p2 = ordered_points[2];
+                // Apex weight: the product of the three edge weights yields
+                // the rational triangle that hugs the sphere most closely.
+                let w_apex = w01 * w12 * w20;
 
-                // Helper: compute the tangent-intersection control point and
-                // weight for a rational quadratic Bézier circular arc from a to b
-                // on the sphere.  The middle CP sits at distance r/cos(θ/2) from
-                // center (the tangent intersection), and the weight is cos(θ/2).
-                let arc_mid_and_weight = |a: Point3, b: Point3| -> Option<(Point3, f64)> {
-                    let va = (a - sphere_center).normalize().ok()?;
-                    let vb = (b - sphere_center).normalize().ok()?;
-                    let r_actual = (a - sphere_center).length();
-                    let sum = va + vb;
-                    let len = sum.length();
-                    if len < 1e-15 {
-                        return None;
-                    }
-                    let dir = Vec3::new(sum.x() / len, sum.y() / len, sum.z() / len);
-                    let cos_half = len / 2.0; // cos(θ/2) for unit vectors
-                    let r_ctrl = r_actual / cos_half;
-                    let cp = Point3::new(
-                        sphere_center.x() + dir.x() * r_ctrl,
-                        sphere_center.y() + dir.y() * r_ctrl,
-                        sphere_center.z() + dir.z() * r_ctrl,
-                    );
-                    Some((cp, cos_half))
-                };
+                // Degree (2,2) rational patch with a degenerate column.
+                let cap_surface = NurbsSurface::new(
+                    2,
+                    2,
+                    vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                    vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                    vec![vec![p0, m20, p2], vec![m01, apex, p2], vec![p1, m12, p2]],
+                    vec![
+                        vec![1.0, w20, 1.0],
+                        vec![w01, w_apex, 1.0],
+                        vec![1.0, w12, 1.0],
+                    ],
+                )
+                .map_err(crate::OperationsError::Math)?;
 
-                // Compute per-edge arc midpoints and weights.
-                if let (Some((m01, w01)), Some((m12, w12)), Some((m20, w20))) = (
-                    arc_mid_and_weight(p0, p1),
-                    arc_mid_and_weight(p1, p2),
-                    arc_mid_and_weight(p2, p0),
-                ) {
-                    // Interior control point: a single degree-(2,2) rational
-                    // patch over a wide spherical triangle sags inward at its
-                    // centre if the interior control point sits on the sphere.
-                    // Place it instead at the intersection of the three corner
-                    // tangent planes (the apex of the tangent cone), pushed out
-                    // along the average radial direction.  For an orthogonal
-                    // (box) corner this lands at center + r·Σdir (overshoot √3),
-                    // and the rational blend then tracks the sphere within a few
-                    // percent of R — inside the corner-blend deviation budget.
-                    let r_actual = (p0 - sphere_center).length();
-                    let dir0 = (p0 - sphere_center) * (1.0 / r_actual);
-                    let dir1 = (p1 - sphere_center) * (1.0 / r_actual);
-                    let dir2 = (p2 - sphere_center) * (1.0 / r_actual);
-                    let radial_sum = dir0 + dir1 + dir2;
-                    let apex = Point3::new(
-                        sphere_center.x() + radial_sum.x() * r_actual,
-                        sphere_center.y() + radial_sum.y() * r_actual,
-                        sphere_center.z() + radial_sum.z() * r_actual,
-                    );
+                // The cap's outward normal must point away from the sphere
+                // centre (for a convex corner) so the tessellated patch faces
+                // outward.  Evaluating the natural normal at an interior
+                // station and comparing against the radial direction gives a
+                // robust reversal flag that is stored on the spec (so it is
+                // not lost when assembly reorders/merges faces).
+                let cap_mid = cap_surface.evaluate(0.5, 0.5);
+                let radial = (cap_mid - sphere_center)
+                    .normalize()
+                    .unwrap_or(blend_normal);
+                let outward = if is_concave { -radial } else { radial };
+                let cap_norm = cap_surface.normal(0.5, 0.5).unwrap_or(outward);
+                let cap_reversed = cap_norm.dot(outward) < 0.0;
 
-                    // Apex weight: the product of the three edge weights yields
-                    // the rational triangle that hugs the sphere most closely.
-                    let w_apex = w01 * w12 * w20;
-
-                    // Degree (2,2) rational patch with a degenerate column.
-                    let cap_surface = NurbsSurface::new(
-                        2,
-                        2,
-                        vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                        vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                        vec![vec![p0, m20, p2], vec![m01, apex, p2], vec![p1, m12, p2]],
-                        vec![
-                            vec![1.0, w20, 1.0],
-                            vec![w01, w_apex, 1.0],
-                            vec![1.0, w12, 1.0],
-                        ],
-                    )
-                    .map_err(crate::OperationsError::Math)?;
-
-                    // The cap's outward normal must point away from the sphere
-                    // centre (for a convex corner) so the tessellated patch faces
-                    // outward.  Evaluating the natural normal at an interior
-                    // station and comparing against the radial direction gives a
-                    // robust reversal flag that is stored on the spec (so it is
-                    // not lost when assembly reorders/merges faces).
-                    let cap_mid = cap_surface.evaluate(0.5, 0.5);
-                    let radial = (cap_mid - sphere_center)
-                        .normalize()
-                        .unwrap_or(blend_normal);
-                    let outward = if is_concave { -radial } else { radial };
-                    let cap_norm = cap_surface.normal(0.5, 0.5).unwrap_or(outward);
-                    let cap_reversed = cap_norm.dot(outward) < 0.0;
-
-                    all_specs.push(FaceSpec::Surface {
-                        vertices: ordered_points,
-                        surface: FaceSurface::Nurbs(cap_surface),
-                        reversed: cap_reversed,
-                        inner_wires: vec![],
-                    });
-                    continue;
-                }
+                all_specs.push(FaceSpec::Surface {
+                    vertices: ordered_points,
+                    surface: FaceSurface::Nurbs(cap_surface),
+                    reversed: cap_reversed,
+                    inner_wires: vec![],
+                });
+                continue;
             }
         }
 
@@ -1880,19 +1880,19 @@ pub fn fillet_rolling_ball(
             if face_polygons.contains_key(&fid.index()) {
                 continue;
             }
-            if let Ok(face) = topo.face(fid) {
-                if let Ok(wire) = topo.wire(face.outer_wire()) {
-                    for oe in wire.edges() {
-                        if let Ok(edge_data) = topo.edge(oe.edge()) {
-                            let vid = oe.oriented_start(edge_data);
-                            if let Ok(v) = topo.vertex(vid) {
-                                let p = v.point();
-                                let already = original_verts
-                                    .iter()
-                                    .any(|existing| (*existing - p).length() < tol.linear);
-                                if !already {
-                                    original_verts.push(p);
-                                }
+            if let Ok(face) = topo.face(fid)
+                && let Ok(wire) = topo.wire(face.outer_wire())
+            {
+                for oe in wire.edges() {
+                    if let Ok(edge_data) = topo.edge(oe.edge()) {
+                        let vid = oe.oriented_start(edge_data);
+                        if let Ok(v) = topo.vertex(vid) {
+                            let p = v.point();
+                            let already = original_verts
+                                .iter()
+                                .any(|existing| (*existing - p).length() < tol.linear);
+                            if !already {
+                                original_verts.push(p);
                             }
                         }
                     }

--- a/crates/operations/src/measure/area.rs
+++ b/crates/operations/src/measure/area.rs
@@ -209,22 +209,21 @@ fn analytic_cone_face_area(
                     v_vals.push(v);
                 }
             }
-            if !edge.is_closed() {
-                if let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve() {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        let ts = circle.project(sv.point());
-                        let te = circle.project(ev.point());
-                        let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
-                        let mid_t = if fwd <= std::f64::consts::PI {
-                            ts + fwd * 0.5
-                        } else {
-                            ts - (std::f64::consts::TAU - fwd) * 0.5
-                        };
-                        let mid = circle.evaluate(mid_t);
-                        let (u, _) = cone.project_point(mid);
-                        u_vals.push(u);
-                    }
-                }
+            if !edge.is_closed()
+                && let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+            {
+                let ts = circle.project(sv.point());
+                let te = circle.project(ev.point());
+                let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
+                let mid_t = if fwd <= std::f64::consts::PI {
+                    ts + fwd * 0.5
+                } else {
+                    ts - (std::f64::consts::TAU - fwd) * 0.5
+                };
+                let mid = circle.evaluate(mid_t);
+                let (u, _) = cone.project_point(mid);
+                u_vals.push(u);
             }
         }
     }
@@ -282,22 +281,21 @@ fn analytic_torus_face_area(
                     v_vals.push(v);
                 }
             }
-            if !edge.is_closed() {
-                if let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve() {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        let ts = circle.project(sv.point());
-                        let te = circle.project(ev.point());
-                        let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
-                        let mid_t = if fwd <= std::f64::consts::PI {
-                            ts + fwd * 0.5
-                        } else {
-                            ts - (std::f64::consts::TAU - fwd) * 0.5
-                        };
-                        let mid = circle.evaluate(mid_t);
-                        let (u, _) = tor.project_point(mid);
-                        u_vals.push(u);
-                    }
-                }
+            if !edge.is_closed()
+                && let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+            {
+                let ts = circle.project(sv.point());
+                let te = circle.project(ev.point());
+                let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
+                let mid_t = if fwd <= std::f64::consts::PI {
+                    ts + fwd * 0.5
+                } else {
+                    ts - (std::f64::consts::TAU - fwd) * 0.5
+                };
+                let mid = circle.evaluate(mid_t);
+                let (u, _) = tor.project_point(mid);
+                u_vals.push(u);
             }
         }
     }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -74,44 +74,47 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         }
     }
 
-    if let Some(r) = sphere_r {
-        if cyl.is_none() && cone_params.is_none() && torus_params.is_none() && planes.is_empty() {
-            // A non-uniform scale transforms vertices but leaves the sphere
-            // surface radius unchanged, making the analytic formula wrong.
-            let sphere_faces: Vec<_> = shell.faces().to_vec();
-            let center = if let Ok(f) = topo.face(sphere_faces[0]) {
-                if let FaceSurface::Sphere(s) = f.surface() {
-                    s.center()
-                } else {
-                    return None;
-                }
+    if let Some(r) = sphere_r
+        && cyl.is_none()
+        && cone_params.is_none()
+        && torus_params.is_none()
+        && planes.is_empty()
+    {
+        // A non-uniform scale transforms vertices but leaves the sphere
+        // surface radius unchanged, making the analytic formula wrong.
+        let sphere_faces: Vec<_> = shell.faces().to_vec();
+        let center = if let Ok(f) = topo.face(sphere_faces[0]) {
+            if let FaceSurface::Sphere(s) = f.surface() {
+                s.center()
             } else {
                 return None;
-            };
-            let mut max_dist = 0.0_f64;
-            let mut min_dist = f64::INFINITY;
-            for &fid in &sphere_faces {
-                if let Ok(face) = topo.face(fid) {
-                    if let Ok(wire) = topo.wire(face.outer_wire()) {
-                        for oe in wire.edges() {
-                            if let Ok(e) = topo.edge(oe.edge()) {
-                                if let Ok(v) = topo.vertex(e.start()) {
-                                    let d = (v.point() - center).length();
-                                    max_dist = max_dist.max(d);
-                                    min_dist = min_dist.min(d);
-                                }
-                            }
-                        }
+            }
+        } else {
+            return None;
+        };
+        let mut max_dist = 0.0_f64;
+        let mut min_dist = f64::INFINITY;
+        for &fid in &sphere_faces {
+            if let Ok(face) = topo.face(fid)
+                && let Ok(wire) = topo.wire(face.outer_wire())
+            {
+                for oe in wire.edges() {
+                    if let Ok(e) = topo.edge(oe.edge())
+                        && let Ok(v) = topo.vertex(e.start())
+                    {
+                        let d = (v.point() - center).length();
+                        max_dist = max_dist.max(d);
+                        min_dist = min_dist.min(d);
                     }
                 }
             }
-            // If all vertices are equidistant (within 1%), use analytic formula
-            if (max_dist - min_dist).abs() < r * 0.01 {
-                return Some(4.0 / 3.0 * PI * r * r * r);
-            }
-            // Non-uniform scale detected -- fall through to tessellation
-            return None;
         }
+        // If all vertices are equidistant (within 1%), use analytic formula
+        if (max_dist - min_dist).abs() < r * 0.01 {
+            return Some(4.0 / 3.0 * PI * r * r * r);
+        }
+        // Non-uniform scale detected -- fall through to tessellation
+        return None;
     }
 
     // A pure cylinder has exactly 1 cylindrical face and 2 planar caps.
@@ -119,19 +122,18 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     // with a drilled hole has 1 cylindrical hole-wall + 6 box faces).
     // In the compound case the cylindrical face is a concave inner surface
     // and the formula pi*r^2*h would compute the cylinder volume, not the solid.
-    if let Some((origin, axis, r)) = cyl {
-        if cone_params.is_none()
-            && torus_params.is_none()
-            && sphere_r.is_none()
-            && planes.len() == 2
-        {
-            let origin_vec = Vec3::new(origin.x(), origin.y(), origin.z());
-            let mut ts = cap_t_values(origin_vec, axis, &planes);
-            if ts.len() >= 2 {
-                ts.sort_by(f64::total_cmp);
-                if let (Some(&t_min), Some(&t_max)) = (ts.first(), ts.last()) {
-                    return Some(PI * r * r * (t_max - t_min));
-                }
+    if let Some((origin, axis, r)) = cyl
+        && cone_params.is_none()
+        && torus_params.is_none()
+        && sphere_r.is_none()
+        && planes.len() == 2
+    {
+        let origin_vec = Vec3::new(origin.x(), origin.y(), origin.z());
+        let mut ts = cap_t_values(origin_vec, axis, &planes);
+        if ts.len() >= 2 {
+            ts.sort_by(f64::total_cmp);
+            if let (Some(&t_min), Some(&t_max)) = (ts.first(), ts.last()) {
+                return Some(PI * r * r * (t_max - t_min));
             }
         }
     }
@@ -139,47 +141,52 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     // Cap radii are read directly from the Circle3D edges of the cap faces,
     // bypassing the ConicalSurface parameterization entirely. Heights are
     // derived from the circle centers projected onto the cone axis.
-    if let Some((apex, axis)) = cone_params {
-        if cyl.is_none() && torus_params.is_none() && sphere_r.is_none() {
-            let apex_vec = Vec3::new(apex.x(), apex.y(), apex.z());
+    if let Some((apex, axis)) = cone_params
+        && cyl.is_none()
+        && torus_params.is_none()
+        && sphere_r.is_none()
+    {
+        let apex_vec = Vec3::new(apex.x(), apex.y(), apex.z());
 
-            // Collect (circle_center, radius) from each plane cap face.
-            let mut cap_circles: Vec<(Point3, f64)> = Vec::new();
-            for &fid in &plane_face_ids {
-                if let Some(cap) = find_cap_circle(topo, fid) {
-                    cap_circles.push(cap);
-                }
+        // Collect (circle_center, radius) from each plane cap face.
+        let mut cap_circles: Vec<(Point3, f64)> = Vec::new();
+        for &fid in &plane_face_ids {
+            if let Some(cap) = find_cap_circle(topo, fid) {
+                cap_circles.push(cap);
             }
+        }
 
-            // If any cap face did not yield a circle, the cone is degenerate or
-            // unsupported -- fall back to tessellation rather than silently wrong answer.
-            if cap_circles.len() != plane_face_ids.len() {
-                return None;
-            }
+        // If any cap face did not yield a circle, the cone is degenerate or
+        // unsupported -- fall back to tessellation rather than silently wrong answer.
+        if cap_circles.len() != plane_face_ids.len() {
+            return None;
+        }
 
-            match cap_circles.as_slice() {
-                [(c, r)] => {
-                    // Pointed cone: h = distance from apex to cap center along axis.
-                    let c_vec = Vec3::new(c.x(), c.y(), c.z());
-                    let h = (c_vec - apex_vec).dot(axis).abs();
-                    return Some(PI / 3.0 * r * r * h);
-                }
-                [(c1, r1), (c2, r2)] => {
-                    // Frustum: h = distance between cap centers projected onto axis.
-                    let c1_vec = Vec3::new(c1.x(), c1.y(), c1.z());
-                    let c2_vec = Vec3::new(c2.x(), c2.y(), c2.z());
-                    let h = (c2_vec - c1_vec).dot(axis).abs();
-                    return Some(PI * h / 3.0 * (r1 * r1 + r1 * r2 + r2 * r2));
-                }
-                _ => {}
+        match cap_circles.as_slice() {
+            [(c, r)] => {
+                // Pointed cone: h = distance from apex to cap center along axis.
+                let c_vec = Vec3::new(c.x(), c.y(), c.z());
+                let h = (c_vec - apex_vec).dot(axis).abs();
+                return Some(PI / 3.0 * r * r * h);
             }
+            [(c1, r1), (c2, r2)] => {
+                // Frustum: h = distance between cap centers projected onto axis.
+                let c1_vec = Vec3::new(c1.x(), c1.y(), c1.z());
+                let c2_vec = Vec3::new(c2.x(), c2.y(), c2.z());
+                let h = (c2_vec - c1_vec).dot(axis).abs();
+                return Some(PI * h / 3.0 * (r1 * r1 + r1 * r2 + r2 * r2));
+            }
+            _ => {}
         }
     }
 
-    if let Some((r_major, r_minor)) = torus_params {
-        if cyl.is_none() && cone_params.is_none() && sphere_r.is_none() && planes.is_empty() {
-            return Some(2.0 * PI * PI * r_major * r_minor * r_minor);
-        }
+    if let Some((r_major, r_minor)) = torus_params
+        && cyl.is_none()
+        && cone_params.is_none()
+        && sphere_r.is_none()
+        && planes.is_empty()
+    {
+        return Some(2.0 * PI * PI * r_major * r_minor * r_minor);
     }
 
     None
@@ -398,23 +405,22 @@ fn analytic_cylinder_signed_volume(
                 }
             }
             // Sample circle-edge midpoints for angular coverage.
-            if !edge.is_closed() {
-                if let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve() {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        let ts = circle.project(sv.point());
-                        let te = circle.project(ev.point());
-                        // Choose the shorter arc for the midpoint.
-                        let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
-                        let mid_t = if fwd <= std::f64::consts::PI {
-                            ts + fwd * 0.5
-                        } else {
-                            ts - (std::f64::consts::TAU - fwd) * 0.5
-                        };
-                        let mid = circle.evaluate(mid_t);
-                        let (u, _) = cyl.project_point(mid);
-                        u_vals.push(u);
-                    }
-                }
+            if !edge.is_closed()
+                && let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+            {
+                let ts = circle.project(sv.point());
+                let te = circle.project(ev.point());
+                // Choose the shorter arc for the midpoint.
+                let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
+                let mid_t = if fwd <= std::f64::consts::PI {
+                    ts + fwd * 0.5
+                } else {
+                    ts - (std::f64::consts::TAU - fwd) * 0.5
+                };
+                let mid = circle.evaluate(mid_t);
+                let (u, _) = cyl.project_point(mid);
+                u_vals.push(u);
             }
         }
     }
@@ -480,22 +486,21 @@ fn analytic_cone_signed_volume(
                     v_vals.push(v);
                 }
             }
-            if !edge.is_closed() {
-                if let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve() {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        let ts = circle.project(sv.point());
-                        let te = circle.project(ev.point());
-                        let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
-                        let mid_t = if fwd <= std::f64::consts::PI {
-                            ts + fwd * 0.5
-                        } else {
-                            ts - (std::f64::consts::TAU - fwd) * 0.5
-                        };
-                        let mid = circle.evaluate(mid_t);
-                        let (u, _) = cone.project_point(mid);
-                        u_vals.push(u);
-                    }
-                }
+            if !edge.is_closed()
+                && let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+            {
+                let ts = circle.project(sv.point());
+                let te = circle.project(ev.point());
+                let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
+                let mid_t = if fwd <= std::f64::consts::PI {
+                    ts + fwd * 0.5
+                } else {
+                    ts - (std::f64::consts::TAU - fwd) * 0.5
+                };
+                let mid = circle.evaluate(mid_t);
+                let (u, _) = cone.project_point(mid);
+                u_vals.push(u);
             }
         }
     }
@@ -584,22 +589,21 @@ fn analytic_sphere_signed_volume(
                     v_vals.push(v);
                 }
             }
-            if !edge.is_closed() {
-                if let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve() {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        let ts = circle.project(sv.point());
-                        let te = circle.project(ev.point());
-                        let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
-                        let mid_t = if fwd <= std::f64::consts::PI {
-                            ts + fwd * 0.5
-                        } else {
-                            ts - (std::f64::consts::TAU - fwd) * 0.5
-                        };
-                        let mid = circle.evaluate(mid_t);
-                        let (u, _) = sph.project_point(mid);
-                        u_vals.push(u);
-                    }
-                }
+            if !edge.is_closed()
+                && let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+            {
+                let ts = circle.project(sv.point());
+                let te = circle.project(ev.point());
+                let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
+                let mid_t = if fwd <= std::f64::consts::PI {
+                    ts + fwd * 0.5
+                } else {
+                    ts - (std::f64::consts::TAU - fwd) * 0.5
+                };
+                let mid = circle.evaluate(mid_t);
+                let (u, _) = sph.project_point(mid);
+                u_vals.push(u);
             }
         }
     }
@@ -713,22 +717,21 @@ fn analytic_torus_signed_volume(
                     v_vals.push(v);
                 }
             }
-            if !edge.is_closed() {
-                if let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve() {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        let ts = circle.project(sv.point());
-                        let te = circle.project(ev.point());
-                        let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
-                        let mid_t = if fwd <= std::f64::consts::PI {
-                            ts + fwd * 0.5
-                        } else {
-                            ts - (std::f64::consts::TAU - fwd) * 0.5
-                        };
-                        let mid = circle.evaluate(mid_t);
-                        let (u, _) = tor.project_point(mid);
-                        u_vals.push(u);
-                    }
-                }
+            if !edge.is_closed()
+                && let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+            {
+                let ts = circle.project(sv.point());
+                let te = circle.project(ev.point());
+                let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
+                let mid_t = if fwd <= std::f64::consts::PI {
+                    ts + fwd * 0.5
+                } else {
+                    ts - (std::f64::consts::TAU - fwd) * 0.5
+                };
+                let mid = circle.evaluate(mid_t);
+                let (u, _) = tor.project_point(mid);
+                u_vals.push(u);
             }
         }
     }

--- a/crates/operations/src/mesh_boolean.rs
+++ b/crates/operations/src/mesh_boolean.rs
@@ -71,25 +71,25 @@ pub fn mesh_boolean_with_metadata(
 ) -> Result<MeshBooleanResult, OperationsError> {
     let tri_count_a = mesh_a.indices.len() / 3;
     let tri_count_b = mesh_b.indices.len() / 3;
-    if let Some(p) = planar_a {
-        if p.len() != tri_count_a {
-            return Err(OperationsError::InvalidInput {
-                reason: format!(
-                    "mesh_boolean_with_metadata: planar_a length {} != triangle count {tri_count_a}",
-                    p.len()
-                ),
-            });
-        }
+    if let Some(p) = planar_a
+        && p.len() != tri_count_a
+    {
+        return Err(OperationsError::InvalidInput {
+            reason: format!(
+                "mesh_boolean_with_metadata: planar_a length {} != triangle count {tri_count_a}",
+                p.len()
+            ),
+        });
     }
-    if let Some(p) = planar_b {
-        if p.len() != tri_count_b {
-            return Err(OperationsError::InvalidInput {
-                reason: format!(
-                    "mesh_boolean_with_metadata: planar_b length {} != triangle count {tri_count_b}",
-                    p.len()
-                ),
-            });
-        }
+    if let Some(p) = planar_b
+        && p.len() != tri_count_b
+    {
+        return Err(OperationsError::InvalidInput {
+            reason: format!(
+                "mesh_boolean_with_metadata: planar_b length {} != triangle count {tri_count_b}",
+                p.len()
+            ),
+        });
     }
 
     // Step 1: BVH broad-phase
@@ -861,12 +861,10 @@ fn split_triangle_by_points(
         let mut inserted = false;
 
         for (tv0, tv1, tv2) in &tris {
-            if !inserted {
-                if let Some(sub) = try_split_triangle(*tv0, *tv1, *tv2, pt, tolerance) {
-                    new_tris.extend(sub);
-                    inserted = true;
-                    continue;
-                }
+            if !inserted && let Some(sub) = try_split_triangle(*tv0, *tv1, *tv2, pt, tolerance) {
+                new_tris.extend(sub);
+                inserted = true;
+                continue;
             }
             new_tris.push((*tv0, *tv1, *tv2));
         }

--- a/crates/operations/src/offset_trim.rs
+++ b/crates/operations/src/offset_trim.rs
@@ -70,10 +70,10 @@ pub fn trim_offset_self_intersections(
     offset_distance: f64,
     tolerance: f64,
 ) -> Result<NurbsSurface, OperationsError> {
-    if let Ok(ssi_curves) = detect_self_intersection(offset, SSI_GRID, tolerance) {
-        if !ssi_curves.is_empty() {
-            return trim_via_ssi(original, offset, offset_distance, tolerance, &ssi_curves);
-        }
+    if let Ok(ssi_curves) = detect_self_intersection(offset, SSI_GRID, tolerance)
+        && !ssi_curves.is_empty()
+    {
+        return trim_via_ssi(original, offset, offset_distance, tolerance, &ssi_curves);
     }
 
     trim_via_sampling(original, offset, offset_distance, tolerance)

--- a/crates/operations/src/shell_op.rs
+++ b/crates/operations/src/shell_op.rs
@@ -337,37 +337,37 @@ pub fn shell(
             }
             FaceSurface::Cylinder(cyl) => {
                 let new_radius = cyl.radius() - thickness;
-                if new_radius > tol.linear {
-                    if let Ok(new_cyl) = brepkit_math::surfaces::CylindricalSurface::new(
+                if new_radius > tol.linear
+                    && let Ok(new_cyl) = brepkit_math::surfaces::CylindricalSurface::new(
                         cyl.origin(),
                         cyl.axis(),
                         new_radius,
-                    ) {
-                        // Full-circle cylinders: use Surface (the dense sample
-                        // polygon from face_polygon contains seam-duplicate
-                        // vertices that CylindricalFace can't handle cleanly).
-                        // Partial-arc cylinders: use CylindricalFace to create
-                        // Circle edges that preserve angular range info.
-                        let wire = topo.wire(face.outer_wire())?;
-                        let has_closed_edge = wire
-                            .edges()
-                            .iter()
-                            .any(|oe| topo.edge(oe.edge()).is_ok_and(|e| e.start() == e.end()));
-                        if has_closed_edge {
-                            result_specs.push(FaceSpec::Surface {
-                                vertices: inner_verts,
-                                surface: FaceSurface::Cylinder(new_cyl),
-                                reversed: true,
-                                inner_wires: vec![],
-                            });
-                        } else {
-                            result_specs.push(FaceSpec::CylindricalFace {
-                                vertices: inner_verts,
-                                cylinder: new_cyl,
-                                reversed: true,
-                                inner_wires: vec![],
-                            });
-                        }
+                    )
+                {
+                    // Full-circle cylinders: use Surface (the dense sample
+                    // polygon from face_polygon contains seam-duplicate
+                    // vertices that CylindricalFace can't handle cleanly).
+                    // Partial-arc cylinders: use CylindricalFace to create
+                    // Circle edges that preserve angular range info.
+                    let wire = topo.wire(face.outer_wire())?;
+                    let has_closed_edge = wire
+                        .edges()
+                        .iter()
+                        .any(|oe| topo.edge(oe.edge()).is_ok_and(|e| e.start() == e.end()));
+                    if has_closed_edge {
+                        result_specs.push(FaceSpec::Surface {
+                            vertices: inner_verts,
+                            surface: FaceSurface::Cylinder(new_cyl),
+                            reversed: true,
+                            inner_wires: vec![],
+                        });
+                    } else {
+                        result_specs.push(FaceSpec::CylindricalFace {
+                            vertices: inner_verts,
+                            cylinder: new_cyl,
+                            reversed: true,
+                            inner_wires: vec![],
+                        });
                     }
                 }
             }
@@ -433,10 +433,10 @@ pub fn shell(
     let edge_face_map = brepkit_topology::explorer::edge_to_face_map(topo, solid)?;
     let mut boundary_edge_ids: Vec<brepkit_topology::edge::EdgeId> = Vec::new();
     for (&edge_idx, faces) in &edge_face_map {
-        if faces.len() == 1 {
-            if let Some(eid) = topo.edge_id_from_index(edge_idx) {
-                boundary_edge_ids.push(eid);
-            }
+        if faces.len() == 1
+            && let Some(eid) = topo.edge_id_from_index(edge_idx)
+        {
+            boundary_edge_ids.push(eid);
         }
     }
 
@@ -550,15 +550,14 @@ pub fn shell(
     let rim_normal = {
         let mut n = Vec3::new(0.0, 0.0, 1.0);
         for &(fid, _) in &face_verts {
-            if open_set.contains(&fid.index()) {
-                if let Ok(f) = topo.face(fid) {
-                    if let FaceSurface::Plane { normal, .. } = f.surface() {
-                        // The rim normal should point in the same direction as the
-                        // removed face's outward normal (away from solid interior).
-                        n = if f.is_reversed() { -*normal } else { *normal };
-                        break;
-                    }
-                }
+            if open_set.contains(&fid.index())
+                && let Ok(f) = topo.face(fid)
+                && let FaceSurface::Plane { normal, .. } = f.surface()
+            {
+                // The rim normal should point in the same direction as the
+                // removed face's outward normal (away from solid interior).
+                n = if f.is_reversed() { -*normal } else { *normal };
+                break;
             }
         }
         n

--- a/crates/operations/src/shell_op/tests.rs
+++ b/crates/operations/src/shell_op/tests.rs
@@ -19,13 +19,12 @@ fn find_faces_by_normal(topo: &Topology, solid: SolidId, target_normal: Vec3) ->
     let mut result = Vec::new();
     for &fid in sh.faces() {
         let f = topo.face(fid).unwrap();
-        if let FaceSurface::Plane { normal, .. } = f.surface() {
-            if tol.approx_eq(normal.x(), target_normal.x())
-                && tol.approx_eq(normal.y(), target_normal.y())
-                && tol.approx_eq(normal.z(), target_normal.z())
-            {
-                result.push(fid);
-            }
+        if let FaceSurface::Plane { normal, .. } = f.surface()
+            && tol.approx_eq(normal.x(), target_normal.x())
+            && tol.approx_eq(normal.y(), target_normal.y())
+            && tol.approx_eq(normal.z(), target_normal.z())
+        {
+            result.push(fid);
         }
     }
     result

--- a/crates/operations/src/tessellate/edge_sampling.rs
+++ b/crates/operations/src/tessellate/edge_sampling.rs
@@ -421,12 +421,11 @@ pub(super) fn sample_wire_positions(
         }
     }
 
-    if positions.len() > 2 {
-        if let (Some(first), Some(last)) = (positions.first(), positions.last()) {
-            if (*last - *first).length() < tol {
-                positions.pop();
-            }
-        }
+    if positions.len() > 2
+        && let (Some(first), Some(last)) = (positions.first(), positions.last())
+        && (*last - *first).length() < tol
+    {
+        positions.pop();
     }
 
     Ok(positions)

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -319,15 +319,14 @@ pub fn sample_solid_edges_filtered(
     };
 
     for edge_id in &edges {
-        if let Some(ref efm) = edge_face_map {
-            if let Some(faces) = efm.get(&edge_id.index()) {
-                if faces.len() == 2 {
-                    let fa = topo.face(faces[0])?;
-                    let fb = topo.face(faces[1])?;
-                    if surfaces_equivalent(fa.surface(), fb.surface()) {
-                        continue;
-                    }
-                }
+        if let Some(ref efm) = edge_face_map
+            && let Some(faces) = efm.get(&edge_id.index())
+            && faces.len() == 2
+        {
+            let fa = topo.face(faces[0])?;
+            let fb = topo.face(faces[1])?;
+            if surfaces_equivalent(fa.surface(), fb.surface()) {
+                continue;
             }
         }
 

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -226,18 +226,15 @@ pub(super) fn tessellate_nonplanar_cdt(
         }
     }
 
-    if boundary_3d.len() > 2 {
-        if let (Some(&(_, first_gid, _, _)), Some(&(_, last_gid, _, _))) =
+    if boundary_3d.len() > 2
+        && let (Some(&(_, first_gid, _, _)), Some(&(_, last_gid, _, _))) =
             (boundary_3d.first(), boundary_3d.last())
-        {
-            if first_gid == last_gid
-                || (merged.positions[first_gid as usize] - merged.positions[last_gid as usize])
-                    .length()
-                    < tol_dup
-            {
-                boundary_3d.pop();
-            }
-        }
+        && (first_gid == last_gid
+            || (merged.positions[first_gid as usize] - merged.positions[last_gid as usize])
+                .length()
+                < tol_dup)
+    {
+        boundary_3d.pop();
     }
 
     let n_boundary = boundary_3d.len();

--- a/crates/operations/src/tessellate/nurbs.rs
+++ b/crates/operations/src/tessellate/nurbs.rs
@@ -129,43 +129,43 @@ where
 
                 // Sample edge midpoints to provide angular coverage
                 // between vertices.
-                if !edge.is_closed() {
-                    if let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) {
-                        match edge.curve() {
-                            EdgeCurve::Circle(circle) => {
-                                let ts = circle.project(sv.point());
-                                let te = circle.project(ev.point());
-                                let fwd = (te - ts).rem_euclid(TAU);
-                                let mid_t = if fwd <= std::f64::consts::PI {
-                                    ts + fwd * 0.5
-                                } else {
-                                    ts - (TAU - fwd) * 0.5
-                                };
-                                let mid = circle.evaluate(mid_t);
-                                let (u, _) = project(mid);
-                                angles.push(u);
-                            }
-                            EdgeCurve::Ellipse(ellipse) => {
-                                let ts = ellipse.project(sv.point());
-                                let te = ellipse.project(ev.point());
-                                let fwd = (te - ts).rem_euclid(TAU);
-                                let mid_t = if fwd <= std::f64::consts::PI {
-                                    ts + fwd * 0.5
-                                } else {
-                                    ts - (TAU - fwd) * 0.5
-                                };
-                                let mid = ellipse.evaluate(mid_t);
-                                let (u, _) = project(mid);
-                                angles.push(u);
-                            }
-                            EdgeCurve::NurbsCurve(nurbs) => {
-                                let (t0, t1) = nurbs.domain();
-                                let mid = nurbs.evaluate(f64::midpoint(t0, t1));
-                                let (u, _) = project(mid);
-                                angles.push(u);
-                            }
-                            EdgeCurve::Line => {}
+                if !edge.is_closed()
+                    && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+                {
+                    match edge.curve() {
+                        EdgeCurve::Circle(circle) => {
+                            let ts = circle.project(sv.point());
+                            let te = circle.project(ev.point());
+                            let fwd = (te - ts).rem_euclid(TAU);
+                            let mid_t = if fwd <= std::f64::consts::PI {
+                                ts + fwd * 0.5
+                            } else {
+                                ts - (TAU - fwd) * 0.5
+                            };
+                            let mid = circle.evaluate(mid_t);
+                            let (u, _) = project(mid);
+                            angles.push(u);
                         }
+                        EdgeCurve::Ellipse(ellipse) => {
+                            let ts = ellipse.project(sv.point());
+                            let te = ellipse.project(ev.point());
+                            let fwd = (te - ts).rem_euclid(TAU);
+                            let mid_t = if fwd <= std::f64::consts::PI {
+                                ts + fwd * 0.5
+                            } else {
+                                ts - (TAU - fwd) * 0.5
+                            };
+                            let mid = ellipse.evaluate(mid_t);
+                            let (u, _) = project(mid);
+                            angles.push(u);
+                        }
+                        EdgeCurve::NurbsCurve(nurbs) => {
+                            let (t0, t1) = nurbs.domain();
+                            let mid = nurbs.evaluate(f64::midpoint(t0, t1));
+                            let (u, _) = project(mid);
+                            angles.push(u);
+                        }
+                        EdgeCurve::Line => {}
                     }
                 }
             }
@@ -232,10 +232,10 @@ pub fn compute_sphere_v_range(
     let mut wire_pts = Vec::new();
     if let Ok(wire) = topo.wire(face_data.outer_wire()) {
         for oe in wire.edges() {
-            if let Ok(edge) = topo.edge(oe.edge()) {
-                if let Ok(vertex) = topo.vertex(edge.start()) {
-                    wire_pts.push(vertex.point());
-                }
+            if let Ok(edge) = topo.edge(oe.edge())
+                && let Ok(vertex) = topo.vertex(edge.start())
+            {
+                wire_pts.push(vertex.point());
             }
         }
     }
@@ -533,10 +533,10 @@ fn needs_conforming_subdivision(
     ];
 
     for &(pu, pv) in &probes {
-        if let Some(neighbor_depth) = find_leaf_depth_at(cells, pu, pv) {
-            if neighbor_depth > depth + 1 {
-                return true;
-            }
+        if let Some(neighbor_depth) = find_leaf_depth_at(cells, pu, pv)
+            && neighbor_depth > depth + 1
+        {
+            return true;
         }
     }
     false

--- a/crates/operations/src/tessellate/planar.rs
+++ b/crates/operations/src/tessellate/planar.rs
@@ -389,12 +389,11 @@ pub(super) fn tessellate_planar(
     }
 
     // Remove last point if it duplicates the first (closed wire).
-    if positions.len() > 2 {
-        if let (Some(first), Some(last)) = (positions.first(), positions.last()) {
-            if (*last - *first).length() < tol {
-                positions.pop();
-            }
-        }
+    if positions.len() > 2
+        && let (Some(first), Some(last)) = (positions.first(), positions.last())
+        && (*last - *first).length() < tol
+    {
+        positions.pop();
     }
 
     let n = positions.len();
@@ -858,33 +857,28 @@ pub(super) fn remove_closing_duplicate_global(
     all_positions: &[Point3],
     tol: f64,
 ) {
-    if global_ids.len() > 2 {
-        if let (Some(&Some(first)), Some(&Some(last))) = (global_ids.first(), global_ids.last()) {
-            if first == last
-                || ((first as usize) < all_positions.len()
-                    && (last as usize) < all_positions.len()
-                    && (all_positions[first as usize] - all_positions[last as usize]).length()
-                        < tol)
-            {
-                positions.pop();
-                global_ids.pop();
-            }
-        }
+    if global_ids.len() > 2
+        && let (Some(&Some(first)), Some(&Some(last))) = (global_ids.first(), global_ids.last())
+        && (first == last
+            || ((first as usize) < all_positions.len()
+                && (last as usize) < all_positions.len()
+                && (all_positions[first as usize] - all_positions[last as usize]).length() < tol))
+    {
+        positions.pop();
+        global_ids.pop();
     }
 }
 
 /// Remove the last element from a global ID list if it duplicates the first.
 pub(super) fn remove_closing_duplicate_ids(ids: &mut Vec<u32>, positions: &[Point3], tol: f64) {
-    if ids.len() > 2 {
-        if let (Some(&first), Some(&last)) = (ids.first(), ids.last()) {
-            if first == last
-                || ((first as usize) < positions.len()
-                    && (last as usize) < positions.len()
-                    && (positions[first as usize] - positions[last as usize]).length() < tol)
-            {
-                ids.pop();
-            }
-        }
+    if ids.len() > 2
+        && let (Some(&first), Some(&last)) = (ids.first(), ids.last())
+        && (first == last
+            || ((first as usize) < positions.len()
+                && (last as usize) < positions.len()
+                && (positions[first as usize] - positions[last as usize]).length() < tol))
+    {
+        ids.pop();
     }
 }
 

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -179,11 +179,11 @@ fn tessellate_solid_core(
     } else {
         let mut map = DetHashMap::default();
         for &edge_idx in &edge_indices {
-            if let Some(edge_id) = topo.edge_id_from_index(edge_idx) {
-                if let Ok(edge_data) = topo.edge(edge_id) {
-                    let points = sample_edge(topo, edge_data, deflection, angular_tol)?;
-                    map.insert(edge_idx, points);
-                }
+            if let Some(edge_id) = topo.edge_id_from_index(edge_idx)
+                && let Ok(edge_data) = topo.edge(edge_id)
+            {
+                let points = sample_edge(topo, edge_data, deflection, angular_tol)?;
+                map.insert(edge_idx, points);
             }
         }
         map
@@ -249,17 +249,17 @@ fn tessellate_solid_core(
                         continue;
                     };
 
-                    if let Some(pts) = edge_points.get(&edge_idx) {
-                        if pts.len() < expected_count {
-                            let (t_start, t_end) = circle_param_range(topo, edge_data, circle)?;
-                            let new_pts = brepkit_geometry::sampling::sample_uniform(
-                                circle,
-                                t_start,
-                                t_end,
-                                expected_count,
-                            );
-                            edge_points.insert(edge_idx, new_pts);
-                        }
+                    if let Some(pts) = edge_points.get(&edge_idx)
+                        && pts.len() < expected_count
+                    {
+                        let (t_start, t_end) = circle_param_range(topo, edge_data, circle)?;
+                        let new_pts = brepkit_geometry::sampling::sample_uniform(
+                            circle,
+                            t_start,
+                            t_end,
+                            expected_count,
+                        );
+                        edge_points.insert(edge_idx, new_pts);
                     }
                 }
             }
@@ -398,78 +398,70 @@ fn tessellate_solid_core(
     for (fi, &face_id) in all_faces.iter().enumerate() {
         let face_data = topo.face(face_id)?;
         let has_inner = !face_data.inner_wires().is_empty();
-        if let FaceSurface::Plane { normal, .. } = face_data.surface() {
-            if has_inner {
-                let normal = *normal;
-                let is_reversed = face_data.is_reversed();
-                let wire = topo.wire(face_data.outer_wire())?;
-                let tol = 1e-10;
+        if let FaceSurface::Plane { normal, .. } = face_data.surface()
+            && has_inner
+        {
+            let normal = *normal;
+            let is_reversed = face_data.is_reversed();
+            let wire = topo.wire(face_data.outer_wire())?;
+            let tol = 1e-10;
 
-                let (mut all_positions, mut all_global_ids) = collect_wire_global_vertices(
-                    wire,
-                    &edge_global_indices,
-                    &merged.positions,
-                    tol,
-                );
-                remove_closing_duplicate_global(
-                    &mut all_positions,
-                    &mut all_global_ids,
-                    &merged.positions,
-                    tol,
-                );
-                let outer_count = all_positions.len();
+            let (mut all_positions, mut all_global_ids) =
+                collect_wire_global_vertices(wire, &edge_global_indices, &merged.positions, tol);
+            remove_closing_duplicate_global(
+                &mut all_positions,
+                &mut all_global_ids,
+                &merged.positions,
+                tol,
+            );
+            let outer_count = all_positions.len();
 
-                let mut inner_wire_ranges: Vec<(usize, usize)> = Vec::new();
-                for &iw_id in face_data.inner_wires() {
-                    let iw = topo.wire(iw_id)?;
-                    let start = all_positions.len();
-                    let (inner_pos, inner_gids) = collect_wire_global_vertices(
-                        iw,
-                        &edge_global_indices,
-                        &merged.positions,
-                        tol,
-                    );
-                    let mut inner_flat_ids: Vec<u32> = Vec::with_capacity(inner_gids.len());
-                    let mut next_sentinel = u32::MAX;
-                    for (pos, gid_opt) in inner_pos.into_iter().zip(inner_gids) {
-                        let gid = gid_opt.unwrap_or_else(|| {
-                            debug_assert!(false, "inner wire vertex had no global ID");
-                            let s = next_sentinel;
-                            next_sentinel = next_sentinel.wrapping_sub(1);
-                            s
-                        });
-                        inner_flat_ids.push(gid);
-                        all_positions.push(pos);
-                        all_global_ids.push(Some(gid));
-                    }
-                    if inner_flat_ids.len() > 2 {
-                        remove_closing_duplicate_ids(&mut inner_flat_ids, &merged.positions, tol);
-                        let expected_end = start + inner_flat_ids.len();
-                        all_positions.truncate(expected_end);
-                        all_global_ids.truncate(expected_end);
-                    }
-                    let end = all_positions.len();
-                    inner_wire_ranges.push((start, end));
+            let mut inner_wire_ranges: Vec<(usize, usize)> = Vec::new();
+            for &iw_id in face_data.inner_wires() {
+                let iw = topo.wire(iw_id)?;
+                let start = all_positions.len();
+                let (inner_pos, inner_gids) =
+                    collect_wire_global_vertices(iw, &edge_global_indices, &merged.positions, tol);
+                let mut inner_flat_ids: Vec<u32> = Vec::with_capacity(inner_gids.len());
+                let mut next_sentinel = u32::MAX;
+                for (pos, gid_opt) in inner_pos.into_iter().zip(inner_gids) {
+                    let gid = gid_opt.unwrap_or_else(|| {
+                        debug_assert!(false, "inner wire vertex had no global ID");
+                        let s = next_sentinel;
+                        next_sentinel = next_sentinel.wrapping_sub(1);
+                        s
+                    });
+                    inner_flat_ids.push(gid);
+                    all_positions.push(pos);
+                    all_global_ids.push(Some(gid));
                 }
-
-                let pts2d: Vec<brepkit_math::vec::Point2> = all_positions
-                    .iter()
-                    .map(|&p| project_by_normal(p, normal))
-                    .collect();
-
-                #[allow(clippy::cast_possible_truncation)]
-                cdt_jobs.push(CdtJob {
-                    face_index: fi as u32,
-                    pts2d,
-                    outer_count,
-                    inner_wire_ranges,
-                    all_global_ids,
-                    all_positions,
-                    normal,
-                    is_reversed,
-                });
-                continue;
+                if inner_flat_ids.len() > 2 {
+                    remove_closing_duplicate_ids(&mut inner_flat_ids, &merged.positions, tol);
+                    let expected_end = start + inner_flat_ids.len();
+                    all_positions.truncate(expected_end);
+                    all_global_ids.truncate(expected_end);
+                }
+                let end = all_positions.len();
+                inner_wire_ranges.push((start, end));
             }
+
+            let pts2d: Vec<brepkit_math::vec::Point2> = all_positions
+                .iter()
+                .map(|&p| project_by_normal(p, normal))
+                .collect();
+
+            #[allow(clippy::cast_possible_truncation)]
+            cdt_jobs.push(CdtJob {
+                face_index: fi as u32,
+                pts2d,
+                outer_count,
+                inner_wire_ranges,
+                all_global_ids,
+                all_positions,
+                normal,
+                is_reversed,
+            });
+            continue;
         }
         other_face_indices.push(fi);
     }

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -1347,22 +1347,22 @@ fn per_face_tessellation_matches_face_normal() {
     for &fid in shell.faces() {
         let mesh = tessellate(&topo, fid, 0.1).unwrap();
         let face = topo.face(fid).unwrap();
-        if let FaceSurface::Plane { normal, .. } = face.surface() {
-            if mesh.indices.len() >= 3 {
-                let i0 = mesh.indices[0] as usize;
-                let i1 = mesh.indices[1] as usize;
-                let i2 = mesh.indices[2] as usize;
-                let a = mesh.positions[i1] - mesh.positions[i0];
-                let b = mesh.positions[i2] - mesh.positions[i0];
-                let tri_normal = a.cross(b);
-                let dot = tri_normal.dot(*normal);
-                assert!(
-                    dot > 0.0,
-                    "Face normal {:?} disagrees with tri normal {:?} (dot={dot})",
-                    normal,
-                    tri_normal
-                );
-            }
+        if let FaceSurface::Plane { normal, .. } = face.surface()
+            && mesh.indices.len() >= 3
+        {
+            let i0 = mesh.indices[0] as usize;
+            let i1 = mesh.indices[1] as usize;
+            let i2 = mesh.indices[2] as usize;
+            let a = mesh.positions[i1] - mesh.positions[i0];
+            let b = mesh.positions[i2] - mesh.positions[i0];
+            let tri_normal = a.cross(b);
+            let dot = tri_normal.dot(*normal);
+            assert!(
+                dot > 0.0,
+                "Face normal {:?} disagrees with tri normal {:?} (dot={dot})",
+                normal,
+                tri_normal
+            );
         }
     }
 }

--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -461,11 +461,11 @@ fn verified_plane(samples: &WireSamples) -> Option<(Vec3, f64)> {
     // is independent of traversal order; downstream consumers (e.g. extrude)
     // require the normal to follow the boundary's CCW winding so cap and wall
     // orientations come out correct.
-    if let Some(winding_normal) = newell_normal(&samples.ordered) {
-        if normal.dot(winding_normal) < 0.0 {
-            normal = -normal;
-            d = -d;
-        }
+    if let Some(winding_normal) = newell_normal(&samples.ordered)
+        && normal.dot(winding_normal) < 0.0
+    {
+        normal = -normal;
+        d = -d;
     }
     Some((normal, d))
 }

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -950,25 +950,25 @@ fn gridfinity_d1_lip_ring_loft_cut() {
             .collect();
         eprintln!("  Boundary edges: {}", boundary.len());
         for &eidx in boundary.iter().take(8) {
-            if let Some(eid) = k.topo.edge_id_from_index(eidx) {
-                if let Ok(edge) = k.topo.edge(eid) {
-                    let s = k.topo.vertex(edge.start()).unwrap().point();
-                    let e = k.topo.vertex(edge.end()).unwrap().point();
-                    let curve = match edge.curve() {
-                        brepkit_topology::edge::EdgeCurve::Line => "line",
-                        brepkit_topology::edge::EdgeCurve::Circle(_) => "circle",
-                        _ => "other",
-                    };
-                    eprintln!(
-                        "    edge[{eidx}] {curve}: ({:.3},{:.3},{:.3}) → ({:.3},{:.3},{:.3})",
-                        s.x(),
-                        s.y(),
-                        s.z(),
-                        e.x(),
-                        e.y(),
-                        e.z()
-                    );
-                }
+            if let Some(eid) = k.topo.edge_id_from_index(eidx)
+                && let Ok(edge) = k.topo.edge(eid)
+            {
+                let s = k.topo.vertex(edge.start()).unwrap().point();
+                let e = k.topo.vertex(edge.end()).unwrap().point();
+                let curve = match edge.curve() {
+                    brepkit_topology::edge::EdgeCurve::Line => "line",
+                    brepkit_topology::edge::EdgeCurve::Circle(_) => "circle",
+                    _ => "other",
+                };
+                eprintln!(
+                    "    edge[{eidx}] {curve}: ({:.3},{:.3},{:.3}) → ({:.3},{:.3},{:.3})",
+                    s.x(),
+                    s.y(),
+                    s.z(),
+                    e.x(),
+                    e.y(),
+                    e.z()
+                );
             }
         }
     }
@@ -1475,25 +1475,25 @@ fn gridfinity_d5_box_with_filleted_lip() {
             .collect();
         eprintln!("  D5 lip boundary edges: {}", bounds.len());
         for &eidx in bounds.iter().take(4) {
-            if let Some(eid) = k.topo.edge_id_from_index(eidx) {
-                if let Ok(edge) = k.topo.edge(eid) {
-                    let s = k.topo.vertex(edge.start()).unwrap().point();
-                    let e = k.topo.vertex(edge.end()).unwrap().point();
-                    let curve = match edge.curve() {
-                        brepkit_topology::edge::EdgeCurve::Line => "line",
-                        brepkit_topology::edge::EdgeCurve::Circle(_) => "circle",
-                        _ => "other",
-                    };
-                    eprintln!(
-                        "    edge[{eidx}] {curve}: ({:.2},{:.2},{:.2})→({:.2},{:.2},{:.2})",
-                        s.x(),
-                        s.y(),
-                        s.z(),
-                        e.x(),
-                        e.y(),
-                        e.z()
-                    );
-                }
+            if let Some(eid) = k.topo.edge_id_from_index(eidx)
+                && let Ok(edge) = k.topo.edge(eid)
+            {
+                let s = k.topo.vertex(edge.start()).unwrap().point();
+                let e = k.topo.vertex(edge.end()).unwrap().point();
+                let curve = match edge.curve() {
+                    brepkit_topology::edge::EdgeCurve::Line => "line",
+                    brepkit_topology::edge::EdgeCurve::Circle(_) => "circle",
+                    _ => "other",
+                };
+                eprintln!(
+                    "    edge[{eidx}] {curve}: ({:.2},{:.2},{:.2})→({:.2},{:.2},{:.2})",
+                    s.x(),
+                    s.y(),
+                    s.z(),
+                    e.x(),
+                    e.y(),
+                    e.z()
+                );
             }
         }
     }

--- a/crates/wasm/src/bindings/io.rs
+++ b/crates/wasm/src/bindings/io.rs
@@ -194,7 +194,7 @@ impl BrepKernel {
     ) -> Result<u32, JsError> {
         use brepkit_math::vec::Point3;
 
-        if positions.len() % 3 != 0 {
+        if !positions.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "positions length {} is not a multiple of 3",
@@ -203,7 +203,7 @@ impl BrepKernel {
             }
             .into());
         }
-        if indices.len() % 3 != 0 {
+        if !indices.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!("indices length {} is not a multiple of 3", indices.len()),
             }

--- a/crates/wasm/src/bindings/nurbs.rs
+++ b/crates/wasm/src/bindings/nurbs.rs
@@ -183,7 +183,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "interpolatePoints")]
     #[allow(clippy::needless_pass_by_value)]
     pub fn interpolate_points(&mut self, coords: Vec<f64>, degree: u32) -> Result<u32, JsError> {
-        if coords.len() % 3 != 0 {
+        if !coords.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "coordinate array length must be a multiple of 3, got {}",

--- a/crates/wasm/src/bindings/operations.rs
+++ b/crates/wasm/src/bindings/operations.rs
@@ -147,25 +147,25 @@ impl BrepKernel {
 
         // If startPoint is given, create a tiny degenerate triangle face at that point
         // and prepend it to the profiles.
-        if let Some(sp) = opts.get("startPoint").and_then(|v| v.as_array()) {
-            if sp.len() >= 3 {
-                let x = sp[0].as_f64().unwrap_or(0.0);
-                let y = sp[1].as_f64().unwrap_or(0.0);
-                let z = sp[2].as_f64().unwrap_or(0.0);
-                let apex_face = create_apex_face(self.topo_mut(), Point3::new(x, y, z), &face_ids)?;
-                face_ids.insert(0, apex_face);
-            }
+        if let Some(sp) = opts.get("startPoint").and_then(|v| v.as_array())
+            && sp.len() >= 3
+        {
+            let x = sp[0].as_f64().unwrap_or(0.0);
+            let y = sp[1].as_f64().unwrap_or(0.0);
+            let z = sp[2].as_f64().unwrap_or(0.0);
+            let apex_face = create_apex_face(self.topo_mut(), Point3::new(x, y, z), &face_ids)?;
+            face_ids.insert(0, apex_face);
         }
 
         // If endPoint is given, create a tiny degenerate triangle face and append.
-        if let Some(ep) = opts.get("endPoint").and_then(|v| v.as_array()) {
-            if ep.len() >= 3 {
-                let x = ep[0].as_f64().unwrap_or(0.0);
-                let y = ep[1].as_f64().unwrap_or(0.0);
-                let z = ep[2].as_f64().unwrap_or(0.0);
-                let apex_face = create_apex_face(self.topo_mut(), Point3::new(x, y, z), &face_ids)?;
-                face_ids.push(apex_face);
-            }
+        if let Some(ep) = opts.get("endPoint").and_then(|v| v.as_array())
+            && ep.len() >= 3
+        {
+            let x = ep[0].as_f64().unwrap_or(0.0);
+            let y = ep[1].as_f64().unwrap_or(0.0);
+            let z = ep[2].as_f64().unwrap_or(0.0);
+            let apex_face = create_apex_face(self.topo_mut(), Point3::new(x, y, z), &face_ids)?;
+            face_ids.push(apex_face);
         }
 
         let ruled = opts
@@ -456,7 +456,7 @@ impl BrepKernel {
         path_weights: Vec<f64>,
     ) -> Result<u32, JsError> {
         // Validate coordinate array length.
-        if path_control_points.len() % 3 != 0 {
+        if !path_control_points.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "path_control_points length must be a multiple of 3, got {}",
@@ -551,7 +551,7 @@ impl BrepKernel {
             }
             .into());
         }
-        if spine_control_points.len() % 3 != 0 {
+        if !spine_control_points.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "spine_control_points length must be a multiple of 3, got {}",
@@ -633,7 +633,7 @@ impl BrepKernel {
         path_control_points: Vec<f64>,
         path_weights: Vec<f64>,
     ) -> Result<u32, JsError> {
-        if path_control_points.len() % 3 != 0 {
+        if !path_control_points.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "path_control_points length must be a multiple of 3, got {}",
@@ -841,7 +841,7 @@ impl BrepKernel {
         path_control_points: Vec<f64>,
         path_weights: Vec<f64>,
     ) -> Result<u32, JsError> {
-        if path_control_points.len() % 3 != 0 {
+        if !path_control_points.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "path_control_points length must be a multiple of 3, got {}",
@@ -1125,7 +1125,7 @@ impl BrepKernel {
         };
 
         let scale_law: Option<Box<dyn Fn(f64) -> f64 + Send + Sync>> =
-            if scale_values.len() >= 4 && scale_values.len() % 2 == 0 {
+            if scale_values.len() >= 4 && scale_values.len().is_multiple_of(2) {
                 let pairs: Vec<(f64, f64)> =
                     scale_values.chunks_exact(2).map(|c| (c[0], c[1])).collect();
                 Some(Box::new(move |t: f64| -> f64 {
@@ -1211,7 +1211,7 @@ impl BrepKernel {
                 }
                 .into());
             }
-            if cps.len() % 3 != 0 {
+            if !cps.len().is_multiple_of(3) {
                 return Err(WasmError::InvalidInput {
                     reason: format!("{label}_control_points length must be a multiple of 3"),
                 }

--- a/crates/wasm/src/bindings/polygon2d.rs
+++ b/crates/wasm/src/bindings/polygon2d.rs
@@ -27,7 +27,7 @@ impl BrepKernel {
         distance: f64,
         tolerance: f64,
     ) -> Result<Vec<f64>, JsError> {
-        if coords.len() % 2 != 0 {
+        if !coords.len().is_multiple_of(2) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "2D coordinate array length must be even, got {}",
@@ -58,7 +58,7 @@ impl BrepKernel {
         px: f64,
         py: f64,
     ) -> Result<bool, JsError> {
-        if polygon_coords.len() % 2 != 0 || polygon_coords.len() < 6 {
+        if !polygon_coords.len().is_multiple_of(2) || polygon_coords.len() < 6 {
             return Err(WasmError::InvalidInput {
                 reason: "polygon needs at least 3 points (6 coordinates)".into(),
             }

--- a/crates/wasm/src/bindings/shapes.rs
+++ b/crates/wasm/src/bindings/shapes.rs
@@ -61,7 +61,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "makePolygon")]
     #[allow(clippy::needless_pass_by_value)] // wasm-bindgen requires owned Vec
     pub fn make_polygon(&mut self, coords: Vec<f64>) -> Result<u32, JsError> {
-        if coords.len() % 3 != 0 {
+        if !coords.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "coordinate array length must be a multiple of 3, got {}",
@@ -490,7 +490,7 @@ impl BrepKernel {
         control_points: Vec<f64>,
         weights: Vec<f64>,
     ) -> Result<u32, JsError> {
-        if control_points.len() % 3 != 0 {
+        if !control_points.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "control_points length must be a multiple of 3, got {}",
@@ -716,7 +716,7 @@ impl BrepKernel {
     #[wasm_bindgen(js_name = "convexHull")]
     #[allow(clippy::needless_pass_by_value)]
     pub fn convex_hull(&mut self, coords: Vec<f64>) -> Result<u32, JsError> {
-        if coords.len() % 3 != 0 {
+        if !coords.len().is_multiple_of(3) {
             return Err(WasmError::InvalidInput {
                 reason: format!(
                     "coordinate array length must be a multiple of 3, got {}",

--- a/crates/wasm/src/bindings/sketch.rs
+++ b/crates/wasm/src/bindings/sketch.rs
@@ -73,10 +73,10 @@ fn build_gcs_from_state(sk: &SketchState) -> Result<GcsBuildResult, JsError> {
                                   a: usize,
                                   b: usize|
      -> Option<brepkit_operations::sketch::LineId> {
-        if let std::collections::hash_map::Entry::Vacant(e) = line_cache.entry((a, b)) {
-            if let Ok(lid) = sys.add_line(ids[a], ids[b]) {
-                e.insert(lid);
-            }
+        if let std::collections::hash_map::Entry::Vacant(e) = line_cache.entry((a, b))
+            && let Ok(lid) = sys.add_line(ids[a], ids[b])
+        {
+            e.insert(lid);
         }
         line_cache.get(&(a, b)).copied()
     };

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -24,7 +24,7 @@ pub const TOL: f64 = 1e-7;
 
 /// Parse flat `[x,y,z, ...]` coordinates into `Vec<Point3>`.
 pub fn parse_points(coords: &[f64]) -> Result<Vec<Point3>, JsError> {
-    if coords.len() % 3 != 0 {
+    if !coords.len().is_multiple_of(3) {
         return Err(WasmError::InvalidInput {
             reason: format!(
                 "coordinate array length must be a multiple of 3, got {}",
@@ -183,20 +183,20 @@ pub fn try_fillet(
         };
 
     // Try engines in preference order; accept the first valid result.
-    if let Ok(s) = brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edges, radius) {
-        if is_valid(topo, s) {
-            return Ok(s);
-        }
+    if let Ok(s) = brepkit_operations::fillet::fillet_rolling_ball(topo, solid_id, edges, radius)
+        && is_valid(topo, s)
+    {
+        return Ok(s);
     }
-    if let Ok(r) = brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edges, radius) {
-        if is_valid(topo, r.solid) {
-            return Ok(r.solid);
-        }
+    if let Ok(r) = brepkit_operations::blend_ops::fillet_v2(topo, solid_id, edges, radius)
+        && is_valid(topo, r.solid)
+    {
+        return Ok(r.solid);
     }
-    if let Ok(s) = brepkit_operations::fillet::fillet(topo, solid_id, edges, radius) {
-        if is_valid(topo, s) {
-            return Ok(s);
-        }
+    if let Ok(s) = brepkit_operations::fillet::fillet(topo, solid_id, edges, radius)
+        && is_valid(topo, s)
+    {
+        return Ok(s);
     }
 
     // No engine produced a valid solid — leave the input unchanged.
@@ -282,7 +282,7 @@ pub fn build_triangle_mesh(
     positions: &[f64],
     indices: &[u32],
 ) -> Result<tessellate::TriangleMesh, JsError> {
-    if positions.len() % 3 != 0 {
+    if !positions.len().is_multiple_of(3) {
         return Err(WasmError::InvalidInput {
             reason: format!(
                 "positions length must be a multiple of 3, got {}",
@@ -448,7 +448,7 @@ pub fn parse_sketch_constraint(
 
 /// Parse flat `[x,y, ...]` coordinates into `Vec<Point2>`.
 pub fn parse_polygon_2d(coords: &[f64]) -> Result<Vec<Point2>, JsError> {
-    if coords.len() % 2 != 0 || coords.len() < 6 {
+    if !coords.len().is_multiple_of(2) || coords.len() < 6 {
         return Err(WasmError::InvalidInput {
             reason: "polygon needs at least 3 points (6 coordinates)".into(),
         }

--- a/crates/wasm/src/kernel.rs
+++ b/crates/wasm/src/kernel.rs
@@ -1025,15 +1025,15 @@ impl BrepKernel {
 
                     let mut inner_oriented = Vec::new();
                     for (i, eid_val) in edge_arr.iter().enumerate() {
-                        if let Some(eid) = eid_val.as_u64() {
-                            if let Some(&edge_id) = edge_map.get(&(eid as u32)) {
-                                let fwd = orient_arr
-                                    .as_ref()
-                                    .and_then(|arr| arr.get(i))
-                                    .and_then(|v| v.as_bool())
-                                    .unwrap_or(true);
-                                inner_oriented.push(OrientedEdge::new(edge_id, fwd));
-                            }
+                        if let Some(eid) = eid_val.as_u64()
+                            && let Some(&edge_id) = edge_map.get(&(eid as u32))
+                        {
+                            let fwd = orient_arr
+                                .as_ref()
+                                .and_then(|arr| arr.get(i))
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(true);
+                            inner_oriented.push(OrientedEdge::new(edge_id, fwd));
                         }
                     }
                     if !inner_oriented.is_empty() {


### PR DESCRIPTION
## Summary

Raises the declared **MSRV from 1.85 → 1.88** and refreshes the dependency tree to match.

### MSRV
- `Cargo.toml`: `rust-version = "1.88"`.
- CI `msrv` job: now selects the toolchain via an explicit `toolchain: "1.88.0"` input on the SHA-pinned dtolnay action (previously relied on the action tag's baked-in default, which is fragile when pinning to a SHA).

### Dependency refresh (`cargo update`)
34 packages bumped to their latest **1.88-compatible** versions — notably `zip 8.3→8.6` (requires Rust 1.88, the reason for the MSRV bump), `rayon 1.11→1.12`, `proptest 1.10→1.11`, plus `bitflags`, `log`, `env_logger`, `hashbrown`, `indexmap`, `jiff`, `regex`, `zerocopy`, etc. `wasm-bindgen` stays pinned at `=0.2.122` (matches the CI cli).

### let-chains
1.88 stabilizes **let-chains**, so clippy (run at `-D warnings`) flags ~70 nested `if`s across the workspace as collapsible. Applied via `cargo clippy --fix` — mechanical and semantics-preserving. This is the bulk of the diff.

## Verification

- `cargo clippy --workspace --all-targets` (1.96.0) — clean
- `cargo test --workspace` — all pass
- `cargo fmt --all --check` — clean
- `cargo check --workspace --all-features` on **1.88** (the CI MSRV command) — compiles, let-chains included