### PR TITLE
feat(topology): add make_ellipse_arc trimmed-ellipse-arc constructor + wasm export

### DIFF
--- a/crates/topology/src/builder.rs
+++ b/crates/topology/src/builder.rs
@@ -171,6 +171,44 @@ pub fn make_ellipse_edge(
     )
 }
 
+/// Create a trimmed elliptical arc edge between `start` and `end`.
+///
+/// Builds an [`Ellipse3D`] from `center`, `normal`, the semi-axes, and the
+/// `ref_dir` major-axis direction, then an edge whose distinct start/end
+/// vertices trim it. [`EdgeCurve::domain_with_endpoints`] projects those
+/// endpoints onto the ellipse and returns the CCW angular range, so the edge
+/// traces exactly the arc. `start`/`end` must lie on the ellipse. When the
+/// endpoints coincide the edge is closed (full `[0, 2π]` domain).
+///
+/// # Errors
+///
+/// Returns an error if either semi-axis is non-positive, `semi_minor` exceeds
+/// `semi_major`, or `normal`/`ref_dir` is degenerate.
+#[allow(clippy::too_many_arguments)]
+pub fn make_ellipse_arc(
+    topo: &mut Topology,
+    center: Point3,
+    normal: Vec3,
+    semi_major: f64,
+    semi_minor: f64,
+    ref_dir: Vec3,
+    start: Point3,
+    end: Point3,
+    tolerance: f64,
+) -> Result<EdgeId, crate::TopologyError> {
+    let ellipse = Ellipse3D::new_with_ref(center, normal, semi_major, semi_minor, ref_dir)
+        .map_err(|e| crate::TopologyError::NonManifold {
+            reason: format!("invalid ellipse: {e}"),
+        })?;
+    let v_start = topo.add_vertex(Vertex::new(start, tolerance));
+    let v_end = if (start - end).length() < tolerance * 100.0 {
+        v_start
+    } else {
+        topo.add_vertex(Vertex::new(end, tolerance))
+    };
+    Ok(topo.add_edge(Edge::new(v_start, v_end, EdgeCurve::Ellipse(ellipse))))
+}
+
 /// Create a closed wire from an ordered list of points.
 ///
 /// Each consecutive pair of points becomes a line edge, and the last
@@ -962,6 +1000,45 @@ mod tests {
             "default-frame seam.y should be 5.0, got {}",
             seam2.y()
         );
+    }
+
+    #[test]
+    fn make_ellipse_arc_traces_quarter_arc() {
+        // Quarter arc of an ellipse (semi_major 5 along +x, semi_minor 2 along
+        // +y, normal +z) from angle 0 to π/2: start (5,0,0), end (0,2,0).
+        let mut topo = Topology::new();
+        let start = Point3::new(5.0, 0.0, 0.0);
+        let end = Point3::new(0.0, 2.0, 0.0);
+        let eid = make_ellipse_arc(
+            &mut topo,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            5.0,
+            2.0,
+            Vec3::new(1.0, 0.0, 0.0),
+            start,
+            end,
+            TOL,
+        )
+        .unwrap();
+
+        let edge = topo.edge(eid).unwrap();
+        assert_eq!(edge.curve().type_tag(), "ellipse");
+        // Distinct endpoints ⇒ trimmed (not closed).
+        assert_ne!(edge.start(), edge.end());
+
+        // The trimmed domain is the CCW angular range [0, π/2]; its midpoint
+        // angle π/4 maps to (5·cos45, 2·sin45, 0) ≈ (3.5355, 1.4142, 0).
+        let (a0, a1) = edge.curve().domain_with_endpoints(start, end);
+        assert!(a0.abs() < 1e-9, "a0 {a0}");
+        assert!((a1 - std::f64::consts::FRAC_PI_2).abs() < 1e-9, "a1 {a1}");
+        let mid = edge
+            .curve()
+            .evaluate_with_endpoints(a0.midpoint(a1), start, end);
+        let s = std::f64::consts::FRAC_1_SQRT_2;
+        assert!((mid.x() - 5.0 * s).abs() < 1e-9, "mid.x {}", mid.x());
+        assert!((mid.y() - 2.0 * s).abs() < 1e-9, "mid.y {}", mid.y());
+        assert!(mid.z().abs() < 1e-9, "mid.z {}", mid.z());
     }
 
     #[test]

--- a/crates/wasm/src/bindings/shapes.rs
+++ b/crates/wasm/src/bindings/shapes.rs
@@ -472,6 +472,85 @@ impl BrepKernel {
         Ok(edge_id_to_u32(eid))
     }
 
