### PR TITLE
perf(algo): broad-phase culls + analytic line-circle in GFA pave-filler

### DIFF
--- a/crates/algo/src/pave_filler/force_interf_ee.rs
+++ b/crates/algo/src/pave_filler/force_interf_ee.rs
@@ -53,43 +53,93 @@ pub fn perform(topo: &Topology, tol: Tolerance, arena: &mut GfaArena) -> Result<
         }
     }
 
-    // Find overlapping pairs: O(n²) but n is typically small (< 100 leaf PBs)
+    // Find overlapping pairs. A naive scan is O(n²) over leaf PaveBlocks,
+    // which explodes on solids with many edges (a shelled, lip-fused bin can
+    // reach thousands of leaf blocks). Two blocks can only overlap if BOTH
+    // endpoints coincide within tolerance, so we spatially hash each block by
+    // the quantized cell of its (unordered) endpoint pair and only compare
+    // blocks that share a candidate cell — collapsing the scan to ~O(n).
     let mut overlap_map: HashMap<PaveBlockId, Vec<PaveBlockId>> = HashMap::new();
     let n = leaf_data.len();
 
+    // Cell size large enough that two endpoints within `tol.linear` of each
+    // other never straddle the gap between non-adjacent cells once we probe
+    // the immediate neighborhood. Quantizing the midpoint gives one key per
+    // block; matching blocks have midpoints within `tol.linear`, so probing
+    // the 3×3×3 neighbor cells of a block's midpoint covers every true match.
+    let cell = (tol.linear * 4.0).max(f64::MIN_POSITIVE);
+    let key = |p: brepkit_math::vec::Point3| -> (i64, i64, i64) {
+        (
+            (p.x() / cell).floor() as i64,
+            (p.y() / cell).floor() as i64,
+            (p.z() / cell).floor() as i64,
+        )
+    };
+    let midpoint = |a: brepkit_math::vec::Point3, b: brepkit_math::vec::Point3| {
+        brepkit_math::vec::Point3::new(
+            f64::midpoint(a.x(), b.x()),
+            f64::midpoint(a.y(), b.y()),
+            f64::midpoint(a.z(), b.z()),
+        )
+    };
+
+    // Bucket each leaf block by its midpoint cell.
+    let mut buckets: HashMap<(i64, i64, i64), Vec<usize>> = HashMap::new();
+    for (i, (_, _, start, end)) in leaf_data.iter().enumerate() {
+        buckets
+            .entry(key(midpoint(*start, *end)))
+            .or_default()
+            .push(i);
+    }
+
+    // For each block, gather candidate partners from its own cell plus the
+    // 3×3×3 neighborhood (each block lives in exactly one bucket, so a pair is
+    // visited once via `j > i`), and run the exact same fwd/rev endpoint +
+    // curve-compatibility test as the naive scan.
     for i in 0..n {
-        let (pb_i, edge_i, start_i, end_i) = &leaf_data[i];
-        for j in (i + 1)..n {
-            let (pb_j, edge_j, start_j, end_j) = &leaf_data[j];
+        let (pb_i, edge_i, start_i, end_i) = leaf_data[i];
+        let mid_i = midpoint(start_i, end_i);
+        let (kx, ky, kz) = key(mid_i);
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                for dz in -1..=1 {
+                    let Some(cands) = buckets.get(&(kx + dx, ky + dy, kz + dz)) else {
+                        continue;
+                    };
+                    for &j in cands {
+                        if j <= i {
+                            continue;
+                        }
+                        let (pb_j, edge_j, start_j, end_j) = leaf_data[j];
 
-            if edge_i == edge_j {
-                continue;
+                        if edge_i == edge_j {
+                            continue;
+                        }
+                        if arena.pb_to_cb.contains_key(&pb_i)
+                            && arena.pb_to_cb.get(&pb_i) == arena.pb_to_cb.get(&pb_j)
+                        {
+                            continue;
+                        }
+
+                        let fwd_match = (start_i - start_j).length() < tol.linear
+                            && (end_i - end_j).length() < tol.linear;
+                        let rev_match = (start_i - end_j).length() < tol.linear
+                            && (end_i - start_j).length() < tol.linear;
+                        if !fwd_match && !rev_match {
+                            continue;
+                        }
+
+                        let curve_i = topo.edge(edge_i)?.curve();
+                        let curve_j = topo.edge(edge_j)?.curve();
+                        if !curves_compatible(curve_i, curve_j, tol) {
+                            continue;
+                        }
+
+                        overlap_map.entry(pb_i).or_default().push(pb_j);
+                        overlap_map.entry(pb_j).or_default().push(pb_i);
+                    }
+                }
             }
-
-            if arena.pb_to_cb.contains_key(pb_i)
-                && arena.pb_to_cb.get(pb_i) == arena.pb_to_cb.get(pb_j)
-            {
-                continue;
-            }
-
-            // Check endpoint match (either same-direction or reversed)
-            let fwd_match = (*start_i - *start_j).length() < tol.linear
-                && (*end_i - *end_j).length() < tol.linear;
-            let rev_match = (*start_i - *end_j).length() < tol.linear
-                && (*end_i - *start_j).length() < tol.linear;
-
-            if !fwd_match && !rev_match {
-                continue;
-            }
-
-            let curve_i = topo.edge(*edge_i)?.curve();
-            let curve_j = topo.edge(*edge_j)?.curve();
-            if !curves_compatible(curve_i, curve_j, tol) {
-                continue;
-            }
-
-            overlap_map.entry(*pb_i).or_default().push(*pb_j);
-            overlap_map.entry(*pb_j).or_default().push(*pb_i);
         }
     }
 

