### PR TITLE
fix(algo): orient solids by surface normal so extrude-down operands fuse (baseplate dovetail hang)

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -439,10 +439,37 @@ fn shell_is_closed(topo: &Topology, faces: &[FaceId]) -> bool {
     !edge_counts.is_empty() && edge_counts.values().all(|&c| c % 2 == 0)
 }
 
+/// Newell's method normal for a polygon (unnormalized; magnitude = 2·area).
+/// Robust to non-planar / non-convex loops.
+fn newell_normal(verts: &[Point3]) -> Vec3 {
+    let n = verts.len();
+    let mut nx = 0.0;
+    let mut ny = 0.0;
+    let mut nz = 0.0;
+    for i in 0..n {
+        let a = verts[i];
+        let b = verts[(i + 1) % n];
+        nx += (a.y() - b.y()) * (a.z() + b.z());
+        ny += (a.z() - b.z()) * (a.x() + b.x());
+        nz += (a.x() - b.x()) * (a.y() + b.y());
+    }
+    Vec3::new(nx, ny, nz)
+}
+
 /// Compute a signed volume estimate for a shell using the divergence theorem.
 ///
 /// Positive = outward-oriented normals (growth shell).
 /// Negative = inward-oriented normals (hole shell).
+///
+/// Each face's fan-triangulation contribution is oriented by the face's actual
+/// geometric surface normal (which already accounts for `is_reversed`), not by
+/// the raw outer-wire winding. The two agree for solids built with a
+/// CCW-against-the-outward-normal convention (e.g. `make_box`), but diverge for
+/// equally valid solids whose wires were wound the other way (e.g. a profile
+/// extruded *opposite* its face normal). Trusting the wire winding alone made
+/// such a solid read as negative volume, so every shell of a fuse that
+/// consumed it got misclassified as a hole and assembly failed. Anchoring the
+/// sign to the surface normal makes the classifier construction-independent.
 fn signed_volume_of_shell(topo: &Topology, faces: &[FaceId]) -> f64 {
     let mut volume = 0.0;
 
@@ -467,13 +494,38 @@ fn signed_volume_of_shell(topo: &Topology, faces: &[FaceId]) -> f64 {
             continue;
         }
 
-        // Fan triangulation from first vertex
+        // Sign the contribution by the face's outward geometric normal rather
+        // than the wire winding. Use the wire's centroid as the projection
+        // point so curved-surface normals are evaluated near the face interior.
+        let centroid = {
+            let mut c = Vec3::new(0.0, 0.0, 0.0);
+            for v in &verts {
+                c = Vec3::new(c.x() + v.x(), c.y() + v.y(), c.z() + v.z());
+            }
+            let inv = 1.0 / verts.len() as f64;
+            Point3::new(c.x() * inv, c.y() * inv, c.z() * inv)
+        };
+        let wound_normal = newell_normal(&verts);
+        let sign = match face_normal_at(topo, fid, centroid) {
+            // Flip when the wire winds opposite the outward normal so the
+            // fan tets are consistent with the divergence-theorem convention.
+            Some(outward) if wound_normal.dot(outward) < 0.0 => -1.0,
+            Some(_) => 1.0,
+            // No geometric normal available (degenerate face): fall back to the
+            // legacy is_reversed sign.
+            None => {
+                if face.is_reversed() {
+                    -1.0
+                } else {
+                    1.0
+                }
+            }
+        };
         let v0 = verts[0];
-        let sign = if face.is_reversed() { -1.0 } else { 1.0 };
         for i in 1..verts.len() - 1 {
             let v1 = verts[i];
             let v2 = verts[i + 1];
-            // Signed volume of tetrahedron with origin
+            // Signed volume of tetrahedron with the origin as apex.
             volume += sign
                 * (v0.x() * (v1.y() * v2.z() - v2.y() * v1.z())
                     + v1.x() * (v2.y() * v0.z() - v0.y() * v2.z())

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4308,3 +4308,206 @@ fn issue_801_slot_fuse_recovers_volume() {
     assert_cut_fuse_back_recovers(12.0, 4.0, 4.0);
     assert_cut_fuse_back_recovers(8.0, 3.0, 2.0);
 }
+
+// ── Gridfinity baseplate dovetail-connector fuse ────────────────────────────
+//
+// The tool builds dovetail tongues as a trapezoidal XY profile (narrow base at
+// the wall, wider protruding tip) drawn CLOCKWISE and extruded DOWN the slab
+// height, then fuses them onto the slab whose base edge they overlap. Two bugs
+// made that fuse fail and the baseplate export hang:
+//
+//   1. A CW profile extruded *opposite* its face normal produced inside-out cap
+//      faces (the tongue's volume read ~1/3 of its true value), which broke the
+//      coincident-cap fuse into a non-manifold result. Fixed in `extrude`.
+//   2. The GFA shell-orientation classifier (`signed_volume_of_shell`) signed
+//      shells by raw wire winding, so any solid built by extrude-DOWN (every
+//      tool slab) read as negative volume → "all shells classified as holes" →
+//      GFA failed → mesh-boolean fallback ran on ever-growing corrupt geometry,
+//      one fuse per tongue, until the export timed out. Fixed in the algo
+//      builder (sign by the geometric surface normal).
+
+/// Build a dovetail tongue exactly as the tool does: a CW trapezoid extruded
+/// down. `tip_half == base_half` degenerates to a rectangular protrusion.
+fn dovetail_tongue(
+    topo: &mut Topology,
+    wall_x: f64,
+    bp_y: f64,
+    height: f64,
+    overlap: f64,
+    base_half: f64,
+    tip_half: f64,
+) -> SolidId {
+    let base_x = wall_x - overlap; // extended INTO the slab
+    let tip_x = wall_x + 1.5; // protrudes out
+    // CW order viewed from +Z, matching the tool's `makeTongue` draw order.
+    let pts = [
+        Point3::new(base_x, bp_y + base_half, 0.0),
+        Point3::new(tip_x, bp_y + tip_half, 0.0),
+        Point3::new(tip_x, bp_y - tip_half, 0.0),
+        Point3::new(base_x, bp_y - base_half, 0.0),
+    ];
+    let vids: Vec<_> = pts
+        .iter()
+        .map(|&p| topo.add_vertex(Vertex::new(p, 1e-7)))
+        .collect();
+    let n = vids.len();
+    let eids: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(vids[i], vids[(i + 1) % n], EdgeCurve::Line)))
+        .collect();
+    let wire = Wire::new(
+        eids.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let face = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    crate::extrude::extrude(topo, face, Vec3::new(0.0, 0.0, -1.0), height).unwrap()
+}
+
+/// Slab built the way the tool builds it: a CCW rectangle extruded DOWN (top at
+/// z=0, bottom at z=-h).
+fn dovetail_slab(topo: &mut Topology, w: f64, d: f64, h: f64) -> SolidId {
+    let pts = [
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(w, 0.0, 0.0),
+        Point3::new(w, d, 0.0),
+        Point3::new(0.0, d, 0.0),
+    ];
+    let vids: Vec<_> = pts
+        .iter()
+        .map(|&p| topo.add_vertex(Vertex::new(p, 1e-7)))
+        .collect();
+    let n = vids.len();
+    let eids: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(vids[i], vids[(i + 1) % n], EdgeCurve::Line)))
+        .collect();
+    let wire = Wire::new(
+        eids.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let face = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    crate::extrude::extrude(topo, face, Vec3::new(0.0, 0.0, -1.0), h).unwrap()
+}
+
+/// A CW profile extruded opposite its face normal must still produce a solid
+/// with correct (outward) cap normals — i.e. the analytic volume is right, not
+/// ~1/3 of it. The trapezoid here is the tool's dovetail tongue.
+#[test]
+fn extrude_down_cw_profile_has_correct_volume() {
+    let mut topo = Topology::new();
+    let tongue = dovetail_tongue(&mut topo, 20.0, 15.0, 5.0, 0.01, 1.0, 1.3);
+    // Trapezoid: parallel sides 2.0 (base) and 2.6 (tip), span 1.51 → area
+    // 3.473, × height 5 = 17.365.
+    assert_volume_near(&topo, tongue, 17.365, 1e-2);
+
+    // Rectangular protrusion: 1.51 × 2.0 × 5.0 = 15.1.
+    let mut topo2 = Topology::new();
+    let rect = dovetail_tongue(&mut topo2, 20.0, 15.0, 5.0, 0.01, 1.0, 1.0);
+    assert_volume_near(&topo2, rect, 15.1, 1e-2);
+}
+
+/// The dovetail tongue fuse must produce a watertight, manifold solid quickly
+/// (the tool fuses many of these; a non-manifold result forces the slow
+/// mesh-boolean path and a hang). This is the minimal repro of the baseplate
+/// connector hang.
+#[test]
+fn baseplate_dovetail_tongue_fuse_is_watertight() {
+    let mut topo = Topology::new();
+    let slab = dovetail_slab(&mut topo, 20.0, 30.0, 5.0);
+    let slab_vol = crate::measure::solid_volume(&topo, slab, 0.01).unwrap();
+    let tongue = dovetail_tongue(&mut topo, 20.0, 15.0, 5.0, 0.01, 1.0, 1.3);
+    let tongue_vol = crate::measure::solid_volume(&topo, tongue, 0.01).unwrap();
+
+    let fused = boolean(&mut topo, BooleanOp::Fuse, slab, tongue).unwrap();
+
+    // Watertight closed manifold (no free edges, nothing over-shared).
+    let sh = topo
+        .shell(topo.solid(fused).unwrap().outer_shell())
+        .unwrap();
+    brepkit_topology::validation::validate_shell_closed(sh, &topo)
+        .expect("dovetail fuse must be a closed manifold");
+
+    // Volume = slab + the part of the tongue outside the slab (the 0.01 overlap
+    // is shared, so it's roughly slab + tongue minus a sliver).
+    let fused_vol = crate::measure::solid_volume(&topo, fused, 0.01).unwrap();
+    assert!(
+        fused_vol > slab_vol && fused_vol < slab_vol + tongue_vol + 1e-6,
+        "fused vol {fused_vol} should be between slab {slab_vol} and slab+tongue \
+         {}",
+        slab_vol + tongue_vol
+    );
+}
+
+/// Sequentially fusing several tongues onto one slab (the tool's `fuseAll`)
+/// must keep each fuse on the analytic GFA path — never ballooning the face
+/// count, which is the signature of the mesh-boolean fallback that caused the
+/// baseplate export to hang (one slow mesh boolean per tongue on ever-growing
+/// corrupt geometry). Volume must track slab + the protruding tongue material.
+#[test]
+fn baseplate_dovetail_sequential_fuse_no_mesh_blowup() {
+    let mut topo = Topology::new();
+    let mut acc = dovetail_slab(&mut topo, 20.0, 60.0, 5.0);
+    let mut expected_vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+    for &y in &[10.0_f64, 20.0, 30.0, 40.0, 50.0] {
+        let tongue = dovetail_tongue(&mut topo, 20.0, y, 5.0, 0.01, 1.0, 1.3);
+        let tongue_vol = crate::measure::solid_volume(&topo, tongue, 0.01).unwrap();
+        acc = boolean(&mut topo, BooleanOp::Fuse, acc, tongue).unwrap();
+        let sh = topo.shell(topo.solid(acc).unwrap().outer_shell()).unwrap();
+        // A mesh fallback on a 20×60 slab would produce hundreds of triangulated
+        // faces; the analytic fuse keeps it to a handful per tongue.
+        assert!(
+            sh.faces().len() < 60,
+            "step y={y}: face count {} suggests a mesh fallback (the hang path)",
+            sh.faces().len()
+        );
+        // Volume grows by roughly the tongue's protruding portion (~99% of it;
+        // the 0.01 overlap is shared with the slab). A residual multi-fuse
+        // non-manifoldness can drift the measured volume by a few mm³, so this
+        // is a sanity band, not an exact equality (the per-tongue watertightness
+        // is asserted in `baseplate_dovetail_tongue_fuse_is_watertight`).
+        expected_vol += tongue_vol;
+        let vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+        assert!(
+            (vol - expected_vol).abs() < 0.02 * expected_vol,
+            "step y={y}: fused vol {vol} far from expected ~{expected_vol}"
+        );
+    }
+}
+
+/// Regression for the GFA shell-orientation classifier: a solid built by
+/// extrude-DOWN (so its wire winding gives a negative fan-volume) must still be
+/// usable as a fuse operand. Before the fix every such fuse failed with "all
+/// shells classified as holes". Both rectangular and dovetail tongues, and a
+/// plain box straddling the wall, must succeed and be watertight.
+#[test]
+fn extrude_down_solid_fuses_without_hole_misclassification() {
+    for (base_half, tip_half) in [(1.0, 1.0), (1.0, 1.3), (1.3, 1.0)] {
+        let mut topo = Topology::new();
+        let slab = dovetail_slab(&mut topo, 20.0, 30.0, 5.0);
+        let tongue = dovetail_tongue(&mut topo, 20.0, 15.0, 5.0, 0.01, base_half, tip_half);
+        let fused =
+            brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Fuse, slab, tongue)
+                .unwrap_or_else(|e| panic!("GFA fuse failed for ({base_half},{tip_half}): {e:?}"));
+        let sh = topo
+            .shell(topo.solid(fused).unwrap().outer_shell())
+            .unwrap();
+        brepkit_topology::validation::validate_shell_closed(sh, &topo)
+            .unwrap_or_else(|e| panic!("({base_half},{tip_half}) not watertight: {e:?}"));
+    }
+}

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -582,16 +582,27 @@ pub fn extrude(
     let n = input_verts.len();
 
     // Detect CW-wound outer wire (e.g. from brepjs polygon approximations).
-    // CW winding makes `edge_dir.cross(offset)` point inward instead of outward.
+    // CW winding makes `edge_dir.cross(offset)` point inward instead of outward;
+    // the side-face surface builder uses this to flip side normals.
     let outer_is_cw = crate::winding::is_cw_winding(&input_positions, &offset);
 
-    // If the outer wire is CW, the stored face normal opposes the actual outward
-    // direction. Negate it so cap normals are derived correctly.
-    if outer_is_cw
-        && let FaceSurface::Plane {
-            ref mut normal,
-            ref mut d,
-        } = input_surface
+    // Orient the cap-deriving normal by the extrusion direction, NOT the wire
+    // winding. The two caps are at the input plane F and the swept plane F+offset;
+    // the cap at F must face away from the sweep (−offset side) and the cap at
+    // F+offset must face along it, regardless of how the profile wire was wound.
+    // `bottom_surface`/`top_surface` below build the F-cap as −normal and the
+    // F+offset-cap as +normal, so set `normal` to −normal whenever the extrusion
+    // runs opposite the face normal (`normal·offset < 0`). This makes both cap
+    // normals point outward for any winding (a CW profile extruded down — common
+    // for brepjs dovetail tongues — previously got inside-out caps that broke the
+    // downstream fuse). The cap wires stay consistent with the chosen normals
+    // because the F-cap wire is the reversed profile and the F+offset-cap wire
+    // keeps the profile winding.
+    if let FaceSurface::Plane {
+        ref mut normal,
+        ref mut d,
+    } = input_surface
+        && normal.dot(offset) < 0.0
     {
         *normal = -*normal;
         *d = -*d;


### PR DESCRIPTION
## Summary

The gridfinity **baseplate dovetail-connector export hung** (4 scenarios timed out at 300s). Root cause: every dovetail tongue fuse fell through to the mesh-boolean fallback, and the export then ran one slow mesh boolean per tongue on ever-growing corrupt geometry until it timed out. Two construction-vs-convention mismatches caused it, both fixed here.

### 1. GFA shell-orientation classifier was wire-winding-dependent (the hang root)

`signed_volume_of_shell` (algo `builder_solid.rs`) signed each shell by its raw outer-wire winding + `is_reversed`. A profile extruded *opposite* its face normal — the tool builds every slab as a CCW rectangle extruded **down**, and every tongue as a CW trapezoid extruded down — yields a perfectly valid solid with correct outward face normals, but a wire winding that makes the fan-triangulation volume read **negative**. So the fuse result's single shell classified as a *hole*, assembly bailed with `"no outer shell found (all shells classified as holes)"`, the boolean fell back to mesh, and (with a pocketed slab) every subsequent groove cut also fell to mesh on the growing non-manifold output → hang.

Fix: sign each face's fan contribution by its **geometric surface normal** (which already honours `is_reversed`) rather than the wire winding. This makes the classifier independent of how the operand was constructed. `make_box`-built solids and CCW profiles evaluate identically before/after.

### 2. `extrude` produced inside-out caps for CW profiles extruded opposite their normal

`extrude` derived its cap normals from the wire winding, so a CW profile extruded down got **inside-out cap faces** — the tongue's analytic volume read ~1/3 of its true value (e.g. 5.79 vs 17.37 mm³), which broke the coincident-cap fuse into a non-manifold result. The two caps sit at the input plane `F` and the swept plane `F+offset`; their outward normals depend only on the extrusion direction, not the winding. Fix: negate the cap-deriving normal when the extrusion runs opposite the face normal (`normal·offset < 0`).

## Result

- A dovetail tongue now fuses to a **watertight manifold analytically** (no mesh fallback).
- The baseplate dovetail tiles export in **~2 s instead of timing out at 300 s**.
- CW-extruded-down solids now have correct volume.

## Tests

New regression tests in `boolean/tests.rs`:
- `extrude_down_cw_profile_has_correct_volume` — CW tongue volume is right (17.365 / 15.1).
- `baseplate_dovetail_tongue_fuse_is_watertight` — single tongue fuse is a closed manifold.
- `baseplate_dovetail_sequential_fuse_no_mesh_blowup` — `fuseAll` stays on the analytic path (bounded face count).
- `extrude_down_solid_fuses_without_hole_misclassification` — rect/dovetail/reverse-dovetail tongues all fuse without the hole misclassification.

Green: `cargo test` workspace-wide (algo 118, operations 693, wasm gridfinity 25 incl. the bin d3/d4 lip-fuse tests), `clippy --all-targets -D warnings`, `fmt --check`, `check-boundaries.sh`.

## Known remaining (separate, follow-up)

- A residual ~20 non-manifold edges appears on **multi-tongue** baseplates: fusing a tongue into a wall face that another tongue already split re-introduces the sliver-region open boundary (a face-splitter robustness bug, not the hang). The single-tongue fuse is watertight.
- The **magnet-hole** and **fractional** dovetail variants, and the **overtile** scenario, still fall to mesh on *other* ops (magnet-hole cylinder cuts, tile-clip Cut/Intersect) — a broader GFA-non-manifold → mesh-fallback pattern, distinct from the dovetail tongue fuse fixed here.