+    /// Create a trimmed elliptical arc edge.
+    ///
+    /// The ellipse is defined by `center`, `axis` (plane normal), the
+    /// `ref` major-axis direction, and `semi_major`/`semi_minor`. The
+    /// `start`/`end` points trim it to the CCW arc between them (they must
+    /// lie on the ellipse). Produces an `EdgeCurve::Ellipse` edge — not a
+    /// NURBS approximation — so it reports CIRCLE/ELLIPSE-class geometry.
+    ///
+    /// Returns an edge handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any coordinate is NaN/infinite, a semi-axis is
+    /// non-positive, `semi_minor` exceeds `semi_major`, or `axis`/`ref` is
+    /// a zero vector.
+    #[wasm_bindgen(js_name = "makeEllipseArc3d")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn make_ellipse_arc_3d(
+        &mut self,
+        start_x: f64,
+        start_y: f64,
+        start_z: f64,
+        end_x: f64,
+        end_y: f64,
+        end_z: f64,
+        center_x: f64,
+        center_y: f64,
+        center_z: f64,
+        axis_x: f64,
+        axis_y: f64,
+        axis_z: f64,
+        ref_x: f64,
+        ref_y: f64,
+        ref_z: f64,
+        semi_major: f64,
+        semi_minor: f64,
+    ) -> Result<u32, JsError> {
+        for (v, name) in [
+            (start_x, "start_x"),
+            (start_y, "start_y"),
+            (start_z, "start_z"),
+            (end_x, "end_x"),
+            (end_y, "end_y"),
+            (end_z, "end_z"),
+            (center_x, "center_x"),
+            (center_y, "center_y"),
+            (center_z, "center_z"),
+            (axis_x, "axis_x"),
+            (axis_y, "axis_y"),
+            (axis_z, "axis_z"),
+            (ref_x, "ref_x"),
+            (ref_y, "ref_y"),
+            (ref_z, "ref_z"),
+        ] {
+            validate_finite(v, name)?;
+        }
+        validate_positive(semi_major, "semi_major")?;
+        validate_positive(semi_minor, "semi_minor")?;
+
+        let center = Point3::new(center_x, center_y, center_z);
+        let axis = Vec3::new(axis_x, axis_y, axis_z);
+        let ref_dir = Vec3::new(ref_x, ref_y, ref_z);
+        let start_pt = Point3::new(start_x, start_y, start_z);
+        let end_pt = Point3::new(end_x, end_y, end_z);
+
+        let eid = brepkit_topology::builder::make_ellipse_arc(
+            self.topo_mut(),
+            center,
+            axis,
+            semi_major,
+            semi_minor,
+            ref_dir,
+            start_pt,
+            end_pt,
+            TOL,
+        )?;
+        Ok(edge_id_to_u32(eid))
+    }
+
     /// Create a NURBS curve edge.
     ///
     /// Returns an edge handle (`u32`).


### PR DESCRIPTION
## Phase A of #858 — the brepkit ellipse-arc primitive

The ellipse-arc 2D→3D lift parity gap (`sketcher3d.ellipseTo`/`halfEllipseTo`) needs an exact elliptical-arc edge so the brepjs adapter can stop dense-sampling ellipse arcs into a NURBS that collapses the swept region. This PR lands the **brepkit-side foundation** — additive and self-contained:

- `topology::builder::make_ellipse_arc` — builds an exact `EdgeCurve::Ellipse` edge trimmed by distinct start/end vertices. The CCW angular range comes from `EdgeCurve::domain_with_endpoints` (which already handles ellipses), so the edge traces exactly the arc. Coincident endpoints ⇒ closed full-`[0, 2π]` edge.
- `makeEllipseArc3d` wasm export — the elliptical analog of the existing `makeCircleArc3d`, same validate-and-delegate shape (`validate_finite`/`validate_positive`, returns a `u32` edge handle). Produces real CIRCLE/ELLIPSE-class geometry, not a NURBS approximation.

## Why now

Extracted as a clean single commit onto current `main` (the brepkit half of the fix), so a release can ship the primitive and the brepjs adapter can consume it. It was previously held back to avoid shipping unused API; landing it is the unblocker for the cross-repo Phase B.

## Tests

- `make_ellipse_arc_traces_quarter_arc` (topology) — trimmed `[0, π/2]` domain; midpoint at `π/4` lands on the ellipse at `(5·√½, 2·√½, 0)`.
- Builds clean for the `wasm32-unknown-unknown` target; the binding mirrors `makeCircleArc3d`, which is itself covered via the gridfinity integration tests.

## Scope / follow-up (not in this PR)

This does **not** by itself close #858. The user-visible parity fix is **Phase B in brepjs** (fix the `reverseCurve2d` no-op and add an exact ellipse-arc branch in `liftCurve2dToPlane` that calls `makeEllipseArc3d`) — a separate, cross-repo change that lands after this releases and brepjs re-syncs types. #858 stays open until that ships.
