### PR TITLE
perf(operations): memoize boolean post-processing traversals + cut-fragmentation root-cause report

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -563,12 +563,20 @@ pub fn boolean(
                 // If Euler>2, try merging duplicate vertices before unify.
                 // This fixes the flush-face case where duplicate vertices at
                 // cross-rank positions inflate V.
-                if euler_pre > 2 {
+                let merged_vertices = euler_pre > 2;
+                if merged_vertices {
                     // Best-effort: don't abort on merge failure
                     let _ = merge_result_vertices(topo, result, tol);
                 }
 
-                let (f2, e2, v2) = brepkit_topology::explorer::solid_entity_counts(topo, result)?;
+                // Re-count only when the merge above ran; otherwise the counts
+                // are unchanged from the pre-merge measurement (the merge is the
+                // only mutation in between).
+                let (f2, e2, v2) = if merged_vertices {
+                    brepkit_topology::explorer::solid_entity_counts(topo, result)?
+                } else {
+                    (f_pre, e_pre, v_pre)
+                };
                 #[allow(clippy::cast_possible_wrap)]
                 let euler_pre2 = (v2 as i64) - (e2 as i64) + (f2 as i64);
 
@@ -600,15 +608,34 @@ pub fn boolean(
                 // only pairs faces across opposing ranks with identical edge
                 // sets, so within-rank or different-boundary overlaps slip
                 // through; unify_faces is the safety net for those (issue #696).
-                let needs_unify = !euler_balanced_pre || !is_closed_manifold(topo, result)?;
+                // `is_closed_manifold` is a whole-solid walk. It is needed both
+                // here (to decide unify) and again after unify (the acceptance
+                // gate). Compute the pre-unify value at most once, and reuse it
+                // for the gate when unify changes nothing. It is only evaluated
+                // when `euler_balanced_pre` holds (otherwise `||` short-circuits
+                // and `needs_unify` is already true).
+                let manifold_pre = if euler_balanced_pre {
+                    Some(is_closed_manifold(topo, result)?)
+                } else {
+                    None
+                };
+                let needs_unify = !euler_balanced_pre || manifold_pre == Some(false);
+                let mut unified = false;
                 if needs_unify {
                     for _ in 0..3 {
                         if crate::heal::unify_faces(topo, result)? == 0 {
                             break;
                         }
+                        unified = true;
                     }
                 }
-                let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(topo, result)?;
+                // Re-count only when unify actually merged faces; otherwise the
+                // counts are unchanged from the (post-merge) measurement above.
+                let (f, e, v) = if unified {
+                    brepkit_topology::explorer::solid_entity_counts(topo, result)?
+                } else {
+                    (f2, e2, v2)
+                };
                 #[allow(clippy::cast_possible_wrap)]
                 let euler = (v as i64) - (e as i64) + (f as i64);
                 // Free edges in an Intersect result mean faces were dropped
@@ -625,17 +652,33 @@ pub fn boolean(
                 // acceptance additionally requires a closed manifold so that
                 // accidental cancellations (open shells whose missing faces
                 // offset the inner-wire surplus) still fail safe to the mesh
-                // fallback.
-                let inner_wire_count = solid_inner_wire_count(topo, result)?;
+                // fallback. Reuse the pre-unify count when unify made no change.
+                let inner_wire_count = if unified {
+                    solid_inner_wire_count(topo, result)?
+                } else {
+                    inner_wire_count_pre
+                };
+                // `is_closed_manifold` walks every face/edge of the result; the
+                // hollow gate, the genus-acceptance gate, and the multi-region
+                // gate below all need it on the same (post-unify) topology, so
+                // compute it once. Reuse the pre-unify value when it was already
+                // computed AND unify changed nothing — the only intervening
+                // mutation. Propagating a topology-query error with `?` here is
+                // equivalent to the old multi-region `unwrap_or(false)`: that
+                // call ran on this same solid, so an error would have surfaced
+                // at the hollow gate (reached first) regardless.
+                let closed_manifold = match manifold_pre {
+                    Some(m) if !unified => m,
+                    _ => is_closed_manifold(topo, result)?,
+                };
                 // A hollow result must additionally have every shell closed:
                 // a missing cavity face could otherwise cancel against the
                 // inner-shell surplus and balance Euler by accident.
-                let hollow_ok = inner_shell_surplus == 0 || is_closed_manifold(topo, result)?;
+                let hollow_ok = inner_shell_surplus == 0 || closed_manifold;
                 let euler_eff = euler - inner_shell_surplus;
                 let euler_ok = hollow_ok
                     && (euler_eff == 2
-                        || (euler_balanced(euler_eff, inner_wire_count)
-                            && is_closed_manifold(topo, result)?));
+                        || (euler_balanced(euler_eff, inner_wire_count) && closed_manifold));
                 if euler_ok && open_shell_ok && validate_boolean_result(topo, result).is_ok() {
                     log::info!(
                         "GFA boolean succeeded in {:.1}ms ({result_faces} faces)",
@@ -679,7 +722,10 @@ pub fn boolean(
                     && euler == expected_euler
                     && components_are_disjoint_pieces(topo, &components_vec)
                     && cut_safe
-                    && is_closed_manifold(topo, result).unwrap_or(false)
+                    // Reuse the `closed_manifold` computed above: nothing between
+                    // it and here mutates the result (only read-only component
+                    // and classifier queries run in between).
+                    && closed_manifold
                     && validate_boolean_result(topo, result).is_ok()
                 {
                     log::info!(


### PR DESCRIPTION
## Summary

Two parts, matching the perf-loop's two work streams. The dominant 37x case (2×2 compartments+scoop) is driven by a **layered GFA cut-correctness problem that forces a mesh-boolean fallback** — fixing it safely needs a careful multi-bug change (it broke `d4_shelled_box_fuse_lip` on first attempt), so per the loop's contract this PR lands the **safe post-processing win** and a **precise, evidence-backed root-cause report** for a focused follow-up.

This stacks conceptually on #881 (broad-phase culls) — rebased onto current `main` which already contains it.

## What this PR changes (safe, results-identical)

`boolean()`'s GFA-accept path recomputed several **whole-solid traversals** between mutation points:
- `solid_entity_counts` — 3×
- `is_closed_manifold` — up to 4×
- `solid_inner_wire_count` — 2×

Each walks every face/edge of the result. They're now reused when the intervening step (`merge_result_vertices`, `unify_faces`) made no change, and `is_closed_manifold` is computed once where the hollow gate, genus-acceptance gate, and multi-region gate all need it on the same post-unify topology. Substitutions only span code that does not mutate the result, so **every volume / manifoldness / Euler outcome is bit-identical**.

This is a small win (the post-processing is only ~5–20 ms per cut), and it does **not** materially move the 37x case — see below.

## Root-cause report: where the fragmentation originates (edge-count evidence)

Reproduced natively by building the real lip-fused 1×1 bin and cutting compartment pockets (the small `gridfinity_tests` proxies are plain boxes <10 ms and do NOT reproduce it). Per-stage env-gated `Instant` timing (`perf`/flamegraph are broken on this host).

**The fragmentation IS the mesh-boolean fallback.** For the first compartment-pocket cut on the lip bin:
- GFA `assemble` produces a clean-ish result, but it is **non-manifold (18 free edges)** → the operations-layer acceptance gate correctly rejects it → `mesh_boolean_fallback` tessellates → **156 → 785 edges (+629), 68 → 253 faces**.
- Cost split per cut: GFA ~157 ms, post-processing ~6 ms, **mesh fallback ~280 ms**. Subsequent cuts then run GFA on the bloated 785+-edge mesh result, so the cost compounds (cut 1 GFA ~350 ms, cut 2 ~435 ms). This cascade is the 37x.

**Why the GFA cut goes non-manifold — three layered roots:**

1. **Section crossings are not materialised (the primary root).** When a box tool passes through a target, the tool's wall face receives section lines from BOTH the target's perpendicular caps and walls. In `face_splitter::split_face_2d`, these section lines are added to the wire arrangement but are **not split at their mutual crossings / T-junctions**. A section whose endpoints land on *another section's interior* (a "doubly-dangling divider") therefore has no shared vertex, is flagged as pendant by `wire_builder::remove_pendant_sections`, and is **dropped**. Confirmed: the divider wall's 4 correct section lines (2 cap lines + 2 wall lines) collapse to just the 2 cap lines, so the wall splits into 3 horizontal bands instead of carving out the in-tool rectangle → the cut wall is kept un-trimmed (spans the full tool, beyond the target) → free edges.
   - A prototype that splits sections at their 3D crossings fixes the cut-wall carve, but **regresses `d4_shelled_box_fuse_lip`**: the *same* doubly-dangling pattern appears on the fuse's lip-wall faces, where the wire builder already traces the L-shaped cross-section correctly, and the split disrupts it. A safe fix needs to discriminate "divider to keep/carve" (Cut) from "loop boundary to trace" (Fuse) — which means plumbing the operation down into `split_face_2d` (it currently only knows the rank), or a wire-builder-level rule. That is the careful change to scope next.

2. **Multi-region disjoint-piece assembly.** A full-through cut splits the target into 2 disjoint pieces; `builder_solid::assemble` finds both (`2 shells [8,8] → 2 growth`) but keeps only the largest-volume growth shell and joins others **only if `shell_is_closed`**. Both pieces' cut walls are malformed (root #1), so the second piece is dropped → result has one piece + free edges. Even with root #1 fixed, this path needs work (a true `Compound`/multi-solid result, per the existing TODO).

3. **Pocket-into-cavity partition.** A pocket cut into the hollow bin interacts with the cavity floor / walls / lip via a *different* partition mechanism (not the perpendicular grid of #1), also yielding free edges. This is the one that actually dominates the realistic 2×2 workload.

Because these are layered, fixing only #1 (even safely, Cut-gated) does **not** get any end-to-end case to manifold — so no safe subset removes the mesh fallback today. That is why this PR ships the post-processing win + report rather than a partial GFA change that would change topology without eliminating the fallback.

## Gates

- gridfinity `26/26`, run 3× (deterministic)
- `cargo test -p brepkit-operations` (lib 694 + integration + golden) — 0 failures
- `cargo test -p brepkit-algo` — 124 pass
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `./scripts/check-boundaries.sh` — clean

Do not auto-merge.
