### PR TITLE
fix(operations): close arc-runout corners in rolling-ball fillet

### DIFF
--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -822,6 +822,68 @@ pub fn fillet_rolling_ball(
     };
     log::debug!("fillet contact map: {} entries", fillet_contact_map.len());
 
+    // Arc-runout closure data. When a single arc fillet terminates tangent to a
+    // flat neighbour, its strip end cross-section straddles two planes (the two
+    // contact-face planes) and cannot be shared by either neighbour alone. The
+    // gap is a small planar triangle: the original corner C, the contact A on
+    // one fillet face, and the contact B on the other. Closing it requires both
+    // contact faces to keep C (so the triangle's two straight legs C→A and C→B
+    // are shared) plus the triangle facet itself (Phase 5e).
+    //
+    // Key: corner vertex index → (corner C, contact A on fa, fa, contact B on fb, fb).
+    #[allow(clippy::type_complexity)]
+    let arc_runout: HashMap<usize, (Point3, Point3, usize, Point3, usize)> = {
+        let mut map = HashMap::new();
+        for &edge_id in &filtered_edges {
+            // Only arcs run out tangent to a neighbour; straight fillets meet a
+            // perpendicular face whose plane already contains the strip end.
+            let Ok(edge) = topo.edge(edge_id) else {
+                continue;
+            };
+            if !matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Circle(_)) {
+                continue;
+            }
+            let Some(face_list) = edge_to_faces.get(&edge_id.index()) else {
+                continue;
+            };
+            if face_list.len() < 2 {
+                continue;
+            }
+            let (fa, fb) = (face_list[0], face_list[1]);
+            for vid in [edge.start(), edge.end()] {
+                let vi = vid.index();
+                // Exactly one filleted edge ends here (a true runout endpoint,
+                // not an interior chain junction handled by the corner patch).
+                if vertex_fillet_edges.get(&vi).map_or(0, Vec::len) != 1 {
+                    continue;
+                }
+                if g1_chain_vertices.contains(&vi) {
+                    continue;
+                }
+                let (Some(&ca), Some(&cb)) = (
+                    fillet_contact_map.get(&(vi, edge_id.index(), fa.index())),
+                    fillet_contact_map.get(&(vi, edge_id.index(), fb.index())),
+                ) else {
+                    continue;
+                };
+                let c = match topo.vertex(vid) {
+                    Ok(v) => v.point(),
+                    Err(_) => continue,
+                };
+                // Skip degenerate triangles (contacts coincident with the
+                // corner or each other).
+                if (ca - c).length() < tol.linear
+                    || (cb - c).length() < tol.linear
+                    || (ca - cb).length() < tol.linear
+                {
+                    continue;
+                }
+                map.insert(vi, (c, ca, fa.index(), cb, fb.index()));
+            }
+        }
+        map
+    };
+
     // Phase 3: Build modified (trimmed) planar faces.
     let mut all_specs: Vec<FaceSpec> = Vec::new();
 
