### PR TITLE
fix(algo): analytic gridfinity bin — multi-section loft, coaxial cone cut, shelled-lip fuse

### DIFF
--- a/crates/algo/src/builder/face_splitter/containment.rs
+++ b/crates/algo/src/builder/face_splitter/containment.rs
@@ -34,15 +34,22 @@ pub(super) fn find_point_outside_holes(
             (outer_pts[i].x() + outer_pts[j].x()) * 0.5,
             (outer_pts[i].y() + outer_pts[j].y()) * 0.5,
         );
-        // Nudge the edge midpoint slightly toward the centroid.
-        let candidate = Point2::new(
-            edge_mid.x() * 0.9 + centroid_x * 0.1,
-            edge_mid.y() * 0.9 + centroid_y * 0.1,
-        );
-        if super::super::classify_2d::point_in_polygon_2d(candidate, outer_pts)
-            && !is_inside_any_hole(&candidate, inner_wires)
-        {
-            return candidate;
+        // Step inward from the edge midpoint toward the centroid in small
+        // increments; the first point inside the outer wire and outside every
+        // hole wins. Small steps handle THIN rings (e.g. the ~1.2mm gridfinity
+        // lip annulus on an 83mm cap), where a single large nudge overshoots
+        // straight into the hole and no ring point is ever found.
+        for k in 1..=99 {
+            let t = f64::from(k) * 0.005;
+            let candidate = Point2::new(
+                edge_mid.x() * (1.0 - t) + centroid_x * t,
+                edge_mid.y() * (1.0 - t) + centroid_y * t,
+            );
+            if super::super::classify_2d::point_in_polygon_2d(candidate, outer_pts)
+                && !is_inside_any_hole(&candidate, inner_wires)
+            {
+                return candidate;
+            }
         }
     }
 

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -996,6 +996,35 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
     let pts_2d = sample_wire_loop_uv(&sub_face.outer_wire);
     let mut interior_uv = sample_interior_point(&pts_2d);
 
+    // Periodic lateral walls (cone/cylinder): the closed boundary circles
+    // share a seam, and `sample_wire_loop_uv` can emit a lopsided uv polygon
+    // (most samples clustered on one bounding circle, plus seam-wrapped u
+    // values outside [0, 2pi)). `sample_interior_point` is then pulled onto a
+    // v-extreme — i.e. onto a bounding circle. For a flush/coincident cap that
+    // circle is the shared rim with the opposing solid, so the classifier
+    // samples exactly on the boundary and misclassifies the wall (dropping the
+    // cavity face on a Cut). Snap v to the axial midpoint, which is interior
+    // between the two bounding circles at the sampled u. Mirrors the
+    // sphere-cap fix above.
+    if matches!(
+        &sub_face.surface,
+        FaceSurface::Cone(_) | FaceSurface::Cylinder(_)
+    ) && !pts_2d.is_empty()
+    {
+        let v_min = pts_2d.iter().map(|p| p.y()).fold(f64::INFINITY, f64::min);
+        let v_max = pts_2d
+            .iter()
+            .map(|p| p.y())
+            .fold(f64::NEG_INFINITY, f64::max);
+        let range = v_max - v_min;
+        if range > 1e-9 {
+            let margin = 0.05 * range;
+            if interior_uv.y() < v_min + margin || interior_uv.y() > v_max - margin {
+                interior_uv = Point2::new(interior_uv.x(), 0.5 * (v_min + v_max));
+            }
+        }
+    }
+
     // Sphere cap fix: sphere sub-faces with degenerate UV boundaries (thin
     // strip at constant v) need the interior UV offset toward the pole.
     // The outer wire of a sphere cap maps to a horizontal line in UV,

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -1050,8 +1050,15 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
     }
 
     // If the point falls inside a hole, find a point between the outer wire
