### PR TITLE
perf(operations): short-circuit disjoint Fuse to a cheap shell merge

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -532,7 +532,7 @@ pub fn boolean(
         let copy_a = crate::copy::copy_solid(topo, a)?;
         let copy_b = crate::copy::copy_solid(topo, b)?;
         let merged = crate::compound_ops::merge_disjoint_solids(topo, &[copy_a, copy_b])?;
-        log::info!("Fuse short-circuited via disjoint shell merge");
+        log::debug!("Fuse short-circuited via disjoint shell merge");
         return Ok(merged);
     }
 

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -512,6 +512,30 @@ pub fn boolean(
         }
     }
 
+    // Disjoint-fuse fast path: when A and B are provably spatially disjoint,
+    // their union is a multi-region solid — the same result GFA produces for
+    // disjoint inputs, but built by a cheap shell merge instead of the full
+    // pavefiller/assembly pipeline. This is what makes a pairwise-accumulate
+    // loop over many disjoint pieces (e.g. one tapered foot per gridfinity
+    // cell) scale linearly: each fuse onto the growing accumulator short-
+    // circuits here.
+    //
+    // Disjointness is decided per connected component (not per whole-solid
+    // bbox): the accumulator spans many pieces, so its overall box overlaps
+    // the next piece's box even when no piece actually touches. Component
+    // boxes are conservative outer bounds, and the gap test uses a positive
+    // tolerance margin, so the path only fires on a clear gap — touching or
+    // overlapping operands fall through to GFA, which welds the shared
+    // geometry. The result is independent of the inputs (each operand is
+    // deep-copied before merging), preserving the boolean contract.
+    if op == BooleanOp::Fuse && solids_provably_disjoint(topo, a, b, tol.linear) {
+        let copy_a = crate::copy::copy_solid(topo, a)?;
+        let copy_b = crate::copy::copy_solid(topo, b)?;
+        let merged = crate::compound_ops::merge_disjoint_solids(topo, &[copy_a, copy_b])?;
+        log::info!("Fuse short-circuited via disjoint shell merge");
+        return Ok(merged);
+    }
+
     let algo_op = match op {
         BooleanOp::Fuse => brepkit_algo::bop::BooleanOp::Fuse,
         BooleanOp::Cut => brepkit_algo::bop::BooleanOp::Cut,
@@ -1758,6 +1782,67 @@ fn aabbs_separated(
         || b.max.y() < a.min.y() + margin
         || a.max.z() < b.min.z() + margin
         || b.max.z() < a.min.z() + margin
+}
+
+/// Returns `true` when two axis-aligned boxes have a *clear gap* exceeding
+/// `margin` on at least one axis — i.e. they are separated by a real positive
+/// distance, not merely touching.
+///
+/// This is intentionally stricter than [`aabbs_separated`]: a shared
+/// face/edge/corner (zero gap) returns `false` here. Touching solids must NOT
+/// be treated as disjoint by the fuse fast path — their shared geometry has to
+/// be welded by GFA.
+fn aabbs_clear_gap(
+    a: &brepkit_math::aabb::Aabb3,
+    b: &brepkit_math::aabb::Aabb3,
+    margin: f64,
+) -> bool {
+    b.min.x() - a.max.x() > margin
+        || a.min.x() - b.max.x() > margin
+        || b.min.y() - a.max.y() > margin
+        || a.min.y() - b.max.y() > margin
+        || b.min.z() - a.max.z() > margin
+        || a.min.z() - b.max.z() > margin
+}
+
+/// Returns `true` when solids `a` and `b` are provably spatially disjoint with
+/// a clear gap: every connected face component of `a` is separated from every
+/// connected face component of `b` by more than `margin` on some axis.
+///
+/// Soundness: component AABBs come from [`crate::measure::face_set_bounding_box`],
+/// which is a conservative *outer* bound (vertices plus surface-curvature
+/// expansion). If two components' true geometry overlapped or touched, their
+/// boxes would touch or overlap and [`aabbs_clear_gap`] would (correctly)
+/// return `false`. So a `true` result guarantees a real positive gap between
+/// the two solids — never a false "disjoint" for touching/coincident inputs,
+/// which must still go through GFA to weld shared geometry.
+///
+/// Component-level (rather than whole-solid) granularity is essential: a
+/// multi-region solid (e.g. an accumulator of several already-merged disjoint
+/// pieces) has a single outer shell whose overall box overlaps a nearby piece,
+/// yet none of its pieces actually touch that piece. [`assembly::face_components`]
+/// recovers the individual pieces from the merged shell.
+///
+/// Returns `false` on any topology error or empty operand (fall through to the
+/// general path) rather than risking an unsound merge.
+fn solids_provably_disjoint(topo: &Topology, a: SolidId, b: SolidId, margin: f64) -> bool {
+    let comps_a = assembly::face_components(topo, a);
+    let comps_b = assembly::face_components(topo, b);
+    if comps_a.is_empty() || comps_b.is_empty() {
+        return false;
+    }
+    let boxes = |comps: &[Vec<FaceId>]| -> Option<Vec<brepkit_math::aabb::Aabb3>> {
+        comps
+            .iter()
+            .map(|faces| crate::measure::face_set_bounding_box(topo, faces).ok())
+            .collect()
+    };
+    let (Some(boxes_a), Some(boxes_b)) = (boxes(&comps_a), boxes(&comps_b)) else {
+        return false;
+    };
+    boxes_a
+        .iter()
+        .all(|ba| boxes_b.iter().all(|bb| aabbs_clear_gap(ba, bb, margin)))
 }
 
 /// Check whether every boundary vertex of `solid` is classified as

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -127,6 +127,128 @@ fn fuse_disjoint_cubes_volume_chained() {
     );
 }
 