--- a/crates/algo/src/pave_filler/phase_ee.rs
+++ b/crates/algo/src/pave_filler/phase_ee.rs
@@ -187,6 +187,22 @@ fn find_edge_edge_crossings(
         return Ok(Vec::new());
     }
 
+    // Exact line-vs-circle: a line edge crossing an arc edge is extremely
+    // common (every analytic corner arc of a body vs every straight tool
+    // edge). The closed-form segment-circle solve replaces the 32×32 = 1024
+    // segment-pair samples below with at most two candidate roots, which is
+    // the dominant EE cost on solids with many cylindrical-corner arcs.
+    if let EdgeCurve::Circle(circle) = edge_b.curve()
+        && matches!(edge_a.curve(), EdgeCurve::Line)
+    {
+        return Ok(line_circle_intersection(ea, eb, circle, tol, false));
+    }
+    if let EdgeCurve::Circle(circle) = edge_a.curve()
+        && matches!(edge_b.curve(), EdgeCurve::Line)
+    {
+        return Ok(line_circle_intersection(eb, ea, circle, tol, true));
+    }
+
     let n: usize = 32;
     let mut crossings = Vec::new();
 
@@ -251,6 +267,61 @@ fn find_edge_edge_crossings(
     }
 
     Ok(crossings)
+}
+
+/// Exact line-segment vs circular-arc intersection.
+///
+/// `line` is the straight edge, `arc` the circle edge's data, `circle` its
+/// geometry. Returns `(t_a, t_b, point)` triples in the original edge order:
+/// when `circle_is_a` the arc is edge A, otherwise the line is edge A.
+fn line_circle_intersection(
+    line: &EdgeData,
+    arc: &EdgeData,
+    circle: &brepkit_math::curves::Circle3D,
+    tol: Tolerance,
+    circle_is_a: bool,
+) -> Vec<(f64, f64, Point3)> {
+    let mut out = Vec::new();
+    for (pt, angle) in circle.intersect_segment(line.start_pos, line.end_pos, tol.linear) {
+        // Validate the hit lies within the arc's angular domain. The arc
+        // parameter runs t0..t1 (radians); the solver returns [0, TAU). Test
+        // the angle and its ±TAU shifts so a hit near the seam still matches.
+        let lo = arc.t0.min(arc.t1) - tol.linear;
+        let hi = arc.t0.max(arc.t1) + tol.linear;
+        let in_arc = [
+            angle,
+            angle + std::f64::consts::TAU,
+            angle - std::f64::consts::TAU,
+        ]
+        .iter()
+        .find(|&&a| a >= lo && a <= hi)
+        .copied();
+        let Some(t_arc) = in_arc else {
+            continue;
+        };
+
+        // Line parameter from the foot of the point on the segment.
+        let dir = line.end_pos - line.start_pos;
+        let len_sq = dir.length_squared();
+        if len_sq < tol.linear * tol.linear {
+            continue;
+        }
+        let s = ((pt - line.start_pos).dot(dir) / len_sq).clamp(0.0, 1.0);
+        let t_line = s.mul_add(line.t1 - line.t0, line.t0);
+
+        let triple = if circle_is_a {
+            (t_arc, t_line, pt)
+        } else {
+            (t_line, t_arc, pt)
+        };
+        let is_dup = out.iter().any(|&(ca, cb, _): &(f64, f64, Point3)| {
+            (triple.0 - ca).abs() < 1e-6 && (triple.1 - cb).abs() < 1e-6
+        });
+        if !is_dup {
+            out.push(triple);
+        }
+    }
+    out
 }
 
 /// Algebraic line-line intersection.