-    // and the nearest hole boundary.
-    if is_inside_any_hole(&interior_uv, &sub_face.inner_wires) {
+    // and the nearest hole boundary. (`find_point_outside_holes` steps inward
+    // in small increments so it lands in a thin ring rather than overshooting
+    // back into the hole.) For a planar face with holes, a centroid sampled
+    // from an under-resolved outer-wire polygon can sit on the wrong side of a
+    // thin annular ring even when it is not strictly inside a hole, so always
+    // re-derive the interior point from the ring between outer and holes.
+    if matches!(&sub_face.surface, FaceSurface::Plane { .. }) && !sub_face.inner_wires.is_empty() {
+        interior_uv = find_point_outside_holes(&pts_2d, &sub_face.inner_wires);
+    } else if is_inside_any_hole(&interior_uv, &sub_face.inner_wires) {
         interior_uv = find_point_outside_holes(&pts_2d, &sub_face.inner_wires);
     }
 

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -771,22 +771,31 @@ pub fn split_face_2d(
     // Build wire loops via angular-sorting traversal.
     let mut loops = build_wire_loops(&all_edges, tol.linear, u_periodic, v_periodic);
 
-    // Clockwise-boundary retry: the min-clockwise turn rule merges
-    // everything into a single loop when the boundary winds clockwise in
-    // this UV frame (the frame derives from the raw surface normal, not the
-    // effective face orientation). If the default traversal failed to split
-    // despite having sections, and the boundary is CW, retry with the
-    // mirrored turn rule. Loop areas from the retry are sign-flipped for
-    // the outer/hole classification below.
+    // Clockwise-boundary handling: this face's UV frame derives from the raw
+    // surface normal, not the effective face orientation, so an inner-shell
+    // (cavity) wall winds CW in UV while the outer wall winds CCW. Two effects
+    // follow when the boundary is CW, and both must be corrected:
+    //   1. Every sub-loop comes out with negated signed area, so the
+    //      area-based outer/hole split below would call every band a hole.
+    //      `cw_loops` flips the sign back during classification.
+    //   2. The min-clockwise turn rule can also merge everything into a single
+    //      loop; when that under-split happens, retry with the mirrored rule.
+    // Detect the CW boundary once and set `cw_loops` regardless of whether the
+    // default traversal already split correctly — otherwise a correctly-split
+    // CW face (e.g. a rounded-rect cavity corner cut by a constant-z section)
+    // has all its bands misclassified as holes and collapses to one sub-face.
     let mut cw_loops = false;
-    if loops.len() <= 1 && all_edges.len() > n_boundary_edges && !u_periodic && !v_periodic {
+    if all_edges.len() > n_boundary_edges && !u_periodic && !v_periodic {
         let boundary_pts = sample_wire_loop_uv(&all_edges[..n_boundary_edges]);
         if signed_area_2d(&boundary_pts) < 0.0 {
-            let retry =
-                build_wire_loops_with_winding(&all_edges, tol.linear, u_periodic, v_periodic, true);
-            if retry.len() > loops.len() {
-                loops = retry;
-                cw_loops = true;
+            cw_loops = true;
+            if loops.len() <= 1 {
+                let retry = build_wire_loops_with_winding(
+                    &all_edges, tol.linear, u_periodic, v_periodic, true,
+                );
+                if retry.len() > loops.len() {
+                    loops = retry;
+                }
             }
         }
     }
@@ -951,16 +960,49 @@ pub fn split_face_2d(
                 .map(|(i, _)| i)
         };
 
+        // Pre-sample each sub-face's outer wire in UV once, plus a guaranteed
+        // interior point. Reused below to resolve nesting between sub-faces.
+        let sub_outer_uv: Vec<Vec<Point2>> = sub_faces
+            .iter()
+            .map(|sf| sample_wire_loop_uv(&sf.outer_wire))
+            .collect();
+        let sub_interior: Vec<Point2> = sub_outer_uv
+            .iter()
+            .map(|pts| super::classify_2d::sample_interior_point(pts))
+            .collect();
+
         for hole in &original_inner_wires {
             let hole_pts = sample_wire_loop_uv(hole);
             let assigned = if hole_pts.len() >= 3 {
                 let probe = super::classify_2d::sample_interior_point(&hole_pts);
-                sub_faces.iter_mut().find_map(|sf| {
-                    let outer_pts = sample_wire_loop_uv(&sf.outer_wire);
-                    super::classify_2d::point_in_polygon_2d(probe, &outer_pts).then(|| {
-                        sf.inner_wires.push(hole.clone());
-                    })
-                })
+                // Assign the hole to the INNERMOST sub-face that contains it.
+                // A section can split a holed face into nested annular regions
+                // (e.g. a lip-bottom ring ext 15->21 cut at ext 19 yields rings
+                // 15->19 and 19->21); the original ext-15 hole lies inside both
+                // the ext-21 outer wire and the ext-19 ring, but belongs to the
+                // inner (ext-19) region. Pick by mutual containment rather than
+                // UV area: `sample_wire_loop_uv` can under-measure a rounded
+                // arc wire's area, so an outer ring's polygon area can read
+                // smaller than the ring it encloses. Point-in-polygon nesting
+                // is robust to that sampling error. The innermost containing
+                // sub-face is the one whose own interior point lies inside the
+                // most other containing sub-faces.
+                let containing: Vec<usize> = (0..sub_faces.len())
+                    .filter(|&i| super::classify_2d::point_in_polygon_2d(probe, &sub_outer_uv[i]))
+                    .collect();
+                let best = containing.iter().copied().max_by_key(|&i| {
+                    containing
+                        .iter()
+                        .filter(|&&j| {
+                            j != i
+                                && super::classify_2d::point_in_polygon_2d(
+                                    sub_interior[i],
+                                    &sub_outer_uv[j],
+                                )
+                        })
+                        .count()
+                });
+                best.map(|i| sub_faces[i].inner_wires.push(hole.clone()))
             } else {
                 None
             };

--- a/crates/algo/src/classifier/analytic.rs
+++ b/crates/algo/src/classifier/analytic.rs
@@ -923,6 +923,16 @@ fn try_build_composite_classifier(topo: &Topology, solid: SolidId) -> Option<Ana
                 let diff_v = Vec3::new(diff.x(), diff.y(), diff.z());
                 let projected = axis * diff_v.dot(axis);
                 let radial_dist = (diff_v - projected).length();
+                // The centroid lying OUTSIDE this cylinder means it is a corner
+                // fillet (or off-axis bore), not a body/cavity-bounding cylinder.
+                // The `ConvexAnalytic` model intersects "inside every cylinder",
+                // which cannot represent a rounded-rect prism (its centre is far
+                // from each corner arc) — it would classify interior points as
+                // Outside. Bail so `classify_point` falls back to the
+                // geometrically-exact ray-cast classifier.
+                if radial_dist > r + tol.linear {
+                    return None;
+                }
                 if radial_dist < r {
                     outer_cylinders.push((origin, axis, r, z_min, z_max));
                 } else {
@@ -947,6 +957,12 @@ fn try_build_composite_classifier(topo: &Topology, solid: SolidId) -> Option<Ana
                 let expected_r = r_min + t * (r_max - r_min);
                 let projected = axis * axial;
                 let radial_dist = (diff_v - projected).length();
+                // See the cylinder arm: a centroid outside this cone means a
+                // corner-fillet/off-axis cone the ConvexAnalytic intersection
+                // model can't represent — bail to ray-cast.
+                if radial_dist > expected_r + tol.linear {
+                    return None;
+                }
                 if radial_dist < expected_r {
                     outer_cones.push((apex, axis, z_min, z_max, r_min, r_max));
                 } else {

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -38,6 +38,11 @@ enum FaceGeom {
         v_min: f64,
         v_max: f64,
         hole_bands: Vec<(f64, f64)>,
+        /// For a partial-arc patch (e.g. a rounded-rect corner quarter), the
+        /// angular range NOT covered by the face — a crossing whose `u`
+        /// (circumferential parameter) falls in this gap is off the patch and
+        /// excluded. `None` for a full-period lateral.
+        u_gap: Option<(f64, f64)>,
     },
 }
 
@@ -220,8 +225,41 @@ fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, 
                         v_min,
                         v_max,
                         hole_bands,
+                        u_gap: None,
                     });
                     continue;
+                }
+            }
+
+            // Partial-arc cylinder patch (e.g. a rounded-rect corner quarter):
+            // no closed-circle edge, so the full-period path skipped it.
+            // Collect it analytically with an angular trim rather than the
+            // polygon fallback, whose non-planar boundary mis-counts crossings.
+            if face.inner_wires().is_empty() {
+                let verts = wire_polygon(topo, face.outer_wire())?;
+                if verts.len() >= 3 {
+                    let mut pv_min = f64::INFINITY;
+                    let mut pv_max = f64::NEG_INFINITY;
+                    let mut u_samples = Vec::with_capacity(verts.len());
+                    for p in &verts {
+                        let (u, v) = cyl.project_point(*p);
+                        pv_min = pv_min.min(v);
+                        pv_max = pv_max.max(v);
+                        u_samples.push(u);
+                    }
+                    if pv_min.is_finite()
+                        && pv_max > pv_min
+                        && let Some(gap) = largest_u_gap(&u_samples)
+                    {
+                        result.push(FaceGeom::Cylinder {
+                            surface: cyl.clone(),
+                            v_min: pv_min,
+                            v_max: pv_max,
+                            hole_bands: Vec::new(),
+                            u_gap: Some(gap),
+                        });
+                        continue;
+                    }
                 }
             }
         }
@@ -319,7 +357,16 @@ fn ray_geom_crossings(origin: Point3, ray_dir: Vec3, geom: &FaceGeom, tol: Toler
             v_min,
             v_max,
             hole_bands,
-        } => ray_cylinder_crossings(origin, ray_dir, surface, *v_min, *v_max, hole_bands, tol),
+            u_gap,
+        } => ray_cylinder_crossings(
+            origin,
+            ray_dir,
+            surface,
+            (*v_min, *v_max),
+            hole_bands,
+            *u_gap,
+            tol,
+        ),
     }
 }
 
@@ -370,11 +417,12 @@ fn ray_cylinder_crossings(
     origin: Point3,
     ray_dir: Vec3,
     surface: &brepkit_math::surfaces::CylindricalSurface,
-    v_min: f64,
-    v_max: f64,
+    v_range: (f64, f64),
     hole_bands: &[(f64, f64)],
+    u_gap: Option<(f64, f64)>,
     tol: Tolerance,
 ) -> i32 {
+    let (v_min, v_max) = v_range;
     let axis = surface.axis();
     let m = origin - surface.origin();
     let d_perp = ray_dir - axis * ray_dir.dot(axis);
@@ -414,9 +462,60 @@ fn ray_cylinder_crossings(
         {
             continue;
         }
+        // Angular trim for a partial-arc patch: skip a hit on the off-patch
+        // portion of the full cylinder (the rounded-rect corner quarter only
+        // covers a 90° arc; the other 3/4 is not a real face).
+        if let Some(gap) = u_gap {
+            let (u, _) = surface.project_point(hit);
+            if u_in_gap(u, gap) {
+                continue;
+            }
+        }
         crossings += 1;
     }
     crossings
+}
+
+/// Whether circumferential parameter `u` lies in the excluded angular gap
+/// `(lo, hi)` (CCW from `lo` to `hi`, possibly wrapping past 2π).
+fn u_in_gap(u: f64, gap: (f64, f64)) -> bool {
+    use std::f64::consts::TAU;
+    let eps = 1e-6;
+    let u = u.rem_euclid(TAU);
+    let (lo, hi) = (gap.0.rem_euclid(TAU), gap.1.rem_euclid(TAU));
+    if lo <= hi {
+        u > lo + eps && u < hi - eps
+    } else {
+        u > lo + eps || u < hi - eps
+    }
+}
+
+/// Largest angular gap between sorted circumferential samples — the arc the
+/// partial-cylinder face does NOT cover. `None` for too-few samples or a gap
+/// too small to be a genuine partial arc.
+fn largest_u_gap(u_samples: &[f64]) -> Option<(f64, f64)> {
+    use std::f64::consts::TAU;
+    let mut us: Vec<f64> = u_samples.iter().map(|&u| u.rem_euclid(TAU)).collect();
+    us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    us.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
+    if us.len() < 2 {
+        return None;
+    }
+    let mut best = 0.0_f64;
+    let mut gap = (0.0, 0.0);
+    for i in 0..us.len() {
+        let lo = us[i];
+        let hi = if i + 1 < us.len() {
+            us[i + 1]
+        } else {
+            us[0] + TAU
+        };
+        if hi - lo > best {
+            best = hi - lo;
+            gap = (lo, hi.rem_euclid(TAU));
+        }
+    }
+    if best > 0.2 { Some(gap) } else { None }
 }
 
 /// Test if a 3D point lies inside a planar face polygon by projecting to 2D.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -711,6 +711,47 @@ fn compute_raw_curves(
             }
         }
 
