### PR TITLE
fix(algo): weld near-coincident vertices in solid assembly (#859)

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -75,6 +75,16 @@ pub fn build_solid(topo: &mut Topology, selected: &[SelectedFace]) -> Result<Sol
     // slivers removed above, so they would survive as free edges).
     remove_zero_length_edges(topo, &mut face_ids)?;
 
+    // Step 0a-pre3: Weld vertices that are coincident within snap tolerance.
+    // Intersection in the pavefiller can place a vertex a few ULPs short of an
+    // exact pre-existing vertex (e.g. a coincident-arc tangent point landing at
+    // -11.999999 vs the body's -12.0). Such near-duplicates quantize to
+    // different cells at MERGE_TOL, so the duplicate-edge merge never unifies
+    // the two faces' partitions and the shared boundary stays open. Snapping
+    // them to one canonical vertex (and dropping the resulting zero-length
+    // slivers) lets the merge below see identical partitions.
+    weld_coincident_vertices(topo, &mut face_ids)?;
+
     // Step 0a: Split Line edges at intermediate collinear vertices.
     // Adjacent faces can partition the same geometric boundary differently
     // (one whole edge vs several sub-edges split at paves); refining every
@@ -925,6 +935,191 @@ fn is_degenerate_line_sliver(topo: &Topology, fid: FaceId) -> bool {
         }
     }
     true
