### PR TITLE
fix(algo): deterministic interior-point classification + collinear-disjoint section dedup

### DIFF
--- a/crates/algo/src/builder/classify_2d.rs
+++ b/crates/algo/src/builder/classify_2d.rs
@@ -66,14 +66,15 @@ pub fn sample_interior_point(loop_pts: &[Point2]) -> Point2 {
         if len < 1e-15 {
             continue;
         }
-        // Inward normal depends on winding:
-        // CCW (positive area) -> (dy, -dx) rotated; CW -> the opposite.
+        // Inward normal depends on winding (left normal of the edge for a
+        // CCW loop): CCW (positive area) -> (-dy, dx); CW -> (dy, -dx).
         let inward = if area > 0.0 {
             Vec2::new(-edge_dir.y() / len, edge_dir.x() / len)
         } else {
             Vec2::new(edge_dir.y() / len, -edge_dir.x() / len)
         };
-        // First crossing of the inward ray with any non-adjacent boundary edge.
+        // First crossing of the inward ray with any other boundary edge
+        // (every edge except the current one `i`).
         let mut t_hit = f64::INFINITY;
         for k in 0..n {
             if k == i {
@@ -95,7 +96,14 @@ pub fn sample_interior_point(loop_pts: &[Point2]) -> Point2 {
             mid.x() + inward.x() * t_hit * 0.5,
             mid.y() + inward.y() * t_hit * 0.5,
         );
-        if point_in_polygon_2d(cand, loop_pts) && best.is_none_or(|(_, bt)| t_hit > bt) {
+        // Keep the longest interior chord; break exact ties by the candidate's
+        // lexicographic coordinates so the result is loop-rotation-invariant
+        // (the chosen start edge is HashMap-order-dependent upstream).
+        let better = best.is_none_or(|(bp, bt)| {
+            t_hit > bt + 1e-12
+                || ((t_hit - bt).abs() <= 1e-12 && (cand.x(), cand.y()) < (bp.x(), bp.y()))
+        });
+        if point_in_polygon_2d(cand, loop_pts) && better {
             best = Some((cand, t_hit));
         }
     }

--- a/crates/algo/src/builder/classify_2d.rs
+++ b/crates/algo/src/builder/classify_2d.rs
@@ -38,40 +38,92 @@ pub fn sample_interior_point(loop_pts: &[Point2]) -> Point2 {
         return centroid;
     }
 
+    // Edge-midpoint fallback for non-convex loops. For every boundary edge,
+    // cast a ray inward from its midpoint and take the midpoint of the resulting
+    // interior chord (the segment from the edge to the first opposite boundary
+    // crossing). Keep the candidate with the LONGEST such chord — the deepest,
+    // most robustly-interior point.
+    //
+    // Returning the *deepest* candidate rather than the *first* valid one is
+    // what makes this rotation-invariant: the wire builder emits each loop with
+    // a per-process nondeterministic starting edge (the rim boundary wire's
+    // rotation tracks hash order), so a first-match scan picks a different edge
+    // — and on a non-convex slice (a notched annular rim) a different pocket —
+    // each run, flipping the sub-face's IN/OUT classification and producing an
+    // intermittent mesh fallback. The longest-chord midpoint depends only on
+    // the loop's geometry, not its starting index, and lands far from every
+    // boundary so the downstream point-in-solid test is stable.
     let area = signed_area_2d(loop_pts);
-    for i in 0..loop_pts.len() {
-        let j = (i + 1) % loop_pts.len();
-        let mid = Point2::new(
-            (loop_pts[i].x() + loop_pts[j].x()) * 0.5,
-            (loop_pts[i].y() + loop_pts[j].y()) * 0.5,
-        );
-        let edge_dir = Vec2::new(
-            loop_pts[j].x() - loop_pts[i].x(),
-            loop_pts[j].y() - loop_pts[i].y(),
-        );
+    let n = loop_pts.len();
+    let mut best: Option<(Point2, f64)> = None;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let a = loop_pts[i];
+        let b = loop_pts[j];
+        let mid = Point2::new((a.x() + b.x()) * 0.5, (a.y() + b.y()) * 0.5);
+        let edge_dir = Vec2::new(b.x() - a.x(), b.y() - a.y());
         let len = edge_dir.length();
         if len < 1e-15 {
             continue;
         }
         // Inward normal depends on winding:
-        // CCW (positive area) -> rotate edge 90 deg CW -> (dy, -dx)
-        // CW (negative area) -> rotate edge 90 deg CCW -> (-dy, dx)
+        // CCW (positive area) -> (dy, -dx) rotated; CW -> the opposite.
         let inward = if area > 0.0 {
-            Vec2::new(-edge_dir.y(), edge_dir.x())
+            Vec2::new(-edge_dir.y() / len, edge_dir.x() / len)
         } else {
-            Vec2::new(edge_dir.y(), -edge_dir.x())
+            Vec2::new(edge_dir.y() / len, -edge_dir.x() / len)
         };
-        let nudge = 1e-4;
-        let candidate = Point2::new(
-            mid.x() + inward.x() / len * nudge,
-            mid.y() + inward.y() / len * nudge,
-        );
-        if point_in_polygon_2d(candidate, loop_pts) {
-            return candidate;
+        // First crossing of the inward ray with any non-adjacent boundary edge.
+        let mut t_hit = f64::INFINITY;
+        for k in 0..n {
+            if k == i {
+                continue;
+            }
+            let c = loop_pts[k];
+            let d = loop_pts[(k + 1) % n];
+            if let Some(t) = ray_segment_param(mid, inward, c, d)
+                && t > 1e-9
+                && t < t_hit
+            {
+                t_hit = t;
+            }
         }
+        if !t_hit.is_finite() {
+            continue;
+        }
+        let cand = Point2::new(
+            mid.x() + inward.x() * t_hit * 0.5,
+            mid.y() + inward.y() * t_hit * 0.5,
+        );
+        if point_in_polygon_2d(cand, loop_pts) && best.is_none_or(|(_, bt)| t_hit > bt) {
+            best = Some((cand, t_hit));
+        }
+    }
+    if let Some((pt, _)) = best {
+        return pt;
     }
     // All edge midpoints failed -- return centroid as last resort.
     centroid
+}
+
+/// Parameter `t >= 0` at which the ray `origin + t*dir` first crosses segment
+/// `[s0, s1]`, or `None` if it does not. `dir` is assumed unit-length; `t` is a
+/// world-space distance along the ray.
+fn ray_segment_param(origin: Point2, dir: Vec2, s0: Point2, s1: Point2) -> Option<f64> {
+    let e = Vec2::new(s1.x() - s0.x(), s1.y() - s0.y());
+    let denom = dir.x() * e.y() - dir.y() * e.x();
+    if denom.abs() < 1e-15 {
+        return None; // parallel
+    }
+    let diff = Vec2::new(s0.x() - origin.x(), s0.y() - origin.y());
+    // t along the ray, u along the segment.
+    let t = (diff.x() * e.y() - diff.y() * e.x()) / denom;
+    let u = (diff.x() * dir.y() - diff.y() * dir.x()) / denom;
+    if t >= 0.0 && (0.0..=1.0).contains(&u) {
+        Some(t)
+    } else {
+        None
+    }
 }
 
 /// Scale-aware boundary tolerance for a 2D loop: a small fraction of the

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1700,7 +1700,26 @@ fn dedup_collinear_sections(sections: &mut Vec<SectionEdge>, tol: f64) {
                 continue;
             }
 
-            // Collinear and on the same line. Remove the shorter one.
+            // Collinear and on the same infinite line, but possibly DISJOINT:
+            // two notches on opposite walls cut the same rim along the same
+            // x = ±cut_hw line, yet their cut segments sit at opposite ends of
+            // the face and must both survive. Only treat the shorter section as
+            // a redundant subset when its span actually OVERLAPS the longer one
+            // (a coplanar inner-region edge nested in the full-face FF edge).
+            // Project both segments onto the shared line and compare intervals.
+            let proj = |p: Point3, origin: Point3| (p - origin).dot(dj_unit);
+            let (ia0, ia1) = (proj(si.start, sj.start), proj(si.end, sj.start));
+            let (ib0, ib1) = (proj(sj.start, sj.start), proj(sj.end, sj.start));
+            let (ia_lo, ia_hi) = (ia0.min(ia1), ia0.max(ia1));
+            let (ib_lo, ib_hi) = (ib0.min(ib1), ib0.max(ib1));
+            // Overlap length of the two 1D intervals; require a real (not just
+            // touching) overlap before either can be a subset of the other.
+            let overlap = ia_hi.min(ib_hi) - ia_lo.max(ib_lo);
+            if overlap <= tol {
+                continue;
+            }
+
+            // Overlapping collinear sections. Remove the shorter one.
             let len_i = (si.end - si.start).length();
             let len_j = (sj.end - sj.start).length();
             if len_i < len_j - tol {

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4867,21 +4867,21 @@ fn cut_wall_notch_through_shelled_wall_is_watertight() {
 
 /// The real gridfinity "2×2 wall cutouts" bin cuts ALL FOUR walls at once: it
 /// fuses the four wall-cutout prisms (`merge_disjoint_solids`) and applies ONE
-/// boolean. With the four-shell tool, the rim (top annular face) is carved by
-/// four notch openings, and the angular wire builder emits a SPURIOUS extra
-/// loop re-tracing the notch opening on some walls (a notch whose sections reach
-/// the rim's outer boundary produces a second positive-area loop that re-adds
-/// the removed region) → those rim-bite edges go unshared.
+/// boolean. With the four-shell tool the rim (the shelled top annular face) is
+/// carved by several notch openings whose side cuts share a line across the
+/// face. Two bugs combined to make this intermittently mesh-fall-back. First,
+/// `dedup_collinear_sections` dropped a rim cut whenever it was collinear with
+/// (but disjoint from) a longer cut from the opposite wall — both notches share
+/// the `x = ±cut_hw` line — so the rim lost the sections it needed to carve
+/// cleanly. Second, `sample_interior_point` returned the first inward edge nudge
+/// that tested inside, which depends on the wire builder's per-process
+/// nondeterministic loop rotation; on a notched annular rim slice that picked a
+/// different pocket each run, flipping the sub-face's IN/OUT classification.
 ///
-/// OPEN: this `#[ignore]`d test pins the residual. The dimensions match
-/// `wallCutoutBuilder.ts` for a 2×2 no-lip bin (wallHeight 16, wall 1.2, hw
-/// 28.385, r 1.11, depth 3.4, top z=18). The single-wall path is clean
-/// (`cut_wall_notch_through_shelled_wall_is_watertight`). The planar-arrangement
-/// and arc-hole fixes bring the four-wall result from 18 free / 4 over down to 8
-/// free / 0 over (cylinders preserved), but the spurious-rim-loop asymmetry in
-/// the multi-shell-tool cut is a separate, deeper GFA issue.
+/// The dimensions match `wallCutoutBuilder.ts` for a 2×2 no-lip bin (wallHeight
+/// 16, wall 1.2, hw 28.385, r 1.11, depth 3.4, top z=18). The cut must now be
+/// watertight (free = over = 0) deterministically.
 #[test]
-#[ignore = "open: multi-shell wall-cutout tool leaves spurious rim-bite loops"]
 fn cut_2x2_wall_cutouts_four_walls_is_watertight() {
     use brepkit_math::mat::Mat4;
     use std::f64::consts::FRAC_PI_2;


### PR DESCRIPTION
Fixes two real GFA bugs surfaced by the merged four-wall notch cut (native repro `cut_2x2_wall_cutouts_four_walls_is_watertight` now free=0, deterministic ×10):

1. **`sample_interior_point` was nondeterministic** — it returned the first inward edge-nudge that tested inside, but the wire builder's loop start edge is HashMap-order-dependent, so on a non-convex notched-annular face the chosen interior point flipped between material and cavity across runs (free=16 some runs, 0 others). Now casts the inward ray to the opposite boundary and takes the longest interior-chord midpoint (rotation-invariant, deep in material). This is a real reliability fix — nondeterministic boolean classification is a defect regardless of this case.
2. **`dedup_collinear_sections` dropped a collinear-but-DISJOINT section** — front/back notches cut the same infinite line at disjoint y; the dedup deleted the shorter as a 'subset'. Added a 1D interval-overlap gate.

Zero regressions: algo 126, operations 700 + integration (lip-cut rounded_rect_arc_prism 6/6, wall_notch 3/3, #891 multicavity, #895 same-domain all green), gridfinity 26/26 ×3, fmt/clippy/boundaries clean, EdgeCurve/FaceSurface matches exhaustive.

Note: this does NOT flip the tool's `2×2 wall cutouts` case — that falls back due to a separate fidelity gap (the tool's wall prism is built by brepjs `drawRoundedRectangle().extrude()` with a different corner-face/seam structure than brepkit's native `make_rounded_rect_arc_prism`; the native repro is clean, the tool's actual geometry isn't). Next: STEP-export the tool's actual cut operands to debug the faithful geometry.