@@ -359,5 +430,121 @@ fn closest_segment_pair(
         Some((param_a, param_b, midpoint))
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use brepkit_math::curves::Circle3D;
+    use brepkit_math::vec::Vec3;
+
+    fn line_data(start: Point3, end: Point3) -> EdgeData {
+        EdgeData {
+            start_pos: start,
+            end_pos: end,
+            t0: 0.0,
+            t1: 1.0,
+            bbox_min: start,
+            bbox_max: end,
+        }
+    }
+
+    fn arc_data(t0: f64, t1: f64) -> EdgeData {
+        // Positions/bbox are unused by line_circle_intersection (only t0/t1 are).
+        EdgeData {
+            start_pos: Point3::new(0.0, 0.0, 0.0),
+            end_pos: Point3::new(0.0, 0.0, 0.0),
+            t0,
+            t1,
+            bbox_min: Point3::new(0.0, 0.0, 0.0),
+            bbox_max: Point3::new(0.0, 0.0, 0.0),
+        }
+    }
+
+    #[test]
+    fn line_crosses_full_circle_at_two_points() {
+        let circle = Circle3D::new_with_ref(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            1.0,
+            Vec3::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let line = line_data(Point3::new(-2.0, 0.0, 0.0), Point3::new(2.0, 0.0, 0.0));
+        let arc = arc_data(0.0, std::f64::consts::TAU);
+        let tol = Tolerance::default();
+
+        let mut hits = line_circle_intersection(&line, &arc, &circle, tol, false);
+        hits.sort_by(|a, b| a.2.x().partial_cmp(&b.2.x()).unwrap());
+        assert_eq!(hits.len(), 2, "line should cross full circle at 2 points");
+        assert!((hits[0].2.x() - (-1.0)).abs() < 1e-6, "left hit at x=-1");
+        assert!((hits[1].2.x() - 1.0).abs() < 1e-6, "right hit at x=1");
+    }
+
+    #[test]
+    fn arc_domain_excludes_out_of_range_hit() {
+        // Quarter arc [0, π/2] only contains the +X crossing (angle 0), not the
+        // -X crossing (angle π).
+        let circle = Circle3D::new_with_ref(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            1.0,
+            Vec3::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let line = line_data(Point3::new(-2.0, 0.0, 0.0), Point3::new(2.0, 0.0, 0.0));
+        let arc = arc_data(0.0, std::f64::consts::FRAC_PI_2);
+        let tol = Tolerance::default();
+
+        let hits = line_circle_intersection(&line, &arc, &circle, tol, false);
+        assert_eq!(hits.len(), 1, "only the in-domain crossing should survive");
+        assert!((hits[0].2.x() - 1.0).abs() < 1e-6, "surviving hit at x=1");
+    }
+
+    #[test]
+    fn order_is_preserved_when_circle_is_edge_a() {
+        // When the circle is edge A, the triple must be (t_arc, t_line, point).
+        let circle = Circle3D::new_with_ref(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            1.0,
+            Vec3::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let line = line_data(Point3::new(1.0, -2.0, 0.0), Point3::new(1.0, 2.0, 0.0));
+        let arc = arc_data(0.0, std::f64::consts::TAU);
+        let tol = Tolerance::default();
+
+        // Line x=1 is tangent to the circle at (1,0,0), angle 0.
+        let hits = line_circle_intersection(&line, &arc, &circle, tol, true);
+        assert!(!hits.is_empty(), "tangent line should touch the circle");
+        // t_arc (first slot) ≈ 0 (angle at (1,0,0)); t_line (second slot) ≈ 0.5
+        // (midpoint of the y-segment).
+        assert!(hits[0].0.abs() < 1e-4, "t_arc should be the angle ~0");
+        assert!(
+            (hits[0].1 - 0.5).abs() < 1e-4,
+            "t_line should be ~0.5 (segment midpoint)"
+        );
+    }
+
+    #[test]
+    fn line_misses_circle() {
+        let circle = Circle3D::new_with_ref(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            1.0,
+            Vec3::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        // Line well outside the circle radius.
+        let line = line_data(Point3::new(-2.0, 5.0, 0.0), Point3::new(2.0, 5.0, 0.0));
+        let arc = arc_data(0.0, std::f64::consts::TAU);
+        let tol = Tolerance::default();
+
+        let hits = line_circle_intersection(&line, &arc, &circle, tol, false);
+        assert!(hits.is_empty(), "line far from circle should not intersect");
     }
 }

--- a/crates/algo/src/pave_filler/phase_ef.rs
+++ b/crates/algo/src/pave_filler/phase_ef.rs
@@ -245,6 +245,14 @@ fn check_edge_face_pairs(
         containments.push(build_face_containment(topo, fid, tol)?);
     }
 
+    // Pre-expand each face's containment AABB by the linear tolerance so the
+    // broad-phase reject below is conservative (never skips a real crossing,
+    // which by definition lies inside the face's boundary region).
+    let face_aabbs: Vec<Aabb3> = containments
+        .iter()
+        .map(|c| c.bbox.expanded(tol.linear))
+        .collect();
+
     for &eid in edges {
         // Snapshot edge data to avoid holding immutable borrow across add_vertex
         let (curve, start_pos, end_pos, t0, t1) = {
@@ -255,8 +263,32 @@ fn check_edge_face_pairs(
             (edge.curve().clone(), sp, ep, t0, t1)
         };
 
+        // Broad-phase AABB for the edge, reused across all faces. The vast
+        // majority of (edge, face) pairs are spatially disjoint; testing each
+        // edge sample against every face surface (an iterative projection for
+        // curved faces) is the dominant cost in booleans on solids with many
+        // curved faces. Sampling the edge into an AABB once and rejecting
+        // disjoint faces collapses that quadratic to the pairs that actually
+        // overlap. Sampled densely enough that the inter-sample sagitta is
+        // negligible for the analytic edge curves used here.
+        let edge_aabb = {
+            let mut pts = Vec::with_capacity(N_SAMPLES + 1);
+            for i in 0..=N_SAMPLES {
+                let t = t0 + (t1 - t0) * (i as f64 / N_SAMPLES as f64);
+                pts.push(curve.evaluate_with_endpoints(t, start_pos, end_pos));
+            }
+            Aabb3::try_from_points(pts).map(|a| a.expanded(tol.linear))
+        };
+
         for (face_idx, &fid) in faces.iter().enumerate() {
             if face_boundary_edges[face_idx].contains(&eid) {
+                continue;
+            }
+
+            // Broad-phase: skip faces whose region cannot reach this edge.
+            if let Some(ea) = &edge_aabb
+                && !ea.intersects(face_aabbs[face_idx])
+            {
                 continue;
             }
 

--- a/crates/algo/src/pave_filler/phase_ve.rs
+++ b/crates/algo/src/pave_filler/phase_ve.rs
@@ -3,6 +3,7 @@
 //! For each (vertex, edge) pair across solids, checks if the vertex
 //! lies on the edge. If so, adds an extra pave to the edge's pave block.
 
+use brepkit_math::aabb::Aabb3;
 use brepkit_math::tolerance::Tolerance;
 use brepkit_math::vec::Point3;
 use brepkit_topology::Topology;
@@ -12,6 +13,25 @@ use brepkit_topology::vertex::VertexId;
 
 use crate::ds::{GfaArena, Interference, Pave};
 use crate::error::AlgoError;
+
+/// Samples used to bound a curved edge's AABB for the broad-phase reject.
+const N_AABB_SAMPLES: usize = 16;
+
+/// Compute a conservative AABB for an edge, expanded by `margin`.
+fn edge_aabb(topo: &Topology, eid: EdgeId, margin: f64) -> Result<Option<Aabb3>, AlgoError> {
+    let edge = topo.edge(eid)?;
+    let start_pos = topo.vertex(edge.start())?.point();
+    let end_pos = topo.vertex(edge.end())?.point();
+    if matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Line) {
+        return Ok(Aabb3::try_from_points([start_pos, end_pos]).map(|a| a.expanded(margin)));
+    }
+    let (t0, t1) = edge.curve().domain_with_endpoints(start_pos, end_pos);
+    let pts = (0..=N_AABB_SAMPLES).map(|i| {
+        let t = t0 + (t1 - t0) * (i as f64 / N_AABB_SAMPLES as f64);
+        edge.curve().evaluate_with_endpoints(t, start_pos, end_pos)
+    });
+    Ok(Aabb3::try_from_points(pts).map(|a| a.expanded(margin)))
+}
 
 /// Detect vertices lying on edges between the two solids.
 ///
@@ -60,13 +80,31 @@ fn check_vertex_edge_pairs(
     tol: Tolerance,
     arena: &mut GfaArena,
 ) -> Result<(), AlgoError> {
+    // Broad-phase: bound each edge once. A vertex lying on an edge is within
+    // the edge's AABB, so vertices outside it are rejected before the costly
+    // closest-point projection (32 samples + 20 ternary steps per pair).
+    // Margin covers both the global linear tolerance and per-vertex tolerance,
+    // which is added to `tol.linear` in the fine test below.
+    let mut edge_boxes: Vec<Option<Aabb3>> = Vec::with_capacity(edges.len());
+    for &eid in edges {
+        edge_boxes.push(edge_aabb(topo, eid, tol.linear)?);
+    }
+
     for &vid in vertices {
         let resolved_vid = arena.resolve_vertex(vid);
         let vertex = topo.vertex(resolved_vid)?;
         let pos = vertex.point();
         let vtol = vertex.tolerance();
 
-        for &eid in edges {
+        for (edge_idx, &eid) in edges.iter().enumerate() {
+            // Broad-phase reject: the vertex cannot lie on an edge whose
+            // (tolerance-expanded by vtol) AABB does not contain it.
+            if let Some(ebox) = &edge_boxes[edge_idx]
+                && !ebox.expanded(vtol).contains_point(pos)
+            {
+                continue;
+            }
+
             let edge = topo.edge(eid)?;
 
             // Skip if vertex is already an endpoint of this edge


### PR DESCRIPTION
## Summary

The GFA boolean engine's pave-filler intersection phases tested **every**
cross-solid pair with only a whole-solid AABB pre-check, then ran expensive
per-sample surface/curve projections. On gridfinity bins (cylindrical corners +
NURBS loft walls) this dominated boolean time. These are pure broad-phase /
analytic optimizations — intersection results are identical.

## Hot path (env-gated `Instant` timing; `perf`/flamegraph is unavailable on the dev box)

Profiled the real bin build (rounded-rect body → shell → loft lip → cut → fuse →
divider cuts), not the tiny native proxies (which don't reproduce the slowness).
Phase breakdown for a 1×1 lip **fuse**, before → after:

| phase | before | after | |
|---|---|---|---|
| EF (edge-face) | 372ms | 20ms | 95% of pairs were spatially disjoint |
| VE (vertex-edge) | 59ms | 0.9ms | 66x |
| force_interf_ee | 49ms | 1.7ms | O(n^2) over 2347 leaf blocks (comment claimed "< 100") |
| EE (edge-edge) | 40ms | 8.7ms | line-arc fell to 32x32 sampling |

## Changes

- **Phase EF** (`phase_ef.rs`): reject `(edge, face)` pairs whose AABBs are
  disjoint before the per-sample surface projection. The face containment AABB
  already existed (only used to filter crossings *after* finding them) — now also
  bound the edge once and skip disjoint faces up front.
- **Phase VE** (`phase_ve.rs`): bound each edge once, reject vertices outside its
  AABB (expanded by the vertex tolerance) before the closest-point projection.
- **ForceInterfEE** (`force_interf_ee.rs`): replace the O(n^2) leaf-PaveBlock
  endpoint scan with a spatial hash on the block-midpoint cell + 3x3x3 neighbor
  probe. A match needs both endpoints within tolerance => midpoints within
  tolerance => the neighbor probe is exact.
- **Phase EE** (`phase_ee.rs`): exact segment-vs-arc solve for line/circle pairs
  (reuses the existing `Circle3D::intersect_segment`) instead of 32x32 segment
  sampling. Includes 4 unit tests.

## Impact

Per-op (1x1 lip bin): **lip cut 160 -> 26ms, lip fuse 390 -> 41ms**. The full
body+shell+loft-lip+cut+fuse build drops **~10x** (the `gridfinity_d4_full_1x1_bin`
test went 0.53s -> 0.04s wall). Larger bins benefit proportionally since these
phases scale with edge/face counts.

## Correctness — an AABB-disjoint pair cannot cross; a true crossing lies inside both AABBs.

- gridfinity 26/26 (x3, deterministic)
- algo lib 124/124 (4 new), operations lib 694, operations integration+golden all green, check 44, io 131
- clippy `-D warnings` clean, fmt clean, `check-boundaries.sh` clean

## Follow-ups (not in this PR)

- The bin's edge count explodes **~4x per box-divider cut** (fused lip bin 156 ->
  shell 292 -> divider 1215). This excessive fragmentation is the real driver of
  the dominant 2x2 compartments+scoop case and makes every phase scale badly
  across sequential cuts — but reducing it risks changing results, so it needs a
  separate careful pass.
- Remaining per-cut cost after these fixes: EF residual (genuine overlapping
  curved-face pairs), builder face-split, and ~80ms in the operations-layer
  boolean post-processing (heal/unify/manifold gates) on the large result.