@@ -1078,6 +1140,33 @@ pub fn fillet_rolling_ball(
                 // Side face: use the two unique Phase 4 fillet contacts,
                 // paired by proximity to boundary offsets.
                 (false, false, true) => {
+                    // Arc runout: this flat side face only touches the strip at
+                    // a single contact lying on its own plane (the tangent
+                    // point). Keep the corner and split the adjacent edge there
+                    // so the runout triangle's leg corner→contact is shared.
+                    let runout_contact = arc_runout.get(&vi).and_then(|&(_, ca, _, cb, _)| {
+                        [ca, cb].into_iter().find(|p| {
+                            (poly.normal.dot(Vec3::new(p.x(), p.y(), p.z())) - poly.d).abs()
+                                < tol.linear * 100.0
+                        })
+                    });
+                    if let Some(b) = runout_contact {
+                        // Orient: keep the corner on the side of the un-split
+                        // edge, place the contact on the edge it lies along.
+                        let on_next = (next_pos - pos)
+                            .normalize()
+                            .ok()
+                            .is_some_and(|dn| (b - pos).dot(dn) > 0.0);
+                        if on_next {
+                            new_verts.push(pos);
+                            new_verts.push(b);
+                        } else {
+                            new_verts.push(b);
+                            new_verts.push(pos);
+                        }
+                        continue;
+                    }
+
                     let mut unique_contacts: Vec<Point3> = Vec::new();
                     for (&(vi_k, _, _), &pt) in &fillet_contact_map {
                         if vi_k == vi {
@@ -1117,6 +1206,12 @@ pub fn fillet_rolling_ball(
                         let dir = (next_pos - pos).normalize()?;
                         new_verts.push(pos + dir * radius);
                     }
+                    // Arc runout: keep the original corner so the runout
+                    // triangle's leg (contact→corner, along the unfilleted edge)
+                    // is shared with this face (Phase 5e closes the strip end).
+                    if arc_runout.contains_key(&vi) {
+                        new_verts.push(pos);
+                    }
                     // The "after" edge is the unfilleted edge at this corner.
                     // If the filleted edge was set back here, preserve it.
                     if setback_map.contains_key(&(ei, vi))
@@ -1138,6 +1233,11 @@ pub fn fillet_rolling_ball(
                         let p = pos + dir * radius;
                         new_verts.push(p);
                         corner_preserved.entry(vi).or_insert(p);
+                    }
+                    // Arc runout: keep the original corner (before the contact)
+                    // so the runout triangle's leg is shared with this face.
+                    if arc_runout.contains_key(&vi) {
+                        new_verts.push(pos);
                     }
                     if let Some(&pt) = fillet_contact_map.get(&(vi, ei, fi)) {
                         new_verts.push(pt);
@@ -1952,6 +2052,52 @@ pub fn fillet_rolling_ball(
                 }
             }
         }
+    }
+
+    // Phase 5e: Close arc-runout strip ends with a planar triangle facet.
+    // At a single-arc runout the strip end cross-section (contact A → contact B)
+    // is joined to the original corner C via two legs (C→A on one fillet face,
+    // C→B on the other, both kept in Phase 3). The triangle A–C–B fills the gap.
+    for (&vi, &(c, ca, _fa, cb, _fb)) in &arc_runout {
+        // Outward direction: along the filleted arc's tangent at C, pointing
+        // away from the edge interior (out of the solid at the runout).
+        let outward = vertex_fillet_edges
+            .get(&vi)
+            .and_then(|edges| edges.first().copied())
+            .and_then(|eid| {
+                let edge = topo.edge(eid).ok()?;
+                let p_s = topo.vertex(edge.start()).ok()?.point();
+                let p_e = topo.vertex(edge.end()).ok()?.point();
+                let curve = edge.curve().clone();
+                let (t_self, sign) = if edge.start().index() == vi {
+                    (0.0, -1.0)
+                } else {
+                    (1.0, 1.0)
+                };
+                (sample_edge_tangent(&curve, p_s, p_e, t_self) * sign)
+                    .normalize()
+                    .ok()
+            });
+        let Some(outward) = outward else { continue };
+
+        // Order (C, A, B) so the facet normal agrees with `outward`.
+        let n = (ca - c).cross(cb - c);
+        let verts = if n.dot(outward) >= 0.0 {
+            vec![c, ca, cb]
+        } else {
+            vec![c, cb, ca]
+        };
+        let normal = match (verts[1] - verts[0]).cross(verts[2] - verts[0]).normalize() {
+            Ok(nn) => nn,
+            Err(_) => continue,
+        };
+        let d = dot_normal_point(normal, verts[0]);
+        all_specs.push(FaceSpec::Planar {
+            vertices: verts,
+            normal,
+            d,
+            inner_wires: vec![],
+        });
     }
 
     // Phase 6: Assemble the solid using mixed-surface assembly.  Each fillet

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -1365,7 +1365,10 @@ fn gridfinity_d3_shelled_box_with_lip() {
 /// Like D3 but with fillet on the lip ring before fuse.
 /// Tests whether the analytic boolean handles torus faces from fillet.
 #[test]
-#[ignore = "boolean cut is now clean (Euler=2, val=0); fillet re-introduces boundary edges at cap planes — 3 validation issues vs <=2 asserted, post-fillet Euler=1"]
+#[ignore = "fillet is now watertight (post-fillet Euler=2, val=0, 0 boundary edges); \
+            the remaining blocker is the lip→body fuse falling back to mesh boolean \
+            (coincident box-top/lip-bottom contact, same path d3 takes) which yields \
+            >200 faces. That fuse is a separate GFA same-domain bug, not the fillet."]
 fn gridfinity_d5_box_with_filleted_lip() {
     let mut k = BrepKernel::new();
 
@@ -1501,11 +1504,10 @@ fn gridfinity_d5_box_with_filleted_lip() {
         }
     }
 
-    // The boolean cut now produces a manifold lip (val=0 before fillet).
-    // The fillet re-introduces boundary edges at cap planes (z=4.40, z=-1.20)
-    // because trimmed faces don't share edges with untouched cap faces —
-    // a separate fillet-level issue. Assert the fillet doesn't make things
-    // worse than the known 16 boundary edges (2 validation errors).
+    // The boolean cut produces a manifold lip (val=0 before fillet) and the
+    // fillet now closes its arc-runout corners, so the filleted lip is itself a
+    // watertight closed shell (Euler=2, val=0, zero boundary edges). The fuse
+    // below is the remaining blocker (see the #[ignore] note).
     assert!(
         lip_val <= 2,
         "filleted lip should have <= 2 validation issues, got {lip_val}"


### PR DESCRIPTION
## Summary

Fixes a watertightness bug in the rolling-ball fillet engine when a single **circular-arc** edge is filleted and **runs out tangent to a flat neighbour** — e.g. the rounded bottom rim of a gridfinity lip ring.

Previously, the filleted lip in `gridfinity_d5_box_with_filleted_lip` came out as an **open shell** (Euler=0, 4 free edges at the rounded corner). It is now a genuinely **watertight closed shell**: post-fillet **Euler=2, val=0, zero boundary edges**.

## Root cause

The rolling-ball engine rebuilds every face as a polygon and re-assembles via `assemble_solid_mixed`, which shares edges by coincident vertex pairs. At an arc-runout endpoint the fillet strip's end cross-section runs from a contact `A` on one fillet face to a contact `B` on the other; that segment **straddles two contact-face planes** and cannot be shared by either neighbour alone, so the strip end was a free edge.

Two concrete defects:
1. The flat **side face** trim (`(false,false,true)` branch) absorbed *both* contacts at the shared corner — including the contact on the *perpendicular* face, an off-plane point — which zig-zagged the wall boundary and opened a 4-edge hole.
2. Nothing closed the strip end: with only one filleted arc at the vertex, no corner patch was built (Phase 5b only fires for 2+ edge junctions).

## Fix

- Detect arc-runout endpoints: exactly one filleted **Circle** edge terminating at a non-G1, non-chain vertex (`arc_runout` map).
- The two contact faces now **keep the original corner C**, so the triangle's straight legs `C→A` and `C→B` are shared edges.
- The side-face trim uses **only the contact lying on its own plane**, keeps `C`, and splits the adjacent edge there.
- New **Phase 5e** adds a planar triangle facet `A–C–B` that closes each strip end (outward-oriented from the arc tangent).

The change is guarded on `Circle` edges, so the straight-box-edge fillet path is untouched.

## Verification

- `gridfinity_d5` filleted lip: **F=45 E=103 V=60 Euler=2 val=0, 0 boundary edges** (was Euler=0, 4 free edges).
- `cargo test -p brepkit-operations` (689 lib + integration), `-p brepkit-blend` (93), `-p brepkit-wasm` (225), and the full `gridfinity` suite (25) — **all green**, no regressions.
- fmt, `clippy --workspace --all-targets -D warnings`, `check-boundaries.sh` — clean.

## Why d5 stays `#[ignore]`d

This PR makes the **fillet** watertight, which was the goal. The d5 test then proceeds to **fuse the lip onto the box**, and that fuse falls back to the mesh boolean (yielding >200 faces, failing the test's `< 200` assertion). That fallback is a **separate, pre-existing GFA same-domain bug** at the coincident box-top / lip-bottom contact — the exact same fallback `gridfinity_d3` already takes (d3 just lands under the face limit). It is unrelated to the fillet, so d5 remains ignored with an updated reason. This PR does **not** claim d5 passes.