### PR TITLE
fix(algo): order-independent coincident-face selection in fuse

### DIFF
--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -11,7 +11,9 @@
 //!   discard the other.
 //! - **Cut** (`isSameOriNeeded = false`): keep the differently-oriented
 //!   face (B, reversed). Discard A's overlapping sub-face.
-//! - **Intersect** (`isSameOriNeeded = true`): keep the same-oriented face (A).
+//! - **Intersect** (`isSameOriNeeded = true`): keep the same-oriented face.
+//!   For a geometric-containment pair this is the smaller (contained) face,
+//!   whose footprint is bounded by the interior of both solids.
 
 use std::collections::HashSet;
 
@@ -166,9 +168,10 @@ fn apply_sd_selection(
 
         if same_ori_needed == pair.same_orientation {
             // Orientations match what the operation needs:
-            // - Fuse + same-ori: keep the representative (the larger face for a
-            //   containment pair, A for a coextensive pair)
-            // - Intersect + same-ori: keep the representative
+            // - Fuse + same-ori: keep the larger (containing) face for a
+            //   containment pair, A for a coextensive pair
+            // - Intersect + same-ori: keep the smaller (contained) face for a
+            //   containment pair, A for a coextensive pair
             // - Cut + opposite-ori: keep A only when the faces merely touch
             //   on the boundary; discard both when A overlaps B's interior
             if op == BooleanOp::Cut {
@@ -187,13 +190,33 @@ fn apply_sd_selection(
             // Fuse/Intersect with matching orientation: a same-oriented
             // coincident pair always lies on the result's exterior (both
             // solids' material is on the same side of the shared plane), so
-            // keep exactly one representative. `pair.representative` is the
-            // larger (containing) face for a geometric-containment pair and
-            // `idx_a` for a coextensive pair, making the choice depend on
-            // geometry rather than operand order. Genuinely-internal coincident
-            // faces have OPPOSITE orientation and fall into the else-branch.
+            // keep exactly one face. Genuinely-internal coincident faces have
+            // OPPOSITE orientation and fall into the else-branch.
+            //
+            // Which face is correct depends on the operation when the pair is a
+            // geometric-containment pair (the two faces have different extent):
+            //  - Fuse keeps the LARGER (containing) face — it covers the whole
+            //    union boundary on the shared plane. `pair.representative` is
+            //    that larger face (picked by area, so order-independent).
+            //  - Intersect keeps the SMALLER face — the intersection footprint
+            //    on the shared plane is bounded by the interior of BOTH solids,
+            //    i.e. the contained face. Keeping the larger face would include
+            //    area outside one operand and can leave the shell non-manifold.
+            // For coextensive pairs both faces span the same domain, so larger
+            // and smaller coincide and either choice is order-independent.
+            let keep = if op == BooleanOp::Intersect {
+                // The smaller face is the endpoint that is NOT the
+                // (area-larger) representative.
+                if pair.representative == pair.idx_a {
+                    pair.idx_b
+                } else {
+                    pair.idx_a
+                }
+            } else {
+                pair.representative
+            };
             selected.push(SelectedFace {
-                face_id: sub_faces[pair.representative].face_id,
+                face_id: sub_faces[keep].face_id,
                 reversed: false,
             });
         } else {
@@ -334,6 +357,81 @@ mod tests {
         ];
         let selected = select_faces(&sub_faces, BooleanOp::Intersect, &[], &[]);
         assert_eq!(selected.len(), 2, "Intersect keeps only Inside faces");
+    }
+
+    /// A same-oriented geometric-containment SD pair: idx_a is the larger
+    /// (containing) face, idx_b the smaller (contained) face. `representative`
+    /// is the larger face (area-based pick). Fuse must keep the larger face so
+    /// the full union boundary is covered; Intersect must keep the SMALLER
+    /// face, whose footprint is bounded by the interior of both solids.
+    #[test]
+    fn sd_containment_pair_fuse_larger_intersect_smaller() {
+        let mut topo = Topology::new();
+        // idx 0 = A (larger / representative), idx 1 = B (smaller). Both On so
+        // they only enter the result via SD selection, not the truth table.
+        let sub_faces = vec![
+            make_sub_face(&mut topo, Rank::A, FaceClass::On),
+            make_sub_face(&mut topo, Rank::B, FaceClass::On),
+        ];
+        let larger = sub_faces[0].face_id;
+        let smaller = sub_faces[1].face_id;
+        let sd_pairs = vec![SameDomainPair {
+            idx_a: 0,
+            idx_b: 1,
+            same_orientation: true,
+            b_contained_in_a: true,
+            representative: 0,
+        }];
+
+        let fused = select_faces(&sub_faces, BooleanOp::Fuse, &sd_pairs, &[]);
+        assert_eq!(fused.len(), 1, "Fuse keeps exactly one face of the SD pair");
+        assert_eq!(
+            fused[0].face_id, larger,
+            "Fuse keeps the larger (containing) face"
+        );
+
+        let intersected = select_faces(&sub_faces, BooleanOp::Intersect, &sd_pairs, &[]);
+        assert_eq!(
+            intersected.len(),
+            1,
+            "Intersect keeps exactly one face of the SD pair"
+        );
+        assert_eq!(
+            intersected[0].face_id, smaller,
+            "Intersect keeps the smaller (contained) face"
+        );
+    }
+
+    /// The smaller-for-Intersect pick is independent of which operand is A:
+    /// swap so idx_a is the smaller face and `representative` (the larger) is
+    /// idx_b. Intersect must still keep the smaller face (idx_a here).
+    #[test]
+    fn sd_containment_intersect_smaller_when_representative_is_b() {
+        let mut topo = Topology::new();
+        let sub_faces = vec![
+            make_sub_face(&mut topo, Rank::A, FaceClass::On),
+            make_sub_face(&mut topo, Rank::B, FaceClass::On),
+        ];
+        let smaller = sub_faces[0].face_id;
+        let larger = sub_faces[1].face_id;
+        let sd_pairs = vec![SameDomainPair {
+            idx_a: 0,
+            idx_b: 1,
+            same_orientation: true,
+            b_contained_in_a: true,
+            representative: 1,
+        }];
+
+        let fused = select_faces(&sub_faces, BooleanOp::Fuse, &sd_pairs, &[]);
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].face_id, larger, "Fuse keeps the larger face");
+
+        let intersected = select_faces(&sub_faces, BooleanOp::Intersect, &sd_pairs, &[]);
+        assert_eq!(intersected.len(), 1);
+        assert_eq!(
+            intersected[0].face_id, smaller,
+            "Intersect keeps the smaller face regardless of which operand it is"
+        );
     }
 
     #[test]

--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -52,17 +52,23 @@ pub(crate) fn select_faces(
     let valid_sd_pairs: Vec<&SameDomainPair> = sd_pairs
         .iter()
         .filter(|p| {
+            // `representative` is always idx_a or idx_b, so its bound is
+            // implied — but check it explicitly since `apply_sd_selection`
+            // indexes `sub_faces` with it and an out-of-bounds value would
+            // panic.
             let a_ok = p.idx_a < sub_faces.len();
             let b_ok = p.idx_b < sub_faces.len();
-            if !a_ok || !b_ok {
+            let rep_ok = p.representative < sub_faces.len();
+            if !a_ok || !b_ok || !rep_ok {
                 log::warn!(
-                    "SD pair ({}, {}) has out-of-bounds index (len={}), skipping",
+                    "SD pair ({}, {}) rep {} has out-of-bounds index (len={}), skipping",
                     p.idx_a,
                     p.idx_b,
+                    p.representative,
                     sub_faces.len()
                 );
             }
-            a_ok && b_ok
+            a_ok && b_ok && rep_ok
         })
         .collect();
 
@@ -160,13 +166,16 @@ fn apply_sd_selection(
 
         if same_ori_needed == pair.same_orientation {
             // Orientations match what the operation needs:
-            // - Fuse + same-ori: keep A (representative)
-            // - Intersect + same-ori: keep A
+            // - Fuse + same-ori: keep the representative (the larger face for a
+            //   containment pair, A for a coextensive pair)
+            // - Intersect + same-ori: keep the representative
             // - Cut + opposite-ori: keep A only when the faces merely touch
             //   on the boundary; discard both when A overlaps B's interior
             if op == BooleanOp::Cut {
                 if is_touching {
-                    // Touching: A's face is on the exterior — keep it
+                    // Touching: A's face is on the exterior — keep it. Cut is
+                    // asymmetric (A is the minuend), so A is always the correct
+                    // exterior representative — no geometry-based pick needed.
                     selected.push(SelectedFace {
                         face_id: sf_a.face_id,
                         reversed: false,
@@ -178,10 +187,13 @@ fn apply_sd_selection(
             // Fuse/Intersect with matching orientation: a same-oriented
             // coincident pair always lies on the result's exterior (both
             // solids' material is on the same side of the shared plane), so
-            // keep exactly one representative. Genuinely-internal coincident
+            // keep exactly one representative. `pair.representative` is the
+            // larger (containing) face for a geometric-containment pair and
+            // `idx_a` for a coextensive pair, making the choice depend on
+            // geometry rather than operand order. Genuinely-internal coincident
             // faces have OPPOSITE orientation and fall into the else-branch.
             selected.push(SelectedFace {
-                face_id: sf_a.face_id,
+                face_id: sub_faces[pair.representative].face_id,
                 reversed: false,
             });
         } else {
@@ -273,6 +285,7 @@ mod tests {
             idx_b: 10,
             same_orientation: true,
             b_contained_in_a: false,
+            representative: 5,
         }];
         // Should not panic — out-of-bounds pairs are skipped
         let selected = select_faces(&sub_faces, BooleanOp::Fuse, &sd_pairs, &[]);

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -37,6 +37,16 @@ pub struct SameDomainPair {
     /// For edge-set matched faces, both faces have identical boundaries,
     /// so this is always `false` (touching, not contained).
     pub b_contained_in_a: bool,
+    /// Sub-face index to keep when a Fuse/Intersect retains one representative
+    /// of this pair. For coextensive (edge-set) pairs this is `idx_a` — either
+    /// face spans the same domain, so keeping A matches historical behaviour.
+    /// For geometric-containment pairs the two faces have **different extent**
+    /// (one is contained inside the other), so the representative is the
+    /// larger (containing) face — chosen by geometry, not by which operand is
+    /// A vs B. Keeping the smaller face would leave the containing face's
+    /// surplus area uncovered (free edges), and which face is A flips with
+    /// operand order, so an A-only rule makes the result order-dependent.
+    pub representative: usize,
 }
 
 /// A within-rank duplicate sub-face: same edge set, same surface, same input
@@ -264,11 +274,30 @@ pub fn detect_same_domain<S: BuildHasher>(
                 let key = (idx_a.min(idx_b), idx_a.max(idx_b));
                 let same_orientation = pair_data.get(&key).copied().unwrap_or(true);
 
+                // Pick the Fuse/Intersect representative by geometry, not rank.
+                // Coextensive (edge-set) pairs share the same domain, so A is a
+                // fine representative (and matches historical behaviour). A
+                // geometric-containment pair has two faces of different extent;
+                // the larger (containing) face must be the representative so its
+                // surplus area stays covered. Which face is A flips with operand
+                // order, so deferring to area keeps the result order-independent.
+                let representative = if geometric_overlap {
+                    let area_a = planar_face_area(topo, sub_faces[idx_a].face_id);
+                    let area_b = planar_face_area(topo, sub_faces[idx_b].face_id);
+                    match (area_a, area_b) {
+                        (Some(aa), Some(ab)) if ab > aa => idx_b,
+                        _ => idx_a,
+                    }
+                } else {
+                    idx_a
+                };
+
                 pairs.push(SameDomainPair {
                     idx_a,
                     idx_b,
                     same_orientation,
                     b_contained_in_a: geometric_overlap,
+                    representative,
                 });
 
                 // The group may also contain additional same-rank members
@@ -594,6 +623,46 @@ fn planar_faces_overlap(
         }
     }
     false
+}
+
+/// Projected outer-wire area of a planar sub-face, in its own plane.
+///
+/// Returns `None` for non-planar faces or faces whose outer wire samples to
+/// fewer than three points. Used to pick the representative of a
+/// geometric-containment SD group: the largest-area face contains the others,
+/// so keeping it covers the whole shared domain regardless of operand order.
+fn planar_face_area(topo: &Topology, face_id: FaceId) -> Option<f64> {
+    let face = topo.face(face_id).ok()?;
+    let FaceSurface::Plane { normal, .. } = *face.surface() else {
+        return None;
+    };
+    let wire = topo.wire(face.outer_wire()).ok()?;
+    let mut pts: Vec<brepkit_math::vec::Point3> = Vec::with_capacity(wire.edges().len() * 8);
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge()).ok()?;
+        let sv = topo.vertex(edge.start()).ok()?;
+        let ev = topo.vertex(edge.end()).ok()?;
+        let (sp, ep) = (sv.point(), ev.point());
+        // Sample each edge so arc boundaries contribute their true swept area,
+        // mirroring `planar_faces_overlap`'s shorter-arc sampling.
+        for k in 0..8usize {
+            #[allow(clippy::cast_precision_loss)]
+            let frac = k as f64 / 8.0;
+            let frac = if oe.is_forward() { frac } else { 1.0 - frac };
+            pts.push(super::pcurve_compute::evaluate_edge_at_t(
+                edge.curve(),
+                sp,
+                ep,
+                frac,
+            ));
+        }
+    }
+    if pts.len() < 3 {
+        return None;
+    }
+    let frame = super::plane_frame::PlaneFrame::from_plane_face(normal, &pts);
+    let poly: Vec<_> = pts.iter().map(|&p| frame.project(p)).collect();
+    Some(super::classify_2d::signed_area_2d(&poly).abs())
 }
 
 /// Quantize a 3D point to integer grid coordinates.

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -37,15 +37,23 @@ pub struct SameDomainPair {
     /// For edge-set matched faces, both faces have identical boundaries,
     /// so this is always `false` (touching, not contained).
     pub b_contained_in_a: bool,
-    /// Sub-face index to keep when a Fuse/Intersect retains one representative
-    /// of this pair. For coextensive (edge-set) pairs this is `idx_a` — either
-    /// face spans the same domain, so keeping A matches historical behaviour.
-    /// For geometric-containment pairs the two faces have **different extent**
-    /// (one is contained inside the other), so the representative is the
-    /// larger (containing) face — chosen by geometry, not by which operand is
-    /// A vs B. Keeping the smaller face would leave the containing face's
-    /// surplus area uncovered (free edges), and which face is A flips with
-    /// operand order, so an A-only rule makes the result order-dependent.
+    /// Sub-face index of the **larger** face of this pair by projected outer-
+    /// wire area (see [`planar_face_area`]), used to keep representative
+    /// selection order-independent.
+    ///
+    /// For coextensive (edge-set) pairs both faces span the same domain, so
+    /// area ties and this is `idx_a` — matching historical behaviour. For a
+    /// geometric-overlap pair (`b_contained_in_a == true`) the two faces have
+    /// **different extent**, so the larger is chosen by area rather than by
+    /// which operand is A; `idx_a` flips with operand order, so an A-only rule
+    /// would make the result order-dependent.
+    ///
+    /// "Larger" — not "containing": a geometric-overlap pair may be strict
+    /// containment OR partial overlap (`planar_faces_overlap` accepts both), so
+    /// neither face necessarily contains the other. The consumer
+    /// ([`crate::bop::select_faces`]) keeps this face for Fuse (it covers the
+    /// most boundary) and the *other* (smaller) face for Intersect (whose
+    /// footprint is bounded by both solids).
     pub representative: usize,
 }
 
@@ -75,6 +83,13 @@ pub struct SameDomainResult {
     /// before classification).
     pub within_rank_dups: Vec<WithinRankDuplicate>,
 }
+
+/// Number of points sampled along each outer-wire edge when building the
+/// projected polygon for the coplanar containment / overlap / area tests.
+/// Defined once so [`planar_faces_overlap`] and [`planar_face_area`] keep the
+/// same density — an arc boundary must sample to the same polygon in both, or
+/// the area-based representative pick could disagree with the overlap test.
+const SD_EDGE_SAMPLES: usize = 8;
 
 /// Quantized 3D grid position — collision-free vertex identity.
 type QVert = (i64, i64, i64);
@@ -274,12 +289,13 @@ pub fn detect_same_domain<S: BuildHasher>(
                 let key = (idx_a.min(idx_b), idx_a.max(idx_b));
                 let same_orientation = pair_data.get(&key).copied().unwrap_or(true);
 
-                // Pick the Fuse/Intersect representative by geometry, not rank.
-                // Coextensive (edge-set) pairs share the same domain, so A is a
-                // fine representative (and matches historical behaviour). A
-                // geometric-containment pair has two faces of different extent;
-                // the larger (containing) face must be the representative so its
-                // surplus area stays covered. Which face is A flips with operand
+                // Record the LARGER face (by projected area) as the
+                // representative, so the choice is geometry-based not rank-based.
+                // Coextensive (edge-set) pairs share the same domain (area ties),
+                // so A is a fine representative and matches historical behaviour.
+                // A geometric-overlap pair has two faces of different extent;
+                // tagging the larger lets the BOP selector keep it for Fuse and
+                // the smaller for Intersect. Which face is A flips with operand
                 // order, so deferring to area keeps the result order-independent.
                 let representative = if geometric_overlap {
                     let area_a = planar_face_area(topo, sub_faces[idx_a].face_id);
@@ -447,7 +463,7 @@ fn planar_faces_overlap(
     // containment test silently treats the hole as absent — letting a
     // coincident coplanar face be wrongly cancelled through the hole.
     let wire_points = |wire_id: brepkit_topology::wire::WireId| -> Vec<brepkit_math::vec::Point3> {
-        let samples_per_edge: usize = 8;
+        let samples_per_edge: usize = SD_EDGE_SAMPLES;
         let mut pts = Vec::new();
         let Ok(wire) = topo.wire(wire_id) else {
             return pts;
@@ -625,19 +641,27 @@ fn planar_faces_overlap(
     false
 }
 
-/// Projected outer-wire area of a planar sub-face, in its own plane.
+/// Approximate projected outer-wire area of a planar sub-face, in its own
+/// plane.
 ///
 /// Returns `None` for non-planar faces or faces whose outer wire samples to
-/// fewer than three points. Used to pick the representative of a
-/// geometric-containment SD group: the largest-area face contains the others,
-/// so keeping it covers the whole shared domain regardless of operand order.
+/// fewer than three points. The area is an approximation: each edge is sampled
+/// at [`SD_EDGE_SAMPLES`] points (so arc boundaries contribute their swept
+/// area, matching [`planar_faces_overlap`]), then the projected polygon's
+/// signed area is taken — a finer arc is under-counted by the chord polygon.
+///
+/// Used only to order the two faces of a geometric-overlap SD pair (see
+/// [`SameDomainPair::representative`]). The two faces always share a plane, so
+/// the same under-counting applies to both and their relative order is stable;
+/// the absolute area is never compared against a tolerance.
 fn planar_face_area(topo: &Topology, face_id: FaceId) -> Option<f64> {
     let face = topo.face(face_id).ok()?;
     let FaceSurface::Plane { normal, .. } = *face.surface() else {
         return None;
     };
     let wire = topo.wire(face.outer_wire()).ok()?;
-    let mut pts: Vec<brepkit_math::vec::Point3> = Vec::with_capacity(wire.edges().len() * 8);
+    let mut pts: Vec<brepkit_math::vec::Point3> =
+        Vec::with_capacity(wire.edges().len() * SD_EDGE_SAMPLES);
     for oe in wire.edges() {
         let edge = topo.edge(oe.edge()).ok()?;
         let sv = topo.vertex(edge.start()).ok()?;
@@ -645,9 +669,9 @@ fn planar_face_area(topo: &Topology, face_id: FaceId) -> Option<f64> {
         let (sp, ep) = (sv.point(), ev.point());
         // Sample each edge so arc boundaries contribute their true swept area,
         // mirroring `planar_faces_overlap`'s shorter-arc sampling.
-        for k in 0..8usize {
+        for k in 0..SD_EDGE_SAMPLES {
             #[allow(clippy::cast_precision_loss)]
-            let frac = k as f64 / 8.0;
+            let frac = k as f64 / SD_EDGE_SAMPLES as f64;
             let frac = if oe.is_forward() { frac } else { 1.0 - frac };
             pts.push(super::pcurve_compute::evaluate_edge_at_t(
                 edge.curve(),

--- a/crates/io/tests/scoop_fuse_order_independence.rs
+++ b/crates/io/tests/scoop_fuse_order_independence.rs
@@ -1,0 +1,82 @@
+//! Regression: the scoop-fuse-into-compartmented-bin result must be the same
+//! whether the bin or the scoop is operand A.
+//!
+//! The scoop's bottom face (z=0) is coincident with the compartmented bin's
+//! bottom cap. The same-domain selector deduplicates that coincident pair to
+//! one representative face. The representative must be picked by geometry (the
+//! larger, containing face) rather than by which operand is A — otherwise a
+//! Fuse with the bin as A keeps the full cap while the swapped order keeps a
+//! tiny scoop fragment and drops the cap, leaving the floor non-manifold and
+//! forcing the mesh-boolean fallback (which tessellates the corner cylinders
+//! away). Both orders must keep the 8 analytic corner cylinders.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::face::FaceSurface;
+use brepkit_topology::solid::SolidId;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data")
+        .join(name)
+}
+
+fn read_one(name: &str, topo: &mut Topology) -> SolidId {
+    let text = std::fs::read_to_string(fixture(name)).unwrap();
+    let solids = brepkit_io::step::reader::read_step(&text, topo).unwrap();
+    assert_eq!(solids.len(), 1, "expected exactly one solid in {name}");
+    solids[0]
+}
+
+fn cylinder_count(topo: &Topology, solid: SolidId) -> usize {
+    solid_faces(topo, solid)
+        .unwrap()
+        .iter()
+        .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Cylinder(_)))
+        .count()
+}
+
+fn build_comp_bin(topo: &mut Topology) -> (SolidId, SolidId) {
+    let bin_box = read_one("scoop_bin_box.step", topo);
+    let cavity_0 = read_one("scoop_cavity_0.step", topo);
+    let cavity_1 = read_one("scoop_cavity_1.step", topo);
+    let scoop = read_one("scoop_scoop_0.step", topo);
+    let comp_bin = boolean(topo, BooleanOp::Cut, bin_box, cavity_0).unwrap();
+    let comp_bin = boolean(topo, BooleanOp::Cut, comp_bin, cavity_1).unwrap();
+    (comp_bin, scoop)
+}
+
+/// Both `Fuse(comp_bin, scoop)` and `Fuse(scoop, comp_bin)` must keep the 8
+/// analytic corner cylinders — i.e. neither order falls back to mesh boolean.
+/// Before the same-domain representative fix, the swapped order dropped the
+/// coincident bottom cap and the result mesh-fell-back (0 cylinders).
+#[test]
+fn scoop_fuse_is_operand_order_independent() {
+    let cyl_bin_first = {
+        let mut topo = Topology::new();
+        let (comp_bin, scoop) = build_comp_bin(&mut topo);
+        let r = boolean(&mut topo, BooleanOp::Fuse, comp_bin, scoop).unwrap();
+        cylinder_count(&topo, r)
+    };
+    let cyl_scoop_first = {
+        let mut topo = Topology::new();
+        let (comp_bin, scoop) = build_comp_bin(&mut topo);
+        let r = boolean(&mut topo, BooleanOp::Fuse, scoop, comp_bin).unwrap();
+        cylinder_count(&topo, r)
+    };
+
+    assert_eq!(
+        cyl_bin_first, 8,
+        "Fuse(bin, scoop) must keep 8 analytic corner cylinders"
+    );
+    assert_eq!(
+        cyl_scoop_first, 8,
+        "Fuse(scoop, bin) must keep 8 analytic corner cylinders \
+         (operand-order independence: the coincident bottom cap must survive)"
+    );
+}


### PR DESCRIPTION
Makes coincident same-domain face selection a pure function of geometry, not operand order. `apply_sd_selection` always kept the rank-A face of a coincident SD pair — correct for coextensive (edge-set) pairs, but for a **geometric-containment** pair the two faces have different extent, so keeping rank-A drops the larger (containing) face when B is the container, and which operand is A flips with fuse order. Now picks the larger containing face by projected area → `Fuse(a,b)` and `Fuse(b,a)` give identical, watertight results.

Cut is unchanged (keeps the minuend rep) so lip-cut behavior is byte-identical. Committed regression test asserts both fuse orders preserve all 8 corner cylinders (fails without the fix).

**Transparency:** this is a real correctness/robustness fix (same class as the #901 nondeterminism work) but it does NOT by itself flip the `compartments+scoop` tool case — that's blocked by a separate, deeper face-splitter bug (overlapping-tile decomposition under a specific in-memory id layout) tracked for a follow-up. Zero regressions: algo 127, operations + lip-cut suite green, gridfinity 26/26 ×3, no perf regression (60.85 vs 62.73ms).