### PR TITLE
fix(algo): treat near-collinear wire-builder junctions as continuations

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -439,10 +439,37 @@ fn shell_is_closed(topo: &Topology, faces: &[FaceId]) -> bool {
     !edge_counts.is_empty() && edge_counts.values().all(|&c| c % 2 == 0)
 }
 
+/// Newell's method normal for a polygon (unnormalized; magnitude = 2·area).
+/// Robust to non-planar / non-convex loops.
+fn newell_normal(verts: &[Point3]) -> Vec3 {
+    let n = verts.len();
+    let mut nx = 0.0;
+    let mut ny = 0.0;
+    let mut nz = 0.0;
+    for i in 0..n {
+        let a = verts[i];
+        let b = verts[(i + 1) % n];
+        nx += (a.y() - b.y()) * (a.z() + b.z());
+        ny += (a.z() - b.z()) * (a.x() + b.x());
+        nz += (a.x() - b.x()) * (a.y() + b.y());
+    }
+    Vec3::new(nx, ny, nz)
+}
+
 /// Compute a signed volume estimate for a shell using the divergence theorem.
 ///
 /// Positive = outward-oriented normals (growth shell).
 /// Negative = inward-oriented normals (hole shell).
+///
+/// Each face's fan-triangulation contribution is oriented by the face's actual
+/// geometric surface normal (which already accounts for `is_reversed`), not by
+/// the raw outer-wire winding. The two agree for solids built with a
+/// CCW-against-the-outward-normal convention (e.g. `make_box`), but diverge for
+/// equally valid solids whose wires were wound the other way (e.g. a profile
+/// extruded *opposite* its face normal). Trusting the wire winding alone made
+/// such a solid read as negative volume, so every shell of a fuse that
+/// consumed it got misclassified as a hole and assembly failed. Anchoring the
+/// sign to the surface normal makes the classifier construction-independent.
 fn signed_volume_of_shell(topo: &Topology, faces: &[FaceId]) -> f64 {
     let mut volume = 0.0;
 
@@ -467,13 +494,38 @@ fn signed_volume_of_shell(topo: &Topology, faces: &[FaceId]) -> f64 {
             continue;
         }
 
-        // Fan triangulation from first vertex
+        // Sign the contribution by the face's outward geometric normal rather
+        // than the wire winding. Use the wire's centroid as the projection
+        // point so curved-surface normals are evaluated near the face interior.
+        let centroid = {
+            let mut c = Vec3::new(0.0, 0.0, 0.0);
+            for v in &verts {
+                c = Vec3::new(c.x() + v.x(), c.y() + v.y(), c.z() + v.z());
+            }
+            let inv = 1.0 / verts.len() as f64;
+            Point3::new(c.x() * inv, c.y() * inv, c.z() * inv)
+        };
+        let wound_normal = newell_normal(&verts);
+        let sign = match face_normal_at(topo, fid, centroid) {
+            // Flip when the wire winds opposite the outward normal so the
+            // fan tets are consistent with the divergence-theorem convention.
+            Some(outward) if wound_normal.dot(outward) < 0.0 => -1.0,
+            Some(_) => 1.0,
+            // No geometric normal available (degenerate face): fall back to the
+            // legacy is_reversed sign.
+            None => {
+                if face.is_reversed() {
+                    -1.0
+                } else {
+                    1.0
+                }
+            }
+        };
         let v0 = verts[0];
-        let sign = if face.is_reversed() { -1.0 } else { 1.0 };
         for i in 1..verts.len() - 1 {
             let v1 = verts[i];
             let v2 = verts[i + 1];
-            // Signed volume of tetrahedron with origin
+            // Signed volume of tetrahedron with the origin as apex.
             volume += sign
                 * (v0.x() * (v1.y() * v2.z() - v2.y() * v1.z())
                     + v1.x() * (v2.y() * v0.z() - v0.y() * v2.z())

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -433,13 +433,28 @@ fn pcurve_tangent_at_endpoint(edge: &OrientedPCurveEdge, at_start: bool) -> (f64
 ///
 /// Returns a value in (0, 2pi].
 fn clockwise_angle(angle_in: f64, angle_out: f64) -> f64 {
+    // A candidate that continues straight ahead (angle_out ~= travel) must rank
+    // worst so the traversal hugs the rightmost real turn instead of running on
+    // through a collinear junction. At a T-junction the bar passes straight
+    // through (two collinear boundary edges meet the section stem), and `da`
+    // for that continuation collapses to rounding noise: the angles flow through
+    // `atan2`, subtraction, and `rem_euclid`, so the residual lands anywhere in
+    // ~[0, 1e-12] depending on the vertex coordinates. A 1e-14 cutoff caught it
+    // only by luck (the same tongue split correctly at y=9 with da=1.8e-15 but
+    // wove a zero-area slit at y=49 with da=1.7e-13). Treat anything within a
+    // small angular band of a straight continuation as a continuation. This is
+    // safe: at a 2-edge junction the lone continuation is still the min and gets
+    // taken regardless, and at a 3+-edge junction a numerically-collinear
+    // continuation should always lose to a genuine branch (that is exactly the
+    // face split the traversal exists to find).
+    const CONTINUATION_EPS: f64 = 1e-9;
     // Travel direction = opposite of incoming (which points backward).
     let travel = (angle_in + std::f64::consts::PI).rem_euclid(TAU);
     let da = (travel - angle_out).rem_euclid(TAU);
-    if da < 1e-14 {
-        TAU // Exact continuation -> maximum angle.
-    } else {
+    if (CONTINUATION_EPS..=TAU - CONTINUATION_EPS).contains(&da) {
         da
+    } else {
+        TAU // Straight continuation -> maximum angle (worst).
     }
 }
 
@@ -582,6 +597,64 @@ mod tests {
 
         let cw3 = clockwise_angle(PI, 0.0);
         assert!((cw3 - TAU).abs() < 1e-10, "cw3 = {cw3}");
+    }
+
+    /// A near-collinear continuation (incoming and candidate almost exactly
+    /// opposite, so `da` is rounding noise just above 0) must rank as a straight
+    /// continuation (TAU = worst), not a razor-thin rightmost turn. The
+    /// multi-tongue baseplate fuse wove a zero-area slit because this `da`
+    /// landed at 1.7e-13 at one tongue but 1.8e-15 at another, and only the
+    /// latter cleared the old 1e-14 cutoff.
+    #[test]
+    fn clockwise_angle_treats_near_collinear_as_continuation() {
+        // angle_out within rounding noise of the travel direction (angle_in+pi).
+        let angle_in = 1.374_674_651_606_426_8;
+        let angle_out = 4.516_267_305_196_049; // travel ends up ~1.7e-13 larger
+        let cw = clockwise_angle(angle_in, angle_out);
+        assert!(
+            (cw - TAU).abs() < 1e-10,
+            "near-collinear continuation must score TAU, got {cw}"
+        );
+    }
+
+    /// A convex quad whose bottom edge is split at an interior vertex by a
+    /// section stem rising to the top edge (a T-junction with a collinear bar)
+    /// must split into two loops, never one loop plus a degenerate slit. This is
+    /// the minimal 2D form of the tongue-cap split that the collinear-junction
+    /// rounding bug broke.
+    #[test]
+    fn t_junction_with_collinear_bar_splits_into_two() {
+        // Bottom edge runs straight from (0,0) to (10,0), split at (4,0). The
+        // section stem rises from (4,0) to (4,10) on the top edge.
+        let mut edges = vec![
+            make_line_edge(Point2::new(0.0, 0.0), Point2::new(4.0, 0.0)),
+            make_line_edge(Point2::new(4.0, 0.0), Point2::new(10.0, 0.0)),
+            make_line_edge(Point2::new(10.0, 0.0), Point2::new(10.0, 10.0)),
+            make_line_edge(Point2::new(10.0, 10.0), Point2::new(4.0, 10.0)),
+            make_line_edge(Point2::new(4.0, 10.0), Point2::new(0.0, 10.0)),
+            make_line_edge(Point2::new(0.0, 10.0), Point2::new(0.0, 0.0)),
+        ];
+        // Section stem, both orientations (one per adjacent sub-face).
+        edges.push(make_section_edge(
+            Point2::new(4.0, 0.0),
+            Point2::new(4.0, 10.0),
+            100,
+        ));
+        edges.push(make_section_edge(
+            Point2::new(4.0, 10.0),
+            Point2::new(4.0, 0.0),
+            100,
+        ));
+
+        let loops = build_wire_loops(&edges, 1e-7, false, false);
+        assert_eq!(loops.len(), 2, "T-junction must split into two loops");
+        for l in &loops {
+            assert!(
+                l.len() >= 3,
+                "no degenerate slit loop, got {} edges",
+                l.len()
+            );
+        }
     }
 
     #[test]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4308,3 +4308,206 @@ fn issue_801_slot_fuse_recovers_volume() {
     assert_cut_fuse_back_recovers(12.0, 4.0, 4.0);
     assert_cut_fuse_back_recovers(8.0, 3.0, 2.0);
 }
+
+// ── Gridfinity baseplate dovetail-connector fuse ────────────────────────────
+//
+// The tool builds dovetail tongues as a trapezoidal XY profile (narrow base at
+// the wall, wider protruding tip) drawn CLOCKWISE and extruded DOWN the slab
+// height, then fuses them onto the slab whose base edge they overlap. Two bugs
+// made that fuse fail and the baseplate export hang:
+//
+//   1. A CW profile extruded *opposite* its face normal produced inside-out cap
+//      faces (the tongue's volume read ~1/3 of its true value), which broke the
+//      coincident-cap fuse into a non-manifold result. Fixed in `extrude`.
+//   2. The GFA shell-orientation classifier (`signed_volume_of_shell`) signed
+//      shells by raw wire winding, so any solid built by extrude-DOWN (every
+//      tool slab) read as negative volume → "all shells classified as holes" →
+//      GFA failed → mesh-boolean fallback ran on ever-growing corrupt geometry,
+//      one fuse per tongue, until the export timed out. Fixed in the algo
+//      builder (sign by the geometric surface normal).
+
+/// Build a dovetail tongue exactly as the tool does: a CW trapezoid extruded
+/// down. `tip_half == base_half` degenerates to a rectangular protrusion.
+fn dovetail_tongue(
+    topo: &mut Topology,
+    wall_x: f64,
+    bp_y: f64,
+    height: f64,
+    overlap: f64,
+    base_half: f64,
+    tip_half: f64,
+) -> SolidId {
+    let base_x = wall_x - overlap; // extended INTO the slab
+    let tip_x = wall_x + 1.5; // protrudes out
+    // CW order viewed from +Z, matching the tool's `makeTongue` draw order.
+    let pts = [
+        Point3::new(base_x, bp_y + base_half, 0.0),
+        Point3::new(tip_x, bp_y + tip_half, 0.0),
+        Point3::new(tip_x, bp_y - tip_half, 0.0),
+        Point3::new(base_x, bp_y - base_half, 0.0),
+    ];
+    let vids: Vec<_> = pts
+        .iter()
+        .map(|&p| topo.add_vertex(Vertex::new(p, 1e-7)))
+        .collect();
+    let n = vids.len();
+    let eids: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(vids[i], vids[(i + 1) % n], EdgeCurve::Line)))
+        .collect();
+    let wire = Wire::new(
+        eids.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let face = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    crate::extrude::extrude(topo, face, Vec3::new(0.0, 0.0, -1.0), height).unwrap()
+}
+
+/// Slab built the way the tool builds it: a CCW rectangle extruded DOWN (top at
+/// z=0, bottom at z=-h).
+fn dovetail_slab(topo: &mut Topology, w: f64, d: f64, h: f64) -> SolidId {
+    let pts = [
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(w, 0.0, 0.0),
+        Point3::new(w, d, 0.0),
+        Point3::new(0.0, d, 0.0),
+    ];
+    let vids: Vec<_> = pts
+        .iter()
+        .map(|&p| topo.add_vertex(Vertex::new(p, 1e-7)))
+        .collect();
+    let n = vids.len();
+    let eids: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(vids[i], vids[(i + 1) % n], EdgeCurve::Line)))
+        .collect();
+    let wire = Wire::new(
+        eids.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let face = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    crate::extrude::extrude(topo, face, Vec3::new(0.0, 0.0, -1.0), h).unwrap()
+}
+
+/// A CW profile extruded opposite its face normal must still produce a solid
+/// with correct (outward) cap normals — i.e. the analytic volume is right, not
+/// ~1/3 of it. The trapezoid here is the tool's dovetail tongue.
+#[test]
+fn extrude_down_cw_profile_has_correct_volume() {
+    let mut topo = Topology::new();
+    let tongue = dovetail_tongue(&mut topo, 20.0, 15.0, 5.0, 0.01, 1.0, 1.3);
+    // Trapezoid: parallel sides 2.0 (base) and 2.6 (tip), span 1.51 → area
+    // 3.473, × height 5 = 17.365.
+    assert_volume_near(&topo, tongue, 17.365, 1e-2);
+
+    // Rectangular protrusion: 1.51 × 2.0 × 5.0 = 15.1.
+    let mut topo2 = Topology::new();
+    let rect = dovetail_tongue(&mut topo2, 20.0, 15.0, 5.0, 0.01, 1.0, 1.0);
+    assert_volume_near(&topo2, rect, 15.1, 1e-2);
+}
+
+/// The dovetail tongue fuse must produce a watertight, manifold solid quickly
+/// (the tool fuses many of these; a non-manifold result forces the slow
+/// mesh-boolean path and a hang). This is the minimal repro of the baseplate
+/// connector hang.
+#[test]
+fn baseplate_dovetail_tongue_fuse_is_watertight() {
+    let mut topo = Topology::new();
+    let slab = dovetail_slab(&mut topo, 20.0, 30.0, 5.0);
+    let slab_vol = crate::measure::solid_volume(&topo, slab, 0.01).unwrap();
+    let tongue = dovetail_tongue(&mut topo, 20.0, 15.0, 5.0, 0.01, 1.0, 1.3);
+    let tongue_vol = crate::measure::solid_volume(&topo, tongue, 0.01).unwrap();
+
+    let fused = boolean(&mut topo, BooleanOp::Fuse, slab, tongue).unwrap();
+
+    // Watertight closed manifold (no free edges, nothing over-shared).
+    let sh = topo
+        .shell(topo.solid(fused).unwrap().outer_shell())
+        .unwrap();
+    brepkit_topology::validation::validate_shell_closed(sh, &topo)
+        .expect("dovetail fuse must be a closed manifold");
+
+    // Volume = slab + the part of the tongue outside the slab (the 0.01 overlap
+    // is shared, so it's roughly slab + tongue minus a sliver).
+    let fused_vol = crate::measure::solid_volume(&topo, fused, 0.01).unwrap();
+    assert!(
+        fused_vol > slab_vol && fused_vol < slab_vol + tongue_vol + 1e-6,
+        "fused vol {fused_vol} should be between slab {slab_vol} and slab+tongue \
+         {}",
+        slab_vol + tongue_vol
+    );
+}
+
+/// Sequentially fusing several tongues onto one slab (the tool's `fuseAll`)
+/// must keep each fuse on the analytic GFA path — never ballooning the face
+/// count, which is the signature of the mesh-boolean fallback that caused the
+/// baseplate export to hang (one slow mesh boolean per tongue on ever-growing
+/// corrupt geometry). Volume must track slab + the protruding tongue material.
+#[test]
+fn baseplate_dovetail_sequential_fuse_no_mesh_blowup() {
+    let mut topo = Topology::new();
+    let mut acc = dovetail_slab(&mut topo, 20.0, 60.0, 5.0);
+    let mut expected_vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+    for &y in &[10.0_f64, 20.0, 30.0, 40.0, 50.0] {
+        let tongue = dovetail_tongue(&mut topo, 20.0, y, 5.0, 0.01, 1.0, 1.3);
+        let tongue_vol = crate::measure::solid_volume(&topo, tongue, 0.01).unwrap();
+        acc = boolean(&mut topo, BooleanOp::Fuse, acc, tongue).unwrap();
+        let sh = topo.shell(topo.solid(acc).unwrap().outer_shell()).unwrap();
+        // A mesh fallback on a 20×60 slab would produce hundreds of triangulated
+        // faces; the analytic fuse keeps it to a handful per tongue.
+        assert!(
+            sh.faces().len() < 60,
+            "step y={y}: face count {} suggests a mesh fallback (the hang path)",
+            sh.faces().len()
+        );
+        // Volume grows by roughly the tongue's protruding portion (~99% of it;
+        // the 0.01 overlap is shared with the slab). A residual multi-fuse
+        // non-manifoldness can drift the measured volume by a few mm³, so this
+        // is a sanity band, not an exact equality (the per-tongue watertightness
+        // is asserted in `baseplate_dovetail_tongue_fuse_is_watertight`).
+        expected_vol += tongue_vol;
+        let vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+        assert!(
+            (vol - expected_vol).abs() < 0.02 * expected_vol,
+            "step y={y}: fused vol {vol} far from expected ~{expected_vol}"
+        );
+    }
+}
+
+/// Regression for the GFA shell-orientation classifier: a solid built by
+/// extrude-DOWN (so its wire winding gives a negative fan-volume) must still be
+/// usable as a fuse operand. Before the fix every such fuse failed with "all
+/// shells classified as holes". Both rectangular and dovetail tongues, and a
+/// plain box straddling the wall, must succeed and be watertight.
+#[test]
+fn extrude_down_solid_fuses_without_hole_misclassification() {
+    for (base_half, tip_half) in [(1.0, 1.0), (1.0, 1.3), (1.3, 1.0)] {
+        let mut topo = Topology::new();
+        let slab = dovetail_slab(&mut topo, 20.0, 30.0, 5.0);
+        let tongue = dovetail_tongue(&mut topo, 20.0, 15.0, 5.0, 0.01, base_half, tip_half);
+        let fused =
+            brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Fuse, slab, tongue)
+                .unwrap_or_else(|e| panic!("GFA fuse failed for ({base_half},{tip_half}): {e:?}"));
+        let sh = topo
+            .shell(topo.solid(fused).unwrap().outer_shell())
+            .unwrap();
+        brepkit_topology::validation::validate_shell_closed(sh, &topo)
+            .unwrap_or_else(|e| panic!("({base_half},{tip_half}) not watertight: {e:?}"));
+    }
+}

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4463,10 +4463,14 @@ fn baseplate_dovetail_tongue_fuse_is_watertight() {
 fn baseplate_dovetail_sequential_fuse_no_mesh_blowup() {
     let mut topo = Topology::new();
     let mut acc = dovetail_slab(&mut topo, 20.0, 60.0, 5.0);
-    let mut expected_vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+    let mut prev_vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+    // Each tongue is identical and sits clear of the others, so every fuse adds
+    // the same protruding volume. Capture the first step's increment and require
+    // the rest to match it: a mesh fallback or a re-split that drops the overlap
+    // sliver would change the increment (and the volume).
+    let mut per_tongue_increment: Option<f64> = None;
     for &y in &[10.0_f64, 20.0, 30.0, 40.0, 50.0] {
         let tongue = dovetail_tongue(&mut topo, 20.0, y, 5.0, 0.01, 1.0, 1.3);
-        let tongue_vol = crate::measure::solid_volume(&topo, tongue, 0.01).unwrap();
         acc = boolean(&mut topo, BooleanOp::Fuse, acc, tongue).unwrap();
         let sh = topo.shell(topo.solid(acc).unwrap().outer_shell()).unwrap();
         // A mesh fallback on a 20×60 slab would produce hundreds of triangulated
@@ -4476,17 +4480,22 @@ fn baseplate_dovetail_sequential_fuse_no_mesh_blowup() {
             "step y={y}: face count {} suggests a mesh fallback (the hang path)",
             sh.faces().len()
         );
-        // Volume grows by roughly the tongue's protruding portion (~99% of it;
-        // the 0.01 overlap is shared with the slab). A residual multi-fuse
-        // non-manifoldness can drift the measured volume by a few mm³, so this
-        // is a sanity band, not an exact equality (the per-tongue watertightness
-        // is asserted in `baseplate_dovetail_tongue_fuse_is_watertight`).
-        expected_vol += tongue_vol;
+        // Every step must stay a closed manifold. Fusing tongue N into a slab
+        // whose +X wall earlier tongues already split must re-split that face
+        // cleanly — the multi-tongue bug left ~20 free/over-shared edges here.
+        brepkit_topology::validation::validate_shell_closed(sh, &topo)
+            .unwrap_or_else(|e| panic!("step y={y}: result not watertight: {e:?}"));
         let vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
-        assert!(
-            (vol - expected_vol).abs() < 0.02 * expected_vol,
-            "step y={y}: fused vol {vol} far from expected ~{expected_vol}"
-        );
+        let increment = vol - prev_vol;
+        match per_tongue_increment {
+            None => per_tongue_increment = Some(increment),
+            Some(first) => assert!(
+                (increment - first).abs() < 1e-4,
+                "step y={y}: volume increment {increment} differs from the first tongue's \
+                 {first} — a re-split into an already-split wall changed the volume"
+            ),
+        }
+        prev_vol = vol;
     }
 }
 
@@ -4510,4 +4519,35 @@ fn extrude_down_solid_fuses_without_hole_misclassification() {
         brepkit_topology::validation::validate_shell_closed(sh, &topo)
             .unwrap_or_else(|e| panic!("({base_half},{tip_half}) not watertight: {e:?}"));
     }
+}
+
+/// Fusing a SECOND tongue onto a slab whose wall face a FIRST tongue already
+/// split must keep the result a closed manifold. The tongues are 40 mm apart so
+/// they never touch each other — the only shared face is the slab's +X wall,
+/// which tongue A has already fragmented into sub-faces. Re-splitting that
+/// already-split face is where the multi-tongue baseplate fuse went
+/// non-manifold (≈20 free/over-shared edges) and fell back to mesh boolean.
+#[test]
+fn baseplate_two_tongues_far_apart_resplit_is_watertight() {
+    let mut topo = Topology::new();
+    let slab = dovetail_slab(&mut topo, 20.0, 60.0, 5.0);
+
+    // Tongue A on a clean slab — must be watertight (baseline).
+    let tongue_a = dovetail_tongue(&mut topo, 20.0, 10.0, 5.0, 0.01, 1.0, 1.3);
+    let after_a = boolean(&mut topo, BooleanOp::Fuse, slab, tongue_a).unwrap();
+    let sh_a = topo
+        .shell(topo.solid(after_a).unwrap().outer_shell())
+        .unwrap();
+    brepkit_topology::validation::validate_shell_closed(sh_a, &topo)
+        .expect("tongue A on a clean slab must be watertight");
+
+    // Tongue B, 40 mm away, fused into the A-result. Attaches to the SAME +X
+    // wall that A already split.
+    let tongue_b = dovetail_tongue(&mut topo, 20.0, 50.0, 5.0, 0.01, 1.0, 1.3);
+    let after_b = boolean(&mut topo, BooleanOp::Fuse, after_a, tongue_b).unwrap();
+    let sh_b = topo
+        .shell(topo.solid(after_b).unwrap().outer_shell())
+        .unwrap();
+    brepkit_topology::validation::validate_shell_closed(sh_b, &topo)
+        .expect("tongue B fused into the A-split wall must stay watertight");
 }

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -582,16 +582,27 @@ pub fn extrude(
     let n = input_verts.len();
 
     // Detect CW-wound outer wire (e.g. from brepjs polygon approximations).
-    // CW winding makes `edge_dir.cross(offset)` point inward instead of outward.
+    // CW winding makes `edge_dir.cross(offset)` point inward instead of outward;
+    // the side-face surface builder uses this to flip side normals.
     let outer_is_cw = crate::winding::is_cw_winding(&input_positions, &offset);
 
-    // If the outer wire is CW, the stored face normal opposes the actual outward
-    // direction. Negate it so cap normals are derived correctly.
-    if outer_is_cw
-        && let FaceSurface::Plane {
-            ref mut normal,
-            ref mut d,
-        } = input_surface
+    // Orient the cap-deriving normal by the extrusion direction, NOT the wire
+    // winding. The two caps are at the input plane F and the swept plane F+offset;
+    // the cap at F must face away from the sweep (−offset side) and the cap at
+    // F+offset must face along it, regardless of how the profile wire was wound.
+    // `bottom_surface`/`top_surface` below build the F-cap as −normal and the
+    // F+offset-cap as +normal, so set `normal` to −normal whenever the extrusion
+    // runs opposite the face normal (`normal·offset < 0`). This makes both cap
+    // normals point outward for any winding (a CW profile extruded down — common
+    // for brepjs dovetail tongues — previously got inside-out caps that broke the
+    // downstream fuse). The cap wires stay consistent with the chosen normals
+    // because the F-cap wire is the reversed profile and the F+offset-cap wire
+    // keeps the profile winding.
+    if let FaceSurface::Plane {
+        ref mut normal,
+        ref mut d,
+    } = input_surface
+        && normal.dot(offset) < 0.0
     {
         *normal = -*normal;
         *d = -*d;


### PR DESCRIPTION
## Summary

Fixes the multi-tongue gridfinity baseplate dovetail fuse going non-manifold (~20 free/over-shared edges) when a tongue is fused into a wall face that an earlier tongue already split.

**Stacks on #875** (the dovetail FUSE-hang fix). Base that branch first if reviewing the full series; this PR is diffed against `main` and may need a trivial rebase once #875 merges.

## Root cause (confirmed by native repro, not assumed)

The GFA face splitter's minimum-clockwise-angle wire-builder traversal (`clockwise_angle` in `crates/algo/src/builder/wire_builder.rs`) wove a **zero-area slit** instead of splitting a face when a section edge met two **collinear** boundary edges at a T-junction.

The gridfinity tongue cap is exactly this: a trapezoid whose slanted base edge passes straight through the wall-line section point (the 0.01 mm overlap puts that point exactly on the base line). At the junction the boundary "bar" continues straight and the section "stem" branches perpendicular; the min-clockwise rule must pick the stem (the face split), and a straight continuation is meant to score TAU (worst).

`clockwise_angle` only flagged a straight continuation when the swept angle `da < 1e-14`. But at a collinear junction `da` is pure rounding noise (the angles flow through `atan2`, subtraction, `rem_euclid`) and lands anywhere up to ~1e-12 depending on the vertex coordinates. The **same tongue** split cleanly at `y=9` (`da=1.8e-15`, under the cutoff → TAU) but failed 40 mm away at `y=49` (`da=1.7e-13`, over the cutoff → scored ~0). When it scored ~0 the boundary continuation **beat** the real section branch, so the section never split the cap: the cap stayed whole and overlapped its own sliver, producing 3 edges shared by 3 faces plus 1 free edge per tongue (~20 across the baseplate), which forced the slow mesh-boolean fallback.

This was localized by dumping, per cap face: the section edges, the parent loop, the wire-builder loop set, each loop's area, and finally the traversal's per-junction turn scores — which showed identical UV geometry but a `da` flipping across the 1e-14 boundary between the two tongues.

## Fix

Widen the continuation band in `clockwise_angle` from `1e-14` to `1e-9` rad (and fold the symmetric near-TAU case). Safe by construction:
- At a 2-edge junction the lone continuation is still the minimum and is taken regardless of its score.
- At a 3+-edge junction a numerically-collinear continuation should always lose to a genuine branch — which is exactly the face split the traversal exists to find.

## Tests

- `wire_builder`: `clockwise_angle_treats_near_collinear_as_continuation` (the exact `da=1.7e-13` case — fails under the old 1e-14 cutoff) and `t_junction_with_collinear_bar_splits_into_two` (the minimal 2D form).
- `boolean`: new `baseplate_two_tongues_far_apart_resplit_is_watertight` (tongue A on a clean slab is watertight; tongue B 40 mm away fused into the A-split wall must stay watertight — failed before, passes now), and `baseplate_dovetail_sequential_fuse_no_mesh_blowup` now asserts a closed manifold at **every** step plus a constant per-tongue volume increment.

## Scope note

This fixes the multi-tongue re-split of **plain trapezoidal** tongues. The gridfinity tool's *basic* dovetail tile still falls to mesh because each tongue is additionally **relieved** with a through-cut gridfinity pocket (a 5-section ruled loft with rounded-rect/tapered sections), so the fused operand carries curved + sloped surfaces — a separate, deeper boolean path. Confirmed via 5 native repros (two-tongue, realistic-baseplate perpendicular-edge, slab-with-pocket, grid-of-pockets, box-relieved tongue) that the plain-tongue path is now watertight; the relieved-tongue/curved-boolean fuse is out of scope for this change.

## Gates
- `cargo test -p brepkit-algo` — 120 passed
- `cargo test -p brepkit-operations --lib` — 694 passed
- `cargo test -p brepkit-wasm --lib gridfinity` — 25 passed, 1 ignored (d5, pre-existing)
- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, `./scripts/check-boundaries.sh` — clean