### PR TITLE
fix(algo): detect partial-overlap coincident faces in same-domain pass

### DIFF
--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -587,7 +587,9 @@ fn planar_faces_overlap(
         let area_i = super::classify_2d::signed_area_2d(&poly_i).abs();
         let area_j = super::classify_2d::signed_area_2d(&poly_j).abs();
         let smaller = area_i.min(area_j);
-        if smaller > tol.linear && overlap > smaller * 0.5 {
+        // `smaller` and `overlap` are areas, so the degenerate-face guard
+        // compares against the squared linear tolerance (area), not `linear`.
+        if smaller > tol.linear_sq() && overlap > smaller * 0.5 {
             return true;
         }
     }

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -203,7 +203,7 @@ pub fn detect_same_domain<S: BuildHasher>(
                 if uf.find(i) == uf.find(j) {
                     continue; // already grouped
                 }
-                if planar_faces_overlap(topo, sub_faces, i, j) {
+                if planar_faces_overlap(topo, sub_faces, i, j, tol) {
                     uf.union(i, j);
                     let key = (i.min(j), i.max(j));
                     pair_data.insert(key, same_dir ^ (reversed[i] != reversed[j]));
@@ -391,7 +391,13 @@ fn compute_edge_set_quantized(
 /// is the conservative criterion that catches boolean residue (issue #696)
 /// — typically a small "filling" face inside a larger face's outer
 /// boundary — without firing on legitimate adjacent face pairs.
-fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usize) -> bool {
+fn planar_faces_overlap(
+    topo: &Topology,
+    sub_faces: &[SubFace],
+    i: usize,
+    j: usize,
+    tol: Tolerance,
+) -> bool {
     let Ok(face_i) = topo.face(sub_faces[i].face_id) else {
         return false;
     };
@@ -555,6 +561,35 @@ fn planar_faces_overlap(topo: &Topology, sub_faces: &[SubFace], i: usize, j: usi
         && !footprint_in_holes(p_j_2d, &poly_j, &poly_i, face_i)
     {
         return true;
+    }
+
+    // Partial overlap. Two coplanar faces can share a genuine 2D area without
+    // either being fully contained in the other — e.g. a faceted scoop ramp's
+    // staircase-shaped wall sub-face lying against a rectangular ramp side
+    // facet. Full-containment misses these; the result is a coincident face
+    // pair that survives the boolean and goes non-manifold.
+    //
+    // Detect it by the intersection AREA of the projected polygons. A positive
+    // intersection area means real overlap; faces that merely tile side-by-side
+    // (sharing only a boundary segment) have zero intersection area, so this
+    // does not reintroduce the side-by-side false positive the containment
+    // guards above defend against. Require the overlap to cover a meaningful
+    // fraction of the smaller face so a sliver of numerical overlap along a
+    // shared edge does not pair disjoint faces.
+    if face_j.inner_wires().is_empty() && face_i.inner_wires().is_empty() {
+        let inter = brepkit_math::polygon_boolean::polygon_boolean(
+            &poly_i,
+            &poly_j,
+            brepkit_math::polygon_boolean::BooleanOp::Intersection,
+            tol.linear,
+        );
+        let overlap = inter.area().abs();
+        let area_i = super::classify_2d::signed_area_2d(&poly_i).abs();
+        let area_j = super::classify_2d::signed_area_2d(&poly_j).abs();
+        let smaller = area_i.min(area_j);
+        if smaller > tol.linear && overlap > smaller * 0.5 {
+            return true;
+        }
     }
     false
 }

--- a/crates/algo/src/builder/same_domain/tests.rs
+++ b/crates/algo/src/builder/same_domain/tests.rs
@@ -205,6 +205,111 @@ fn reversed_face_flips_same_orientation() {
     );
 }
 
+/// Cross-rank coplanar faces that PARTIALLY overlap — neither fully
+/// contained in the other — must still be paired by the geometric pass.
+/// Two boxes stacked with a lateral offset share a partially-overlapping
+/// coincident planar contact face (a sub-rectangle); the contained-only
+/// test misses this, leaving the coincident pieces un-cancelled and the
+/// fused result non-manifold. Closes the documented same-domain "detects
+/// containment but not overlap" gap.
+///
+/// Discriminating: without the partial-overlap branch in
+/// `planar_faces_overlap`, `pairs` is empty (neither face is contained in
+/// the other, so the two containment checks both fail); with it, the
+/// intersection-area test pairs them.
+#[test]
+fn cross_rank_partial_overlap_marks_overlapping() {
+    let mut topo = Topology::new();
+    let arena = GfaArena::new();
+    let face_ranks: HashMap<FaceId, Rank> = HashMap::new();
+    let tol = Tolerance::new();
+
+    // A: [0,10]x[0,10] (area 100). B: [3,13]x[0,10] (area 100), shifted +3x.
+    // Overlap [3,10]x[0,10] = 70 > 50% of the smaller face. B's x=13 lies
+    // outside A and A's x=0 lies outside B, so neither is contained.
+    let face_a = rect_sub_face(
+        &mut topo,
+        0.0,
+        10.0,
+        0.0,
+        10.0,
+        Rank::A,
+        Point3::new(5.0, 5.0, 0.0),
+    );
+    let face_b = rect_sub_face(
+        &mut topo,
+        3.0,
+        13.0,
+        0.0,
+        10.0,
+        Rank::B,
+        Point3::new(8.0, 5.0, 0.0),
+    );
+    let sub_faces = vec![face_a, face_b];
+
+    let result = detect_same_domain(&topo, &arena, &sub_faces, &face_ranks, tol);
+
+    assert!(
+        result.within_rank_dups.is_empty(),
+        "cross-rank pair should not be reported as within-rank dup"
+    );
+    assert_eq!(
+        result.pairs.len(),
+        1,
+        "partially-overlapping coplanar cross-rank faces must be paired"
+    );
+    assert!(
+        result.pairs[0].b_contained_in_a,
+        "geometric overlap must set b_contained_in_a=true so Cut cancels both"
+    );
+}
+
+/// The partial-overlap branch is gated at 50% of the smaller face: two
+/// coplanar faces sharing only a thin sliver of area must NOT be paired,
+/// so a numerical overlap along a shared edge does not annihilate disjoint
+/// faces.
+#[test]
+fn cross_rank_small_overlap_not_paired() {
+    let mut topo = Topology::new();
+    let arena = GfaArena::new();
+    let face_ranks: HashMap<FaceId, Rank> = HashMap::new();
+    let tol = Tolerance::new();
+
+    // A: [0,10]x[0,10] (area 100). B: [9,19]x[0,10] (area 100), shifted +9x.
+    // Overlap [9,10]x[0,10] = 10 < 50% of the smaller face.
+    let face_a = rect_sub_face(
+        &mut topo,
+        0.0,
+        10.0,
+        0.0,
+        10.0,
+        Rank::A,
+        Point3::new(5.0, 5.0, 0.0),
+    );
+    let face_b = rect_sub_face(
+        &mut topo,
+        9.0,
+        19.0,
+        0.0,
+        10.0,
+        Rank::B,
+        Point3::new(14.0, 5.0, 0.0),
+    );
+    let sub_faces = vec![face_a, face_b];
+
+    let result = detect_same_domain(&topo, &arena, &sub_faces, &face_ranks, tol);
+
+    assert!(
+        result.pairs.is_empty(),
+        "sub-threshold overlap must not pair coplanar faces, got {} pair(s)",
+        result.pairs.len()
+    );
+    assert!(
+        result.within_rank_dups.is_empty(),
+        "sub-threshold overlap must not produce within-rank dups"
+    );
+}
+
 #[test]
 fn planes_same_domain_same_direction() {
     let tol = Tolerance::new();


### PR DESCRIPTION
## What

`same_domain::planar_faces_overlap` previously paired two coplanar faces only when one was **fully contained** in the other (every outer-wire vertex inside). It now also detects **partial overlap**: it projects both faces to a common plane frame and pairs them when the **intersection area** of the projected polygons (via `brepkit_math::polygon_boolean(.., Intersection)`, #889) exceeds 50% of the smaller face's area.

This closes the long-documented same-domain "detects containment but not overlap" gap: the common boolean-residue pattern where two coplanar faces share a genuine 2D region without either containing the other (e.g. a faceted ramp's staircase-shaped wall sub-face lying against a rectangular facet) was previously missed, so the coincident pieces survived classification and the result went non-manifold.

## Why it is safe

- Faces that merely **tile side-by-side** (sharing only a boundary segment) have **zero intersection area**, so the documented side-by-side false positive the containment guards defend against is **not** reintroduced.
- The 50%-of-smaller-face threshold rejects a sliver of numerical overlap along a shared edge.
- Threading `tol` into `planar_faces_overlap` (it was hard-coded before) is the only signature change.

## Test

Added two unit tests in `crates/algo/src/builder/same_domain/tests.rs` exercising the new branch directly through `detect_same_domain`:

- `cross_rank_partial_overlap_marks_overlapping` — two coplanar cross-rank faces (`[0,10]x[0,10]` vs `[3,13]x[0,10]`, overlap 70 of a 100-area face, neither contained) must be paired with `b_contained_in_a=true`. **Verified it genuinely fails without the fix** (`pairs.len()` is 0 — the containment-only path does not pair partial overlaps) and passes with it.
- `cross_rank_small_overlap_not_paired` — sub-threshold overlap (10 of 100) must **not** pair, pinning the 50% gate.

A synthetic laterally-offset stacked-box **fuse** integration test was attempted first but produced an identical clean manifold result (F=12, over=0) with and without the fix — the native rebuild does not reproduce the conditions where partial-overlap SD detection is load-bearing (the real repro is a STEP-fixture scoop case that does not reach watertight on its own). So a fuse test would pass regardless of the fix; the direct unit test is the correct discriminating guard.

## Gates (all green)

- gridfinity 26/26 x3 (`brepkit-wasm` lib)
- `brepkit-algo` (126, incl. the 2 new)
- `brepkit-operations` (all binaries)
- `brepkit-io` `multicavity_cut` (#891 regression) stays clean
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `scripts/check-boundaries.sh`

## Scope

This is a **building block**. It does NOT by itself close the gridfinity compartments+scoop case — the separate sharp-scoop x rounded-corner-cylinder interpenetration (the faceted ramp poking through the bin's corner cylinders) remains, which needs faceted-surface x cylinder section assembly.