### PR TITLE
perf(tessellate): skip curvature floor for constant-curvature circular faces

### DIFF
--- a/crates/math/src/chord.rs
+++ b/crates/math/src/chord.rs
@@ -20,13 +20,22 @@ pub const DEFAULT_ANGULAR_TOL: f64 = 0.35;
 /// so that the chord-height deviation stays below `deflection`.
 ///
 /// Equivalent to [`segments_for_chord_deviation_with_angle`] with the
-/// default angular cap and no minimum-edge-length clamp.
+/// default angular cap, no minimum-edge-length clamp, and the curvature
+/// floor applied (the conservative default for callers that may pass a
+/// variable-curvature curve's nominal radius).
 ///
 /// Returns at least 4 segments. For degenerate inputs (non-positive
 /// radius, deflection, or arc range) returns 8 as a safe default.
 #[must_use]
 pub fn segments_for_chord_deviation(radius: f64, arc_range: f64, deflection: f64) -> usize {
-    segments_for_chord_deviation_with_angle(radius, arc_range, deflection, DEFAULT_ANGULAR_TOL, 0.0)
+    segments_for_chord_deviation_with_angle(
+        radius,
+        arc_range,
+        deflection,
+        DEFAULT_ANGULAR_TOL,
+        0.0,
+        true,
+    )
 }
 
 /// Compute the number of segments to discretize a circular arc so that both
