### PR TITLE
fix(algo): split shelled-wall notch side faces via planar arrangement

### DIFF
--- a/crates/algo/src/builder/face_splitter/containment.rs
+++ b/crates/algo/src/builder/face_splitter/containment.rs
@@ -18,10 +18,12 @@ fn hole_chord_polygon(hole: &[OrientedPCurveEdge]) -> Vec<Point2> {
     let mut pts: Vec<Point2> = Vec::with_capacity(hole.len() + 1);
     for e in hole {
         pts.push(e.start_uv);
-        // Densify a curved edge with its midpoint so a large corner arc keeps a
-        // closer-to-true hull than a single chord. Cheap and robust: just adds
-        // the arc's stored midpoint endpoint when present, otherwise the chord
-        // midpoint. Either way it stays inside the true arc, never outside.
+        // Densify a curved edge with its chord midpoint so a large corner arc
+        // keeps a closer-to-true hull than a single chord. The chord midpoint
+        // lies on the concave side of the arc, so it stays inside the true arc,
+        // never outside — the conservative direction for a hole-containment
+        // polygon (a point judged inside this under-approximation is genuinely
+        // inside the hole).
         if !matches!(e.pcurve, Curve2D::Line(_)) {
             pts.push(Point2::new(
                 0.5 * (e.start_uv.x() + e.end_uv.x()),

--- a/crates/algo/src/builder/face_splitter/containment.rs
+++ b/crates/algo/src/builder/face_splitter/containment.rs
@@ -1,13 +1,49 @@
 //! Point containment tests for UV-space hole detection.
 
+use brepkit_math::curves2d::Curve2D;
 use brepkit_math::vec::Point2;
 
 use super::super::split_types::OrientedPCurveEdge;
 use super::sampling::sample_wire_loop_uv;
 
+/// Build a UV polygon for a hole wire from its edges' endpoint UVs (chords),
+/// not from `sample_wire_loop_uv`. The pcurve of a projected arc edge can be a
+/// `Nurbs2D` whose parameter domain traces a path inconsistent with its stored
+/// `start_uv`/`end_uv` (the pcurve was fitted in a different frame), so sampling
+/// it yields a self-crossing garbage polygon. The stored endpoint UVs ARE
+/// correct and chain edge-to-edge, so the chord polygon faithfully approximates
+/// the hole for a point-in-polygon containment test (a rounded-rect's corner
+/// arcs are clipped to chords, well away from any interior test point).
+fn hole_chord_polygon(hole: &[OrientedPCurveEdge]) -> Vec<Point2> {
+    let mut pts: Vec<Point2> = Vec::with_capacity(hole.len() + 1);
+    for e in hole {
+        pts.push(e.start_uv);
+        // Densify a curved edge with its midpoint so a large corner arc keeps a
+        // closer-to-true hull than a single chord. Cheap and robust: just adds
+        // the arc's stored midpoint endpoint when present, otherwise the chord
+        // midpoint. Either way it stays inside the true arc, never outside.
+        if !matches!(e.pcurve, Curve2D::Line(_)) {
+            pts.push(Point2::new(
+                0.5 * (e.start_uv.x() + e.end_uv.x()),
+                0.5 * (e.start_uv.y() + e.end_uv.y()),
+            ));
+        }
+    }
+    pts
+}
+
 /// Check if a UV point is inside any of the inner wire (hole) polygons.
 pub(super) fn is_inside_any_hole(pt: &Point2, inner_wires: &[Vec<OrientedPCurveEdge>]) -> bool {
     for hole in inner_wires {
+        // Prefer the chord polygon (endpoint-derived). Fall back to the sampled
+        // polygon only when the hole degenerates to < 3 endpoints.
+        let chord = hole_chord_polygon(hole);
+        if chord.len() >= 3 {
+            if super::super::classify_2d::point_in_polygon_2d(*pt, &chord) {
+                return true;
+            }
+            continue;
+        }
         let hole_pts = sample_wire_loop_uv(hole);
         if hole_pts.len() >= 3 && super::super::classify_2d::point_in_polygon_2d(*pt, &hole_pts) {
             return true;

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -131,7 +131,12 @@ fn split_sections_at_t_junctions(
         let splits = match &edge.curve_3d {
             EdgeCurve::Circle(circle) => find_splits_on_circle(circle, &edge, &endpoints, tol),
             EdgeCurve::Ellipse(ellipse) => find_splits_on_ellipse(ellipse, &edge, &endpoints, tol),
-            _ => find_splits_on_line(&edge, &endpoints, tol),
+            // Lines split on the chord; a NURBS section (rare here) has no
+            // specialized splitter, so the chord-based line search is the
+            // closest available approximation.
+            EdgeCurve::Line | EdgeCurve::NurbsCurve(_) => {
+                find_splits_on_line(&edge, &endpoints, tol)
+            }
         };
         if splits.is_empty() {
             // Keep the original source id so an unsplit pair stays paired.
@@ -230,7 +235,9 @@ fn split_plane_boundary_arcs_at_points(
         let (circle_proj, on_curve): (f64, Point3) = match curve {
             EdgeCurve::Circle(c) => (c.project(p), c.evaluate(c.project(p))),
             EdgeCurve::Ellipse(e) => (e.project(p), e.evaluate(e.project(p))),
-            _ => return None,
+            // Only arc edges have a circle/ellipse parameter; a line or NURBS
+            // edge is never split by this arc-only path.
+            EdgeCurve::Line | EdgeCurve::NurbsCurve(_) => return None,
         };
         if (p - on_curve).length() > tol {
             return None;
@@ -238,7 +245,7 @@ fn split_plane_boundary_arcs_at_points(
         let (a0, a_end) = match curve {
             EdgeCurve::Circle(c) => (c.project(start), c.project(end)),
             EdgeCurve::Ellipse(e) => (e.project(start), e.project(end)),
-            _ => return None,
+            EdgeCurve::Line | EdgeCurve::NurbsCurve(_) => return None,
         };
         let span = super::pcurve_compute::shorter_arc_delta(a_end - a0);
         if span.abs() < 1e-12 {
@@ -333,9 +340,10 @@ fn integrate_holes_plane(
     // Sections must be all-Line. Hole (inner-wire) edges may be arcs: a curved
     // cavity (rounded-rect opening) has Circle corner edges, but a notch only
     // ever crosses the cavity's STRAIGHT walls, never its corner arcs. Arc hole
-    // edges are preserved unchanged when uncrossed; a section crossing an arc
-    // hole edge bails to None (the chord lerp would flatten a kept arc into a
-    // chord and free-edge against the cavity cylinder).
+    // edges are preserved unchanged when uncrossed; if a section crosses an arc
+    // hole edge's CHORD (the conservative UV test used below, not the true arc)
+    // the whole pass bails to None (the chord lerp would flatten a kept arc into
+    // a chord and free-edge against the cavity cylinder).
     if sections
         .iter()
         .any(|s| !matches!(s.curve_3d, EdgeCurve::Line))

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -330,23 +330,34 @@ fn integrate_holes_plane(
     frame: &PlaneFrame,
     base_src: usize,
 ) -> Option<Vec<OrientedPCurveEdge>> {
-    // All-Line geometry only.
-    let line = |e: &OrientedPCurveEdge| matches!(e.curve_3d, EdgeCurve::Line);
-    if inner_wires.iter().flatten().any(|e| !line(e))
-        || sections
-            .iter()
-            .any(|s| !matches!(s.curve_3d, EdgeCurve::Line))
+    // Sections must be all-Line. Hole (inner-wire) edges may be arcs: a curved
+    // cavity (rounded-rect opening) has Circle corner edges, but a notch only
+    // ever crosses the cavity's STRAIGHT walls, never its corner arcs. Arc hole
+    // edges are preserved unchanged when uncrossed; a section crossing an arc
+    // hole edge bails to None (the chord lerp would flatten a kept arc into a
+    // chord and free-edge against the cavity cylinder).
+    if sections
+        .iter()
+        .any(|s| !matches!(s.curve_3d, EdgeCurve::Line))
     {
         return None;
     }
 
+    // Chord polygon per hole (arc edges contribute their start endpoint, which
+    // is the right fidelity for the "is this section sub-segment inside the
+    // cavity" point test — the test points are on the straight walls, far from
+    // the corner arcs).
     let hole_polys: Vec<Vec<Point2>> = inner_wires
         .iter()
         .map(|w| w.iter().map(|e| frame.project(e.start_3d)).collect())
         .collect();
+    // Straight hole edges only feed the section-split crossing set (a section
+    // entering the cavity crosses a straight wall). Arc edges are carried
+    // through separately below.
     let hole_segs: Vec<(Point2, Point2, Point3, Point3)> = inner_wires
         .iter()
         .flatten()
+        .filter(|e| matches!(e.curve_3d, EdgeCurve::Line))
         .map(|e| {
             (
                 frame.project(e.start_3d),
@@ -478,7 +489,386 @@ fn integrate_holes_plane(
         }
     }
 
+    // Arc hole edges: preserve unchanged. Bail if any section crosses an arc's
+    // chord (we don't split arcs here, and emitting the arc whole alongside a
+    // section that cuts it would leave a dangling crossing).
+    for arc in inner_wires
+        .iter()
+        .flatten()
+        .filter(|e| !matches!(e.curve_3d, EdgeCurve::Line))
+    {
+        let a0 = frame.project(arc.start_3d);
+        let a1 = frame.project(arc.end_3d);
+        for (s0, s1) in &sec_uv {
+            if seg_cross_param(a0, a1, *s0, *s1).is_some() {
+                return None;
+            }
+        }
+        out.push(arc.clone());
+    }
+
     any_crossing.then_some(out)
+}
+
+/// Decompose a planar face into its minimal interior regions via a 2D
+/// straight-line arrangement.
+///
+/// The angular wire builder ([`build_wire_loops`]) and the single-crossing
+/// helper ([`try_split_crossing_plane_face`]) under-partition a plane face cut
+/// by three or more line sections that form a partial grid (e.g. a notch side
+/// wall on a SHELLED body, crossed by the outer wall, the inner cavity wall, and
+/// the rim) — they hand back one self-crossing wire, which makes the shared
+/// section edge non-manifold and forces a mesh fallback.
+///
+/// This builds the full planar subdivision instead: every boundary and section
+/// segment is split at all mutual intersections, directed half-edges are traced
+/// into minimal faces by the leftmost-turn rule, and the unbounded outer face is
+/// dropped. Each interior region becomes a [`SplitSubFace`] whose 3D points come
+/// from the plane frame (UV↔3D is an exact bijection on a plane). Each
+/// arrangement sub-segment carries a unique `source_edge_idx` shared by its two
+/// directed uses, so `build_topology_face` welds the two adjacent regions along
+/// it into one shared edge.
+///
+/// Restricted to **all-line** inputs (boundary and sections): a planar face
+/// whose boundary or sections include arcs keeps the existing curved paths,
+/// A directed half-edge in the planar line arrangement traced by
+/// [`split_plane_face_by_line_arrangement`]. `seg_id` is the undirected
+/// sub-segment index, shared by both directions so adjacent regions weld.
+struct ArrHalfEdge {
+    from: (i64, i64),
+    to: (i64, i64),
+    seg_id: usize,
+    /// Direction angle at `from`.
+    angle: f64,
+}
+
+/// which the lip-cut tests rely on. Returns `None` when the arrangement could
+/// not be traced or yields no interior region.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn split_plane_face_by_line_arrangement(
+    surface: &FaceSurface,
+    boundary_edges: &[OrientedPCurveEdge],
+    sections: &[SectionEdge],
+    rank: Rank,
+    reversed: bool,
+    face_id: FaceId,
+    frame: &PlaneFrame,
+    tol: f64,
+) -> Option<Vec<SplitSubFace>> {
+    use brepkit_math::curves2d::{Curve2D, Line2D};
+    use brepkit_math::vec::Vec2;
+
+    // All inputs must be line segments — curved boundaries/sections are left to
+    // the existing paths.
+    if !boundary_edges
+        .iter()
+        .all(|e| matches!(e.curve_3d, EdgeCurve::Line))
+    {
+        return None;
+    }
+    if !sections
+        .iter()
+        .all(|s| matches!(s.curve_3d, EdgeCurve::Line))
+    {
+        return None;
+    }
+
+    // Collect undirected UV segments. Boundary edges already carry UV in this
+    // frame; project section endpoints into the same frame so both live in one
+    // coordinate system.
+    let mut segs: Vec<(Point2, Point2)> = Vec::new();
+    for e in boundary_edges {
+        segs.push((e.start_uv, e.end_uv));
+    }
+    for s in sections {
+        segs.push((frame.project(s.start), frame.project(s.end)));
+    }
+    // Drop degenerate (zero-length) segments.
+    segs.retain(|(a, b)| (*a - *b).length() > tol);
+    if segs.len() < 3 {
+        return None;
+    }
+
+    // Quantize UV points so coincident vertices merge. Use a grid an order of
+    // magnitude finer than the linear tolerance (UV on a plane is metric).
+    let qscale = 1.0 / tol.max(1e-12);
+    let qkey = |p: Point2| -> (i64, i64) {
+        (
+            (p.x() * qscale).round() as i64,
+            (p.y() * qscale).round() as i64,
+        )
+    };
+
+    // Split each segment at every intersection with every other segment, plus
+    // at any other segment's endpoint that lands on its interior. Collect the
+    // resulting break parameters, then emit sub-segments between consecutive
+    // breaks.
+    let mut vert_pos: std::collections::HashMap<(i64, i64), Point2> =
+        std::collections::HashMap::new();
+    let register =
+        |p: Point2, map: &mut std::collections::HashMap<(i64, i64), Point2>| -> (i64, i64) {
+            let k = qkey(p);
+            map.entry(k).or_insert(p);
+            k
+        };
+
+    // Undirected sub-segments keyed by endpoint vertex pair.
+    let mut sub_edges: Vec<((i64, i64), (i64, i64))> = Vec::new();
+    for i in 0..segs.len() {
+        let (a0, a1) = segs[i];
+        let d = a1 - a0;
+        let len = d.length();
+        if len < tol {
+            continue;
+        }
+        // Break parameters along this segment (t in [0,1]).
+        let mut ts: Vec<f64> = vec![0.0, 1.0];
+        for (j, &(b0, b1)) in segs.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            // Proper interior crossing.
+            if let Some(t) = seg_cross_param(a0, a1, b0, b1) {
+                ts.push(t);
+            }
+            // Other segment's endpoints landing on this segment's interior
+            // (T-junctions where a section merely touches another).
+            for bp in [b0, b1] {
+                let w = (bp - a0).dot(d) / (len * len);
+                if w > 1e-6 && w < 1.0 - 1e-6 {
+                    let on = a0 + d * w;
+                    if (on - bp).length() < tol {
+                        ts.push(w);
+                    }
+                }
+            }
+        }
+        ts.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+        ts.dedup_by(|x, y| (*x - *y).abs() < 1e-6);
+        for w in ts.windows(2) {
+            let (ta, tb) = (w[0], w[1]);
+            if tb - ta < 1e-6 {
+                continue;
+            }
+            let pa = a0 + d * ta;
+            let pb = a0 + d * tb;
+            let ka = register(pa, &mut vert_pos);
+            let kb = register(pb, &mut vert_pos);
+            if ka != kb {
+                sub_edges.push((ka, kb));
+            }
+        }
+    }
+
+    // Deduplicate undirected sub-edges (the same physical edge can arise from
+    // two overlapping input segments).
+    sub_edges.sort_unstable();
+    sub_edges.dedup();
+    if sub_edges.is_empty() {
+        return None;
+    }
+
+    // Build the directed half-edge adjacency. Each undirected sub-edge id maps
+    // to two directed half-edges; both carry that id so adjacent regions share
+    // one topology edge. Half-edge index 2*k = forward (va->vb), 2*k+1 = reverse.
+    let mut halfs: Vec<ArrHalfEdge> = Vec::with_capacity(sub_edges.len() * 2);
+    for (seg_id, &(ka, kb)) in sub_edges.iter().enumerate() {
+        let pa = vert_pos[&ka];
+        let pb = vert_pos[&kb];
+        let fwd = pb - pa;
+        let rev = pa - pb;
+        halfs.push(ArrHalfEdge {
+            from: ka,
+            to: kb,
+            seg_id,
+            angle: fwd.y().atan2(fwd.x()),
+        });
+        halfs.push(ArrHalfEdge {
+            from: kb,
+            to: ka,
+            seg_id,
+            angle: rev.y().atan2(rev.x()),
+        });
+    }
+
+    // Outgoing half-edges per vertex.
+    let mut out_at: std::collections::HashMap<(i64, i64), Vec<usize>> =
+        std::collections::HashMap::new();
+    for (hi, h) in halfs.iter().enumerate() {
+        out_at.entry(h.from).or_default().push(hi);
+    }
+
+    // Trace minimal faces. From each unused half-edge, at every arrival vertex
+    // pick the next outgoing half-edge that turns most clockwise from the
+    // arriving direction (the "next edge in face" rule for a CCW-bounded face),
+    // i.e. minimize the CCW angle from the reverse-of-arrival to the candidate.
+    let mut used = vec![false; halfs.len()];
+    let mut faces: Vec<Vec<usize>> = Vec::new();
+    for start in 0..halfs.len() {
+        if used[start] {
+            continue;
+        }
+        let mut face: Vec<usize> = Vec::new();
+        let mut cur = start;
+        let mut ok = true;
+        loop {
+            if used[cur] {
+                // Returned to an already-used half-edge that is not the start —
+                // this trace is degenerate; abandon it.
+                ok = cur == start && !face.is_empty();
+                break;
+            }
+            used[cur] = true;
+            face.push(cur);
+            let arrive_to = halfs[cur].to;
+            if arrive_to == halfs[start].from && !face.is_empty() {
+                // Closed the loop back to the start vertex.
+                break;
+            }
+            // Incoming direction reversed = the direction we'd leave back along.
+            let back_angle =
+                (halfs[cur].angle + std::f64::consts::PI).rem_euclid(std::f64::consts::TAU);
+            let twin = cur ^ 1; // the reverse half-edge of `cur`
+            let Some(cands) = out_at.get(&arrive_to) else {
+                ok = false;
+                break;
+            };
+            // Pick the candidate minimizing the CCW turn from `back_angle`,
+            // excluding the immediate twin (which would U-turn). The smallest
+            // positive CCW offset hugs the boundary on the left = minimal face.
+            let mut best: Option<usize> = None;
+            let mut best_off = f64::MAX;
+            for &c in cands {
+                if used[c] || c == twin {
+                    continue;
+                }
+                let off = (halfs[c].angle - back_angle).rem_euclid(std::f64::consts::TAU);
+                if off < best_off {
+                    best_off = off;
+                    best = Some(c);
+                }
+            }
+            // If the only continuation is the twin (dangling edge), allow it so
+            // the trace can retreat; otherwise abandon.
+            let next = best.or_else(|| cands.iter().copied().find(|&c| !used[c] && c == twin));
+            let Some(next) = next else {
+                ok = false;
+                break;
+            };
+            if next == start {
+                break;
+            }
+            cur = next;
+            if face.len() > halfs.len() {
+                ok = false;
+                break;
+            }
+        }
+        if ok && face.len() >= 3 {
+            faces.push(face);
+        }
+    }
+    if faces.is_empty() {
+        return None;
+    }
+
+    // Every simple arrangement that tiles a bounded region produces exactly one
+    // unbounded "outer" face whose boundary trace re-walks the region perimeter;
+    // its |area| equals the sum of all interior face |areas| and is therefore
+    // strictly the largest single magnitude. Drop that one face and keep the
+    // rest as interior regions — this is independent of the boundary winding
+    // (which can be CW for a cavity wall, CCW for an outer wall).
+    let face_area = |face: &[usize]| -> f64 {
+        let pts: Vec<Point2> = face.iter().map(|&h| vert_pos[&halfs[h].from]).collect();
+        signed_area_2d(&pts)
+    };
+    if faces.len() < 2 {
+        return None;
+    }
+    let outer_idx = (0..faces.len()).max_by(|&a, &b| {
+        face_area(&faces[a])
+            .abs()
+            .partial_cmp(&face_area(&faces[b]).abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })?;
+    let interior: Vec<&Vec<usize>> = faces
+        .iter()
+        .enumerate()
+        .filter(|(i, f)| *i != outer_idx && face_area(f).abs() > tol * tol)
+        .map(|(_, f)| f)
+        .collect();
+    if interior.is_empty() {
+        return None;
+    }
+
+    // Build sub-faces. Map each half-edge to an OrientedPCurveEdge line in UV
+    // with 3D from the plane frame.
+    let mk_edge = |from: (i64, i64), to: (i64, i64), seg_id: usize| -> Option<OrientedPCurveEdge> {
+        let su = vert_pos[&from];
+        let eu = vert_pos[&to];
+        let dir = eu - su;
+        let len = dir.length();
+        let direction = if len > 1e-12 {
+            Vec2::new(dir.x() / len, dir.y() / len)
+        } else {
+            Vec2::new(1.0, 0.0)
+        };
+        let pcurve = Curve2D::Line(
+            Line2D::new(su, direction)
+                .or_else(|_| Line2D::new(su, Vec2::new(1.0, 0.0)))
+                .ok()?,
+        );
+        Some(OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Line,
+            pcurve,
+            start_uv: su,
+            end_uv: eu,
+            start_3d: frame.evaluate(su.x(), su.y()),
+            end_3d: frame.evaluate(eu.x(), eu.y()),
+            forward: true,
+            source_edge_idx: Some(seg_id),
+            pave_block_id: None,
+        })
+    };
+
+    let mut result = Vec::new();
+    for face in interior {
+        // Orient the region CCW in UV (positive signed area) so it is a valid
+        // outer wire. The trace can hand back either winding depending on the
+        // boundary's winding; reverse the half-edge order and each edge's
+        // direction when negative.
+        let ccw: Vec<usize> = if face_area(face) < 0.0 {
+            face.iter().rev().copied().collect()
+        } else {
+            face.clone()
+        };
+        let reverse_each = face_area(face) < 0.0;
+        let mut wire = Vec::with_capacity(ccw.len());
+        for &h in &ccw {
+            let he = &halfs[h];
+            let (from, to) = if reverse_each {
+                (he.to, he.from)
+            } else {
+                (he.from, he.to)
+            };
+            wire.push(mk_edge(from, to, he.seg_id)?);
+        }
+        result.push(SplitSubFace {
+            surface: surface.clone(),
+            outer_wire: wire,
+            inner_wires: Vec::new(),
+            reversed,
+            parent: face_id,
+            rank,
+            // Leave None: a region can be non-convex (an L), so the centroid
+            // is unsafe. `interior_point_3d` derives a robust interior sample.
+            precomputed_interior: None,
+        });
+    }
+    if result.is_empty() {
+        return None;
+    }
+    Some(result)
 }
 
 /// Split a face by its section edges, producing sub-faces.
@@ -1113,6 +1503,25 @@ pub fn split_face_2d(
         && let Some(ref boundary) = boundary_edges_backup
         && let Some(result) = try_split_crossing_plane_face(
             &surface, boundary, sections, rank, reversed, face_id, frame, tol,
+        )
+        && result.len() > loops.len()
+    {
+        return result;
+    }
+
+    // General planar arrangement fallback: a plane face cut by three or more
+    // line sections forming a partial grid (e.g. a notch side wall on a SHELLED
+    // body crossed by the outer wall, the inner cavity wall, and the rim) is not
+    // covered by `try_split_crossing_plane_face` (2/4-section X/T/star only), and
+    // the angular wire builder hands back a single self-crossing loop. Decompose
+    // the full arrangement into minimal regions when it yields more than the
+    // wire builder did. All-line only; curved faces keep the existing paths.
+    if sections.len() >= 2
+        && is_plane
+        && !holes_integrated
+        && let Some(ref boundary) = boundary_edges_backup
+        && let Some(result) = split_plane_face_by_line_arrangement(
+            &surface, boundary, sections, rank, reversed, face_id, frame, tol.linear,
         )
         && result.len() > loops.len()
     {

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -18,7 +18,9 @@ use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::face::{FaceId, FaceSurface};
 
 use super::classify_2d::{sample_interior_point, signed_area_2d};
-use super::pcurve_compute::evaluate_edge_at_t;
+use super::pcurve_compute::{
+    compute_pcurve_on_surface, evaluate_edge_at_t, project_point_on_surface,
+};
 use super::plane_frame::PlaneFrame;
 use super::split_types::{OrientedPCurveEdge, SectionEdge, SplitSubFace, SurfaceInfo};
 use super::wire_builder::{build_wire_loops, build_wire_loops_with_winding};
@@ -29,7 +31,10 @@ use conversion::{
     boundary_edges_to_pcurve, extract_plane_normal, is_point_on_boundary_uv,
     uv_endpoints_from_pcurve,
 };
-use edge_splitting::split_boundary_edges_at_3d_points;
+use edge_splitting::{
+    find_splits_on_circle, find_splits_on_ellipse, find_splits_on_line,
+    split_boundary_edges_at_3d_points,
+};
 use sampling::{sample_wire_loop_uv, sample_wire_loop_uv_periodic};
 use special_cases::{
     split_face_with_internal_loops, split_noseam_face_direct, split_periodic_face_into_bands,
@@ -59,6 +64,250 @@ fn seg_cross_param(a0: Point2, a1: Point2, b0: Point2, b1: Point2) -> Option<f64
     // `t`/`u` are normalized [0,1] parameters, so these epsilons are already
     // scale-invariant fractions of each segment.
     (t > 1e-6 && t < 1.0 - 1e-6 && u > -1e-6 && u < 1.0 + 1e-6).then_some(t)
+}
+
+/// Split section edges at interior T-junctions with other sections.
+///
+/// `all_edges[section_start..]` holds the section edges as consecutive
+/// forward/reverse pairs (both carrying the same `source_edge_idx`). When one
+/// section's 3D endpoint lands strictly inside another section's span, the
+/// crossed section is split there so both meet at a shared vertex — without
+/// this the dangling end is pruned as a pendant and the face never splits at
+/// that junction. Boundary edges (`..section_start`) are left untouched.
+///
+/// This covers the analytic (cylinder/cone) faces that
+/// `try_split_crossing_plane_face` (plane-only) does not reach — e.g. a
+/// rounded notch corner whose perpendicular-cut arc meets the axis-parallel
+/// wall-top line on a corner cylinder. Each split piece gets a fresh unique
+/// `source_edge_idx` (forward/reverse of a piece share it) so
+/// `build_topology_face` still shares one topology edge per piece.
+fn split_sections_at_t_junctions(
+    all_edges: &mut Vec<OrientedPCurveEdge>,
+    section_start: usize,
+    surface: &FaceSurface,
+    frame: Option<&PlaneFrame>,
+    wire_pts: &[Point3],
+    tol: f64,
+) {
+    // Every distinct section endpoint (3D) is a candidate split point.
+    let mut endpoints: Vec<Point3> = Vec::new();
+    for e in &all_edges[section_start..] {
+        for p in [e.start_3d, e.end_3d] {
+            if !endpoints.iter().any(|q| (*q - p).length() < tol) {
+                endpoints.push(p);
+            }
+        }
+    }
+
+    let boundary: Vec<OrientedPCurveEdge> = all_edges[..section_start].to_vec();
+    let sections: Vec<OrientedPCurveEdge> = all_edges[section_start..].to_vec();
+
+    // A unique source id per geometric piece, kept stable across the
+    // forward/reverse pair so the topology builder shares one edge per piece.
+    // Start above every existing source id (sections already use ids ≥
+    // section_start) so a fresh piece never collides with an unsplit edge.
+    let mut next_src = all_edges
+        .iter()
+        .filter_map(|e| e.source_edge_idx)
+        .max()
+        .map_or(section_start, |m| m + 1);
+    let mut piece_src: std::collections::HashMap<(i64, i64, i64, i64, i64, i64), usize> =
+        std::collections::HashMap::new();
+    let key = |a: Point3, b: Point3| -> (i64, i64, i64, i64, i64, i64) {
+        let q = |x: f64| (x / tol).round() as i64;
+        let ka = (q(a.x()), q(a.y()), q(a.z()));
+        let kb = (q(b.x()), q(b.y()), q(b.z()));
+        // Order-independent so forward and reverse halves map to one id.
+        if ka <= kb {
+            (ka.0, ka.1, ka.2, kb.0, kb.1, kb.2)
+        } else {
+            (kb.0, kb.1, kb.2, ka.0, ka.1, ka.2)
+        }
+    };
+
+    let mut new_sections: Vec<OrientedPCurveEdge> = Vec::with_capacity(sections.len());
+    for edge in sections {
+        // `find_splits_on_*` already exclude the edge's own endpoints.
+        let splits = match &edge.curve_3d {
+            EdgeCurve::Circle(circle) => find_splits_on_circle(circle, &edge, &endpoints, tol),
+            EdgeCurve::Ellipse(ellipse) => find_splits_on_ellipse(ellipse, &edge, &endpoints, tol),
+            _ => find_splits_on_line(&edge, &endpoints, tol),
+        };
+        if splits.is_empty() {
+            // Keep the original source id so an unsplit pair stays paired.
+            new_sections.push(edge);
+            continue;
+        }
+
+        // The face's section edges already carry UV unwrapped into the face's
+        // continuous parameter window (the partial-band u-unwrap runs earlier),
+        // but a fresh surface projection of a split point returns the raw
+        // parameter (e.g. u in [0, 2pi)). Snap it to the period nearest the
+        // running anchor so the split vertex stays in the same window.
+        let (u_period, v_period) = super::pcurve_compute::surface_periods(surface);
+        let project = |p: Point3, near: Point2| -> Point2 {
+            let raw = if let Some(f) = frame {
+                f.project(p)
+            } else {
+                project_point_on_surface(p, surface, wire_pts, None)
+            };
+            if frame.is_some() {
+                return raw;
+            }
+            let snap = |val: f64, anchor: f64, period: Option<f64>| -> f64 {
+                match period {
+                    Some(p) if p > 1e-12 => val + ((anchor - val) / p).round() * p,
+                    _ => val,
+                }
+            };
+            Point2::new(
+                snap(raw.x(), near.x(), u_period),
+                snap(raw.y(), near.y(), v_period),
+            )
+        };
+
+        let mut prev_3d = edge.start_3d;
+        let mut prev_uv = edge.start_uv;
+        let mut push_piece = |s3: Point3, e3: Point3, s_uv: Point2, e_uv: Point2| {
+            let src = *piece_src.entry(key(s3, e3)).or_insert_with(|| {
+                let v = next_src;
+                next_src += 1;
+                v
+            });
+            let pcurve =
+                compute_pcurve_on_surface(&edge.curve_3d, s3, e3, surface, wire_pts, frame);
+            new_sections.push(OrientedPCurveEdge {
+                curve_3d: edge.curve_3d.clone(),
+                pcurve,
+                start_uv: s_uv,
+                end_uv: e_uv,
+                start_3d: s3,
+                end_3d: e3,
+                forward: edge.forward,
+                source_edge_idx: Some(src),
+                // A split piece is a sub-segment of the original section, so
+                // it must not inherit the parent's pave_block_id — vertex
+                // resolution would snap both halves to the PaveBlock's
+                // (un-split) endpoints. Resolve by position instead;
+                // cross-face sharing is recovered by merge_duplicate_edges.
+                pave_block_id: None,
+            });
+        };
+        for &(t, _) in &splits {
+            let s3 = evaluate_edge_at_t(&edge.curve_3d, edge.start_3d, edge.end_3d, t);
+            let s_uv = project(s3, prev_uv);
+            push_piece(prev_3d, s3, prev_uv, s_uv);
+            prev_3d = s3;
+            prev_uv = s_uv;
+        }
+        push_piece(prev_3d, edge.end_3d, prev_uv, edge.end_uv);
+    }
+
+    all_edges.truncate(0);
+    all_edges.extend(boundary);
+    all_edges.extend(new_sections);
+}
+
+/// Split a plane face's boundary arc/line edges at 3D points that land on their
+/// interior. Used to attach a section whose endpoint lands mid-arc on a convex
+/// rounded corner (the notch-straddle case).
+///
+/// Unlike [`split_boundary_edges_at_3d_points`], the arc split parameter is
+/// computed with the SHORTER-arc convention that `evaluate_edge_at_t` uses, so
+/// a corner arc traversed clockwise in its circle frame (as plane-face boundary
+/// arcs are) is split at the geometrically-correct location rather than being
+/// missed because the `domain_with_endpoints` CCW span excludes it.
+fn split_plane_boundary_arcs_at_points(
+    edges: Vec<OrientedPCurveEdge>,
+    split_pts_3d: &[Point3],
+    surface: &FaceSurface,
+    frame: &PlaneFrame,
+    tol: f64,
+) -> Vec<OrientedPCurveEdge> {
+    // Shorter-arc parameter t in (0,1) of `p` on the arc edge from `start` to
+    // `end`, or None if `p` is not on the arc interior.
+    let arc_param = |curve: &EdgeCurve, start: Point3, end: Point3, p: Point3| -> Option<f64> {
+        let (circle_proj, on_curve): (f64, Point3) = match curve {
+            EdgeCurve::Circle(c) => (c.project(p), c.evaluate(c.project(p))),
+            EdgeCurve::Ellipse(e) => (e.project(p), e.evaluate(e.project(p))),
+            _ => return None,
+        };
+        if (p - on_curve).length() > tol {
+            return None;
+        }
+        let (a0, a_end) = match curve {
+            EdgeCurve::Circle(c) => (c.project(start), c.project(end)),
+            EdgeCurve::Ellipse(e) => (e.project(start), e.project(end)),
+            _ => return None,
+        };
+        let span = super::pcurve_compute::shorter_arc_delta(a_end - a0);
+        if span.abs() < 1e-12 {
+            return None;
+        }
+        let d = super::pcurve_compute::shorter_arc_delta(circle_proj - a0);
+        let t = d / span;
+        (t > tol && t < 1.0 - tol).then_some(t)
+    };
+
+    let mut result = Vec::with_capacity(edges.len());
+    for edge in edges {
+        let mut splits: Vec<f64> = match &edge.curve_3d {
+            EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => split_pts_3d
+                .iter()
+                .filter_map(|&p| arc_param(&edge.curve_3d, edge.start_3d, edge.end_3d, p))
+                .collect(),
+            EdgeCurve::Line => {
+                let dir = edge.end_3d - edge.start_3d;
+                let len_sq = dir.dot(dir);
+                if len_sq < tol * tol {
+                    Vec::new()
+                } else {
+                    split_pts_3d
+                        .iter()
+                        .filter_map(|&p| {
+                            let t = (p - edge.start_3d).dot(dir) / len_sq;
+                            let closest = edge.start_3d + dir * t;
+                            ((p - closest).length() < tol && t > tol && t < 1.0 - tol).then_some(t)
+                        })
+                        .collect()
+                }
+            }
+            EdgeCurve::NurbsCurve(_) => Vec::new(),
+        };
+        splits.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        splits.dedup_by(|a, b| (*a - *b).abs() < tol);
+        if splits.is_empty() {
+            result.push(edge);
+            continue;
+        }
+
+        let mut prev_3d = edge.start_3d;
+        let mut prev_uv = edge.start_uv;
+        let mut push_piece = |s3: Point3, e3: Point3, s_uv: Point2, e_uv: Point2| {
+            let pcurve =
+                compute_pcurve_on_surface(&edge.curve_3d, s3, e3, surface, &[], Some(frame));
+            result.push(OrientedPCurveEdge {
+                curve_3d: edge.curve_3d.clone(),
+                pcurve,
+                start_uv: s_uv,
+                end_uv: e_uv,
+                start_3d: s3,
+                end_3d: e3,
+                forward: edge.forward,
+                source_edge_idx: None,
+                pave_block_id: None,
+            });
+        };
+        for &t in &splits {
+            let s3 = evaluate_edge_at_t(&edge.curve_3d, edge.start_3d, edge.end_3d, t);
+            let s_uv = frame.project(s3);
+            push_piece(prev_3d, s3, prev_uv, s_uv);
+            prev_3d = s3;
+            prev_uv = s_uv;
+        }
+        push_piece(prev_3d, edge.end_3d, prev_uv, edge.end_uv);
+    }
+    result
 }
 
 /// Weave hole boundaries into the section arrangement of a planar face.
@@ -760,6 +1009,59 @@ pub fn split_face_2d(
         }
     }
 
+    // Split section edges where another section's endpoint lands on their
+    // interior (L/T junctions). Needs ≥ 2 distinct sections (one pair to cross
+    // another); runs after the partial-band u-unwrap so split UVs match the
+    // face's continuous window.
+    if all_edges.len() > n_boundary_edges + 2 {
+        split_sections_at_t_junctions(
+            &mut all_edges,
+            n_boundary_edges,
+            &surface,
+            if is_plane { Some(frame) } else { None },
+            &wire_pts,
+            tol.linear,
+        );
+    }
+
+    // Split BOUNDARY arc edges where a section endpoint lands strictly on their
+    // interior. A section clipped out to a convex rounded corner's TRUE arc (a
+    // notch corner straddling a wall's top edge) ends MID-ARC on the boundary;
+    // without splitting the arc there, the wire builder can't route through the
+    // junction and the section is pruned as a pendant. Plane faces only: their
+    // frame projection is periodicity-free, so the split UV is unambiguous (the
+    // periodic-cylinder boundary is handled by the section-side T-junction split
+    // above).
+    let mut n_boundary_edges = n_boundary_edges;
+    if is_plane && all_edges.len() > n_boundary_edges {
+        let mut section_endpoints: Vec<Point3> = Vec::new();
+        for e in &all_edges[n_boundary_edges..] {
+            for p in [e.start_3d, e.end_3d] {
+                if !section_endpoints
+                    .iter()
+                    .any(|q| (*q - p).length() < tol.linear)
+                {
+                    section_endpoints.push(p);
+                }
+            }
+        }
+        let boundary: Vec<OrientedPCurveEdge> = all_edges[..n_boundary_edges].to_vec();
+        let split_boundary = split_plane_boundary_arcs_at_points(
+            boundary,
+            &section_endpoints,
+            &surface,
+            frame,
+            tol.linear,
+        );
+        if split_boundary.len() != n_boundary_edges {
+            let sections_tail: Vec<OrientedPCurveEdge> = all_edges[n_boundary_edges..].to_vec();
+            n_boundary_edges = split_boundary.len();
+            all_edges.clear();
+            all_edges.extend(split_boundary);
+            all_edges.extend(sections_tail);
+        }
+    }
+
     // Drop pendant section edges that dangle into the face interior — left
     // in, the traversal walks out and back along them, spuriously
     // over-splitting the face (boundary edges are never removed, so the
@@ -896,6 +1198,48 @@ pub fn split_face_2d(
         let pts: Vec<Point2> = holes[0].iter().map(|e| e.start_uv).collect();
         let area = signed_area_2d(&pts);
         outers.push((holes.remove(0), area));
+    }
+
+    // A negative-area loop is only a true hole if it is geometrically NESTED
+    // inside an outer loop. When a plane face is split by a single section line
+    // into two side-by-side regions, the wire builder can hand back the second
+    // region wound CW (negative area) even though it is ADJACENT, not nested
+    // (e.g. the above-vs-below halves of a notch-straddle tool face split at the
+    // wall-top line). Detect that by probing a point strictly inside the
+    // candidate hole: if it lies in no outer's interior, the loop is a separate
+    // region — reverse it to CCW and promote it to an outer. A genuinely nested
+    // hole's probe lies inside its containing outer, so it is left alone.
+    if !use_structural_classification && !outers.is_empty() && !holes.is_empty() {
+        let outer_uv: Vec<Vec<Point2>> =
+            outers.iter().map(|(w, _)| sample_wire_loop_uv(w)).collect();
+        let mut promoted: Vec<Vec<OrientedPCurveEdge>> = Vec::new();
+        holes.retain(|hole| {
+            let hole_pts = sample_wire_loop_uv(hole);
+            if hole_pts.len() < 3 {
+                return true;
+            }
+            let probe = super::classify_2d::sample_interior_point(&hole_pts);
+            let nested = outer_uv
+                .iter()
+                .any(|o| super::classify_2d::point_in_polygon_2d(probe, o));
+            if nested {
+                true
+            } else {
+                promoted.push(hole.clone());
+                false
+            }
+        });
+        for mut region in promoted {
+            region.reverse();
+            for edge in &mut region {
+                std::mem::swap(&mut edge.start_uv, &mut edge.end_uv);
+                std::mem::swap(&mut edge.start_3d, &mut edge.end_3d);
+                edge.forward = !edge.forward;
+            }
+            let pts: Vec<Point2> = sample_wire_loop_uv(&region);
+            let area = signed_area_2d(&pts).abs();
+            outers.push((region, area));
+        }
     }
 
     let mut sub_faces = Vec::new();

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1739,9 +1739,11 @@ fn arc_segment_crossings(
 ) -> Vec<(Point3, f64)> {
     let circle = match curve {
         EdgeCurve::Circle(c) => c,
-        // Ellipse arcs are not produced on the corner-straddle path; fall back
-        // to the chord for them (handled by the line-line crossing).
-        _ => return Vec::new(),
+        // Only circular arcs are handled here. Ellipse arcs are not produced on
+        // the corner-straddle path, and lines/NURBS sections have no true-arc
+        // geometry — all fall back to the chord (handled by the line-line
+        // crossing in the caller).
+        EdgeCurve::Ellipse(_) | EdgeCurve::Line | EdgeCurve::NurbsCurve(_) => return Vec::new(),
     };
     let hits = circle.intersect_segment(line_start, line_end, tol);
     if hits.is_empty() {
@@ -1812,7 +1814,11 @@ fn clip_line_to_face_boundary(
             EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
                 boundary_arcs.push(Some((edge.curve().clone(), sp, ep)));
             }
-            _ => boundary_arcs.push(None),
+            // A straight edge already equals its chord, and a NURBS boundary edge
+            // has no analytic arc to clip against, so neither contributes a
+            // beyond-the-chord crossing; the chord segment in
+            // `boundary_segments` covers them.
+            EdgeCurve::Line | EdgeCurve::NurbsCurve(_) => boundary_arcs.push(None),
         }
     }
 

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1009,8 +1009,12 @@ fn rebuild_face_with_cb_edges(
 enum SectionSource {
     /// Complete intersection curve — use the curve's geometry, not individual PBs.
     Curve(usize),
-    /// Individual PaveBlock — for IN edges.
-    PaveBlock(PaveBlockId),
+    /// Individual PaveBlock. The optional face is the OPPOSING FF face that the
+    /// same intersection line bounds; a Line section is clipped to it as well as
+    /// to this face, so a wide face (e.g. a box cap) does not extend the section
+    /// past where the narrow opposing face (e.g. a notch tool's front) actually
+    /// is. `None` for IN edges from EF, which have no single opposing face.
+    PaveBlock(PaveBlockId, Option<FaceId>),
 }
 
 /// Tolerance on `|t_range| - 2π` for treating a circle edge as a full circle.
@@ -1111,10 +1115,10 @@ fn build_section_map(topo: &Topology, arena: &GfaArena) -> HashMap<FaceId, Vec<S
             for &pb_id in &curve.pave_blocks {
                 map.entry(curve.face_a)
                     .or_default()
-                    .push(SectionSource::PaveBlock(pb_id));
+                    .push(SectionSource::PaveBlock(pb_id, Some(curve.face_b)));
                 map.entry(curve.face_b)
                     .or_default()
-                    .push(SectionSource::PaveBlock(pb_id));
+                    .push(SectionSource::PaveBlock(pb_id, Some(curve.face_a)));
             }
         } else {
             // Feed the complete curve — critical for closed curves (circles).
@@ -1161,7 +1165,7 @@ fn build_section_map(topo: &Topology, arena: &GfaArena) -> HashMap<FaceId, Vec<S
             }
             map.entry(face_id)
                 .or_default()
-                .push(SectionSource::PaveBlock(pb_id));
+                .push(SectionSource::PaveBlock(pb_id, None));
         }
     }
     map
@@ -1399,7 +1403,7 @@ fn build_section_edges(
                     pave_block_id: None,
                 });
             }
-            SectionSource::PaveBlock(pb_id) => {
+            SectionSource::PaveBlock(pb_id, opposing_face) => {
                 // Individual PaveBlock edge — use the old Line2D pcurve approach.
                 // This preserves the existing behavior for Line section edges
                 // that the face splitter already handles correctly.
@@ -1429,9 +1433,22 @@ fn build_section_edges(
 
                 let (start, end) =
                     if matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Line) {
-                        match clip_line_to_face_boundary(topo, face_id, raw_start, raw_end, tol) {
+                        let clipped = match clip_line_to_face_boundary(
+                            topo, face_id, raw_start, raw_end, tol,
+                        ) {
                             Some(pair) => pair,
                             None => continue,
+                        };
+                        // Also clip to the OPPOSING FF face so a wide face does
+                        // not extend the section past the narrower face's
+                        // boundary (the intersection of the two clips). Only
+                        // tightens; if the opposing face does not bound the line
+                        // here, keep this face's clip.
+                        match opposing_face.and_then(|of| {
+                            clip_line_to_face_boundary(topo, of, clipped.0, clipped.1, tol)
+                        }) {
+                            Some(both) => both,
+                            None => clipped,
                         }
                     } else {
                         (raw_start, raw_end)
@@ -1707,6 +1724,62 @@ fn dedup_collinear_sections(sections: &mut Vec<SectionEdge>, tol: f64) {
     }
 }
 
+/// Intersect a section line with a curved boundary edge's TRUE geometry,
+/// keeping only crossings that fall on the actual arc span (between the edge's
+/// start/end vertices, on the side through its midpoint) — not the full circle.
+///
+/// Returns the 3D crossing points (with the edge's angle, unused by callers).
+fn arc_segment_crossings(
+    curve: &EdgeCurve,
+    edge_start: Point3,
+    edge_end: Point3,
+    line_start: Point3,
+    line_end: Point3,
+    tol: f64,
+) -> Vec<(Point3, f64)> {
+    let circle = match curve {
+        EdgeCurve::Circle(c) => c,
+        // Ellipse arcs are not produced on the corner-straddle path; fall back
+        // to the chord for them (handled by the line-line crossing).
+        _ => return Vec::new(),
+    };
+    let hits = circle.intersect_segment(line_start, line_end, tol);
+    if hits.is_empty() {
+        return hits;
+    }
+    // Angular interval of the arc edge: from start angle to end angle on the
+    // side that passes through the edge's geometric midpoint.
+    let a_start = circle.project(edge_start);
+    let a_end = circle.project(edge_end);
+    let mid = super::pcurve_compute::evaluate_edge_at_t(curve, edge_start, edge_end, 0.5);
+    let a_mid = circle.project(mid);
+    // Normalize so the test is "is `a` between a_start and a_end the short/long
+    // way that contains a_mid". Use unsigned angular distances on the circle.
+    let ang_dist = |x: f64, y: f64| -> f64 {
+        let d = (x - y).abs() % std::f64::consts::TAU;
+        d.min(std::f64::consts::TAU - d)
+    };
+    let span = ang_dist(a_start, a_end);
+    // `a` is on the arc iff dist(start,a)+dist(a,end) ≈ the arc span that
+    // contains the midpoint. Validate the midpoint satisfies this first so a
+    // degenerate (near-full) circle doesn't admit everything.
+    let on_arc = |a: f64| -> bool {
+        let dsa = ang_dist(a_start, a);
+        let dae = ang_dist(a, a_end);
+        (dsa + dae - span).abs() < 1e-6 || (dsa + dae) <= span + 1e-6
+    };
+    if !on_arc(a_mid) {
+        // Edge is the COMPLEMENT (major) arc; flip the test.
+        let major = |a: f64| -> bool {
+            let dsa = ang_dist(a_start, a);
+            let dae = ang_dist(a, a_end);
+            (dsa + dae) > span + 1e-9
+        };
+        return hits.into_iter().filter(|(_, t)| major(*t)).collect();
+    }
+    hits.into_iter().filter(|(_, t)| on_arc(*t)).collect()
+}
+
 /// Clip a 3D line segment to a face's boundary polygon.
 ///
 /// Collects the outer wire vertices as line segments, then finds where
@@ -1723,14 +1796,24 @@ fn clip_line_to_face_boundary(
     let face = topo.face(face_id).ok()?;
     let wire = topo.wire(face.outer_wire()).ok()?;
 
-    // Collect boundary edges as line segments (vertex positions in traversal order)
+    // Collect boundary edges as line segments (vertex positions in traversal
+    // order); for curved edges keep the geometry so the section line can be
+    // clipped to the TRUE arc rather than its chord.
     let edges = wire.edges();
     let mut boundary_segments: Vec<(Point3, Point3)> = Vec::with_capacity(edges.len());
+    let mut boundary_arcs: Vec<Option<(EdgeCurve, Point3, Point3)>> =
+        Vec::with_capacity(edges.len());
     for oe in edges {
         let edge = topo.edge(oe.edge()).ok()?;
         let sp = topo.vertex(oe.oriented_start(edge)).ok()?.point();
         let ep = topo.vertex(oe.oriented_end(edge)).ok()?.point();
         boundary_segments.push((sp, ep));
+        match edge.curve() {
+            EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
+                boundary_arcs.push(Some((edge.curve().clone(), sp, ep)));
+            }
+            _ => boundary_arcs.push(None),
+        }
     }
 
     let line_dir = line_end - line_start;
@@ -1743,7 +1826,22 @@ fn clip_line_to_face_boundary(
     // The section line is: P(t) = line_start + t * line_dir, t in [0, 1].
     let mut crossings: Vec<f64> = Vec::new();
 
-    for (seg_start, seg_end) in &boundary_segments {
+    for (seg_idx, (seg_start, seg_end)) in boundary_segments.iter().enumerate() {
+        // For a curved boundary edge, also record the crossing with the TRUE
+        // arc geometry. A convex rounded corner bulges OUTWARD past its chord,
+        // so the arc crossing extends the section to where it actually exits
+        // the face (e.g. a notch corner that straddles a wall's top edge clips
+        // to x=±13.236, not the chord's x=±12). The crossings are merged below;
+        // the outermost pair is taken, so adding the arc crossing never drops a
+        // chord crossing the existing cases rely on — it only reaches farther
+        // out when the arc genuinely does. Arcs the line misses contribute
+        // nothing (the lip-cut sections that graze a corner chord keep working).
+        if let Some((curve, asp, aep)) = &boundary_arcs[seg_idx] {
+            for (p, _) in arc_segment_crossings(curve, *asp, *aep, line_start, line_end, tol) {
+                let t = (p - line_start).dot(line_dir) / (line_len * line_len);
+                crossings.push(t);
+            }
+        }
         let seg_dir = *seg_end - *seg_start;
         let seg_len = seg_dir.length();
 

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -722,6 +722,25 @@ fn compute_raw_curves(
             plane_plane_intersection(*na, *da, *nb, *db, bbox_a, bbox_b)
         }
 
+        (FaceSurface::Plane { normal, d }, FaceSurface::Cylinder(cyl))
+            if normal.dot(cyl.axis()).abs() < 1e-9 =>
+        {
+            // Plane parallel to the cylinder axis: the intersection is 0 or 2
+            // straight lines along the axis (not a circle/ellipse). The exact
+            // analytic path samples the base circle and only keeps points
+            // that happen to land on the plane, so it returns nothing for a
+            // plane that grazes the lateral surface (e.g. a wall's top edge
+            // plane cutting a rounded notch corner). Solve the two contact
+            // angles directly and emit axis-parallel lines, bbox-trimmed.
+            plane_cylinder_parallel_lines(*normal, *d, cyl, bbox_a, bbox_b)
+        }
+
+        (FaceSurface::Cylinder(cyl), FaceSurface::Plane { normal, d })
+            if normal.dot(cyl.axis()).abs() < 1e-9 =>
+        {
+            plane_cylinder_parallel_lines(*normal, *d, cyl, bbox_a, bbox_b)
+        }
+
         (FaceSurface::Plane { normal, d }, other) if other.as_analytic().is_some() => {
             if let Some(analytic) = other.as_analytic() {
                 plane_analytic_intersection(*normal, *d, &analytic)
@@ -1010,6 +1029,81 @@ fn plane_analytic_intersection(
     Ok(results)
 }
 
+/// Intersect a plane parallel to a cylinder's axis with the cylinder.
+///
+/// When the plane normal is perpendicular to the cylinder axis the contact is
+/// 0 or 2 straight lines running along the axis (not a circle/ellipse). Solve
+/// the contact angle(s) `u` from `r·(cos u·(n·X) + sin u·(n·Y)) = d − n·O` and
+/// emit each as an axis-parallel `Line` raw curve, with its parameter range
+/// trimmed to the two faces' combined AABBs (mirrors `plane_plane_intersection`).
+///
+/// Returns `Result` to match the other `compute_raw_curves` arms (uniform
+/// dispatch); it never actually fails.
+#[allow(clippy::unnecessary_wraps)]
+fn plane_cylinder_parallel_lines(
+    normal: Vec3,
+    d: f64,
+    cyl: &brepkit_math::surfaces::CylindricalSurface,
+    bbox_a: &Aabb3,
+    bbox_b: &Aabb3,
+) -> Result<Vec<RawCurve>, AlgoError> {
+    let axis = cyl.axis();
+    let r = cyl.radius();
+    let origin = cyl.origin();
+    let x = cyl.x_axis();
+    let y = cyl.y_axis();
+
+    // n·P(u,v) = n·O + v·(n·axis) + r·(cos u·(n·X) + sin u·(n·Y)); n·axis ≈ 0.
+    let a = normal.dot(x);
+    let b = normal.dot(y);
+    let n_dot_o = normal.x() * origin.x() + normal.y() * origin.y() + normal.z() * origin.z();
+    let amp = a.hypot(b);
+    if amp < 1e-12 {
+        return Ok(Vec::new());
+    }
+    // R·cos(u − φ) = C, φ = atan2(b, a), C = (d − n·O) / r.
+    let c = (d - n_dot_o) / r;
+    let ratio = c / amp;
+    // |ratio| > 1: the plane misses the cylinder; |ratio| ≈ 1: tangent (single
+    // grazing line that never splits a face — skip).
+    if ratio.abs() > 1.0 - 1e-9 {
+        return Ok(Vec::new());
+    }
+    let phi = b.atan2(a);
+    let delta = ratio.clamp(-1.0, 1.0).acos();
+    let dir = {
+        let len = axis.length();
+        if len < 1e-12 {
+            return Ok(Vec::new());
+        }
+        axis * (1.0 / len)
+    };
+
+    let mut results = Vec::new();
+    for u in [phi + delta, phi - delta] {
+        // A point on the contact line at v = 0.
+        let base = cyl.evaluate(u, 0.0);
+        let t_range = trim_t_range_to_aabb(base, dir, bbox_a, bbox_b);
+        if (t_range.1 - t_range.0).abs() < 1e-9 {
+            continue;
+        }
+        let p0 = base + dir * t_range.0;
+        let p1 = base + dir * t_range.1;
+        let bbox = Aabb3 {
+            min: Point3::new(p0.x().min(p1.x()), p0.y().min(p1.y()), p0.z().min(p1.z())),
+            max: Point3::new(p0.x().max(p1.x()), p0.y().max(p1.y()), p0.z().max(p1.z())),
+        };
+        results.push(RawCurve {
+            curve: EdgeCurve::Line,
+            bbox,
+            t_range,
+            p_start: p0,
+            p_end: p1,
+        });
+    }
+    Ok(results)
+}
+
 /// Analytic-analytic surface intersection using marching.
 fn analytic_analytic_intersection(
     a: &analytic_intersection::AnalyticSurface<'_>,
@@ -1288,6 +1382,51 @@ fn closed_circle_crosses_face_boundaries(
 /// only the non-plane face's crossings are used — those surfaces keep
 /// full closed section circles for the periodic band splitter, and
 /// their seam-line hit must not combine with plane-boundary hits.
+/// Whether a closed section circle crosses any LINE boundary edge of a plane
+/// face at a point interior to that edge (not at a shared endpoint).
+///
+/// Used to distinguish a prism-corner section arc that exits a plane face's
+/// boundary (e.g. a notch corner straddling a wall's top edge) from a
+/// periodic-band section circle that stays inside the plane face.
+fn circle_exits_plane_boundary(
+    topo: &Topology,
+    plane_face: FaceId,
+    circle: &brepkit_math::curves::Circle3D,
+    tol: Tolerance,
+) -> bool {
+    let Ok(face) = topo.face(plane_face) else {
+        return false;
+    };
+    let wires: Vec<brepkit_topology::wire::WireId> = std::iter::once(face.outer_wire())
+        .chain(face.inner_wires().iter().copied())
+        .collect();
+    for wid in wires {
+        let Ok(wire) = topo.wire(wid) else {
+            continue;
+        };
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            if !matches!(edge.curve(), EdgeCurve::Line) {
+                continue;
+            }
+            let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+                continue;
+            };
+            let (sp, ep) = (sv.point(), ev.point());
+            for (p, _) in circle.intersect_segment(sp, ep, tol.linear) {
+                let at_endpoint =
+                    (p - sp).length() < tol.linear * 10.0 || (p - ep).length() < tol.linear * 10.0;
+                if !at_endpoint {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 fn closed_circle_boundary_crossings(
     topo: &Topology,
     face_a: FaceId,
@@ -1341,8 +1480,33 @@ fn closed_circle_boundary_crossings(
         vec![face_a, face_b]
     } else {
         match (is_plane(&surf_a), is_plane(&surf_b)) {
-            (true, false) => vec![face_b],
-            (false, true) => vec![face_a],
+            // Plane x lateral-analytic (cylinder/cone): the analytic face's
+            // boundary alone splits a section circle that stays inside the
+            // plane face (the periodic band case — its seam-line hits drive
+            // the band splitter). But when the circle is a prism CORNER
+            // arc that crosses the plane face's own boundary (e.g. a
+            // rounded-rect notch whose top corner straddles a wall's top
+            // edge), the analytic boundary splits it only at the corner's
+            // angular limits, leaving an arc that bulges past the plane
+            // boundary — `emit_split_circle_arcs` then rejects it by its
+            // midpoint and the corner section is lost. Add the plane face's
+            // crossings too, but only when the circle genuinely exits the
+            // plane boundary, so the in-plane band case is unaffected (it
+            // yields no plane-boundary hits).
+            (true, false) => {
+                if circle_exits_plane_boundary(topo, face_a, circle, tol) {
+                    vec![face_a, face_b]
+                } else {
+                    vec![face_b]
+                }
+            }
+            (false, true) => {
+                if circle_exits_plane_boundary(topo, face_b, circle, tol) {
+                    vec![face_a, face_b]
+                } else {
+                    vec![face_a]
+                }
+            }
             _ => vec![face_a, face_b],
         }
     };

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4755,3 +4755,173 @@ fn cut_wall_notch_straddling_top_edge_is_watertight() {
         "wall-cutout must stay analytic (4 body + 4 tool corner cylinders)"
     );
 }
+
+/// Build a gridfinity-style wall-cutout TOOL: a rounded-rect (`cut_hw` half
+/// width, `total_hh` half height in the plane that becomes Z) extruded `depth`
+/// through the wall, opening at `top_z`, centred on the wall plane at `wall_y`.
+///
+/// The 2D rect is built in XY then rotated -90 about X so it sits in XZ extruded
+/// along +Y; centring on `wall_y` makes the extrude span `[wall_y - depth/2,
+/// wall_y + depth/2]` so a thin wall is cut clean through (matching the
+/// gridfinity builder, which centres the cutout on the wall).
+fn make_wall_notch_tool(
+    topo: &mut Topology,
+    cut_hw: f64,
+    total_hh: f64,
+    r: f64,
+    depth: f64,
+    wall_y: f64,
+    top_z: f64,
+) -> SolidId {
+    use brepkit_math::mat::Mat4;
+    use std::f64::consts::FRAC_PI_2;
+    let tool = make_rounded_rect_arc_prism(topo, cut_hw, total_hh, r, 0.0, depth);
+    crate::transform::transform_solid(topo, tool, &Mat4::rotation_x(-FRAC_PI_2)).unwrap();
+    let z_center = top_z - total_hh;
+    crate::transform::transform_solid(
+        topo,
+        tool,
+        &Mat4::translation(0.0, wall_y - depth / 2.0, z_center),
+    )
+    .unwrap();
+    tool
+}
+
+/// Regression for the real gridfinity "2×2 wall cutouts" geometry through a
+/// SOLID wall: a wide, shallow U-notch whose rounded corners are SMALL relative
+/// to the overshoot (auto corner radius ≈ 1.485 mm for the real bin), so they do
+/// NOT straddle the wall top. The tool is centred on the wall and pokes through
+/// it (the gridfinity builder centres the cutout on the wall plane). The cut
+/// must be watertight and stay analytic (the body's four corner cylinders plus
+/// the notch's two bottom corner cylinders).
+#[test]
+fn cut_wall_notch_through_solid_wall_is_watertight() {
+    let mut topo = Topology::new();
+    let body = make_rounded_rect_arc_prism(&mut topo, 21.0, 21.0, 3.75, 0.0, 30.0);
+    // Shallow notch: top at z=32 (overshoot 2 above the wall top z=30), corner
+    // r=1.485 (arc centre z=30.515 > 30 => no straddle), depth 3.4 centred on
+    // the +Y wall at y=21 so it cuts through.
+    let tool = make_wall_notch_tool(&mut topo, 14.0, 5.95, 1.485, 3.4, 21.0, 32.0);
+    let result =
+        brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Cut, body, tool)
+            .unwrap();
+    let (free, over) = quantized_edge_use(&topo, result);
+    assert_eq!(free, 0, "through-wall notch cut must have no free edges");
+    assert_eq!(
+        over, 0,
+        "through-wall notch cut must have no over-shared edges"
+    );
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "through-wall notch cut must be closed-manifold"
+    );
+    assert_eq!(
+        count_cylinder_faces(&topo, result),
+        6,
+        "through-wall notch must stay analytic (4 body + 2 notch corner cylinders)"
+    );
+}
+
+/// The real gridfinity "2×2 wall cutouts" geometry: the body is SHELLED (a thin
+/// 1.2 mm wall) and the U-notch opens at the wall top, cutting through the top
+/// RIM. The notch's side wall (the tool's `x = ±cut_hw` plane) is then crossed
+/// by the outer wall plane, the inner cavity wall plane, AND the rim plane —
+/// three line sections forming a partial grid that the angular wire builder and
+/// the 2/4-section crossing helper could not partition (they handed back one
+/// self-crossing wire → non-manifold 3-use edges → mesh fallback). The planar
+/// straight-line arrangement decomposition now splits that side wall into clean
+/// minimal regions, and `integrate_holes_plane` carves the bite the notch takes
+/// out of the (arc-cornered) rim, so the shelled cut is watertight and stays
+/// analytic — matching the clean SOLID-wall variant
+/// (`cut_wall_notch_through_solid_wall_is_watertight`).
+#[test]
+fn cut_wall_notch_through_shelled_wall_is_watertight() {
+    let mut topo = Topology::new();
+    let body = make_rounded_rect_arc_prism(&mut topo, 21.0, 21.0, 3.75, 0.0, 30.0);
+    let top = find_top_face(&topo, body);
+    let cup = crate::shell_op::shell(&mut topo, body, 1.2, &[top]).unwrap();
+    let tool = make_wall_notch_tool(&mut topo, 14.0, 5.95, 1.485, 3.4, 21.0, 32.0);
+    let result =
+        brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Cut, cup, tool)
+            .unwrap();
+    let (free, over) = quantized_edge_use(&topo, result);
+    assert_eq!(
+        free, 0,
+        "shelled through-wall notch cut must have no free edges"
+    );
+    assert_eq!(
+        over, 0,
+        "shelled through-wall notch cut must have no over-shared edges"
+    );
+    assert!(
+        !has_free_edges(&topo, result).unwrap(),
+        "shelled through-wall notch cut must have no free edges (per-edge)"
+    );
+    // The notch's two bottom corner cylinders stay analytic (no mesh fallback);
+    // the body's own corner cylinders survive the cut too.
+    assert!(
+        count_cylinder_faces(&topo, result) >= 2,
+        "shelled through-wall notch must stay analytic (notch corner cylinders preserved)"
+    );
+}
+
+/// The real gridfinity "2×2 wall cutouts" bin cuts ALL FOUR walls at once: it
+/// fuses the four wall-cutout prisms (`merge_disjoint_solids`) and applies ONE
+/// boolean. With the four-shell tool, the rim (top annular face) is carved by
+/// four notch openings, and the angular wire builder emits a SPURIOUS extra
+/// loop re-tracing the notch opening on some walls (a notch whose sections reach
+/// the rim's outer boundary produces a second positive-area loop that re-adds
+/// the removed region) → those rim-bite edges go unshared.
+///
+/// OPEN: this `#[ignore]`d test pins the residual. The dimensions match
+/// `wallCutoutBuilder.ts` for a 2×2 no-lip bin (wallHeight 16, wall 1.2, hw
+/// 28.385, r 1.11, depth 3.4, top z=18). The single-wall path is clean
+/// (`cut_wall_notch_through_shelled_wall_is_watertight`). The planar-arrangement
+/// and arc-hole fixes bring the four-wall result from 18 free / 4 over down to 8
+/// free / 0 over (cylinders preserved), but the spurious-rim-loop asymmetry in
+/// the multi-shell-tool cut is a separate, deeper GFA issue.
+#[test]
+#[ignore = "open: multi-shell wall-cutout tool leaves spurious rim-bite loops"]
+fn cut_2x2_wall_cutouts_four_walls_is_watertight() {
+    use brepkit_math::mat::Mat4;
+    use std::f64::consts::FRAC_PI_2;
+    let mut topo = Topology::new();
+    let hw = 41.75;
+    let body = make_rounded_rect_arc_prism(&mut topo, hw, hw, 3.75, 0.0, 16.0);
+    let top = find_top_face(&topo, body);
+    let cup = crate::shell_op::shell(&mut topo, body, 1.2, &[top]).unwrap();
+    let (cut_hw, total_hh, r, depth, z_center) = (28.385, 4.7, 1.11, 3.4, 18.0 - 4.7);
+    let mut tools = Vec::new();
+    for (rotz, wall) in [(false, -hw), (false, hw), (true, -hw), (true, hw)] {
+        let t = make_rounded_rect_arc_prism(&mut topo, cut_hw, total_hh, r, 0.0, depth);
+        crate::transform::transform_solid(&mut topo, t, &Mat4::rotation_x(-FRAC_PI_2)).unwrap();
+        let off = depth / 2.0 * wall.signum();
+        if rotz {
+            crate::transform::transform_solid(&mut topo, t, &Mat4::rotation_z(FRAC_PI_2)).unwrap();
+            crate::transform::transform_solid(
+                &mut topo,
+                t,
+                &Mat4::translation(wall - off, 0.0, z_center),
+            )
+            .unwrap();
+        } else {
+            crate::transform::transform_solid(
+                &mut topo,
+                t,
+                &Mat4::translation(0.0, wall - off, z_center),
+            )
+            .unwrap();
+        }
+        tools.push(t);
+    }
+    let merged = crate::compound_ops::merge_disjoint_solids(&mut topo, &tools).unwrap();
+    let result =
+        brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Cut, cup, merged)
+            .unwrap();
+    let (free, over) = quantized_edge_use(&topo, result);
+    assert_eq!(free, 0, "four-wall cutout cut must have no free edges");
+    assert_eq!(
+        over, 0,
+        "four-wall cutout cut must have no over-shared edges"
+    );
+}

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4673,3 +4673,85 @@ fn baseplate_two_tongues_far_apart_resplit_is_watertight() {
     brepkit_topology::validation::validate_shell_closed(sh_b, &topo)
         .expect("tongue B fused into the A-split wall must stay watertight");
 }
+
+/// Count edges shared by exactly one face (free) and by more than two faces
+/// (over-shared), keyed by quantized endpoint pair — distinct sub-faces make
+/// their own `EdgeId`s, so an `EdgeId` count would miss the real sharing.
+fn quantized_edge_use(topo: &Topology, solid: SolidId) -> (usize, usize) {
+    use std::collections::HashMap;
+    type EdgeKey = (i64, i64, i64, i64, i64, i64);
+    let q = |x: f64| (x / 1e-5).round() as i64;
+    let key = |p: Point3| [q(p.x()), q(p.y()), q(p.z())];
+    let mut counts: HashMap<EdgeKey, usize> = HashMap::new();
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid).unwrap() {
+        let face = topo.face(fid).unwrap();
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            let wire = topo.wire(wid).unwrap();
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge()).unwrap();
+                let a = key(topo.vertex(edge.start()).unwrap().point());
+                let b = key(topo.vertex(edge.end()).unwrap().point());
+                let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                *counts
+                    .entry((lo[0], lo[1], lo[2], hi[0], hi[1], hi[2]))
+                    .or_insert(0) += 1;
+            }
+        }
+    }
+    let free = counts.values().filter(|&&c| c == 1).count();
+    let over = counts.values().filter(|&&c| c > 2).count();
+    (free, over)
+}
+
+/// Regression for the gridfinity "wall cutout" (a U-notch opening at the wall
+/// top, with rounded corners whose radius exceeds the overshoot so the top
+/// corners STRADDLE the wall-top edge). The straddle triggered a cascade of
+/// analytic-trimming bugs that left the cut non-manifold, so the operations
+/// boolean fell back to a mesh result. The GFA cut must now be a watertight,
+/// genus-0, fully-analytic solid (every corner cylinder preserved).
+#[test]
+fn cut_wall_notch_straddling_top_edge_is_watertight() {
+    use brepkit_math::mat::Mat4;
+    use std::f64::consts::FRAC_PI_2;
+    let mut topo = Topology::new();
+    // Solid wall body: rounded-rect arc prism 21x21 r=3.75 z=0..30.
+    let body = make_rounded_rect_arc_prism(&mut topo, 21.0, 21.0, 3.75, 0.0, 30.0);
+    // Tool: a U-notch opening at the top. Built in XY (hw=14, hd=13, r=3,
+    // extrude 6), rotated -90 about X and translated to (0,17,18) so it
+    // straddles the +Y wall at y=21: tool y in [17,23], top corners z in
+    // [25,31] crossing the wall top z=30.
+    let tool = make_rounded_rect_arc_prism(&mut topo, 14.0, 13.0, 3.0, 0.0, 6.0);
+    crate::transform::transform_solid(&mut topo, tool, &Mat4::rotation_x(-FRAC_PI_2)).unwrap();
+    crate::transform::transform_solid(&mut topo, tool, &Mat4::translation(0.0, 17.0, 18.0))
+        .unwrap();
+
+    let result =
+        brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Cut, body, tool)
+            .unwrap();
+
+    let (free, over) = quantized_edge_use(&topo, result);
+    assert_eq!(free, 0, "wall-cutout notch cut must have no free edges");
+    assert_eq!(
+        over, 0,
+        "wall-cutout notch cut must have no over-shared edges"
+    );
+    let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(&topo, result).unwrap();
+    assert_eq!(
+        v as i64 - e as i64 + f as i64,
+        2,
+        "wall-cutout notch cut must be genus-0 (V-E+F=2)"
+    );
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "wall-cutout notch cut must be closed-manifold"
+    );
+    assert!(
+        !has_free_edges(&topo, result).unwrap(),
+        "wall-cutout notch cut must have no free edges"
+    );
+    assert_eq!(
+        count_cylinder_faces(&topo, result),
+        8,
+        "wall-cutout must stay analytic (4 body + 4 tool corner cylinders)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the **single-wall** shelled wall-cutout non-manifold (the precisely-isolated `cut_wall_notch_through_shelled_wall_is_watertight` blocker) and materially improves the real four-wall `2×2 wall cutouts` bin, but does **not** yet flip the bin to analytic — a separate, deeper multi-shell-tool issue remains (documented below).

> Note: stacks on the `b2f888c` notch-corner fix from #898 (the solid-wall through-wall notch is clean only with it). The straddle/cyl×cyl `a82b162` fix from #898 is intentionally **not** included — the real bin never reaches that geometry.

## Root cause (single-wall, fixed)

A planar face cut by **three or more line sections forming a partial grid** — a notch side wall on a SHELLED body, crossed by the outer wall plane, the inner cavity wall plane, and the rim plane — defeated both the angular wire builder and the 2/4-section crossing helper (`try_split_crossing_plane_face`). They returned **one self-crossing wire** (the same edge traced twice), so the shared section edge became non-manifold (3-use) → operations gate rejects → mesh fallback. The SOLID-wall variant is clean (it sees only a clean L-junction); the SHELL adds the second parallel line + the annular rim.

## Fix (3 parts, all regression-free)

1. **`split_plane_face_by_line_arrangement`** (new): builds the full 2D straight-line arrangement — split every boundary/section segment at all mutual intersections, trace minimal faces by the leftmost-turn rule, drop the unbounded outer face (largest |area|, winding-independent). All-line only; curved faces keep the existing paths the lip cuts rely on. Used as a fallback only when it yields more regions than the wire builder.
2. **`is_inside_any_hole`** now builds the hole polygon from edge endpoint chords instead of sampling the arc pcurve. The projected cavity corner arcs carry a `Nurbs2D` pcurve whose parameter domain is inconsistent with its stored UV endpoints, so `sample_wire_loop_uv` traced a self-crossing garbage polygon and let an entirely-in-cavity section through (the rim dipped to the wrong y).
3. **`integrate_holes_plane`** now carries **arc** hole edges through unchanged (it was Line-only), so a rounded-rect cavity opening is carved correctly. It bails to `None` only when a section actually crosses a corner arc.

## Results

- `cut_wall_notch_through_solid_wall_is_watertight`: free=0, analytic ✅
- `cut_wall_notch_through_shelled_wall_is_watertight` (was the open blocker): **free=0, over=0, analytic** ✅
- Thickness sweep: wall=1.2 / 0.8 / 3.0 all free=0 (wall=6 is a separate, pre-existing blind-pocket-in-thick-wall issue, unchanged at free=6 — not the real bin).

### Regression (the whole danger — `split_face_2d` is the core splitter)
- `brepkit-algo`: **126/126**
- `brepkit-operations`: **all pass, 0 failed** (incl. the lip-cut tests `cut_concentric_rounded_rect_arc_prisms_*`, `fuse_*_rounded_rect_arc_prisms_*`, `fuse_shelled_cup_lip_*`, #891 `multicavity_cut`, #895 `same_domain`, and the `regress_hexwall_cuts` stress test)
- gridfinity: **26/26**
- fmt / clippy -D warnings / boundaries: clean

## What this does NOT fix (the tool does not flip yet)

The real `2×2 wall cutouts` bin cuts **all four walls at once** — it fuses the four cutout prisms (`merge_disjoint_solids`) and applies ONE boolean. With the four-shell tool:

- This PR improves the four-wall result from **free=18 / over=4** (base) to **free=8 / over=0**, with the analytic corner cylinders preserved (cyl=12).
- But a **spurious rim-bite loop** remains: a notch whose sections reach the rim's outer boundary makes the wire builder emit a second positive-area loop re-tracing the removed opening, so the rim-bite edges go unshared. It is asymmetric across walls — a notch processed as a boundary-carve is clean, one processed as sections is not — which points at the multi-shell pavefiller ordering, a separate/deeper GFA issue, not the single-wall splitter this PR fixes.

Pinned by the ignored `cut_2x2_wall_cutouts_four_walls_is_watertight`. Tool-side `2×2 wall cutouts`, `2×2 compartments+scoop`, and `3×3 scoop+label+lip` therefore still mesh-fall-back (982 / 3396 / 2363 tris, all-planar) until that residual is closed.