+}
+
+/// Weld vertices on the selected faces that are coincident within the snap
+/// tolerance onto a single canonical vertex, then rebuild any touched wire.
+///
+/// Quantization-based merging (`merge_duplicate_edges`) keys on `MERGE_TOL`
+/// cells, so two vertices a few ULPs apart but within `snap` (10·`MERGE_TOL`)
+/// land in different cells and are never recognized as the same point. This
+/// pass clusters by actual distance (a coarse spatial hash bounds the
+/// neighbour search) so coincident-but-displaced intersection vertices share
+/// one entity. Line edges that collapse to zero length after welding are
+/// dropped; arc edges are kept (a sub-`snap` arc is still a valid tiny arc and
+/// is rare). Clustering is deterministic: vertices are processed in `VertexId`
+/// order and each non-canonical vertex maps to the lowest-index canonical
+/// vertex within `snap`.
+fn weld_coincident_vertices(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result<(), AlgoError> {
+    use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
+    use brepkit_topology::vertex::VertexId;
+
+    let snap = MERGE_TOL * 10.0;
+
+    // Collect distinct vertices (id + position) referenced by the faces.
+    let mut seen: HashSet<VertexId> = HashSet::new();
+    let mut verts: Vec<(VertexId, Point3)> = Vec::new();
+    for &fid in face_ids.iter() {
+        let face = topo.face(fid)?;
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid)?.edges() {
+                let edge = topo.edge(oe.edge())?;
+                for vid in [edge.start(), edge.end()] {
+                    if seen.insert(vid) {
+                        verts.push((vid, topo.vertex(vid)?.point()));
+                    }
+                }
+            }
+        }
+    }
+    // Deterministic clustering order.
+    verts.sort_by_key(|(vid, _)| vid.index());
+
+    // Coarse spatial hash at snap resolution maps a cell to canonical
+    // vertices already chosen there; a candidate only needs to probe its own
+    // and the 26 neighbouring cells to find a canonical within `snap`.
+    let cell = |p: Point3| -> (i64, i64, i64) {
+        let s = 1.0 / snap;
+        (
+            (p.x() * s).floor() as i64,
+            (p.y() * s).floor() as i64,
+            (p.z() * s).floor() as i64,
+        )
+    };
+    let mut buckets: HashMap<(i64, i64, i64), Vec<(VertexId, Point3)>> = HashMap::new();
+    let mut weld: HashMap<VertexId, VertexId> = HashMap::new();
+    for &(vid, p) in &verts {
+        let c = cell(p);
+        let mut canonical: Option<VertexId> = None;
+        'search: for dz in -1..=1 {
+            for dy in -1..=1 {
+                for dx in -1..=1 {
+                    let nc = (c.0 + dx, c.1 + dy, c.2 + dz);
+                    if let Some(list) = buckets.get(&nc) {
+                        for &(cid, cp) in list {
+                            if (cp - p).length() <= snap {
+                                canonical = Some(cid);
+                                break 'search;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        match canonical {
+            Some(cid) => {
+                weld.insert(vid, cid);
+            }
+            None => {
+                buckets.entry(c).or_default().push((vid, p));
+            }
+        }
+    }
+
+    if weld.is_empty() {
+        return Ok(());
+    }
+    let resolve = |vid: VertexId| -> VertexId { weld.get(&vid).copied().unwrap_or(vid) };
+
+    // Cache rewritten edges so a shared EdgeId is rebuilt once and stays shared.
+    let mut edge_remap: HashMap<EdgeId, Option<EdgeId>> = HashMap::new();
+    for fid in face_ids.iter_mut() {
+        let (surface, is_reversed, outer_oes, inner_oes_list) = {
+            let face = topo.face(*fid)?;
+            let surface = face.surface().clone();
+            let is_reversed = face.is_reversed();
+            let collect = |wid| -> Result<Vec<(EdgeId, bool)>, AlgoError> {
+                Ok(topo
+                    .wire(wid)?
+                    .edges()
+                    .iter()
+                    .map(|oe| (oe.edge(), oe.is_forward()))
+                    .collect())
+            };
+            let outer_oes = collect(face.outer_wire())?;
+            let mut inner_oes_list = Vec::new();
+            for &iw in face.inner_wires() {
+                inner_oes_list.push(collect(iw)?);
+            }
+            (surface, is_reversed, outer_oes, inner_oes_list)
+        };
+
+        let touched = outer_oes
+            .iter()
+            .chain(inner_oes_list.iter().flatten())
+            .any(|(eid, _)| {
+                topo.edge(*eid)
+                    .is_ok_and(|e| weld.contains_key(&e.start()) || weld.contains_key(&e.end()))
+            });
+        if !touched {
+            continue;
+        }
+
+        // Rebuild one edge under welding: returns the (possibly cached) new
+        // EdgeId, or None when the edge collapses to a point.
+        let mut rebuild_edge =
+            |topo: &mut Topology, eid: EdgeId| -> Result<Option<EdgeId>, AlgoError> {
+                if let Some(&cached) = edge_remap.get(&eid) {
+                    return Ok(cached);
+                }
+                let edge = topo.edge(eid)?;
+                let curve = edge.curve().clone();
+                let (ov0, ov1) = (edge.start(), edge.end());
+                let nv0 = resolve(ov0);
+                let nv1 = resolve(ov1);
+                // Drop an edge that welding collapsed to a point: a zero-length
+                // line, or a once-distinct arc whose endpoints merged (it must
+                // NOT be re-created with start == end, which this kernel reads
+                // as a full circle). A genuinely closed input edge (ov0 == ov1)
+                // is preserved by the branches below.
+                let collapsed = nv0 == nv1 && (ov0 != ov1 || matches!(curve, EdgeCurve::Line));
+                let result = if collapsed {
+                    None
+                } else if nv0 == ov0 && nv1 == ov1 {
+                    Some(eid)
+                } else {
+                    Some(topo.add_edge(Edge::new(nv0, nv1, curve)))
+                };
+                edge_remap.insert(eid, result);
+                Ok(result)
+            };
+
+        let mut rebuild_wire =
+            |topo: &mut Topology, oes: &[(EdgeId, bool)]| -> Result<Vec<OrientedEdge>, AlgoError> {
+                let mut out = Vec::with_capacity(oes.len());
+                for &(eid, fwd) in oes {
+                    if let Some(new_eid) = rebuild_edge(topo, eid)? {
+                        out.push(OrientedEdge::new(new_eid, fwd));
+                    }
+                }
+                Ok(out)
+            };
+
+        let new_outer = rebuild_wire(topo, &outer_oes)?;
+        if !is_rebuildable_loop(topo, &new_outer) {
+            continue;
+        }
+        let Ok(new_outer_wire) = brepkit_topology::wire::Wire::new(new_outer, true) else {
+            continue;
+        };
+        let new_outer_id = topo.add_wire(new_outer_wire);
+        let mut new_inner_ids = Vec::new();
+        for inner_oes in &inner_oes_list {
+            let kept = rebuild_wire(topo, inner_oes)?;
+            if is_rebuildable_loop(topo, &kept)
+                && let Ok(w) = brepkit_topology::wire::Wire::new(kept, true)
+            {
+                new_inner_ids.push(topo.add_wire(w));
+            }
+        }
+        let mut new_face = Face::new(new_outer_id, new_inner_ids, surface);
+        if is_reversed {
+            new_face.set_reversed(true);
+        }
+        *fid = topo.add_face(new_face);
+    }
+
+    Ok(())
 }
 
 /// Split Line edges at intermediate collinear vertices from the global

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -945,11 +945,13 @@ fn is_degenerate_line_sliver(topo: &Topology, fid: FaceId) -> bool {
 /// land in different cells and are never recognized as the same point. This
 /// pass clusters by actual distance (a coarse spatial hash bounds the
 /// neighbour search) so coincident-but-displaced intersection vertices share
-/// one entity. Line edges that collapse to zero length after welding are
-/// dropped; arc edges are kept (a sub-`snap` arc is still a valid tiny arc and
-/// is rare). Clustering is deterministic: vertices are processed in `VertexId`
-/// order and each non-canonical vertex maps to the lowest-index canonical
-/// vertex within `snap`.
+/// one entity. An edge whose once-distinct endpoints weld together is dropped
+/// — a zero-length line, or an arc that must not be re-created with
+/// `start == end` (the kernel reads that as a full circle); a genuinely closed
+/// input arc is preserved. Clustering is deterministic: vertices are processed
+/// in `VertexId` order and each non-canonical vertex maps to the lowest-index
+/// canonical vertex within `snap`. The pass is O(V log V) and runs on every
+/// `build_solid`, but returns early without rebuilding when nothing welds.
 fn weld_coincident_vertices(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result<(), AlgoError> {
     use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
     use brepkit_topology::vertex::VertexId;
@@ -990,16 +992,21 @@ fn weld_coincident_vertices(topo: &mut Topology, face_ids: &mut [FaceId]) -> Res
     let mut weld: HashMap<VertexId, VertexId> = HashMap::new();
     for &(vid, p) in &verts {
         let c = cell(p);
+        // Pick the lowest-index canonical within `snap` across the 27 cells,
+        // not merely the first one probed, so the choice is independent of cell
+        // iteration order. Canonicals are added in `VertexId` order, so any
+        // match already has a lower index than `vid`.
         let mut canonical: Option<VertexId> = None;
-        'search: for dz in -1..=1 {
+        for dz in -1..=1 {
             for dy in -1..=1 {
                 for dx in -1..=1 {
                     let nc = (c.0 + dx, c.1 + dy, c.2 + dz);
                     if let Some(list) = buckets.get(&nc) {
                         for &(cid, cp) in list {
-                            if (cp - p).length() <= snap {
+                            if (cp - p).length() <= snap
+                                && canonical.is_none_or(|b| cid.index() < b.index())
+                            {
                                 canonical = Some(cid);
-                                break 'search;
                             }
                         }
                     }
@@ -1070,8 +1077,9 @@ fn weld_coincident_vertices(topo: &mut Topology, face_ids: &mut [FaceId]) -> Res
                 // Drop an edge that welding collapsed to a point: a zero-length
                 // line, or a once-distinct arc whose endpoints merged (it must
                 // NOT be re-created with start == end, which this kernel reads
-                // as a full circle). A genuinely closed input edge (ov0 == ov1)
-                // is preserved by the branches below.
+                // as a full circle). A genuinely closed input arc (ov0 == ov1,
+                // e.g. a full circle) is preserved; a zero-length line is always
+                // dropped.
                 let collapsed = nv0 == nv1 && (ov0 != ov1 || matches!(curve, EdgeCurve::Line));
                 let result = if collapsed {
                     None

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4019,6 +4019,84 @@ fn fuse_overlapping_rounded_rect_arc_prisms_same_footprint() {
     );
 }
 
+/// Outcome of [`arc_frame_lip_fuse`].
+struct ArcFrameLipFuse {
+    fused_vol: f64,
+    body_vol: f64,
+    lip_vol: f64,
+    manifold: bool,
+    has_free_edges: bool,
+}
+
+/// #859 repro helper: fuse a rounded-rect FRAME lip on top of a body so the
+/// lip's bottom contact ring is coincident with the body's top-face outer
+/// boundary (arc corners). The pavefiller can place a coincident-ring vertex
+/// a few ULPs off the body's exact vertex; without vertex welding in the GFA
+/// assembler the shared boundary stays open and the fuse drops to a mesh
+/// fallback (correct-ish volume for the square footprint, badly wrong for the
+/// non-square one).
+fn arc_frame_lip_fuse(hw: f64, hd: f64) -> ArcFrameLipFuse {
+    let mut topo = Topology::new();
+    let r = 3.0;
+    let w = 2.0;
+    let body = make_rounded_rect_arc_prism(&mut topo, hw, hd, r, 0.0, 10.0);
+    let body_vol = crate::measure::solid_volume(&topo, body, 0.01).unwrap();
+
+    let outer = make_rounded_rect_arc_prism(&mut topo, hw, hd, r, 10.0, 4.0);
+    let inner = make_rounded_rect_arc_prism(&mut topo, hw - w, hd - w, r - w, 10.0, 4.0);
+    let no_unify = BooleanOptions {
+        unify_faces: false,
+        ..BooleanOptions::default()
+    };
+    let lip = boolean_with_options(&mut topo, BooleanOp::Cut, outer, inner, no_unify).unwrap();
+    let lip_vol = crate::measure::solid_volume(&topo, lip, 0.01).unwrap();
+
+    match boolean_with_options(&mut topo, BooleanOp::Fuse, body, lip, no_unify) {
+        Ok(f) => ArcFrameLipFuse {
+            fused_vol: crate::measure::solid_volume(&topo, f, 0.01).unwrap_or(0.0),
+            body_vol,
+            lip_vol,
+            manifold: is_closed_manifold(&topo, f).unwrap_or(false),
+            has_free_edges: has_free_edges(&topo, f).unwrap_or(true),
+        },
+        Err(_) => ArcFrameLipFuse {
+            fused_vol: 0.0,
+            body_vol,
+            lip_vol,
+            manifold: false,
+            has_free_edges: true,
+        },
+    }
+}
+
+fn assert_arc_frame_lip_fuse_clean(hw: f64, hd: f64) {
+    let r = arc_frame_lip_fuse(hw, hd);
+    let expected = r.body_vol + r.lip_vol;
+    assert!(
+        r.manifold,
+        "fused lip+body must be closed-manifold (hw={hw}, hd={hd})"
+    );
+    assert!(
+        !r.has_free_edges,
+        "fused lip+body must have no free edges (hw={hw}, hd={hd})"
+    );
+    assert!(
+        (r.fused_vol - expected).abs() / expected < 1e-2,
+        "fused volume {:.2} != body+lip {expected:.2} (hw={hw}, hd={hd})",
+        r.fused_vol
+    );
+}
+
+#[test]
+fn fuse_arc_frame_lip_is_manifold_square() {
+    assert_arc_frame_lip_fuse_clean(15.0, 15.0);
+}
+
+#[test]
+fn fuse_arc_frame_lip_is_manifold_nonsquare() {
+    assert_arc_frame_lip_fuse_clean(10.0, 22.0);
+}
+
 #[test]
 fn fuse_stacked_rounded_rect_arc_prisms_nested_footprint() {
     // Tool's coplanar interface face strictly contained in the body's


### PR DESCRIPTION
## ⚠️ Core GFA assembly change — requesting human review before merge (#859)

Fixes the non-square rounded-rect lip fuse that dropped the tool (blocks gridfinity `rectLipSweep`). **This investigation overturned the originally-posted diagnosis** — see below.

### Corrected root cause (the issue's "same-domain" theory and the triage's "arc reconciliation" theory were both wrong)
I first implemented the triage's proposed fix (generalize `split_edges_at_collinear_vertices` to sub-split `Circle`/`Ellipse` arcs). It compiled but **fired zero times** — gated behind a flag, the whole suite stayed green without it — because the coincident arcs already share endpoints; there was nothing to sub-split.

Dumping the literal free edges of the GFA growth shell (before the mesh fallback) showed the real cause: the pavefiller places a coincident-ring intersection vertex a few ULPs short of the body's exact vertex — e.g. `x = -11.999999` vs `-12.0` (~1e-6 apart). `merge_duplicate_edges` keys edges on `quantize_point(p, MERGE_TOL)` with `MERGE_TOL = 1e-7`, so these near-duplicates land in **different cells** and the two faces' shared boundary is never unified. It stays open → `has_free_edges` → the boolean rejects the GFA result and falls back to the mesh boolean (≈correct volume for the symmetric square case, badly wrong — `5383` vs expected `9656` — for the asymmetric non-square one).

### Fix
New `weld_coincident_vertices` pass in `crates/algo/src/builder/builder_solid.rs`, run as "Step 0a-pre3" before the existing edge-split/merge passes:
- Clusters selected-face vertices by **actual distance** at `snap = 10 · MERGE_TOL = 1e-6` (the tolerance `split_edges_at_collinear_vertices` already treats as coincident) via a coarse spatial hash (cell = snap ⇒ a 26-neighbour probe is provably sufficient).
- Snaps each near-duplicate onto the lowest-`VertexId` canonical vertex, rebuilds touched wires, and drops edges that collapse to a point.
- Deterministic (vertex-index order, fixed probe order, shared-edge cache) so no HashMap iteration order leaks into entity IDs.

### Before / after
| case | before | after |
|---|---|---|
| square (15×15) | manifold=false, free edges, vol 9791 | **manifold, no free edges, vol 9791** (exp 9792) |
| non-square (10×22) | **broken: vol 5383**, manifold=false | **manifold, no free edges, vol 9655** (exp 9656) |

### Verification (re-run independently, not just the agent's report)
- `cargo test -p brepkit-operations` — 684 lib + all integration suites, **0 failed**. Canaries green: `d4_shelled_box_fuse_lip`, `fuse_stacked_rounded_rect_arc_prisms_{same,nested}_footprint`, `fuse_overlapping_rounded_rect_arc_prisms_same_footprint`, `cut_concentric_rounded_rect_arc_prisms_overshoot`, `rounded_rect_arc_prism_volume_baseline`.
- `cargo test -p brepkit-algo` — 115 passed, 0 failed.
- `cargo clippy -p brepkit-algo -p brepkit-operations --all-targets -- -D warnings` — clean.
- `./scripts/check-boundaries.sh` — valid.
- New regression: `fuse_arc_frame_lip_is_manifold_{square,nonsquare}`.

### 🔍 What I'd like a reviewer to scrutinize
1. **This runs on every `build_solid` (every boolean).** It's a no-op (early return) when nothing is within `snap`, and the full suites are green — but it's a new pass in the hottest core path. Worth a read of `weld_coincident_vertices` and a thought on perf for very large solids.
2. **`snap = 1e-6` welding moves vertices** by up to 1e-6 (10× `MERGE_TOL`). That matches the engine's existing on-edge coincidence tolerance, but it is a deliberate sub-tolerance snap.
3. **Greedy clustering is single-linkage / non-transitive** — it can *under*-merge (leave the bug unfixed in a pathological chain) but won't *over*-merge here, since real vertices are either ~1e-6 coincident or millimetres apart. If geometry ever has legitimately-distinct vertices ~1e-6 apart they'd be ambiguous to the kernel regardless.
4. **Alternative considered:** fixing it at the source (pavefiller emitting exact coincident vertices) would be deeper but riskier and broader; the downstream weld is the conservative, localized choice.

### Out of scope
`fuse_shelled_box_with_socket_loft` stays `#[ignore]`d — un-ignoring it shows a *different* defect (non-manifold edge shared by 3 faces, `euler=-54`), not the near-coincident-vertex bug. The issue's brepjs `rectLipSweep` un-skip is a downstream follow-up after this releases.