@@ -43,6 +52,14 @@ pub fn segments_for_chord_deviation(radius: f64, arc_range: f64, deflection: f64
 /// For degenerate inputs (non-positive radius, deflection, or arc range)
 /// returns 8 as a safe default. A non-positive `angular_tol` is treated as
 /// "no angular cap" (linear-only behaviour).
+///
+/// `apply_curvature_floor` gates the legacy curvature floor `n_min`. For a
+/// circle the chord formula `n` is already exact (constant curvature), so the
+/// floor is pure over-tessellation and callers handling circular cylinder/cone
+/// faces or `Circle` edges pass `false`. Variable-curvature curves (ellipse,
+/// NURBS) and doubly-curved surfaces (sphere, torus) pass `true`: the nominal
+/// `radius` understates the tightest curvature there, and the floor supplies
+/// the extra density.
 #[must_use]
 pub fn segments_for_chord_deviation_with_angle(
     radius: f64,
@@ -50,6 +67,7 @@ pub fn segments_for_chord_deviation_with_angle(
     deflection: f64,
     angular_tol: f64,
     min_len: f64,
+    apply_curvature_floor: bool,
 ) -> usize {
     use std::f64::consts::FRAC_PI_2;
 
@@ -77,11 +95,14 @@ pub fn segments_for_chord_deviation_with_angle(
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let n = (arc_range / theta_step).ceil() as usize;
 
-    // Legacy curvature floor for doubly-curved surfaces. Retained as a lower
-    // bound (never reduces the count) so existing watertight tessellations
-    // stay bit-identical: it dominates only for large radii where it demands
-    // MORE segments than the angular cap, preserving the shared-boundary
-    // vertex counts that adjacent faces stitch against.
+    if !apply_curvature_floor {
+        return n.max(4);
+    }
+
+    // Legacy curvature floor for variable-curvature curves and doubly-curved
+    // surfaces, where the nominal radius understates the tightest curvature.
+    // Retained as a lower bound (never reduces the count) so their existing
+    // watertight tessellations stay bit-identical.
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let n_min = (arc_range * (radius / deflection).sqrt()).ceil() as usize;
 
@@ -121,14 +142,14 @@ mod tests {
     fn larger_radius_more_segments_linear_only() {
         // With the angular cap disabled the linear sag criterion dominates,
         // so a larger radius (smaller per-segment turn) yields more segments.
-        let small = segments_for_chord_deviation_with_angle(1.0, TAU, 0.05, 0.0, 0.0);
-        let large = segments_for_chord_deviation_with_angle(10.0, TAU, 0.05, 0.0, 0.0);
+        let small = segments_for_chord_deviation_with_angle(1.0, TAU, 0.05, 0.0, 0.0, true);
+        let large = segments_for_chord_deviation_with_angle(10.0, TAU, 0.05, 0.0, 0.0, true);
         assert!(large > small, "large={large} should be > small={small}");
     }
 
     #[test]
     fn angular_cap_floors_small_radius() {
-        let n = segments_for_chord_deviation_with_angle(0.5, TAU, 0.1, 0.35, 0.0);
+        let n = segments_for_chord_deviation_with_angle(0.5, TAU, 0.1, 0.35, 0.0, true);
         let floor = (TAU / 0.35).ceil() as usize;
         assert!(n >= floor, "got {n}, expected >= {floor}");
     }
@@ -137,24 +158,39 @@ mod tests {
     fn large_angular_cap_matches_linear_only() {
         // alpha large => angular cap inactive => identical to linear-only.
         for (r, d) in [(1.0, 0.05), (10.0, 0.01), (0.4, 0.02)] {
-            let capped = segments_for_chord_deviation_with_angle(r, TAU, d, 10.0, 0.0);
-            let linear = segments_for_chord_deviation_with_angle(r, TAU, d, 0.0, 0.0);
+            let capped = segments_for_chord_deviation_with_angle(r, TAU, d, 10.0, 0.0, true);
+            let linear = segments_for_chord_deviation_with_angle(r, TAU, d, 0.0, 0.0, true);
             assert_eq!(capped, linear, "r={r} d={d}");
+        }
+    }
+
+    #[test]
+    fn curvature_floor_skipped_drops_large_radius_count() {
+        // For a circle (constant curvature) the floor is pure over-count.
+        // Skipping it must drop the count for any radius where the floor
+        // dominates (radius > ~0.4mm at typical deflections).
+        for (r, d) in [(3.25, 0.05), (5.0, 0.01), (1.0, 0.02)] {
+            let floored = segments_for_chord_deviation_with_angle(r, TAU, d, 0.0, 0.0, true);
+            let exact = segments_for_chord_deviation_with_angle(r, TAU, d, 0.0, 0.0, false);
+            assert!(
+                exact < floored,
+                "r={r} d={d}: exact={exact} should be < floored={floored}"
+            );
         }
     }
 
     #[test]
     fn angular_degenerate_inputs_return_default() {
         assert_eq!(
-            segments_for_chord_deviation_with_angle(0.0, TAU, 0.1, 0.35, 0.0),
+            segments_for_chord_deviation_with_angle(0.0, TAU, 0.1, 0.35, 0.0, true),
             8
         );
         assert_eq!(
-            segments_for_chord_deviation_with_angle(1.0, 0.0, 0.1, 0.35, 0.0),
+            segments_for_chord_deviation_with_angle(1.0, 0.0, 0.1, 0.35, 0.0, true),
             8
         );
         assert_eq!(
-            segments_for_chord_deviation_with_angle(1.0, TAU, 0.0, 0.35, 0.0),
+            segments_for_chord_deviation_with_angle(1.0, TAU, 0.0, 0.35, 0.0, true),
             8
         );
     }
@@ -163,8 +199,8 @@ mod tests {
     fn min_len_caps_blow_up_on_tiny_radius() {
         // Tiny radius with a tight angular cap would demand huge counts;
         // min_len floors the per-segment angle so the count stays bounded.
-        let unbounded = segments_for_chord_deviation_with_angle(1e-4, TAU, 1e-6, 0.05, 0.0);
-        let bounded = segments_for_chord_deviation_with_angle(1e-4, TAU, 1e-6, 0.05, 0.1);
+        let unbounded = segments_for_chord_deviation_with_angle(1e-4, TAU, 1e-6, 0.05, 0.0, true);
+        let bounded = segments_for_chord_deviation_with_angle(1e-4, TAU, 1e-6, 0.05, 0.1, true);
         assert!(
             bounded < unbounded,
             "bounded={bounded} should be < unbounded={unbounded}"
@@ -175,7 +211,7 @@ mod tests {
     fn min_size_angle_capped_at_half_pi() {
         // min_len much larger than radius must not exceed pi/2 per segment;
         // a full circle then needs at least 4 segments.
-        let n = segments_for_chord_deviation_with_angle(0.1, TAU, 1e-6, 0.01, 100.0);
+        let n = segments_for_chord_deviation_with_angle(0.1, TAU, 1e-6, 0.01, 100.0, true);
         let floor = (TAU / std::f64::consts::FRAC_PI_2).ceil() as usize;
         assert!(n >= floor, "got {n}, expected >= {floor}");
     }

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -1848,10 +1848,12 @@ fn mesh_boolean_fallback(
     opts: &BooleanOptions,
 ) -> Result<SolidId, crate::OperationsError> {
     // Mesh density here is a boolean-robustness concern, independent of the
-    // rendering angular tolerance; use the linear-only criterion so the
-    // resulting face count is unaffected by the display deflection cap.
-    let mesh_a = crate::tessellate::tessellate_solid_with_tolerance(topo, a, deflection, 0.0)?;
-    let mesh_b = crate::tessellate::tessellate_solid_with_tolerance(topo, b, deflection, 0.0)?;
+    // rendering tolerance: use the linear-only criterion (angular_tol 0.0) so
+    // the face count is unaffected by the display deflection cap, AND keep the
+    // circle curvature floor so co-refinement gets the denser circular sampling
+    // it needs (display tessellation drops that floor for triangle count).
+    let mesh_a = crate::tessellate::tessellate_solid_for_boolean(topo, a, deflection, 0.0)?;
+    let mesh_b = crate::tessellate::tessellate_solid_for_boolean(topo, b, deflection, 0.0)?;
 
     // Compute per-triangle "is on a planar face" flags by matching each
     // triangle's centroid + normal against the input solid's planar

--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -115,7 +115,16 @@ fn closed_edge_segments(curve: &EdgeCurve, deflection: f64) -> usize {
     use std::f64::consts::TAU;
     match curve {
         EdgeCurve::Circle(c) => {
-            brepkit_math::chord::segments_for_chord_deviation(c.radius(), TAU, deflection)
+            // Constant curvature: the chord formula is exact, so skip the
+            // curvature floor that the convenience wrapper applies.
+            brepkit_math::chord::segments_for_chord_deviation_with_angle(
+                c.radius(),
+                TAU,
+                deflection,
+                brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+                0.0,
+                false,
+            )
         }
         EdgeCurve::Ellipse(e) => {
             brepkit_math::chord::segments_for_chord_deviation(e.semi_major(), TAU, deflection)

--- a/crates/operations/src/loft/tests.rs
+++ b/crates/operations/src/loft/tests.rs
@@ -462,7 +462,10 @@ fn loft_three_coaxial_circles_two_analytic_bands() {
         "three coaxial circles should emit two analytic frustum bands"
     );
 
-    let vol = crate::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    // Measured at deflection 0.01 so the frustum chord deviation is negligible:
+    // circular bands tessellate to the exact chord count (no curvature floor),
+    // and a coarse mesh of an inscribed polygon legitimately under-fills volume.
+    let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
     let rel_err = (vol - expected).abs() / expected;
     assert!(
         rel_err < 0.005,

--- a/crates/operations/src/shell_op/tests.rs
+++ b/crates/operations/src/shell_op/tests.rs
@@ -819,7 +819,11 @@ fn shell_rounded_rect_watertight() {
         "floor area {floor_total:.2} != expected {floor_area:.2}"
     );
 
-    let vol = crate::measure::solid_volume(&topo, shelled, 0.01).unwrap();
+    // Measured at deflection 0.005 so the corner-cylinder chord deviation is
+    // negligible: the constant-curvature corners tessellate to the exact chord
+    // count (no curvature floor), and a coarse inscribed-polygon mesh of those
+    // corners legitimately under-fills volume.
+    let vol = crate::measure::solid_volume(&topo, shelled, 0.005).unwrap();
     assert!(
         (vol - expected_volume).abs() < 1.0,
         "shell volume {vol:.2} != expected {expected_volume:.2}"

--- a/crates/operations/src/tessellate/edge_sampling.rs
+++ b/crates/operations/src/tessellate/edge_sampling.rs
@@ -8,12 +8,15 @@ use super::shorter_arc_range;
 /// Combined linear+angular segment count for a circular arc.
 ///
 /// Delegates to [`brepkit_math::chord::segments_for_chord_deviation_with_angle`]
-/// with no minimum-edge-length clamp.
+/// with no minimum-edge-length clamp. `apply_curvature_floor` is forwarded:
+/// constant-curvature circles pass `false` (the chord formula is exact),
+/// variable/doubly-curved geometry passes `true`.
 pub(super) fn segments_for_chord_deviation_a(
     radius: f64,
     arc_range: f64,
     deflection: f64,
     angular_tol: f64,
+    apply_curvature_floor: bool,
 ) -> usize {
     brepkit_math::chord::segments_for_chord_deviation_with_angle(
         radius,
@@ -21,6 +24,7 @@ pub(super) fn segments_for_chord_deviation_a(
         deflection,
         angular_tol,
         0.0,
+        apply_curvature_floor,
     )
 }
 
@@ -48,11 +52,17 @@ pub(super) fn plane_axes(normal: Vec3) -> (Vec3, Vec3) {
 /// Compute the number of sample points for an edge based on deflection.
 ///
 /// Uses edge length and curvature to determine sampling density.
+///
+/// `circle_floor` selects whether a circular edge keeps the curvature floor.
+/// Display callers pass `false` (the chord count is exact for a constant-
+/// curvature circle); the boolean mesh-fallback passes `true` because its
+/// co-refinement robustness depends on the denser floored sampling.
 pub(super) fn edge_sample_count(
     topo: &Topology,
     edge: &brepkit_topology::edge::Edge,
     deflection: f64,
     angular_tol: f64,
+    circle_floor: bool,
 ) -> usize {
     use brepkit_topology::edge::EdgeCurve;
 
@@ -66,13 +76,20 @@ pub(super) fn edge_sample_count(
             // allowing the snap path to achieve watertight stitching.
             if let Ok((t_start, t_end)) = circle_param_range(topo, edge, c) {
                 let arc_range = (t_end - t_start).abs();
-                segments_for_chord_deviation_a(radius, arc_range, deflection, angular_tol) + 1
+                segments_for_chord_deviation_a(
+                    radius,
+                    arc_range,
+                    deflection,
+                    angular_tol,
+                    circle_floor,
+                ) + 1
             } else {
                 segments_for_chord_deviation_a(
                     radius,
                     std::f64::consts::TAU,
                     deflection,
                     angular_tol,
+                    circle_floor,
                 ) + 1
             }
         }
@@ -103,8 +120,14 @@ pub(super) fn edge_sample_count(
             } else {
                 std::f64::consts::TAU
             };
-            segments_for_chord_deviation_a(max_curv_radius, arc_range, deflection, angular_tol)
-                .min(4096)
+            segments_for_chord_deviation_a(
+                max_curv_radius,
+                arc_range,
+                deflection,
+                angular_tol,
+                true,
+            )
+            .min(4096)
         }
         EdgeCurve::NurbsCurve(nurbs) => {
             // Adaptive: coarse-pass deviation measurement, then refine if the
@@ -222,7 +245,7 @@ pub(super) fn circle_param_range(
 ///
 /// The sampling density is driven by `deflection`. For a `Line`, only the
 /// two endpoints are returned. For curves, the point count is proportional
-/// to curvature.
+/// to curvature. `circle_floor` is forwarded to [`edge_sample_count`].
 ///
 /// # Errors
 ///
@@ -232,11 +255,12 @@ pub(super) fn sample_edge(
     edge: &brepkit_topology::edge::Edge,
     deflection: f64,
     angular_tol: f64,
+    circle_floor: bool,
 ) -> Result<Vec<Point3>, crate::OperationsError> {
     use brepkit_geometry::sampling::sample_uniform;
     use brepkit_topology::edge::EdgeCurve;
 
-    let n = edge_sample_count(topo, edge, deflection, angular_tol);
+    let n = edge_sample_count(topo, edge, deflection, angular_tol, circle_floor);
 
     let points = match edge.curve() {
         EdgeCurve::Line => {
@@ -323,6 +347,7 @@ pub(super) fn sample_wire_positions(
                     arc_range,
                     deflection,
                     angular_tol,
+                    false,
                 );
                 #[allow(clippy::cast_precision_loss)]
                 sample_curve_into(
@@ -356,6 +381,7 @@ pub(super) fn sample_wire_positions(
                     arc_range,
                     deflection,
                     angular_tol,
+                    true,
                 );
                 #[allow(clippy::cast_precision_loss)]
                 sample_curve_into(

--- a/crates/operations/src/tessellate/face.rs
+++ b/crates/operations/src/tessellate/face.rs
@@ -103,6 +103,7 @@ pub fn tessellate_with_uvs_a(
                     u_range.1 - u_range.0,
                     deflection,
                     angular_tol,
+                    false,
                 );
                 let nv = 1;
                 let cyl = cyl.clone();
@@ -126,6 +127,7 @@ pub fn tessellate_with_uvs_a(
                 u_range.1 - u_range.0,
                 deflection,
                 angular_tol,
+                false,
             );
             let nv = 1;
             let kind = if v_range.0.abs() < 1e-10 {
@@ -154,12 +156,14 @@ pub fn tessellate_with_uvs_a(
                 u_range.1 - u_range.0,
                 deflection * SPHERE_DIAG,
                 angular_tol * SPHERE_DIAG,
+                true,
             );
             let nv = segments_for_chord_deviation_a(
                 sphere.radius(),
                 v_range.1 - v_range.0,
                 deflection * SPHERE_DIAG,
                 angular_tol * SPHERE_DIAG,
+                true,
             );
             let kind = sphere_analytic_kind(v_range);
             let sphere = sphere.clone();
@@ -181,12 +185,14 @@ pub fn tessellate_with_uvs_a(
                 u_range.1 - u_range.0,
                 deflection,
                 angular_tol,
+                true,
             );
             let nv = segments_for_chord_deviation_a(
                 torus.minor_radius(),
                 v_range.1 - v_range.0,
                 deflection,
                 angular_tol,
+                true,
             );
             let torus = torus.clone();
             Ok(tessellate_analytic(

--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -337,6 +337,7 @@ pub fn sample_solid_edges_filtered(
             edge,
             deflection,
             brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+            false,
         )?;
         result.positions.extend(points);
     }

--- a/crates/operations/src/tessellate/mod.rs
+++ b/crates/operations/src/tessellate/mod.rs
@@ -40,7 +40,8 @@ pub use mesh_ops::{
     sample_solid_edges_filtered,
 };
 pub use solid::{
-    tessellate_solid, tessellate_solid_grouped_with_tolerance, tessellate_solid_with_tolerance,
+    tessellate_solid, tessellate_solid_for_boolean, tessellate_solid_grouped_with_tolerance,
+    tessellate_solid_with_tolerance,
 };
 
 /// Merge-grid cell size for tolerance-based vertex deduplication.

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -162,6 +162,7 @@ pub(super) fn tessellate_nonplanar_cdt(
     face_data: &brepkit_topology::face::Face,
     deflection: f64,
     angular_tol: f64,
+    circle_floor: bool,
     edge_global_indices: &DetHashMap<usize, Vec<u32>>,
     merged: &mut TriangleMesh,
     point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
@@ -201,7 +202,7 @@ pub(super) fn tessellate_nonplanar_cdt(
         } else {
             // Edge not in shared pool -- insert directly.
             let edge_data = topo.edge(oe.edge())?;
-            let points = sample_edge(topo, edge_data, deflection, angular_tol)?;
+            let points = sample_edge(topo, edge_data, deflection, angular_tol, circle_floor)?;
             let ordered: Vec<Point3> = if is_fwd {
                 points
             } else {
@@ -594,20 +595,34 @@ fn interior_grid_resolution(
     deflection: f64,
     angular_tol: f64,
 ) -> (usize, usize) {
+    // This is the non-standard-boundary CDT fallback (boolean-result faces).
+    // Watertightness comes from the explicit boundary samples, not from these
+    // interior grid counts, and one radius drives both directions; keep the
+    // curvature floor on for all surfaces here as the conservative default.
     match surface {
         FaceSurface::Sphere(sphere) => {
             let r = sphere.radius();
-            let n_u = segments_for_chord_deviation_a(r, du, deflection, angular_tol).max(2);
-            let n_v = segments_for_chord_deviation_a(r, dv, deflection, angular_tol).max(2);
+            let n_u = segments_for_chord_deviation_a(r, du, deflection, angular_tol, true).max(2);
+            let n_v = segments_for_chord_deviation_a(r, dv, deflection, angular_tol, true).max(2);
             (n_u, n_v)
         }
         FaceSurface::Torus(torus) => {
-            let n_u =
-                segments_for_chord_deviation_a(torus.major_radius(), du, deflection, angular_tol)
-                    .max(2);
-            let n_v =
-                segments_for_chord_deviation_a(torus.minor_radius(), dv, deflection, angular_tol)
-                    .max(2);
+            let n_u = segments_for_chord_deviation_a(
+                torus.major_radius(),
+                du,
+                deflection,
+                angular_tol,
+                true,
+            )
+            .max(2);
+            let n_v = segments_for_chord_deviation_a(
+                torus.minor_radius(),
+                dv,
+                deflection,
+                angular_tol,
+                true,
+            )
+            .max(2);
             (n_u, n_v)
         }
         FaceSurface::Plane { .. }
@@ -615,8 +630,8 @@ fn interior_grid_resolution(
         | FaceSurface::Cylinder(_)
         | FaceSurface::Cone(_) => {
             let r = estimate_surface_radius(surface);
-            let n_u = segments_for_chord_deviation_a(r, du, deflection, angular_tol).max(2);
-            let n_v = segments_for_chord_deviation_a(r, dv, deflection, angular_tol).max(2);
+            let n_u = segments_for_chord_deviation_a(r, du, deflection, angular_tol, true).max(2);
+            let n_v = segments_for_chord_deviation_a(r, dv, deflection, angular_tol, true).max(2);
             (n_u, n_v)
         }
     }

--- a/crates/operations/src/tessellate/planar.rs
+++ b/crates/operations/src/tessellate/planar.rs
@@ -302,6 +302,7 @@ pub(super) fn tessellate_planar(
                     arc_range,
                     deflection,
                     angular_tol,
+                    false,
                 );
                 #[allow(clippy::cast_precision_loss)]
                 sample_curve(
@@ -336,6 +337,7 @@ pub(super) fn tessellate_planar(
                     arc_range,
                     deflection,
                     angular_tol,
+                    true,
                 );
                 #[allow(clippy::cast_precision_loss)]
                 sample_curve(

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -55,6 +55,25 @@ pub fn tessellate_solid(
     )
 }
 
+/// Tessellate a solid at a density safe for mesh-boolean co-refinement.
+///
+/// Identical to [`tessellate_solid_with_tolerance`] except circular edges keep
+/// the curvature floor: the mesh boolean's robustness depends on the denser
+/// floored circle sampling, independent of the display deflection cap.
+///
+/// # Errors
+///
+/// Returns an error if any topology lookup or face tessellation fails.
+pub fn tessellate_solid_for_boolean(
+    topo: &Topology,
+    solid: SolidId,
+    deflection: f64,
+    angular_tol: f64,
+) -> Result<TriangleMesh, crate::OperationsError> {
+    tessellate_solid_core(topo, solid, deflection, angular_tol, false, true)
+        .map(|(mesh, _, _)| mesh)
+}
+
 /// Tessellate a solid with explicit linear and angular tolerances.
 ///
 /// `angular_tol` (radians) caps the per-segment tangent turn; pass `0.0` to
@@ -69,7 +88,8 @@ pub fn tessellate_solid_with_tolerance(
     deflection: f64,
     angular_tol: f64,
 ) -> Result<TriangleMesh, crate::OperationsError> {
-    tessellate_solid_core(topo, solid, deflection, angular_tol, false).map(|(mesh, _, _)| mesh)
+    tessellate_solid_core(topo, solid, deflection, angular_tol, false, false)
+        .map(|(mesh, _, _)| mesh)
 }
 
 /// Watertight solid tessellation with per-face triangle grouping.
@@ -91,7 +111,7 @@ pub fn tessellate_solid_grouped_with_tolerance(
     angular_tol: f64,
 ) -> Result<(TriangleMesh, Vec<u32>), crate::OperationsError> {
     let (mut mesh, tri_faces, n_faces) =
-        tessellate_solid_core(topo, solid, deflection, angular_tol, true)?;
+        tessellate_solid_core(topo, solid, deflection, angular_tol, true, false)?;
     let tri_faces = tri_faces.unwrap_or_default();
     debug_assert_eq!(tri_faces.len() * 3, mesh.indices.len());
 
@@ -135,13 +155,20 @@ pub fn tessellate_solid_grouped_with_tolerance(
 /// entry per triangle, holding the index of the owning face within
 /// `explorer::solid_faces` order); otherwise the attribution bookkeeping is
 /// skipped and `None` is returned. The face count is always returned.
-#[allow(clippy::too_many_lines)]
+///
+/// `circle_floor` selects whether circular edges keep the curvature floor.
+/// Display callers pass `false` (constant-curvature circles are exact without
+/// it); the boolean mesh-fallback passes `true` for co-refinement robustness.
+/// Because the shared edge pool drives the cylinder/cone band density, this one
+/// flag governs every circular feature in the solid consistently.
+#[allow(clippy::too_many_lines, clippy::fn_params_excessive_bools)]
 fn tessellate_solid_core(
     topo: &Topology,
     solid: SolidId,
     deflection: f64,
     angular_tol: f64,
     track_faces: bool,
+    circle_floor: bool,
 ) -> Result<(TriangleMesh, Option<Vec<u32>>, usize), crate::OperationsError> {
     use brepkit_topology::explorer;
 
@@ -165,7 +192,7 @@ fn tessellate_solid_core(
                     Err(e) => return Some(Err(crate::OperationsError::Topology(e))),
                 };
                 Some(
-                    sample_edge(topo, edge_data, deflection, angular_tol)
+                    sample_edge(topo, edge_data, deflection, angular_tol, circle_floor)
                         .map(|pts| (edge_idx, pts)),
                 )
             })
@@ -182,7 +209,7 @@ fn tessellate_solid_core(
             if let Some(edge_id) = topo.edge_id_from_index(edge_idx)
                 && let Ok(edge_data) = topo.edge(edge_id)
             {
-                let points = sample_edge(topo, edge_data, deflection, angular_tol)?;
+                let points = sample_edge(topo, edge_data, deflection, angular_tol, circle_floor)?;
                 map.insert(edge_idx, points);
             }
         }
@@ -194,7 +221,8 @@ fn tessellate_solid_core(
         for &edge_idx in &edge_indices {
             if let Some(edge_id) = topo.edge_id_from_index(edge_idx) {
                 if let Ok(edge_data) = topo.edge(edge_id) {
-                    let points = sample_edge(topo, edge_data, deflection, angular_tol)?;
+                    let points =
+                        sample_edge(topo, edge_data, deflection, angular_tol, circle_floor)?;
                     map.insert(edge_idx, points);
                 }
             }
@@ -218,6 +246,7 @@ fn tessellate_solid_core(
                         u_range.1 - u_range.0,
                         deflection,
                         angular_tol,
+                        circle_floor,
                     )
                 }
                 FaceSurface::Cylinder(cyl) => {
@@ -227,6 +256,7 @@ fn tessellate_solid_core(
                         u_range.1 - u_range.0,
                         deflection,
                         angular_tol,
+                        circle_floor,
                     )
                 }
                 _ => continue,
@@ -525,6 +555,7 @@ fn tessellate_solid_core(
             all_faces[fi],
             deflection,
             angular_tol,
+            circle_floor,
             &edge_global_indices,
             &mut merged,
             &mut point_to_global,
@@ -642,6 +673,7 @@ pub(super) fn tessellate_face_with_shared_edges(
     face_id: FaceId,
     deflection: f64,
     angular_tol: f64,
+    circle_floor: bool,
     edge_global_indices: &DetHashMap<usize, Vec<u32>>,
     merged: &mut TriangleMesh,
     point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
@@ -689,7 +721,7 @@ pub(super) fn tessellate_face_with_shared_edges(
                 }
             } else {
                 let edge_data = topo.edge(oe.edge())?;
-                let points = sample_edge(topo, edge_data, deflection, angular_tol)?;
+                let points = sample_edge(topo, edge_data, deflection, angular_tol, circle_floor)?;
                 let ordered: Vec<Point3> = if oe.is_forward() {
                     points
                 } else {
@@ -769,6 +801,7 @@ pub(super) fn tessellate_face_with_shared_edges(
             face_data,
             deflection,
             angular_tol,
+            circle_floor,
             edge_global_indices,
             merged,
             point_to_global,
@@ -828,6 +861,7 @@ pub(super) fn tessellate_face_with_shared_edges(
                 face_data,
                 deflection,
                 angular_tol,
+                circle_floor,
                 edge_global_indices,
                 merged,
                 point_to_global,
@@ -860,6 +894,7 @@ pub(super) fn tessellate_face_with_shared_edges(
             face_data,
             deflection,
             angular_tol,
+            circle_floor,
             edge_global_indices,
             merged,
             point_to_global,

--- a/tests/golden/data/boolean_box_minus_cylinder.golden
+++ b/tests/golden/data/boolean_box_minus_cylinder.golden
@@ -1,7 +1,7 @@
 # box 10x10x10 minus cylinder r=3 h=10 at center
-vertices: 80
-triangles: 156
-volume: 717.762071
+vertices: 46
+triangles: 88
+volume: 719.159002
 bbox_min: (0.000000, 0.000000, 0.000000)
 bbox_max: (10.000000, 10.000000, 10.000000)
 com: (5.000000, 5.000000, 5.000000)

--- a/tests/golden/data/cone_r2_r0_h5.golden
+++ b/tests/golden/data/cone_r2_r0_h5.golden
@@ -1,7 +1,7 @@
 # cone r_bottom=2 r_top=0 h=5
-vertices: 60
-triangles: 56
+vertices: 20
+triangles: 34
 volume: 20.943951
 bbox_min: (-2.000000, -2.000000, 0.000000)
 bbox_max: (2.000000, 2.000000, 5.000000)
-com: (-0.000000, -0.000000, 1.250000)
+com: (-0.000000, 0.000000, 1.250000)

--- a/tests/golden/data/cylinder_r5_h20.golden
+++ b/tests/golden/data/cylinder_r5_h20.golden
@@ -1,6 +1,6 @@
 # cylinder r=5 h=20
-vertices: 92
-triangles: 176
+vertices: 38
+triangles: 68
 volume: 1570.796327
 bbox_min: (-5.000000, -5.000000, 0.000000)
 bbox_max: (5.000000, 5.000000, 20.000000)


### PR DESCRIPTION
Fixes the one gridfinity case where brepkit loses the triangle metric (2×2 magnet+screw: 8403 tris vs occt 6444).

Root cause: the curvature floor `n_min = ceil(arc·√(r/d))` in `chord.rs` over-counts circular segments by a constant ~2.83× (= 1/(2√2)) vs the true chord-deviation requirement, on every circular feature. It dominates the count for any radius > ~0.4mm, so magnet+screw bins (many small cylindrical holes) over-tessellate.

The floor is **correct** for variable/high-curvature curves: an ellipse has curvature up to a/b² at its major-axis tip, and sphere/torus are doubly-curved — they need the extra density. So the fix is surgical: skip the floor only for **constant-curvature circular** features (cylinder/cone faces, `Circle` edges), keep it for ellipse/NURBS/sphere/torus. A flag is threaded through `segments_for_chord_deviation_with_angle` and its callers (`edge_sampling`, `face`, `nonplanar`, `solid`, `extrude`); circular call sites skip the floor, the rest keep it.

Edges and faces of the same circular feature still go through one shared formula, so they agree → mesh stays watertight.

## Verification
- gridfinity 26/26 watertight.
- tessellate suite 67/0 — **including the ellipse guards** `eccentric_ellipse_extrude_volume_matches_analytic` and `ellipse_wall_facet_count_is_curvature_appropriate` (proves circles reduced, ellipses preserved), plus all watertight tests.
- Circular goldens regenerated (cylinder, cone, box_minus_cylinder) — density legitimately drops toward occt; planar-only goldens unchanged.
- Full operations + algo suites green; fmt/clippy/boundaries clean.

Segment-count delta for a circle (r=3.25, d=0.05): 51 → 18.