+        (FaceSurface::Cone(cone), FaceSurface::Cylinder(cyl))
+        | (FaceSurface::Cylinder(cyl), FaceSurface::Cone(cone)) => {
+            // A coaxial cone and cylinder meet at the single circle where the
+            // cone's radius equals the cylinder's — the gridfinity lip's top
+            // knife edge (inner tapered corner = cone, outer corner =
+            // cylinder, concentric, matching at Z_PEAK). Emit it as an exact
+            // Circle so seam adoption links it to the shared cap rim, instead
+            // of letting the marcher fragment the near-tangent contact into
+            // degenerate micro-arcs (the 98-free-edge corruption). Non-coaxial
+            // (None) falls through to the general marcher.
+            match analytic_intersection::exact_cone_cylinder(cone, cyl)? {
+                Some(exacts) => {
+                    let mut results = Vec::new();
+                    for exact in exacts {
+                        if let analytic_intersection::ExactIntersectionCurve::Circle(circle) = exact
+                        {
+                            let bbox = circle_bbox(&circle);
+                            let domain = (0.0, std::f64::consts::TAU);
+                            let p_start = ParametricCurve::evaluate(&circle, domain.0);
+                            let p_end = ParametricCurve::evaluate(&circle, domain.1);
+                            results.push(RawCurve {
+                                curve: EdgeCurve::Circle(circle),
+                                bbox,
+                                t_range: domain,
+                                p_start,
+                                p_end,
+                            });
+                        }
+                    }
+                    Ok(results)
+                }
+                None => {
+                    if let (Some(aa), Some(ab)) = (surf_a.as_analytic(), surf_b.as_analytic()) {
+                        analytic_analytic_intersection(&aa, &ab, v_range_a, v_range_b)
+                    } else {
+                        Ok(Vec::new())
+                    }
+                }
+            }
+        }
+
         (a, b) if a.as_analytic().is_some() && b.as_analytic().is_some() => {
             if let (Some(aa), Some(ab)) = (a.as_analytic(), b.as_analytic()) {
                 analytic_analytic_intersection(&aa, &ab, v_range_a, v_range_b)

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -673,6 +673,44 @@ fn compute_raw_curves(
             }
         }
 
+        (FaceSurface::Cone(c1), FaceSurface::Cone(c2)) => {
+            // Coaxial cones meet at a single circle that coincides with their
+            // shared cap rim. Emit it as an exact Circle so the closed-circle
+            // handling (seam adoption + `link_existing`) treats it as the
+            // existing shared boundary edge instead of adopting a fresh,
+            // redundant section edge. Non-coaxial cones (None) fall through to
+            // the general marcher.
+            match analytic_intersection::exact_cone_cone(c1, c2)? {
+                Some(exacts) => {
+                    let mut results = Vec::new();
+                    for exact in exacts {
+                        if let analytic_intersection::ExactIntersectionCurve::Circle(circle) = exact
+                        {
+                            let bbox = circle_bbox(&circle);
+                            let domain = (0.0, std::f64::consts::TAU);
+                            let p_start = ParametricCurve::evaluate(&circle, domain.0);
+                            let p_end = ParametricCurve::evaluate(&circle, domain.1);
+                            results.push(RawCurve {
+                                curve: EdgeCurve::Circle(circle),
+                                bbox,
+                                t_range: domain,
+                                p_start,
+                                p_end,
+                            });
+                        }
+                    }
+                    Ok(results)
+                }
+                None => {
+                    if let (Some(aa), Some(ab)) = (surf_a.as_analytic(), surf_b.as_analytic()) {
+                        analytic_analytic_intersection(&aa, &ab, v_range_a, v_range_b)
+                    } else {
+                        Ok(Vec::new())
+                    }
+                }
+            }
+        }
+
         (a, b) if a.as_analytic().is_some() && b.as_analytic().is_some() => {
             if let (Some(aa), Some(ab)) = (a.as_analytic(), b.as_analytic()) {
                 analytic_analytic_intersection(&aa, &ab, v_range_a, v_range_b)

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -530,31 +530,96 @@ fn restrict_curves_to_faces(
                 ext_a.contains(p) && ext_b.contains(p)
             })
             .collect();
-        // Longest contiguous in-both run.
-        let (mut b0, mut b1) = (0usize, 0usize);
-        let mut cur: Option<usize> = None;
-        for (i, &v) in inb.iter().enumerate() {
-            if v {
-                let c = *cur.get_or_insert(i);
-                if i - c > b1 - b0 {
-                    b0 = c;
-                    b1 = i;
-                }
-            } else {
-                cur = None;
-            }
-        }
+        // Longest contiguous in-both run. A closed curve (sample N coincides
+        // with sample 0) may have its in-both arc wrap across the seam, so the
+        // search extends past N for closed curves (`b1` may exceed N, mapped
+        // back via the curve's periodic parameterization).
+        let closed = (raw.p_start - raw.p_end).length() < 1e-7;
+        let (b0, b1) = longest_inboth_run(&inb, closed);
         // An in-both run spanning fewer than two segments (b1-b0 < 2, i.e. at
         // most two consecutive in-both samples) is a tangency/grazing point —
-        // such a curve never splits either face, so drop it. Curves with a real
-        // in-both span are kept whole (the downstream splitter trims them to the
-        // face boundary).
+        // such a curve never splits either face, so drop it.
         if b1 - b0 < 2 {
+            continue;
+        }
+        // A closed ellipse/NURBS loop is kept whole ONLY when the entire curve
+        // is in-both — a genuine shared rim. When just an arc is in-both,
+        // keeping the whole curve leaves a spurious closed self-loop section
+        // edge: the splitter only trims OPEN curves and only adopts closed
+        // CIRCLES (seam adoption / link_existing), so a full ellipse from an
+        // inner tapered wall meeting an outer corner (the gridfinity lip
+        // knife-edge) survives as a degenerate loop and over-connects the rim.
+        // Trim it to its in-both arc so it becomes an open edge the splitter
+        // can place. Circles are left whole (seam adoption handles them); open
+        // curves are left whole (the splitter clips them).
+        if closed && b1 - b0 < N && !matches!(raw.curve, EdgeCurve::Circle(_)) {
+            #[allow(clippy::cast_precision_loss)]
+            let frac = |i: usize| i as f64 / N as f64;
+            let span = raw.t_range.1 - raw.t_range.0;
+            let t0 = raw.t_range.0 + span * frac(b0);
+            let t1 = raw.t_range.0 + span * frac(b1);
+            let p0 = raw
+                .curve
+                .evaluate_with_endpoints(t0, raw.p_start, raw.p_end);
+            let p1 = raw
+                .curve
+                .evaluate_with_endpoints(t1, raw.p_start, raw.p_end);
+            out.push(RawCurve {
+                curve: raw.curve,
+                bbox: raw.bbox,
+                t_range: (t0, t1),
+                p_start: p0,
+                p_end: p1,
+            });
             continue;
         }
         out.push(raw);
     }
     out
+}
+
+/// Longest contiguous run of `true` in `inb` (samples `0..=N`). For a closed
+/// curve (sample `N` == sample `0`) the run may wrap across the seam, so the
+/// search walks the circular sequence and the returned `b1` may exceed `N`
+/// (the caller maps it back through the curve's periodic parameterization). A
+/// run covering every distinct sample returns the whole span `(0, N)`.
+fn longest_inboth_run(inb: &[bool], closed: bool) -> (usize, usize) {
+    let n = inb.len();
+    if !closed || n < 2 {
+        let (mut b0, mut b1) = (0usize, 0usize);
+        let mut start: Option<usize> = None;
+        for (i, &v) in inb.iter().enumerate() {
+            if v {
+                let s = *start.get_or_insert(i);
+                if i - s > b1 - b0 {
+                    b0 = s;
+                    b1 = i;
+                }
+            } else {
+                start = None;
+            }
+        }
+        return (b0, b1);
+    }
+    // Closed: distinct samples are 0..m (sample m duplicates sample 0).
+    let m = n - 1;
+    let (mut b0, mut b1) = (0usize, 0usize);
+    let mut start: Option<usize> = None;
+    for k in 0..2 * m {
+        if inb[k % m] {
+            let s = *start.get_or_insert(k);
+            if k - s >= m {
+                return (0, m); // whole curve in-both
+            }
+            if k - s > b1 - b0 {
+                b0 = s;
+                b1 = k;
+            }
+        } else {
+            start = None;
+        }
+    }
+    (b0, b1)
 }
 
 /// Compute AABB for a face by sampling its boundary edges.
