### PR TITLE
perf(algo): spatial-hash the builder's O(N²) collinear-split + same-domain passes

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1593,7 +1593,7 @@ fn split_arc_edges_at_collinear_vertices(
         // span, so the spatial query covers every vertex that could lie on it.
         let mut amin = sp;
         let mut amax = sp;
-        let arc_samples = 12;
+        let arc_samples = ARC_AABB_SAMPLES;
         for k in 0..=arc_samples {
             let f = f64::from(k) / f64::from(arc_samples);
             let a = a0 + (a1 - a0) * f;
@@ -1950,6 +1950,11 @@ fn build_edge_face_map(
 
 /// Tolerance for position quantization (matches system linear tolerance).
 const MERGE_TOL: f64 = 1e-7;
+
+/// Samples per arc when building its broad-phase AABB for the collinear-split
+/// query (its bulge is covered by inflating the query band with the per-step
+/// sagitta — see `split_arc_edges_at_collinear_vertices`).
+const ARC_AABB_SAMPLES: u32 = 12;
 
 /// Get all edge keys (quantized position-pair) for a face's wires.
 fn face_edge_keys(topo: &Topology, fid: FaceId) -> Result<Vec<VPair>, AlgoError> {

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -951,9 +951,12 @@ impl PointGrid {
         // a long edge): iterating every empty cell would defeat the speedup.
         // Iterating the populated buckets directly is still a superset and
         // bounded by the point count, so correctness is preserved.
-        let cells = (chi.0 - clo.0 + 1)
-            .saturating_mul(chi.1 - clo.1 + 1)
-            .saturating_mul(chi.2 - clo.2 + 1);
+        let cells = chi
+            .0
+            .saturating_sub(clo.0)
+            .saturating_add(1)
+            .saturating_mul(chi.1.saturating_sub(clo.1).saturating_add(1))
+            .saturating_mul(chi.2.saturating_sub(clo.2).saturating_add(1));
         let bucket_budget = i64::try_from(self.buckets.len())
             .unwrap_or(i64::MAX)
             .saturating_mul(4);
@@ -1606,9 +1609,15 @@ fn split_arc_edges_at_collinear_vertices(
                 amax.z().max(q.z()),
             );
         }
+        // A sampled min/max can under-cover the arc's bulge between samples by up
+        // to the sagitta of one angular step; inflate the query band by that bound
+        // so the broad phase stays conservative (never prunes a real collinear cut).
+        let step = (a1 - a0) / f64::from(arc_samples);
+        let sagitta = radius_scale * (1.0 - (step * 0.5).cos());
+        let band = snap + sagitta;
 
         let mut cuts: Vec<(f64, VertexId)> = Vec::new();
-        for ci in grid.box_candidates(amin, amax, snap) {
+        for ci in grid.box_candidates(amin, amax, band) {
             let (vid, p) = verts[ci];
             // Skip the arc's own endpoints.
             if (p - sp).length() < snap || (p - ep).length() < snap {

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -870,6 +870,121 @@ struct EdgeEntry {
     qpair: QPosEdge,
 }
 
+/// Uniform spatial hash over a set of points, for broad-phase "which points
+/// lie near this segment" queries.
+///
+/// [`split_edges_at_collinear_vertices`] otherwise tests every vertex against
+/// every Line edge — O(V·E), which on a body grown by many sequential booleans
+/// (a honeycomb wall) dominates the boolean. A point can only be an interior
+/// cut of a segment if it lies within `snap` of that segment, so bucketing
+/// points by cell and probing only the cells a segment's AABB spans yields the
+/// identical candidate set with O(V + Σ cells-per-segment) work.
+struct PointGrid {
+    inv_cell: f64,
+    buckets: HashMap<(i64, i64, i64), Vec<usize>>,
+}
+
+impl PointGrid {
+    /// Build a grid over `points`, choosing a cell size so the total bucket
+    /// count stays ~O(N): the cube root of the AABB volume per point, but never
+    /// smaller than `min_cell` (the query band) so a segment never has to walk
+    /// an unbounded number of cells.
+    fn new(points: &[Point3], min_cell: f64) -> Self {
+        let cell = Self::choose_cell(points, min_cell);
+        let inv_cell = 1.0 / cell;
+        let mut buckets: HashMap<(i64, i64, i64), Vec<usize>> = HashMap::new();
+        for (i, p) in points.iter().enumerate() {
+            buckets
+                .entry(Self::cell_of(*p, inv_cell))
+                .or_default()
+                .push(i);
+        }
+        Self { inv_cell, buckets }
+    }
+
+    fn choose_cell(points: &[Point3], min_cell: f64) -> f64 {
+        let Some(bb) = brepkit_math::aabb::Aabb3::try_from_points(points.iter().copied()) else {
+            return min_cell.max(1.0);
+        };
+        let ext = bb.max - bb.min;
+        let (dx, dy, dz) = (ext.x().abs(), ext.y().abs(), ext.z().abs());
+        // Largest non-degenerate extent sets the scale; aim for ~N cells along
+        // it so the grid is roughly N cells total across the populated region.
+        let span = dx.max(dy).max(dz);
+        #[allow(clippy::cast_precision_loss)]
+        let n = points.len().max(1) as f64;
+        let target = span / n.cbrt().max(1.0);
+        target.max(min_cell).max(f64::MIN_POSITIVE)
+    }
+
+    fn cell_of(p: Point3, inv_cell: f64) -> (i64, i64, i64) {
+        (
+            (p.x() * inv_cell).floor() as i64,
+            (p.y() * inv_cell).floor() as i64,
+            (p.z() * inv_cell).floor() as i64,
+        )
+    }
+
+    /// Indices of points whose cell lies within the segment `[a, b]`'s AABB,
+    /// inflated by `band` (so every point within `band` of the segment is
+    /// included). Conservative: returns a superset of the truly-near points;
+    /// the caller still applies the exact distance test.
+    fn segment_candidates(&self, a: Point3, b: Point3, band: f64) -> Vec<usize> {
+        let lo = Point3::new(a.x().min(b.x()), a.y().min(b.y()), a.z().min(b.z()));
+        let hi = Point3::new(a.x().max(b.x()), a.y().max(b.y()), a.z().max(b.z()));
+        self.box_candidates(lo, hi, band)
+    }
+
+    /// Indices of points whose cell lies within the AABB `[lo, hi]` inflated by
+    /// `band`. The geometric primitive behind [`Self::segment_candidates`]; a
+    /// caller with a curved edge passes the edge's own sampled AABB so the
+    /// query covers the arc's bulge, not just its chord. Returns a superset of
+    /// the truly-near points (exact test still applies downstream).
+    fn box_candidates(&self, lo: Point3, hi: Point3, band: f64) -> Vec<usize> {
+        let lo = Point3::new(lo.x() - band, lo.y() - band, lo.z() - band);
+        let hi = Point3::new(hi.x() + band, hi.y() + band, hi.z() + band);
+        let (clo, chi) = (
+            Self::cell_of(lo, self.inv_cell),
+            Self::cell_of(hi, self.inv_cell),
+        );
+        // Guard against a pathological cell range (a tiny cell size paired with
+        // a long edge): iterating every empty cell would defeat the speedup.
+        // Iterating the populated buckets directly is still a superset and
+        // bounded by the point count, so correctness is preserved.
+        let cells = (chi.0 - clo.0 + 1)
+            .saturating_mul(chi.1 - clo.1 + 1)
+            .saturating_mul(chi.2 - clo.2 + 1);
+        let bucket_budget = i64::try_from(self.buckets.len())
+            .unwrap_or(i64::MAX)
+            .saturating_mul(4);
+        let mut out = Vec::new();
+        if cells > bucket_budget {
+            for (&(cx, cy, cz), list) in &self.buckets {
+                if cx >= clo.0
+                    && cx <= chi.0
+                    && cy >= clo.1
+                    && cy <= chi.1
+                    && cz >= clo.2
+                    && cz <= chi.2
+                {
+                    out.extend_from_slice(list);
+                }
+            }
+            return out;
+        }
+        for cx in clo.0..=chi.0 {
+            for cy in clo.1..=chi.1 {
+                for cz in clo.2..=chi.2 {
+                    if let Some(list) = self.buckets.get(&(cx, cy, cz)) {
+                        out.extend_from_slice(list);
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
 /// Rebuild faces whose wires contain zero-length Line edges (quantized
 /// start == end), dropping those edges. Closed curved edges (full circles)
 /// legitimately have coincident endpoints and are kept.
@@ -1236,6 +1351,14 @@ fn split_edges_at_collinear_vertices(
     // Deterministic order for sub-edge allocation.
     line_edges.sort_by_key(|(eid, ..)| eid.index());
 
+    // Index the candidate vertices and bucket them spatially. The cut test
+    // below only accepts a vertex within `snap` of the segment, so probing
+    // just the grid cells the segment's AABB spans yields the same candidate
+    // set as the former full scan of `vert_at`, but in O(near) per edge.
+    let verts: Vec<(VertexId, Point3)> = vert_at.values().copied().collect();
+    let positions: Vec<Point3> = verts.iter().map(|&(_, p)| p).collect();
+    let grid = PointGrid::new(&positions, snap);
+
     let mut replacements: HashMap<EdgeId, Vec<OrientedEdge>> = HashMap::new();
     for (eid, sv, ev, sp, ep) in line_edges {
         let dir = ep - sp;
@@ -1244,7 +1367,8 @@ fn split_edges_at_collinear_vertices(
             continue;
         }
         let mut cuts: Vec<(f64, VertexId)> = Vec::new();
-        for &(vid, p) in vert_at.values() {
+        for ci in grid.segment_candidates(sp, ep, snap) {
+            let (vid, p) = verts[ci];
             if (p - sp).length() < snap || (p - ep).length() < snap {
                 continue;
             }
@@ -1261,9 +1385,9 @@ fn split_edges_at_collinear_vertices(
         if cuts.is_empty() {
             continue;
         }
-        // `cuts` is gathered by iterating `vert_at.values()` (a HashMap), so
-        // the `vid` tiebreak makes this a total order — without it, cuts at
-        // equal `t` keep nondeterministic hash order and sub-edge IDs drift.
+        // `cuts` is gathered by iterating grid buckets (a HashMap), so the `vid`
+        // tiebreak makes this a total order — without it, cuts at equal `t` keep
+        // nondeterministic hash order and sub-edge IDs drift.
         cuts.sort_by(|a, b| {
             a.0.total_cmp(&b.0)
                 .then_with(|| a.1.index().cmp(&b.1.index()))
@@ -1419,6 +1543,17 @@ fn split_arc_edges_at_collinear_vertices(
     // Deterministic order for sub-edge allocation.
     arc_edges.sort_by_key(|(eid, ..)| eid.index());
 
+    // Spatially index the candidate vertices: a vertex can only split an arc if
+    // it lies within `snap` of it, so probing the grid cells the arc's AABB
+    // spans yields the same candidate set as scanning all of `vert_at` — but in
+    // O(near) per arc rather than O(V·E). The arc's AABB is bounded by its
+    // endpoints inflated by its sagitta (it can bulge past the chord by up to
+    // the radius), so the band is the radius scale; the grid query is
+    // conservative and the exact on-arc test below still runs per candidate.
+    let verts: Vec<(VertexId, Point3)> = vert_at.values().copied().collect();
+    let positions: Vec<Point3> = verts.iter().map(|&(_, p)| p).collect();
+    let grid = PointGrid::new(&positions, snap);
+
     let mut replacements: HashMap<EdgeId, Vec<OrientedEdge>> = HashMap::new();
     for (eid, sv, ev, sp, ep, curve) in arc_edges {
         // Skip closed (full) arcs: start ≈ end means the whole circle/ellipse,
@@ -1451,8 +1586,30 @@ fn split_arc_edges_at_collinear_vertices(
             continue;
         }
 
+        // The arc's true 3D AABB (it bulges past the chord), sampled along the
+        // span, so the spatial query covers every vertex that could lie on it.
+        let mut amin = sp;
+        let mut amax = sp;
+        let arc_samples = 12;
+        for k in 0..=arc_samples {
+            let f = f64::from(k) / f64::from(arc_samples);
+            let a = a0 + (a1 - a0) * f;
+            let q = curve.evaluate_with_endpoints(a, sp, ep);
+            amin = Point3::new(
+                amin.x().min(q.x()),
+                amin.y().min(q.y()),
+                amin.z().min(q.z()),
+            );
+            amax = Point3::new(
+                amax.x().max(q.x()),
+                amax.y().max(q.y()),
+                amax.z().max(q.z()),
+            );
+        }
+
         let mut cuts: Vec<(f64, VertexId)> = Vec::new();
-        for &(vid, p) in vert_at.values() {
+        for ci in grid.box_candidates(amin, amax, snap) {
+            let (vid, p) = verts[ci];
             // Skip the arc's own endpoints.
             if (p - sp).length() < snap || (p - ep).length() < snap {
                 continue;

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -1078,7 +1078,11 @@ fn face_outer_aabb(topo: &Topology, face_id: FaceId) -> Option<brepkit_math::aab
             continue;
         };
         let (sp, ep) = (sv.point(), ev.point());
-        for k in 0..=SD_EDGE_SAMPLES {
+        // Sample `0..SD_EDGE_SAMPLES` (not `..=`) to match the
+        // `planar_faces_overlap` / `planar_face_area` polygons exactly: the next
+        // edge's `frac=0` already covers each shared vertex, so this drops the
+        // redundant per-vertex duplicate without changing the AABB.
+        for k in 0..SD_EDGE_SAMPLES {
             #[allow(clippy::cast_precision_loss)]
             let frac = k as f64 / SD_EDGE_SAMPLES as f64;
             let frac = if oe.is_forward() { frac } else { 1.0 - frac };

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -1141,12 +1141,36 @@ fn overlap_candidate_pairs(
 
     let mut buckets: HashMap<(i64, i64, i64), Vec<usize>> = HashMap::new();
     let mut pairs: HashSet<(usize, usize)> = HashSet::new();
+    // A face whose expanded AABB spans more cells than this would cost O(cells)
+    // to grid (a broad wall patch among many tiny facets); above it, AABB-test
+    // the face against all faces directly instead — mirrors PointGrid's guard.
+    let cell_budget = i64::try_from(aabbs.len())
+        .unwrap_or(i64::MAX)
+        .saturating_mul(4)
+        .max(64);
     for &(idx, bb) in aabbs {
         let e = bb.expanded(margin);
         let (lo, hi) = (e.min, e.max);
         let (cx0, cx1) = (cell_of(lo.x()), cell_of(hi.x()));
         let (cy0, cy1) = (cell_of(lo.y()), cell_of(hi.y()));
         let (cz0, cz1) = (cell_of(lo.z()), cell_of(hi.z()));
+        let cells = cx1
+            .saturating_sub(cx0)
+            .saturating_add(1)
+            .saturating_mul(cy1.saturating_sub(cy0).saturating_add(1))
+            .saturating_mul(cz1.saturating_sub(cz0).saturating_add(1));
+        if cells > cell_budget {
+            // Candidate set stays a superset of true overlaps (the narrow phase
+            // filters and pairs are sorted before union-find), so the same-domain
+            // result is unchanged — only the cost path differs.
+            for &(jdx, jbb) in aabbs {
+                if jdx != idx && e.intersects(jbb.expanded(margin)) {
+                    let (a, b) = if jdx < idx { (jdx, idx) } else { (idx, jdx) };
+                    pairs.insert((a, b));
+                }
+            }
+            continue;
+        }
         for cx in cx0..=cx1 {
             for cy in cy0..=cy1 {
                 for cz in cz0..=cz1 {

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -219,32 +219,39 @@ pub fn detect_same_domain<S: BuildHasher>(
     // patches that rarely accumulate residue, and a 2D containment test on
     // their parametric domains needs surface-specific handling.
     {
-        let mut planar_indices: Vec<usize> = Vec::new();
+        let mut planar_aabbs: Vec<(usize, brepkit_math::aabb::Aabb3)> = Vec::new();
         for (idx, surf) in surfaces.iter().enumerate() {
-            if matches!(surf, Some(FaceSurface::Plane { .. })) {
-                planar_indices.push(idx);
+            if matches!(surf, Some(FaceSurface::Plane { .. }))
+                && let Some(bb) = face_outer_aabb(topo, sub_faces[idx].face_id)
+            {
+                planar_aabbs.push((idx, bb));
             }
         }
-        for (mi, &i) in planar_indices.iter().enumerate() {
-            for &j in &planar_indices[mi + 1..] {
-                // Cheap surface-match guard first.
-                let same_dir = match (surfaces[i], surfaces[j]) {
-                    (Some(si), Some(sj)) => surfaces_same_domain(si, sj, tol),
-                    _ => None,
-                };
-                let Some(same_dir) = same_dir else { continue };
-                if uf.find(i) == uf.find(j) {
-                    continue; // already grouped
-                }
-                if planar_faces_overlap(topo, sub_faces, i, j, tol) {
-                    uf.union(i, j);
-                    let key = (i.min(j), i.max(j));
-                    pair_data.insert(key, same_dir ^ (reversed[i] != reversed[j]));
-                    // Mark the post-union root so the emission code knows
-                    // this group came from geometric containment, not from
-                    // boundary-identical edge sets.
-                    geometric_overlap_groups.insert(uf.find(i));
-                }
+        // Broad-phase: only test pairs whose AABBs overlap. Two planar faces
+        // that don't share 3D space (expanded by tol for boundary-coincident
+        // outlines) cannot pass `planar_faces_overlap`, so pruning them is
+        // result-preserving while collapsing the former O(n²) scan to
+        // O(near). Candidate pairs come back in ascending (i, j) order — the
+        // same order the nested loop visited — so the union-find sequence (and
+        // hence representative selection) is unchanged.
+        for (i, j) in overlap_candidate_pairs(&planar_aabbs, tol.linear) {
+            // Cheap surface-match guard first.
+            let same_dir = match (surfaces[i], surfaces[j]) {
+                (Some(si), Some(sj)) => surfaces_same_domain(si, sj, tol),
+                _ => None,
+            };
+            let Some(same_dir) = same_dir else { continue };
+            if uf.find(i) == uf.find(j) {
+                continue; // already grouped
+            }
+            if planar_faces_overlap(topo, sub_faces, i, j, tol) {
+                uf.union(i, j);
+                let key = (i.min(j), i.max(j));
+                pair_data.insert(key, same_dir ^ (reversed[i] != reversed[j]));
+                // Mark the post-union root so the emission code knows
+                // this group came from geometric containment, not from
+                // boundary-identical edge sets.
+                geometric_overlap_groups.insert(uf.find(i));
             }
         }
     }
@@ -262,28 +269,33 @@ pub fn detect_same_domain<S: BuildHasher>(
     // the smaller for Intersect, exactly as for the planar geometric-overlap
     // pairs above.
     {
-        let mut analytic_indices: Vec<usize> = Vec::new();
+        let mut analytic_aabbs: Vec<(usize, brepkit_math::aabb::Aabb3)> = Vec::new();
         for (idx, surf) in surfaces.iter().enumerate() {
-            if matches!(surf, Some(FaceSurface::Cylinder(_) | FaceSurface::Cone(_))) {
-                analytic_indices.push(idx);
+            if matches!(surf, Some(FaceSurface::Cylinder(_) | FaceSurface::Cone(_)))
+                && let Some(bb) = face_outer_aabb(topo, sub_faces[idx].face_id)
+            {
+                analytic_aabbs.push((idx, bb));
             }
         }
-        for (mi, &i) in analytic_indices.iter().enumerate() {
-            for &j in &analytic_indices[mi + 1..] {
-                let same_dir = match (surfaces[i], surfaces[j]) {
-                    (Some(si), Some(sj)) => surfaces_same_domain(si, sj, tol),
-                    _ => None,
-                };
-                let Some(same_dir) = same_dir else { continue };
-                if uf.find(i) == uf.find(j) {
-                    continue; // already grouped (e.g. identical edge sets)
-                }
-                if analytic_faces_overlap(topo, sub_faces, i, j, tol) {
-                    uf.union(i, j);
-                    let key = (i.min(j), i.max(j));
-                    pair_data.insert(key, same_dir ^ (reversed[i] != reversed[j]));
-                    geometric_overlap_groups.insert(uf.find(i));
-                }
+        // Broad-phase: as with the planar pass, only test AABB-overlapping
+        // candidate pairs. Two coaxial patches whose 3D AABBs are disjoint
+        // (expanded by tol) cannot share a band, so pruning them preserves the
+        // result. Candidate order is ascending (i, j), matching the former
+        // nested loop, so the union-find sequence is unchanged.
+        for (i, j) in overlap_candidate_pairs(&analytic_aabbs, tol.linear) {
+            let same_dir = match (surfaces[i], surfaces[j]) {
+                (Some(si), Some(sj)) => surfaces_same_domain(si, sj, tol),
+                _ => None,
+            };
+            let Some(same_dir) = same_dir else { continue };
+            if uf.find(i) == uf.find(j) {
+                continue; // already grouped (e.g. identical edge sets)
+            }
+            if analytic_faces_overlap(topo, sub_faces, i, j, tol) {
+                uf.union(i, j);
+                let key = (i.min(j), i.max(j));
+                pair_data.insert(key, same_dir ^ (reversed[i] != reversed[j]));
+                geometric_overlap_groups.insert(uf.find(i));
             }
         }
     }
@@ -1044,6 +1056,117 @@ fn repr_face_area(topo: &Topology, face_id: FaceId) -> Option<f64> {
         FaceSurface::Cylinder(_) | FaceSurface::Cone(_) => analytic_face_param_area(topo, face_id),
         _ => None,
     }
+}
+
+/// Outer-wire AABB of a sub-face, sampled at [`SD_EDGE_SAMPLES`] points per
+/// edge to match the polygons the overlap tests build. Returns `None` when the
+/// wire has no usable points.
+///
+/// Used purely as a broad-phase reject for the geometric-overlap passes: both
+/// [`planar_faces_overlap`] and [`analytic_faces_overlap`] can only return
+/// `true` when the two faces share real 3D area, which requires their AABBs
+/// (expanded by tolerance for boundary-coincident cases) to intersect.
+fn face_outer_aabb(topo: &Topology, face_id: FaceId) -> Option<brepkit_math::aabb::Aabb3> {
+    let face = topo.face(face_id).ok()?;
+    let wire = topo.wire(face.outer_wire()).ok()?;
+    let mut pts: Vec<brepkit_math::vec::Point3> = Vec::new();
+    for oe in wire.edges() {
+        let Ok(edge) = topo.edge(oe.edge()) else {
+            continue;
+        };
+        let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+            continue;
+        };
+        let (sp, ep) = (sv.point(), ev.point());
+        for k in 0..=SD_EDGE_SAMPLES {
+            #[allow(clippy::cast_precision_loss)]
+            let frac = k as f64 / SD_EDGE_SAMPLES as f64;
+            let frac = if oe.is_forward() { frac } else { 1.0 - frac };
+            pts.push(super::pcurve_compute::evaluate_edge_at_t(
+                edge.curve(),
+                sp,
+                ep,
+                frac,
+            ));
+        }
+    }
+    brepkit_math::aabb::Aabb3::try_from_points(pts)
+}
+
+/// Generate the spatially-overlapping candidate pairs among `indices` using a
+/// uniform grid over the faces' (tolerance-expanded) AABBs.
+///
+/// Each face is inserted into every grid cell its expanded AABB touches; any
+/// two faces that ever land in the same cell become a candidate pair (emitted
+/// once, with `i < j` in original-index order, deduplicated). Faces whose AABBs
+/// never share a cell cannot overlap, so they are never tested — turning the
+/// former all-pairs O(n²) scan into O(n + candidate pairs). The pair set is a
+/// superset of the truly-overlapping pairs; the caller still runs the exact
+/// `*_faces_overlap` test on each.
+fn overlap_candidate_pairs(
+    aabbs: &[(usize, brepkit_math::aabb::Aabb3)],
+    margin: f64,
+) -> Vec<(usize, usize)> {
+    if aabbs.len() < 2 {
+        return Vec::new();
+    }
+    // Cell size: the cube root of the per-face AABB volume budget across the
+    // populated region, never below the average face extent, so a face spans a
+    // bounded number of cells.
+    let mut union = aabbs[0].1;
+    let mut ext_sum = 0.0_f64;
+    for &(_, bb) in aabbs {
+        union = union.union(bb);
+        let e = bb.max - bb.min;
+        ext_sum += e.x().abs().max(e.y().abs()).max(e.z().abs());
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let avg_ext = ext_sum / aabbs.len() as f64;
+    let span = {
+        let e = union.max - union.min;
+        e.x().abs().max(e.y().abs()).max(e.z().abs())
+    };
+    #[allow(clippy::cast_precision_loss)]
+    let n = aabbs.len() as f64;
+    let cell = avg_ext
+        .max(span / n.cbrt().max(1.0))
+        .max(margin)
+        .max(f64::MIN_POSITIVE);
+    let inv = 1.0 / cell;
+    let cell_of = |c: f64| (c * inv).floor() as i64;
+
+    let mut buckets: HashMap<(i64, i64, i64), Vec<usize>> = HashMap::new();
+    let mut pairs: HashSet<(usize, usize)> = HashSet::new();
+    for &(idx, bb) in aabbs {
+        let e = bb.expanded(margin);
+        let (lo, hi) = (e.min, e.max);
+        let (cx0, cx1) = (cell_of(lo.x()), cell_of(hi.x()));
+        let (cy0, cy1) = (cell_of(lo.y()), cell_of(hi.y()));
+        let (cz0, cz1) = (cell_of(lo.z()), cell_of(hi.z()));
+        for cx in cx0..=cx1 {
+            for cy in cy0..=cy1 {
+                for cz in cz0..=cz1 {
+                    let bucket = buckets.entry((cx, cy, cz)).or_default();
+                    for &other in bucket.iter() {
+                        let (a, b) = if other < idx {
+                            (other, idx)
+                        } else {
+                            (idx, other)
+                        };
+                        if a != b {
+                            pairs.insert((a, b));
+                        }
+                    }
+                    bucket.push(idx);
+                }
+            }
+        }
+    }
+    let mut out: Vec<(usize, usize)> = pairs.into_iter().collect();
+    // Deterministic order so union-find sequencing (and thus representative
+    // selection) is reproducible regardless of HashSet iteration order.
+    out.sort_unstable();
+    out
 }
 
 /// Quantize a 3D point to integer grid coordinates.


### PR DESCRIPTION
## Problem

Sequential boolean cuts scale **quadratically**: `regress_hexwall_cuts::hexwall_sequential_cuts_full` (133 hex-prism cuts through a wall) took **19.4s release / ~219s debug**, and its own doc says it "must complete in seconds." Each `boolean(Cut, growing_body, small_tool)` was O(body²), so the sequence was quadratic-of-quadratic. brepkit must be performant; a slow test is an engine perf smell.

## Root cause (profiled, not assumed)

The PaveFiller is **not** the culprit — it already AABB-pre-filters face pairs (~13ms/cut). Stage-level timing of the heavy end (cut 131, ~800 body faces, ~309ms) attributes the cost to **three all-pairs passes in the builder/assembly stage**:

| Pass | File | @cut131 | Pattern |
|---|---|---:|---|
| `split_edges_at_collinear_vertices` | `builder_solid.rs` | ~140ms | every vertex × every Line edge — O(V·E) |
| `split_arc_edges_at_collinear_vertices` | `builder_solid.rs` | (O(V·E)) | same, arc edges |
| `detect_same_domain` Steps 3b/3c | `same_domain.rs` | ~140ms | every coplanar/coaxial face pair × polygon-boolean — O(F²) |

## Fix — broad-phase locality at the layer where the cost lives

- A uniform spatial hash `PointGrid` (over candidate vertices) and an AABB-grid candidate-pair generator `overlap_candidate_pairs` (over faces).
- Each pass now probes only the grid cells an edge's/face's AABB spans → **O(near) instead of O(N²)**.
- **Provably result-preserving:** a vertex beyond the snap band from a segment can never be a collinear cut; two faces whose AABBs don't overlap can never pass the overlap test. Candidate pairs are emitted in the **same ascending (i,j) order** the former nested loop used, so the same-domain union-find sequence and representative selection are **byte-identical**.

## `cut_all` batch — investigated and rejected

I implemented a `merge_disjoint_solids`-then-single-cut batch path and found it produces **non-manifold** results for through-hole patterns (the merged disconnected tool shell breaks the cut's shell assembly — fails `compound_cut_matches_sequential_{2x2,3x3,4x4}_grid` manifold assertions, volume right / manifoldness wrong). Dropped it; `compound_cut` stays sequential and correct. The locality fix above is the provable one.

## Results

| Profile | Baseline | Fixed | Speedup |
|---|---:|---:|---:|
| release | 19.40s | **5.18s** | 3.7× |
| debug | ~219s | 62.85s | 3.5× |

The residual is the fundamental "a sequential boolean reprocesses the whole body each cut" floor (now genuinely **linear per cut**, O(body²) total with a 3.5× smaller constant); flattening further needs incremental far-field carry-through — an architecture change, out of scope for a provable local fix.

## Verification

- **Full suites, zero regressions/diffs (1439 tests):** `brepkit-algo` (135, all `same_domain` geometric-overlap cases), `brepkit-operations` (902, incl. `parity_boolean_*` VOLUME oracles, `boolean_stress`/`boolean_invariants`, `coaxial_*`, `compound_cut` grid/shelled), `brepkit-io` (176), `brepkit-wasm` (226, gridfinity d1–d5 + honeycomb + lipfuse). `hexwall_sequential_cuts_20`/`_full` pass (each cut removes the exact prism volume).
- fmt + clippy (`-D warnings`) + `check-boundaries.sh` clean.

## Follow-up (same O(N²) class, not in scope here)

The per-cut O(body) rebuild of `detect_same_domain`'s edge-sets/AABBs is the remaining linear-per-cut floor; eliminating it needs an incremental boolean that carries the untouched far-field through unchanged.