### PR TITLE
fix(algo): treat near-collinear wire-builder junctions as continuations

### DIFF
--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -433,13 +433,28 @@ fn pcurve_tangent_at_endpoint(edge: &OrientedPCurveEdge, at_start: bool) -> (f64
 ///
 /// Returns a value in (0, 2pi].
 fn clockwise_angle(angle_in: f64, angle_out: f64) -> f64 {
+    // A candidate that continues straight ahead (angle_out ~= travel) must rank
+    // worst so the traversal hugs the rightmost real turn instead of running on
+    // through a collinear junction. At a T-junction the bar passes straight
+    // through (two collinear boundary edges meet the section stem), and `da`
+    // for that continuation collapses to rounding noise: the angles flow through
+    // `atan2`, subtraction, and `rem_euclid`, so the residual lands anywhere in
+    // ~[0, 1e-12] depending on the vertex coordinates. A 1e-14 cutoff caught it
+    // only by luck (the same tongue split correctly at y=9 with da=1.8e-15 but
+    // wove a zero-area slit at y=49 with da=1.7e-13). Treat anything within a
+    // small angular band of a straight continuation as a continuation. This is
+    // safe: at a 2-edge junction the lone continuation is still the min and gets
+    // taken regardless, and at a 3+-edge junction a numerically-collinear
+    // continuation should always lose to a genuine branch (that is exactly the
+    // face split the traversal exists to find).
+    const CONTINUATION_EPS: f64 = 1e-9;
     // Travel direction = opposite of incoming (which points backward).
     let travel = (angle_in + std::f64::consts::PI).rem_euclid(TAU);
     let da = (travel - angle_out).rem_euclid(TAU);
-    if da < 1e-14 {
-        TAU // Exact continuation -> maximum angle.
-    } else {
+    if (CONTINUATION_EPS..=TAU - CONTINUATION_EPS).contains(&da) {
         da
+    } else {
+        TAU // Straight continuation -> maximum angle (worst).
     }
 }
 
@@ -582,6 +597,64 @@ mod tests {
 
         let cw3 = clockwise_angle(PI, 0.0);
         assert!((cw3 - TAU).abs() < 1e-10, "cw3 = {cw3}");
+    }
+
+    /// A near-collinear continuation (incoming and candidate almost exactly
+    /// opposite, so `da` is rounding noise just above 0) must rank as a straight
+    /// continuation (TAU = worst), not a razor-thin rightmost turn. The
+    /// multi-tongue baseplate fuse wove a zero-area slit because this `da`
+    /// landed at 1.7e-13 at one tongue but 1.8e-15 at another, and only the
+    /// latter cleared the old 1e-14 cutoff.
+    #[test]
+    fn clockwise_angle_treats_near_collinear_as_continuation() {
+        // angle_out within rounding noise of the travel direction (angle_in+pi).
+        let angle_in = 1.374_674_651_606_426_8;
+        let angle_out = 4.516_267_305_196_049; // travel ends up ~1.7e-13 larger
+        let cw = clockwise_angle(angle_in, angle_out);
+        assert!(
+            (cw - TAU).abs() < 1e-10,
+            "near-collinear continuation must score TAU, got {cw}"
+        );
+    }
+
+    /// A convex quad whose bottom edge is split at an interior vertex by a
+    /// section stem rising to the top edge (a T-junction with a collinear bar)
+    /// must split into two loops, never one loop plus a degenerate slit. This is
+    /// the minimal 2D form of the tongue-cap split that the collinear-junction
+    /// rounding bug broke.
+    #[test]
+    fn t_junction_with_collinear_bar_splits_into_two() {
+        // Bottom edge runs straight from (0,0) to (10,0), split at (4,0). The
+        // section stem rises from (4,0) to (4,10) on the top edge.
+        let mut edges = vec![
+            make_line_edge(Point2::new(0.0, 0.0), Point2::new(4.0, 0.0)),
+            make_line_edge(Point2::new(4.0, 0.0), Point2::new(10.0, 0.0)),
+            make_line_edge(Point2::new(10.0, 0.0), Point2::new(10.0, 10.0)),
+            make_line_edge(Point2::new(10.0, 10.0), Point2::new(4.0, 10.0)),
+            make_line_edge(Point2::new(4.0, 10.0), Point2::new(0.0, 10.0)),
+            make_line_edge(Point2::new(0.0, 10.0), Point2::new(0.0, 0.0)),
+        ];
+        // Section stem, both orientations (one per adjacent sub-face).
+        edges.push(make_section_edge(
+            Point2::new(4.0, 0.0),
+            Point2::new(4.0, 10.0),
+            100,
+        ));
+        edges.push(make_section_edge(
+            Point2::new(4.0, 10.0),
+            Point2::new(4.0, 0.0),
+            100,
+        ));
+
+        let loops = build_wire_loops(&edges, 1e-7, false, false);
+        assert_eq!(loops.len(), 2, "T-junction must split into two loops");
+        for l in &loops {
+            assert!(
+                l.len() >= 3,
+                "no degenerate slit loop, got {} edges",
+                l.len()
+            );
+        }
     }
 
     #[test]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4463,10 +4463,14 @@ fn baseplate_dovetail_tongue_fuse_is_watertight() {
 fn baseplate_dovetail_sequential_fuse_no_mesh_blowup() {
     let mut topo = Topology::new();
     let mut acc = dovetail_slab(&mut topo, 20.0, 60.0, 5.0);
-    let mut expected_vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+    let mut prev_vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
+    // Each tongue is identical and sits clear of the others, so every fuse adds
+    // the same protruding volume. Capture the first step's increment and require
+    // the rest to match it: a mesh fallback or a re-split that drops the overlap
+    // sliver would change the increment (and the volume).
+    let mut per_tongue_increment: Option<f64> = None;
     for &y in &[10.0_f64, 20.0, 30.0, 40.0, 50.0] {
         let tongue = dovetail_tongue(&mut topo, 20.0, y, 5.0, 0.01, 1.0, 1.3);
-        let tongue_vol = crate::measure::solid_volume(&topo, tongue, 0.01).unwrap();
         acc = boolean(&mut topo, BooleanOp::Fuse, acc, tongue).unwrap();
         let sh = topo.shell(topo.solid(acc).unwrap().outer_shell()).unwrap();
         // A mesh fallback on a 20×60 slab would produce hundreds of triangulated
@@ -4476,17 +4480,22 @@ fn baseplate_dovetail_sequential_fuse_no_mesh_blowup() {
             "step y={y}: face count {} suggests a mesh fallback (the hang path)",
             sh.faces().len()
         );
-        // Volume grows by roughly the tongue's protruding portion (~99% of it;
-        // the 0.01 overlap is shared with the slab). A residual multi-fuse
-        // non-manifoldness can drift the measured volume by a few mm³, so this
-        // is a sanity band, not an exact equality (the per-tongue watertightness
-        // is asserted in `baseplate_dovetail_tongue_fuse_is_watertight`).
-        expected_vol += tongue_vol;
+        // Every step must stay a closed manifold. Fusing tongue N into a slab
+        // whose +X wall earlier tongues already split must re-split that face
+        // cleanly — the multi-tongue bug left ~20 free/over-shared edges here.
+        brepkit_topology::validation::validate_shell_closed(sh, &topo)
+            .unwrap_or_else(|e| panic!("step y={y}: result not watertight: {e:?}"));
         let vol = crate::measure::solid_volume(&topo, acc, 0.01).unwrap();
-        assert!(
-            (vol - expected_vol).abs() < 0.02 * expected_vol,
-            "step y={y}: fused vol {vol} far from expected ~{expected_vol}"
-        );
+        let increment = vol - prev_vol;
+        match per_tongue_increment {
+            None => per_tongue_increment = Some(increment),
+            Some(first) => assert!(
+                (increment - first).abs() < 1e-4,
+                "step y={y}: volume increment {increment} differs from the first tongue's \
+                 {first} — a re-split into an already-split wall changed the volume"
+            ),
+        }
+        prev_vol = vol;
     }
 }
 
@@ -4510,4 +4519,35 @@ fn extrude_down_solid_fuses_without_hole_misclassification() {
         brepkit_topology::validation::validate_shell_closed(sh, &topo)
             .unwrap_or_else(|e| panic!("({base_half},{tip_half}) not watertight: {e:?}"));
     }
+}
+
+/// Fusing a SECOND tongue onto a slab whose wall face a FIRST tongue already
+/// split must keep the result a closed manifold. The tongues are 40 mm apart so
+/// they never touch each other — the only shared face is the slab's +X wall,
+/// which tongue A has already fragmented into sub-faces. Re-splitting that
+/// already-split face is where the multi-tongue baseplate fuse went
+/// non-manifold (≈20 free/over-shared edges) and fell back to mesh boolean.
+#[test]
+fn baseplate_two_tongues_far_apart_resplit_is_watertight() {
+    let mut topo = Topology::new();
+    let slab = dovetail_slab(&mut topo, 20.0, 60.0, 5.0);
+
+    // Tongue A on a clean slab — must be watertight (baseline).
+    let tongue_a = dovetail_tongue(&mut topo, 20.0, 10.0, 5.0, 0.01, 1.0, 1.3);
+    let after_a = boolean(&mut topo, BooleanOp::Fuse, slab, tongue_a).unwrap();
+    let sh_a = topo
+        .shell(topo.solid(after_a).unwrap().outer_shell())
+        .unwrap();
+    brepkit_topology::validation::validate_shell_closed(sh_a, &topo)
+        .expect("tongue A on a clean slab must be watertight");
+
+    // Tongue B, 40 mm away, fused into the A-result. Attaches to the SAME +X
+    // wall that A already split.
+    let tongue_b = dovetail_tongue(&mut topo, 20.0, 50.0, 5.0, 0.01, 1.0, 1.3);
+    let after_b = boolean(&mut topo, BooleanOp::Fuse, after_a, tongue_b).unwrap();
+    let sh_b = topo
+        .shell(topo.solid(after_b).unwrap().outer_shell())
+        .unwrap();
+    brepkit_topology::validation::validate_shell_closed(sh_b, &topo)
+        .expect("tongue B fused into the A-split wall must stay watertight");
 }


### PR DESCRIPTION
Rebased-clean replacement for #877 (its base #875 squash-merged, leaving #877 conflicting).

Fixes the multi-tongue dovetail baseplate fuse producing ~20 non-manifold edges. After the dovetail fuse hang fix (#875), fusing a second tongue into a wall face that the first tongue already split re-opened the sliver.

Root cause: `wire_builder.rs::clockwise_angle` used a `1e-14` continuation cutoff, tighter than the `atan2` rounding noise (~1e-13) at a collinear T-junction — so a near-collinear junction was scored as a real turn and the cap wove a zero-area slit instead of splitting. Widened the continuation threshold to `1e-9`.

Regression tests: `baseplate_two_tongues_far_apart_resplit_is_watertight`, `baseplate_dovetail_sequential_fuse_no_mesh_blowup` (both pass; single-tongue `baseplate_dovetail_tongue_fuse_is_watertight` from #875 still green). Full workspace green, zero regressions.

Note: the tool's *relieved* tongues (a lofted/tapered socket pocket cut through each tongue) still fall to the mesh fallback — a separate curved-boolean issue, out of scope.