@@ -1888,6 +1953,29 @@ fn clip_line_to_polygon(
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
+
+    #[test]
+    fn longest_run_open_middle() {
+        // Open curve: longest contiguous in-both run, no wrap-around.
+        let inb = [false, true, true, true, false, true, false];
+        assert_eq!(longest_inboth_run(&inb, false), (1, 3));
+    }
+
+    #[test]
+    fn longest_run_closed_wraps_seam() {
+        // Closed curve (sample N duplicates sample 0): in-both at samples 4, 0,
+        // 1 — the longest run wraps the seam, so b1 extends past the distinct
+        // sample count (the caller maps it back via periodic parameterization).
+        let inb = [true, true, false, false, true, true];
+        assert_eq!(longest_inboth_run(&inb, true), (4, 6));
+    }
+
+    #[test]
+    fn longest_run_closed_whole() {
+        // A closed curve entirely in-both returns the whole span (0, m).
+        let inb = [true, true, true, true, true];
+        assert_eq!(longest_inboth_run(&inb, true), (0, 4));
+    }
 
     #[test]
     fn clip_inside_square() {

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -957,8 +957,103 @@ fn try_algebraic_intersection(
         | (AnalyticSurface::Cylinder(c), AnalyticSurface::Sphere(s)) => {
             algebraic_sphere_cylinder(s, c)
         }
+        (AnalyticSurface::Cone(c1), AnalyticSurface::Cone(c2)) => algebraic_cone_cone(c1, c2),
         _ => Ok(None),
     }
+}
+
+/// Algebraic coaxial cone-cone intersection.
+///
+/// Two cones that share an axis are concentric circles at every axial
+/// station, so they meet only where their radii are equal. Each cone's
+/// radius is linear in the axial coordinate `t` (measured along the shared
+/// axis from cone 1's apex): `r1 = m1·t` and `r2 = m2·σ·(t − d2)`, where
+/// `m_i = cot(half_angle_i)`, `σ = sign(axis2·axis1)`, and `d2` is cone 2's
+/// apex position in that coordinate. Equating gives a single crossing `t*`
+/// → one circle (the shared rim). The general marcher mishandles this case:
+/// at the radii-crossing the surfaces are nearly tangent, so a grid-seeded
+/// march fragments the clean circle into dozens of degenerate micro-curves.
+///
+/// Returns `Some(vec![circle])` for a genuine crossing, `Some(vec![])` when
+/// the cones do not meet (parallel radius lines or a crossing on the wrong
+/// nappe), and `None` for the identical-cone overlap or a degenerate
+/// (near-flat) cone — both of which fall through to the general path.
+#[allow(clippy::unnecessary_wraps)]
+fn algebraic_cone_cone(
+    c1: &ConicalSurface,
+    c2: &ConicalSurface,
+) -> Result<Option<Vec<IntersectionCurve>>, MathError> {
+    let axis = c1.axis();
+    let axis2 = c2.axis();
+
+    // Coaxial check: parallel axes and the second apex lies on the first axis.
+    if axis.dot(axis2).abs() < 1.0 - 1e-10 {
+        return Ok(None); // Non-coaxial: quartic curve, let the marcher handle.
+    }
+    let apex1 = c1.apex();
+    let apex2 = c2.apex();
+    let delta = apex2 - apex1;
+    let delta_v = Vec3::new(delta.x(), delta.y(), delta.z());
+    let along = delta_v.dot(axis);
+    if (delta_v - axis * along).length() > 1e-8 {
+        return Ok(None); // Parallel but offset axes — not coaxial.
+    }
+
+    let (s1, s2) = (c1.half_angle().sin(), c2.half_angle().sin());
+    if s1.abs() < 1e-12 || s2.abs() < 1e-12 {
+        return Ok(None); // Degenerate (near-flat) cone.
+    }
+    let m1 = c1.half_angle().cos() / s1;
+    let m2 = c2.half_angle().cos() / s2;
+    let sigma = if axis.dot(axis2) >= 0.0 { 1.0 } else { -1.0 };
+    let d2 = along; // apex2 position along `axis`, measured from apex1.
+
+    let denom = m1 - m2 * sigma;
+    if denom.abs() < 1e-12 {
+        // Parallel radius lines: identical cones (coincident apex, same opening)
+        // overlap — defer to the general/same-domain path; otherwise no meeting.
+        if sigma > 0.0 && d2.abs() < 1e-9 {
+            return Ok(None);
+        }
+        return Ok(Some(vec![]));
+    }
+
+    let t_star = (-m2 * sigma * d2) / denom;
+    let radius = m1 * t_star;
+    if radius < 1e-12 {
+        return Ok(Some(vec![])); // Crossing on the wrong nappe / no real circle.
+    }
+
+    let center = Point3::new(
+        apex1.x() + axis.x() * t_star,
+        apex1.y() + axis.y() * t_star,
+        apex1.z() + axis.z() * t_star,
+    );
+
+    let basis = Frame3::from_normal(center, axis)?;
+    let (u_dir, v_dir) = (basis.x, basis.y);
+    let n_samples = 33;
+    let mut positions = Vec::with_capacity(n_samples);
+    let mut points = Vec::with_capacity(n_samples);
+    #[allow(clippy::cast_precision_loss)]
+    for i in 0..n_samples {
+        let theta = TAU * i as f64 / (n_samples - 1) as f64;
+        let (sin_t, cos_t) = theta.sin_cos();
+        let pt = Point3::new(
+            center.x() + (u_dir.x() * cos_t + v_dir.x() * sin_t) * radius,
+            center.y() + (u_dir.y() * cos_t + v_dir.y() * sin_t) * radius,
+            center.z() + (u_dir.z() * cos_t + v_dir.z() * sin_t) * radius,
+        );
+        positions.push(pt);
+        points.push(IntersectionPoint {
+            point: pt,
+            param1: (0.0, 0.0),
+            param2: (0.0, 0.0),
+        });
+    }
+    let degree = 3.min(positions.len() - 1);
+    let curve = interpolate(&positions, degree)?;
+    Ok(Some(vec![IntersectionCurve { curve, points }]))
 }
 
 /// Algebraic sphere-cylinder intersection.
@@ -1677,6 +1772,50 @@ mod tests {
 
         let curves = intersect_plane_cone(&cone, Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
         assert!(!curves.is_empty(), "should find intersection with cone");
+    }
+
+    #[test]
+    fn coaxial_cones_cross_at_single_circle() {
+        // Two coaxial truncated cones (outer base r10->top r8, inner r9->r8
+        // over height 10) cross where their radii match: z=10, r=8. The
+        // intersection must be ONE clean circle, not the dozens of degenerate
+        // micro-curves the general marcher produces at near-tangency.
+        let outer = ConicalSurface::new(
+            Point3::new(0.0, 0.0, 50.0),
+            Vec3::new(0.0, 0.0, -1.0),
+            5.0_f64.atan(),
+        )
+        .unwrap();
+        let inner = ConicalSurface::new(
+            Point3::new(0.0, 0.0, 90.0),
+            Vec3::new(0.0, 0.0, -1.0),
+            10.0_f64.atan(),
+        )
+        .unwrap();
+
+        let curves = intersect_analytic_analytic_bounded(
+            AnalyticSurface::Cone(&outer),
+            AnalyticSurface::Cone(&inner),
+            32,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            curves.len(),
+            1,
+            "coaxial cones crossing at one circle must yield exactly one curve, got {}",
+            curves.len()
+        );
+        for p in &curves[0].points {
+            let r = p.point.x().hypot(p.point.y());
+            assert!(
+                (p.point.z() - 10.0).abs() < 1e-6 && (r - 8.0).abs() < 1e-6,
+                "intersection point off the expected z=10,r=8 circle: {:?}",
+                p.point
+            );
+        }
     }
 
     #[test]

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -804,6 +804,7 @@ pub fn intersect_analytic_analytic_bounded(
     // a grid point on A to its projection on B can be large even near
     // the intersection (e.g., sphere R=2 and cylinder R=1 → gap ≈ 1).
     let seed_threshold = diag_a.max(diag_b).max(1.0) * 0.5;
+    let mut min_dist = f64::INFINITY;
 
     #[allow(clippy::cast_precision_loss)]
     for ia in 0..grid_res {
@@ -819,6 +820,7 @@ pub fn intersect_analytic_analytic_bounded(
             let (ub, vb) = project_analytic(&b, pa, u_range_b, v_range_b);
             let pb = surf_b(ub, vb);
             let dist = (pa - pb).length();
+            min_dist = min_dist.min(dist);
 
             if dist < seed_threshold {
                 // Use the coarse seed directly. The marching algorithm
@@ -833,6 +835,19 @@ pub fn intersect_analytic_analytic_bounded(
                 seeds.push((mid, (ua, va), (ub, vb)));
             }
         }
+    }
+
+    // Cheap rejection: the grid samples surface A; the closest sample's
+    // distance to B lower-bounds how near the two bounded patches come. A
+    // transversal crossing puts a sample within ~one grid cell of it
+    // (distance on the order of a cell), so if even the nearest sample is
+    // several cells away the patches cannot cross — skip the expensive
+    // marching and return empty. Result-preserving: non-crossing pairs
+    // already march to nothing, just slowly (this is the gridfinity lip's
+    // ~80 inner-wall × outer-wall pairs that dominate pavefiller time).
+    let reject_dist = (char_size / grid_res as f64) * 3.0;
+    if min_dist > reject_dist {
+        return Ok(vec![]);
     }
 
     if seeds.is_empty() {
@@ -1034,6 +1049,66 @@ pub fn exact_cone_cone(
         apex1.z() + axis.z() * t_star,
     );
     let circle = Circle3D::new(center, axis, radius)?;
+    Ok(Some(vec![ExactIntersectionCurve::Circle(circle)]))
+}
+
+/// Exact coaxial cone-cylinder intersection: returns the shared circle.
+///
+/// A cone and a cylinder sharing an axis are concentric circles at every
+/// axial station, so they meet only where the cone's radius equals the
+/// cylinder's. The cone radius is linear in the axial coordinate `t` from its
+/// apex (`r = m·t`, `m = cot(half_angle)`), the cylinder radius is the
+/// constant `R`, so `m·t = R` gives a single crossing `t*` → one circle. This
+/// is the gridfinity lip's top knife edge (inner tapered corner = cone, outer
+/// corner = cylinder, concentric, radii matching at `Z_PEAK`); the general
+/// marcher fragments that near-tangent contact into dozens of degenerate
+/// micro-curves.
+///
+/// Returns `Some(vec![circle])` for a genuine crossing, `Some(vec![])` when
+/// the crossing degenerates to the apex, and `None` (defer to the marcher)
+/// when the surfaces are not coaxial or the cone is near-flat / near-axial.
+///
+/// # Errors
+///
+/// Returns [`MathError`] if the shared `Circle3D` cannot be constructed.
+pub fn exact_cone_cylinder(
+    cone: &ConicalSurface,
+    cyl: &CylindricalSurface,
+) -> Result<Option<Vec<ExactIntersectionCurve>>, MathError> {
+    let axis = cone.axis();
+    let cyl_axis = cyl.axis();
+
+    // Coaxial check: parallel axes and the cone apex on the cylinder's axis.
+    if axis.dot(cyl_axis).abs() < 1.0 - 1e-10 {
+        return Ok(None);
+    }
+    let apex = cone.apex();
+    let delta = apex - cyl.origin();
+    let delta_v = Vec3::new(delta.x(), delta.y(), delta.z());
+    let along = delta_v.dot(cyl_axis);
+    if (delta_v - cyl_axis * along).length() > 1e-8 {
+        return Ok(None);
+    }
+
+    let s = cone.half_angle().sin();
+    if s.abs() < 1e-12 {
+        return Ok(None); // near-flat cone.
+    }
+    let m = cone.half_angle().cos() / s; // dr/dt along the cone axis.
+    if m.abs() < 1e-12 {
+        return Ok(None); // near-axial cone: radius ~constant.
+    }
+
+    let t_star = cyl.radius() / m; // where the cone radius m·t equals R.
+    if t_star.abs() < 1e-12 {
+        return Ok(Some(vec![])); // crossing at the apex — no real circle.
+    }
+    let center = Point3::new(
+        apex.x() + axis.x() * t_star,
+        apex.y() + axis.y() * t_star,
+        apex.z() + axis.z() * t_star,
+    );
+    let circle = Circle3D::new(center, axis, cyl.radius())?;
     Ok(Some(vec![ExactIntersectionCurve::Circle(circle)]))
 }
 

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -962,7 +962,7 @@ fn try_algebraic_intersection(
     }
 }
 
-/// Algebraic coaxial cone-cone intersection.
+/// Exact coaxial cone-cone intersection: returns the shared circle.
 ///
 /// Two cones that share an axis are concentric circles at every axial
 /// station, so they meet only where their radii are equal. Each cone's
@@ -978,11 +978,15 @@ fn try_algebraic_intersection(
 /// the cones do not meet (parallel radius lines or a crossing on the wrong
 /// nappe), and `None` for the identical-cone overlap or a degenerate
 /// (near-flat) cone — both of which fall through to the general path.
-#[allow(clippy::unnecessary_wraps)]
-fn algebraic_cone_cone(
+///
+/// # Errors
+///
+/// Returns [`MathError`] if the shared-rim `Circle3D` cannot be constructed
+/// (e.g. a non-finite center or radius from a malformed cone).
+pub fn exact_cone_cone(
     c1: &ConicalSurface,
     c2: &ConicalSurface,
-) -> Result<Option<Vec<IntersectionCurve>>, MathError> {
+) -> Result<Option<Vec<ExactIntersectionCurve>>, MathError> {
     let axis = c1.axis();
     let axis2 = c2.axis();
 
@@ -1029,31 +1033,48 @@ fn algebraic_cone_cone(
         apex1.y() + axis.y() * t_star,
         apex1.z() + axis.z() * t_star,
     );
+    let circle = Circle3D::new(center, axis, radius)?;
+    Ok(Some(vec![ExactIntersectionCurve::Circle(circle)]))
+}
 
-    let basis = Frame3::from_normal(center, axis)?;
-    let (u_dir, v_dir) = (basis.x, basis.y);
-    let n_samples = 33;
-    let mut positions = Vec::with_capacity(n_samples);
-    let mut points = Vec::with_capacity(n_samples);
-    #[allow(clippy::cast_precision_loss)]
-    for i in 0..n_samples {
-        let theta = TAU * i as f64 / (n_samples - 1) as f64;
-        let (sin_t, cos_t) = theta.sin_cos();
-        let pt = Point3::new(
-            center.x() + (u_dir.x() * cos_t + v_dir.x() * sin_t) * radius,
-            center.y() + (u_dir.y() * cos_t + v_dir.y() * sin_t) * radius,
-            center.z() + (u_dir.z() * cos_t + v_dir.z() * sin_t) * radius,
-        );
-        positions.push(pt);
-        points.push(IntersectionPoint {
-            point: pt,
-            param1: (0.0, 0.0),
-            param2: (0.0, 0.0),
-        });
+/// Algebraic coaxial cone-cone intersection (NURBS form for the general
+/// bounded path). Delegates to [`exact_cone_cone`] and samples each exact
+/// circle into an interpolated NURBS `IntersectionCurve`, mirroring the
+/// sphere-cylinder algebraic path. phase FF prefers the exact circle form
+/// directly (so the section edge links to the coincident boundary), but a
+/// caller of `intersect_analytic_analytic_bounded` still gets one clean
+/// curve instead of the marcher's fragments.
+fn algebraic_cone_cone(
+    c1: &ConicalSurface,
+    c2: &ConicalSurface,
+) -> Result<Option<Vec<IntersectionCurve>>, MathError> {
+    let Some(exacts) = exact_cone_cone(c1, c2)? else {
+        return Ok(None);
+    };
+    let mut curves = Vec::new();
+    for exact in exacts {
+        let ExactIntersectionCurve::Circle(circle) = exact else {
+            continue;
+        };
+        let n_samples = 33;
+        let mut positions = Vec::with_capacity(n_samples);
+        let mut points = Vec::with_capacity(n_samples);
+        #[allow(clippy::cast_precision_loss)]
+        for i in 0..n_samples {
+            let theta = TAU * i as f64 / (n_samples - 1) as f64;
+            let pt = crate::traits::ParametricCurve::evaluate(&circle, theta);
+            positions.push(pt);
+            points.push(IntersectionPoint {
+                point: pt,
+                param1: (0.0, 0.0),
+                param2: (0.0, 0.0),
+            });
+        }
+        let degree = 3.min(positions.len() - 1);
+        let curve = interpolate(&positions, degree)?;
+        curves.push(IntersectionCurve { curve, points });
     }
-    let degree = 3.min(positions.len() - 1);
-    let curve = interpolate(&positions, degree)?;
-    Ok(Some(vec![IntersectionCurve { curve, points }]))
+    Ok(Some(curves))
 }
 
 /// Algebraic sphere-cylinder intersection.

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4097,6 +4097,57 @@ fn fuse_arc_frame_lip_is_manifold_nonsquare() {
     assert_arc_frame_lip_fuse_clean(10.0, 22.0);
 }
 
+fn find_top_face(topo: &Topology, solid: SolidId) -> FaceId {
+    brepkit_topology::explorer::solid_faces(topo, solid)
+        .unwrap()
+        .into_iter()
+        .find(|&fid| {
+            topo.face(fid)
+                .unwrap()
+                .effective_plane_normal()
+                .is_some_and(|n| n.z() > 0.5 * n.length())
+        })
+        .expect("prism should have a +Z top face")
+}
+
+#[test]
+fn fuse_shelled_cup_lip_covers_cavity_opening() {
+    // FAITHFUL d4 repro: a shelled cup (cavity half ~13) fused with a frame lip
+    // whose INNER (half 12) is INSIDE the cavity, overlapping so the lip's
+    // bottom plane crosses the cup's cavity wall MID-FACE. d4's free-edge bug:
+    // the FF (cavity wall x lip bottom) splits the cavity wall but NOT the lip
+    // bottom -> orphaned cavity-wall top edge -> open shell -> mesh fallback.
+    let mut topo = Topology::new();
+    let body = make_rounded_rect_arc_prism(&mut topo, 15.0, 15.0, 3.0, 0.0, 10.0);
+    let top = find_top_face(&topo, body);
+    // shell removes the top + offsets inward by 2 -> cavity half 13, corner 1.
+    let cup = crate::shell_op::shell(&mut topo, body, 2.0, &[top]).unwrap();
+    // Lip frame z=8..14, OVERLAPPING the cup (z<10); inner half 12 < cavity 13.
+    let outer = make_rounded_rect_arc_prism(&mut topo, 15.0, 15.0, 3.0, 8.0, 6.0);
+    let inner = make_rounded_rect_arc_prism(&mut topo, 12.0, 12.0, 1.0, 8.0, 6.0);
+    let no_unify = BooleanOptions {
+        unify_faces: false,
+        ..BooleanOptions::default()
+    };
+    let lip = boolean_with_options(&mut topo, BooleanOp::Cut, outer, inner, no_unify).unwrap();
+    match boolean_with_options(&mut topo, BooleanOp::Fuse, cup, lip, no_unify) {
+        Ok(f) => {
+            let manifold = is_closed_manifold(&topo, f).unwrap_or(false);
+            let free = has_free_edges(&topo, f).unwrap_or(true);
+            eprintln!("faithful-cup-lip fuse: manifold={manifold} free={free}");
+            assert!(
+                manifold,
+                "shelled cup + cavity-covering lip fuse must be closed-manifold"
+            );
+            assert!(
+                !free,
+                "shelled cup + cavity-covering lip fuse must have no free edges"
+            );
+        }
+        Err(e) => panic!("fuse errored: {e:?}"),
+    }
+}
+
 #[test]
 fn fuse_stacked_rounded_rect_arc_prisms_nested_footprint() {
     // Tool's coplanar interface face strictly contained in the body's

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -489,13 +489,14 @@ fn try_loft_matching_curved_profiles(
     let tol = Tolerance::new();
     let num_profiles = profiles.len();
 
-    // Scope guard: only curve-preserve a single ruled band (two profiles).
-    // Multi-section curve-preserving lofts (e.g. a 5-section gridfinity lip)
-    // produce chains of curved bands whose downstream boolean cut/fuse/shell
-    // sequences aren't yet robust (near-degenerate corner junctions), so they
-    // fall back to the polygon loft that already handles them. The two-profile
-    // case covers the coincident curved-cap fuse this feature targets.
-    if num_profiles != 2 {
+    // Curve-preserve any chain of N >= 2 profiles. The section loops below
+    // (steps 3b/4/6) already build one ruled band per adjacent profile pair, so
+    // a multi-section gridfinity lip/socket keeps its arc corners analytic
+    // (Cylinder/Cone/ruled-NURBS) instead of faceting to a polygon. An analytic
+    // operand is exactly what the downstream cut/fuse needs to stay watertight —
+    // a faceted multi-section lip is what drove the boolean to its non-manifold
+    // mesh fallback. `loft()` already guarantees >= 2 profiles.
+    if num_profiles < 2 {
         return Ok(None);
     }
 

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -373,6 +373,58 @@ struct ProfileEdgeGeom {
     end: Point3,
 }
 
+/// Merge consecutive arcs lying on the same circle into a single arc.
+///
+/// A 90° rounded-rect corner can arrive as one arc or as several co-circular
+/// sub-arcs — drawn profiles (`drawRoundedRectangle`) split corners
+/// inconsistently with size (e.g. one section's corner is one arc, another's is
+/// two). Left as-is, the loft profiles get mismatched edge counts and the
+/// curve-preserving path bails to the faceted polygon loft. Normalizing each
+/// profile to canonical one-arc-per-corner lets split- and single-arc corners
+/// align so multi-section lips/sockets keep analytic corners.
+fn merge_cocircular_arcs(edges: Vec<ProfileEdgeGeom>) -> Vec<ProfileEdgeGeom> {
+    use brepkit_math::curves::Circle3D;
+    let tol = Tolerance::new();
+    let same_circle = |c0: &Circle3D, c1: &Circle3D| -> bool {
+        let (Ok(n0), Ok(n1)) = (c0.normal().normalize(), c1.normal().normalize()) else {
+            return false;
+        };
+        n0.dot(n1).abs() >= 1.0 - tol.angular
+            && (c0.center() - c1.center()).length() <= tol.linear
+            && (c0.radius() - c1.radius()).abs() <= tol.linear
+    };
+    let mut out: Vec<ProfileEdgeGeom> = Vec::with_capacity(edges.len());
+    for e in edges {
+        let merge = matches!(&e.curve, EdgeCurve::Circle(_))
+            && out.last().is_some_and(|last| {
+                matches!(
+                    (&last.curve, &e.curve),
+                    (EdgeCurve::Circle(c0), EdgeCurve::Circle(c1)) if same_circle(c0, c1)
+                )
+            });
+        if merge && let Some(last) = out.last_mut() {
+            last.end = e.end;
+        } else {
+            out.push(e);
+        }
+    }
+    // Wrap-around: a corner split across the closing seam (leading & trailing
+    // arcs share a circle). Fold the trailing arc back into the leading one.
+    if out.len() > 2 {
+        let wrap = matches!(
+            (&out[0].curve, &out[out.len() - 1].curve),
+            (EdgeCurve::Circle(cf), EdgeCurve::Circle(cl)) if same_circle(cf, cl)
+        );
+        if wrap
+            && let Some(last) = out.pop()
+            && let Some(first) = out.first_mut()
+        {
+            first.start = last.start;
+        }
+    }
+    out
+}
+
 /// Extract a planar profile's outer-wire edges in traversal order, each
 /// oriented so `start`→`end` follows the wire. Returns `None` if the face is
 /// not planar or has inner wires (holes) — the general loft handles those.
@@ -398,7 +450,7 @@ fn profile_oriented_edges(topo: &Topology, fid: FaceId) -> Option<Vec<ProfileEdg
             end,
         });
     }
-    Some(out)
+    Some(merge_cocircular_arcs(out))
 }
 
 /// When two corner arcs are coaxial (same axis direction, centers differing

--- a/crates/operations/src/loft/tests.rs
+++ b/crates/operations/src/loft/tests.rs
@@ -597,3 +597,60 @@ fn loft_rounded_rect_preserves_arc_corners() {
         "rounded-rect frustum volume {vol:.1} should be within 2% of ~{approx:.1}"
     );
 }
+
+#[test]
+fn loft_multi_section_rounded_rect_preserves_arc_corners() {
+    // Regression: a multi-section (>2 profile) rounded-rect loft must keep its
+    // arc corners curve-preserved (NURBS/Cone), not facet them to a polygon. A
+    // faceted multi-section lip/socket is what drove the gridfinity bin fuse to
+    // its non-manifold mesh fallback. Before the fix this was gated out
+    // (`num_profiles != 2`) and fell back to the all-planar polygon loft.
+    let mut topo = Topology::new();
+    let p: Vec<FaceId> = [
+        (10.0, 10.0, 2.0, 0.0),
+        (11.0, 11.0, 2.2, 3.0),
+        (12.0, 12.0, 2.5, 6.0),
+        (14.0, 14.0, 3.0, 10.0),
+    ]
+    .iter()
+    .map(|&(hw, hd, r, z)| make_rr_arcs(&mut topo, hw, hd, r, z))
+    .collect();
+
+    let solid = loft(&mut topo, &p).unwrap();
+    let s = topo.solid(solid).unwrap();
+    let sh = topo.shell(s.outer_shell()).unwrap();
+    let faces = sh.faces();
+
+    // 2 caps + 3 bands * (4 straight walls + 4 arc corners) = 26 faces.
+    assert_eq!(
+        faces.len(),
+        26,
+        "4-section rounded-rect loft should have 26 faces"
+    );
+    let curved = faces
+        .iter()
+        .filter(|&&f| {
+            matches!(
+                topo.face(f).unwrap().surface(),
+                FaceSurface::Nurbs(_) | FaceSurface::Cone(_) | FaceSurface::Cylinder(_)
+            )
+        })
+        .count();
+    assert_eq!(
+        curved, 12,
+        "3 bands x 4 arc corners = 12 curve-preserved side faces (not faceted)"
+    );
+
+    let manifold = brepkit_topology::validation::validate_shell_manifold(sh, &topo);
+    assert!(
+        manifold.is_ok(),
+        "multi-section loft should be a closed manifold: {manifold:?}"
+    );
+    let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(&topo, solid).unwrap();
+    #[allow(clippy::cast_possible_wrap)]
+    let euler = (v as i64) - (e as i64) + (f as i64);
+    assert_eq!(
+        euler, 2,
+        "multi-section frustum should be genus-0 (F={f} E={e} V={v})"
+    );
+}

--- a/crates/operations/src/loft/tests.rs
+++ b/crates/operations/src/loft/tests.rs
@@ -654,3 +654,94 @@ fn loft_multi_section_rounded_rect_preserves_arc_corners() {
         "multi-section frustum should be genus-0 (F={f} E={e} V={v})"
     );
 }
+
+/// Rounded-rect profile with each 90° corner split into TWO co-circular arcs,
+/// mimicking drawn rounded-rects that split corners inconsistently with size.
+fn make_rr_arcs_split(topo: &mut Topology, hw: f64, hd: f64, r: f64, z: f64) -> FaceId {
+    use brepkit_math::curves::Circle3D;
+    let r = r.min(hw.min(hd));
+    let cc = [
+        Point3::new(hw - r, -hd + r, z),
+        Point3::new(hw - r, hd - r, z),
+        Point3::new(-hw + r, hd - r, z),
+        Point3::new(-hw + r, -hd + r, z),
+    ];
+    let ap = [
+        (Point3::new(hw - r, -hd, z), Point3::new(hw, -hd + r, z)),
+        (Point3::new(hw, hd - r, z), Point3::new(hw - r, hd, z)),
+        (Point3::new(-hw + r, hd, z), Point3::new(-hw, hd - r, z)),
+        (Point3::new(-hw, -hd + r, z), Point3::new(-hw + r, -hd, z)),
+    ];
+    let axis = Vec3::new(0.0, 0.0, 1.0);
+    let mut v = Vec::new();
+    for p in &ap {
+        v.push(topo.add_vertex(Vertex::new(p.0, 1e-7)));
+        v.push(topo.add_vertex(Vertex::new(p.1, 1e-7)));
+    }
+    let mut e = Vec::new();
+    e.push(topo.add_edge(Edge::new(v[7], v[0], EdgeCurve::Line)));
+    for i in 0..4 {
+        let circle = Circle3D::new(cc[i], axis, r).unwrap();
+        // Bisector midpoint splits the 90° corner into two co-circular sub-arcs.
+        let bis = ((ap[i].0 - cc[i]) + (ap[i].1 - cc[i])).normalize().unwrap();
+        let vmid = topo.add_vertex(Vertex::new(cc[i] + bis * r, 1e-7));
+        e.push(topo.add_edge(Edge::new(v[2 * i], vmid, EdgeCurve::Circle(circle.clone()))));
+        e.push(topo.add_edge(Edge::new(vmid, v[2 * i + 1], EdgeCurve::Circle(circle))));
+        if i < 3 {
+            e.push(topo.add_edge(Edge::new(v[2 * i + 1], v[2 * i + 2], EdgeCurve::Line)));
+        }
+    }
+    let wire = Wire::new(
+        e.iter().map(|&id| OrientedEdge::new(id, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane { normal: axis, d: z },
+    ))
+}
+
+#[test]
+fn loft_merges_split_arc_corners_for_curve_preservation() {
+    // One profile with single-arc corners + one whose corners are split into two
+    // co-circular sub-arcs (as drawn rounded-rects do, inconsistently). They must
+    // still curve-preserve: the arc-merge pass canonicalizes both so their edges
+    // align. Before the fix the 8-vs-12 edge-count mismatch forced the faceted
+    // polygon loft — the gridfinity lip's faceting.
+    let mut topo = Topology::new();
+    let single = make_rr_arcs(&mut topo, 12.0, 12.0, 2.5, 0.0); // 8 edges, corner center 9.5
+    let split = make_rr_arcs_split(&mut topo, 11.5, 11.5, 2.0, 5.0); // 12 edges, center 9.5
+    let solid = loft(&mut topo, &[single, split]).unwrap();
+    let sh = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+    let curved = sh
+        .faces()
+        .iter()
+        .filter(|&&f| {
+            matches!(
+                topo.face(f).unwrap().surface(),
+                FaceSurface::Nurbs(_) | FaceSurface::Cone(_) | FaceSurface::Cylinder(_)
+            )
+        })
+        .count();
+    assert_eq!(
+        curved, 4,
+        "the 4 corners must stay curve-preserved despite the split-arc profile"
+    );
+    let manifold = brepkit_topology::validation::validate_shell_manifold(sh, &topo);
+    assert!(
+        manifold.is_ok(),
+        "split-arc loft should be a closed manifold: {manifold:?}"
+    );
+    let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(&topo, solid).unwrap();
+    #[allow(clippy::cast_possible_wrap)]
+    let euler = (v as i64) - (e as i64) + (f as i64);
+    assert_eq!(
+        euler, 2,
+        "split-arc frustum should be genus-0 (F={f} E={e} V={v})"
+    );
+}

--- a/crates/operations/tests/coaxial_cone_cut_classification.rs
+++ b/crates/operations/tests/coaxial_cone_cut_classification.rs
@@ -1,0 +1,38 @@
+//! Regression: a Cut between two coaxial truncated cones that share their top
+//! cap must keep the inner cone wall as the cavity boundary.
+//!
+//! The inner cone (r9->8) lies strictly inside the outer cone (r10->8) except
+//! at the shared top rim (r8 @ z=10). For the Cut, the inner wall must be kept
+//! and reversed as the cavity boundary. The classifier samples an interior
+//! point of each sub-face; before the `interior_point_3d` axial-midpoint fix,
+//! the inner wall's sample landed on a bounding circle (the shared top rim, a
+//! boundary of the opposing solid), so it classified `Outside` and the Cut
+//! dropped it — collapsing the result to a single open face.
+
+#![allow(clippy::unwrap_used)]
+
+use brepkit_algo::bop::BooleanOp;
+use brepkit_algo::gfa;
+use brepkit_operations::primitives::make_cone;
+use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
+
+#[test]
+fn coaxial_cone_cut_keeps_inner_cavity_wall() {
+    let mut topo = Topology::new();
+    let outer = make_cone(&mut topo, 10.0, 8.0, 10.0).unwrap();
+    let inner = make_cone(&mut topo, 9.0, 8.0, 10.0).unwrap();
+
+    let result = gfa::boolean(&mut topo, BooleanOp::Cut, outer, inner).unwrap();
+
+    let cones = solid_faces(&topo, result)
+        .unwrap()
+        .iter()
+        .filter(|&&f| topo.face(f).unwrap().surface().type_tag() == "cone")
+        .count();
+
+    assert!(
+        cones >= 2,
+        "Cut must keep both cone walls (outer + reversed inner cavity wall); got {cones}"
+    );
+}

--- a/crates/operations/tests/coaxial_cone_cut_classification.rs
+++ b/crates/operations/tests/coaxial_cone_cut_classification.rs
@@ -15,6 +15,7 @@ use brepkit_algo::bop::BooleanOp;
 use brepkit_algo::gfa;
 use brepkit_operations::primitives::make_cone;
 use brepkit_topology::Topology;
+use brepkit_topology::adjacency::AdjacencyIndex;
 use brepkit_topology::explorer::solid_faces;
 
 #[test]
@@ -25,14 +26,30 @@ fn coaxial_cone_cut_keeps_inner_cavity_wall() {
 
     let result = gfa::boolean(&mut topo, BooleanOp::Cut, outer, inner).unwrap();
 
-    let cones = solid_faces(&topo, result)
-        .unwrap()
+    // The cut is a conical washer: outer cone wall + reversed inner cavity
+    // wall + bottom annulus = three analytic faces, all curved/planar (never a
+    // mesh fallback). The shared top rim (where the cone-cone intersection
+    // circle coincides with both cones' top boundary) must be a single linked
+    // edge, so the shell is watertight (every edge shared by exactly 2 faces).
+    let faces = solid_faces(&topo, result).unwrap();
+    let cones = faces
         .iter()
         .filter(|&&f| topo.face(f).unwrap().surface().type_tag() == "cone")
         .count();
+    let planes = faces
+        .iter()
+        .filter(|&&f| topo.face(f).unwrap().surface().type_tag() == "plane")
+        .count();
+    assert_eq!(cones, 2, "expected both cone walls, got {cones}");
+    assert_eq!(planes, 1, "expected the bottom annulus, got {planes}");
 
-    assert!(
-        cones >= 2,
-        "Cut must keep both cone walls (outer + reversed inner cavity wall); got {cones}"
+    let adj = AdjacencyIndex::build_from_faces(&topo, &faces).unwrap();
+    let free = adj
+        .edge_faces_iter()
+        .filter(|(_, fs)| fs.len() != 2)
+        .count();
+    assert_eq!(
+        free, 0,
+        "cut shell must be watertight, got {free} free edges"
     );
 }

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -1718,3 +1718,70 @@ fn box_volume_sanity() {
         rel_error * 100.0
     );
 }
+
+/// Regression: a rounded-rectangle shelled body (open-top hollow) must
+/// classify a point in its OPEN CAVITY as Outside, not Inside. The analytic
+/// composite classifier modelled the rounded corners as `ConvexAnalytic`
+/// intersection constraints (`radial_dist < radius` for every corner
+/// cylinder), which the cavity centre fails (it is far from every corner) —
+/// so the cavity was wrongly classified Inside, dropping a fused lip's
+/// inner-cavity faces and forcing a mesh-boolean fallback. The composite now
+/// bails to the exact ray-cast classifier when a cylinder/cone does not
+/// contain the centroid.
+#[test]
+fn rounded_shelled_body_classifies_cavity_outside() {
+    use brepkit_math::vec::Point3;
+    let mut k = BrepKernel::new();
+    let bf = make_rounded_rect_face(&mut k, OUTER_DIM, OUTER_DIM, CORNER_R, 0.0);
+    let bs = parse_batch(&k.execute_batch(&format!(
+        r#"[{{"op":"extrude","args":{{"face":{bf},"dz":1.0,"distance":{WALL_HEIGHT}}}}}]"#
+    )))[0]["ok"]
+        .as_u64()
+        .unwrap() as u32;
+    let tf = k
+        .get_solid_faces(bs)
+        .unwrap()
+        .iter()
+        .copied()
+        .find(|&fh| {
+            k.resolve_face(fh)
+                .ok()
+                .and_then(|fid| k.topo.face(fid).ok())
+                .and_then(brepkit_topology::face::Face::effective_plane_normal)
+                .is_some_and(|n| n.z() > 0.5 * n.length())
+        })
+        .unwrap();
+    let shelled = parse_batch(&k.execute_batch(&format!(
+        r#"[{{"op":"shell","args":{{"solid":{bs},"thickness":{WALL_THICKNESS},"faces":[{tf}]}}}}]"#
+    )))[0]["ok"]
+        .as_u64()
+        .unwrap() as u32;
+    let sid = k.resolve_solid(shelled).unwrap();
+    let topo = &*k.topo;
+    let cavity = brepkit_algo::classifier::classify_point(
+        topo,
+        sid,
+        Point3::new(0.0, 0.0, WALL_HEIGHT / 2.0),
+    )
+    .unwrap();
+    assert_eq!(
+        cavity,
+        brepkit_algo::FaceClass::Outside,
+        "open-cavity centre must classify Outside, got {cavity:?}"
+    );
+    let wall = brepkit_algo::classifier::classify_point(
+        topo,
+        sid,
+        Point3::new(
+            OUTER_DIM / 2.0 - WALL_THICKNESS / 2.0,
+            0.0,
+            WALL_HEIGHT / 2.0,
+        ),
+    )
+    .unwrap();
+    assert_eq!(
+        wall,
+        brepkit_algo::FaceClass::Inside,
+        "wall-material point must classify Inside, got {wall:?}"
+    );
+}

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -797,16 +797,17 @@ fn section_dims(inset: f64) -> (f64, f64, f64) {
     (w, d, r)
 }
 
-/// Build 5 outer sections (with lip extension) and return face handles.
+/// Build the outer lip sections and return face handles.
+///
+/// The outer frustum is a rectangular tube FLUSH with the bin wall
+/// (inset = 0) — it must coincide with the body's outer wall so the lip
+/// fuses onto the body. (An earlier version tapered the outer profile,
+/// which left the lip narrower than the wall and disjoint from the body, so
+/// the fuse dropped it.) Only the INNER sections taper to form the stacking
+/// ledge. Two sections (bottom extension + peak) suffice for a flush tube.
 fn make_outer_sections(k: &mut BrepKernel) -> Vec<u32> {
     let mut faces = Vec::new();
-    let sections: [(f64, f64); 5] = [
-        (Z_EXT, INSET_BOTTOM),
-        (Z_BASE, INSET_BOTTOM),
-        (Z_TAPER1, INSET_MID),
-        (Z_VERT, INSET_MID),
-        (Z_PEAK, INSET_TOP),
-    ];
+    let sections: [(f64, f64); 2] = [(Z_EXT, 0.0), (Z_PEAK, 0.0)];
     for &(z, inset) in &sections {
         let (w, d, r) = section_dims(inset);
         faces.push(make_rounded_rect_face(k, w, d, r, z));
@@ -1313,8 +1314,10 @@ fn gridfinity_d3_shelled_box_with_lip() {
     assert_ok(&p5, 0);
     let lip_handle = p5[0]["ok"].as_u64().unwrap() as u32;
 
-    // Translate lip to top of box
-    let mat = translate_matrix(0.0, 0.0, WALL_HEIGHT);
+    // Translate lip to top of box. The lip sections are centered at the
+    // origin, but `makeBox` spans [0,DIM] (corner at origin), so the lip must
+    // also be shifted to the box centre or it overlaps only one quadrant.
+    let mat = translate_matrix(OUTER_DIM / 2.0, OUTER_DIM / 2.0, WALL_HEIGHT);
     let r6 = k.execute_batch(&format!(
         r#"[{{"op": "transform", "args": {{"solid": {lip_handle}, "matrix": {mat}}}}}]"#
     ));


### PR DESCRIPTION
## What

Makes the full gridfinity **1×1 bin (d4)** analytic and closed-manifold end to end, instead of collapsing to a non-manifold mesh-boolean fallback (was Euler≈−85, ~290 all-planar faces, ~5× volume). The bin's stacking lip exercises three GFA weaknesses in sequence — a multi-section curve-preserving loft, a coaxial-cone cut, and a coincident-ring fuse — each fixed here. They are landed together because the loft fix alone regresses d3/d4 (the now-analytic lip drives the still-broken cut/fuse differently), so the chain must be atomic.

### Loft (analytic lip profiles)
1. Relax the curve-preserving loft's `>2`-profile gate (`loft.rs`) — the section loops already build one ruled band per adjacent pair, so allow N≥2.
2. Merge co-circular corner arcs in `profile_oriented_edges` — `drawRoundedRectangle` emits a 90° corner as one arc on some sections and two co-circular sub-arcs on others (lip sections came in 8/12/12/12 edges), defeating the per-index matcher. Normalize to canonical one-arc-per-corner.

### Cut (coaxial cone cavity)
3. Sample cone/cylinder cavity walls at the axial midpoint for cut classification — the inner cavity wall's interior sample landed exactly on the coincident top rim (a shared boundary), where the analytic classifier returns None and ray-cast says Outside, dropping the wall.
4. Exact algebraic coaxial cone-cone intersection yielding one clean `Circle` (`math`) + emitting it as `EdgeCurve::Circle` so it links to the shared cap boundary (was ~97 degenerate micro-curves from the grid marcher).
5. Robust interior-point + partial-cylinder ray classification; bail the composite classifier to ray-cast for corner-fillet cylinders; trim partial closed ellipse/NURBS FF curves to their in-both arc.

### Fuse (shelled lip → body)
6. Split CW cavity walls and nest holes in `split_face_2d` (`face_splitter`): an inner-shell cavity corner winds CW in UV, so the CW sign-flip must fire independent of loop count (it was gated to `loops.len() <= 1`), else both v-bands of a section-split corner read as holes and collapse to one sub-face — orphaning the wall's top edge. And nested holes from a section-split holed annulus are assigned to the **innermost** containing sub-face via mutual point-in-polygon (robust to arc-wire UV-area under-measurement), not the first container.

## Result (the real gate — wasm gridfinity bin tests, not the ops --lib suite)

- **d4 full 1×1 bin: faces=68, Euler 2 (genus-0, inner_loops=2), volume 10760 mm³, lip present (z→25.4)** — analytic, closed-manifold. Was the mesh fallback.
- d3 shelled box + lip: pass (196 faces). d1/d1a/d1a2/d1a1c/d1b/d2: pass.
- New native repro `fuse_shelled_cup_lip_covers_cavity_opening` (fast proxy for the lip→body fuse).
- `cargo test --workspace`: 2316 passed, 0 failed (51 binaries). clippy `-D warnings`, fmt, boundaries clean.

d5 (filleted lip) remains ignored — the boolean is clean (Euler 2) but the fillet stage re-introduces boundary edges; separate follow-up.