+/// Fusing many disjoint tapered "feet" (the gridfinity base-socket shape:
+/// frustums wider at the top, with a sub-millimetre gap between neighbours)
+/// via the pairwise-accumulate pattern brepjs uses must keep every piece and
+/// the exact total volume. The disjoint-fuse fast path turns each accumulate
+/// step into a cheap shell merge instead of a full GFA fuse.
+#[test]
+fn fuse_disjoint_tapered_feet_grid_keeps_all_pieces() {
+    use crate::boolean::assembly::face_components;
+    use crate::measure::solid_volume;
+    use std::f64::consts::PI;
+
+    // 3×3 grid of frustums: base r=2, top r=2.4 (tapers OUTWARD upward, so the
+    // widest extent — the bbox footprint — is the top disc, radius 2.4), height
+    // 5. Pitch 5.0 → adjacent top discs are 5.0 - 2*2.4 = 0.2 apart: a clear
+    // positive gap, well above linear tolerance, but tight like the real socket.
+    let r_bot = 2.0_f64;
+    let r_top = 2.4_f64;
+    let h = 5.0_f64;
+    let pitch = 5.0_f64;
+    let n = 3;
+
+    let mut topo = Topology::new();
+    let mut feet = Vec::new();
+    for row in 0..n {
+        for col in 0..n {
+            let x = f64::from(col) * pitch;
+            let y = f64::from(row) * pitch;
+            let foot = crate::primitives::make_cone(&mut topo, r_bot, r_top, h).unwrap();
+            crate::transform::transform_solid(
+                &mut topo,
+                foot,
+                &brepkit_math::mat::Mat4::translation(x, y, 0.0),
+            )
+            .unwrap();
+            feet.push(foot);
+        }
+    }
+
+    // Single-foot volume (frustum): V = (pi*h/3)*(r_bot^2 + r_bot*r_top + r_top^2).
+    // A clean single cone uses the exact analytic path; the merged multi-region
+    // result falls back to tessellation (the analytic detector bails on more
+    // than one cone face), so the summed-volume check below uses a 1% chord
+    // tolerance — the documented accuracy for tessellated curved solids.
+    let v_one = PI * h / 3.0 * r_top.mul_add(r_top, r_bot.mul_add(r_bot, r_bot * r_top));
+    let count = feet.len();
+
+    // Pairwise accumulate (the brepkit-kernel adapter's loop).
+    let mut acc = feet[0];
+    for &foot in &feet[1..] {
+        acc = boolean(&mut topo, BooleanOp::Fuse, acc, foot).unwrap();
+    }
+
+    // Every foot survived as its own connected component.
+    let comps = face_components(&topo, acc);
+    assert_eq!(
+        comps.len(),
+        count,
+        "disjoint fuse should keep all {count} feet as separate components, got {}",
+        comps.len()
+    );
+
+    // Total volume is the sum of all feet — no welding, no dropped pieces. A
+    // dropped foot would be a ~11% miss, far outside the 1% tessellation band.
+    let vol = solid_volume(&topo, acc, 0.01).unwrap();
+    let expected = v_one * count as f64;
+    assert!(
+        (vol - expected).abs() < 0.01 * expected,
+        "fused {count}-foot volume {vol} should equal sum {expected}"
+    );
+
+    // The merged outer shell is manifold (each foot is closed; disconnected
+    // groups don't share edges).
+    let sh = topo.shell(topo.solid(acc).unwrap().outer_shell()).unwrap();
+    validate_shell_manifold(sh, &topo).expect("disjoint-fuse merge should be manifold");
+}
+
+/// The disjoint-fuse fast path must NOT fire when the bounding boxes overlap —
+/// such feet share geometry that GFA has to weld. A frustum pair whose top
+/// discs overlap fuses through GFA into a single connected component, not a
+/// two-piece merge, and the union volume is strictly less than the sum.
+#[test]
+fn fuse_overlapping_tapered_feet_welds_via_gfa() {
+    use crate::boolean::assembly::face_components;
+    use crate::measure::solid_volume;
+    use std::f64::consts::PI;
+
+    let r_bot = 2.0_f64;
+    let r_top = 2.5_f64;
+    let h = 5.0_f64;
+
+    let mut topo = Topology::new();
+    let a = crate::primitives::make_cone(&mut topo, r_bot, r_top, h).unwrap();
+    let b = crate::primitives::make_cone(&mut topo, r_bot, r_top, h).unwrap();
+    // Place B so its top disc overlaps A's (centres 4.0 < 2*r_top = 5.0
+    // apart): the boxes clearly overlap → must go through GFA and weld.
+    crate::transform::transform_solid(
+        &mut topo,
+        b,
+        &brepkit_math::mat::Mat4::translation(4.0, 0.0, 0.0),
+    )
+    .unwrap();
+
+    let v_one = PI * h / 3.0 * r_top.mul_add(r_top, r_bot.mul_add(r_bot, r_bot * r_top));
+    let fused = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+    // Overlapping feet weld into a single connected component (the fast path
+    // would have wrongly left two).
+    let comps = face_components(&topo, fused);
+    assert_eq!(
+        comps.len(),
+        1,
+        "overlapping feet must weld into one component, got {}",
+        comps.len()
+    );
+    // Union volume is strictly less than the sum (the overlap is shared once).
+    let vol = solid_volume(&topo, fused, 0.01).unwrap();
+    assert!(
+        vol < 2.0 * v_one - 1e-3 && vol > v_one,
+        "overlapping union volume {vol} should be between {v_one} and {}",
+        2.0 * v_one
+    );
+}
+
 #[test]
 fn cut_disjoint_returns_a() {
     let mut topo = Topology::new();

--- a/crates/operations/src/compound_ops.rs
+++ b/crates/operations/src/compound_ops.rs
@@ -164,7 +164,10 @@ fn partition_overlapping(bboxes: &[Aabb3]) -> Vec<Vec<usize>> {
 /// acceptable for volume measurement and tessellation (which iterate
 /// faces independently), but algorithms that assume shell connectivity
 /// should be aware. A future improvement would return a `Compound`.
-fn merge_disjoint_solids(
+///
+/// The result references the input solids' existing faces (no deep copy),
+/// so callers that need an independent result must pass copies.
+pub(crate) fn merge_disjoint_solids(
     topo: &mut Topology,
     solids: &[SolidId],
 ) -> Result<SolidId, crate::OperationsError> {

--- a/crates/operations/src/measure/bounding_box.rs
+++ b/crates/operations/src/measure/bounding_box.rs
@@ -1,9 +1,11 @@
 //! Bounding box computation for B-rep solids.
 
+use std::collections::HashSet;
+
 use brepkit_math::aabb::Aabb3;
 use brepkit_math::vec::Point3;
 use brepkit_topology::Topology;
-use brepkit_topology::face::FaceSurface;
+use brepkit_topology::face::{FaceId, FaceSurface};
 use brepkit_topology::solid::SolidId;
 
 use super::helpers::collect_solid_vertex_points;
@@ -35,6 +37,56 @@ pub fn solid_bounding_box(
     let solid_data = topo.solid(solid)?;
     let shell = topo.shell(solid_data.outer_shell())?;
     for &fid in shell.faces() {
+        if let Ok(face) = topo.face(fid) {
+            expand_aabb_for_face(topo, &mut aabb, fid, face.surface());
+        }
+    }
+
+    Ok(aabb)
+}
+
+/// Compute a conservative axis-aligned bounding box over an arbitrary set of
+/// faces (e.g. one connected component of a multi-region solid).
+///
+/// Like [`solid_bounding_box`], the box starts from the faces' vertex
+/// positions and is then expanded for surface curvature, so the returned box
+/// is a conservative *outer* bound of every face in the set. Used by the
+/// disjoint-fuse fast path to test whether two operands' components are
+/// spatially separated.
+///
+/// # Errors
+///
+/// Returns an error if the face set is empty (no vertices) or a topology
+/// lookup fails.
+pub fn face_set_bounding_box(
+    topo: &Topology,
+    faces: &[FaceId],
+) -> Result<Aabb3, crate::OperationsError> {
+    let mut vertex_ids = HashSet::new();
+    for &fid in faces {
+        let face = topo.face(fid)?;
+        for wire_id in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
+        {
+            let wire = topo.wire(wire_id)?;
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge())?;
+                vertex_ids.insert(edge.start());
+                vertex_ids.insert(edge.end());
+            }
+        }
+    }
+
+    let mut points = Vec::with_capacity(vertex_ids.len());
+    for vid in vertex_ids {
+        points.push(topo.vertex(vid)?.point());
+    }
+    let mut aabb = Aabb3::try_from_points(points.iter().copied()).ok_or_else(|| {
+        crate::OperationsError::InvalidInput {
+            reason: "face set has no vertices".into(),
+        }
+    })?;
+
+    for &fid in faces {
         if let Ok(face) = topo.face(fid) {
             expand_aabb_for_face(topo, &mut aabb, fid, face.surface());
         }

--- a/crates/operations/src/measure/mod.rs
+++ b/crates/operations/src/measure/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod helpers;
 mod volume;
 
 pub use area::{face_area, solid_surface_area};
+pub(crate) use bounding_box::face_set_bounding_box;
 pub use bounding_box::solid_bounding_box;
 pub use edge_length::{edge_length, face_perimeter, wire_length};
 pub use volume::{solid_center_of_mass, solid_volume, solid_volume_from_faces};


### PR DESCRIPTION
## Problem

The N-way base-socket fuse (one tapered foot per gridfinity cell) is the dominant base-stage cost for every multi-cell bin. brepjs loops the pairwise \`fuse(a,b)\` binding (no batch fuse is exposed), and each pairwise fuse of the **disjoint** feet pays full GFA pavefiller/assembly overhead → O(N²) scaling.

The feet are genuinely disjoint: the socket top footprint is ≈ cell − clearance (~41.5 mm on a 42 mm pitch → ~0.5 mm gaps), tapering inward below.

## Fix

Add a disjoint fast path to \`operations::boolean()\` for the **Fuse** op: when A and B are provably spatially separated, skip GFA and return a cheap shell merge of deep copies of the operands.

**Disjointness test** (\`solids_provably_disjoint\`): decompose each operand into connected face components, compute a conservative curvature-aware AABB per component, and require every component of A to have a *clear positive gap* (> linear tolerance, via \`aabbs_clear_gap\`) from every component of B.

- **Soundness:** component AABBs are conservative *outer* bounds, and the gap test is strict (zero-gap contact returns false). A \`true\` result guarantees a real gap → the result is a multi-region solid, exactly what GFA already produces for disjoint inputs, just built in O(faces) with no booleans. Touching/overlapping operands fall through to GFA, which welds shared geometry. The result is deep-copied, preserving the boolean's input-independence contract.
- **Why component-level (not whole-solid) granularity:** a pairwise-accumulate loop grows an accumulator that spans many pieces, so its overall box overlaps the next foot — but none of its pieces touch it. \`face_components\` recovers the individual pieces so each accumulate step short-circuits.

Factors out \`compound_ops::merge_disjoint_solids\` (was private) and adds \`measure::face_set_bounding_box\` to back the component AABBs.

## Performance

**Native scaling** — N disjoint tapered feet, pairwise accumulate, identical geometry, before/after:

| feet | GFA (before) | fast path (after) | speedup |
|---|---|---|---|
| 4  | 34.99 ms | 0.111 ms | 315× |
| 9  | 201.93 ms | 0.217 ms | 930× |
| 16 | 813.28 ms | 0.456 ms | 1783× |
| 25 | 2403.66 ms | 1.258 ms | 1910× |

Per-foot cost goes from 8.7/22/51/96 ms (clear O(N²)) to a flat ~0.03 ms/foot (linear).

**Tool-side** — \`buildBaseSocket(W, D, …, forExport=true)\` (the base stage's actual call), brepkit vs the reference kernel, best-of-3:

| grid | brepkit | reference | ratio |
|---|---|---|---|
| 1×1 (single, no fuse) | 1.74 ms | 9.44 ms | 0.18× |
| 2×2 | 8.56 ms | 88.59 ms | **0.10×** |
| 3×3 | 31.58 ms | 316.26 ms | **0.10×** |
| 4×4 | 102.54 ms | 838.90 ms | **0.12×** |

The 3×3 socket fuse drops from ~746 ms (prior measurement) to **~32 ms**, ~10× faster than the reference kernel.

**No brepjs change needed:** brepjs's \`fuseAll\` already does a pairwise tree-reduce for the brepkit kernel; every pairwise fuse of disjoint feet now short-circuits here.

## Correctness

- The fused volume is **exactly N × single-socket volume** to the decimal (1×1=7123.3, 2×2/4=7123.4, 3×3/9=7123.3, 4×4/16=7123.4) — zero pieces dropped, zero volume lost in the fuse. (The ~2.25% brepkit-vs-reference per-socket delta is a pre-existing tessellated-volume measurement difference, present already on the 1×1 single socket with no fuse — unrelated to this change.)
- New native tests: \`fuse_disjoint_tapered_feet_grid_keeps_all_pieces\` (9 feet → 9 components, summed volume, manifold) and \`fuse_overlapping_tapered_feet_welds_via_gfa\` (overlap → 1 welded component).
- gridfinity suite 26/26 ×3; full \`cargo test -p brepkit-operations\` green (0 failures); existing disjoint/touching/adjacent fuse tests (\`fuse_disjoint_cubes\`, \`fuse_adjacent_boxes_shared_face\`, \`fuse_six_disjoint_boxes_2x3_grid\`, …) all still pass.
- fmt / clippy \`-D warnings\` / check-boundaries: clean.