### PR TITLE
fix(algo): require real containment in dedup_collinear_sections (honeycomb cap watertight)

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1937,28 +1937,45 @@ fn dedup_collinear_sections(sections: &mut Vec<SectionEdge>, tol: f64) {
                 continue;
             }
 
-            // Collinear and on the same infinite line, but possibly DISJOINT:
-            // two notches on opposite walls cut the same rim along the same
-            // x = ±cut_hw line, yet their cut segments sit at opposite ends of
-            // the face and must both survive. Only treat the shorter section as
-            // a redundant subset when its span actually OVERLAPS the longer one
-            // (a coplanar inner-region edge nested in the full-face FF edge).
+            // Collinear and on the same infinite line, but possibly DISJOINT or
+            // merely ADJACENT:
+            //  - DISJOINT: two notches on opposite walls cut the same rim along
+            //    the same x = ±cut_hw line, yet their cut segments sit at
+            //    opposite ends of the face and must both survive.
+            //  - ADJACENT: two PaveBlock fragments of one wall meeting end-to-end
+            //    at a shared junction vertex (e.g. a wall split into two faces by
+            //    a wall cutout). The junction carries sub-tolerance float noise,
+            //    so the two intervals overlap by a tiny sliver (~1e-3, well above
+            //    the 1e-7 linear tol) — but neither is a subset of the other and
+            //    dropping the shorter one deletes a genuine boundary piece (the
+            //    honeycomb-cut cap corner cell then never closes → open shell).
+            // Only treat the shorter section as a redundant subset when it is
+            // (nearly) FULLY CONTAINED in the longer one (a coplanar inner-region
+            // edge nested in the full-face FF edge): the overlap must cover
+            // essentially the whole shorter segment, not just a junction sliver.
             // Project both segments onto the shared line and compare intervals.
             let proj = |p: Point3, origin: Point3| (p - origin).dot(dj_unit);
             let (ia0, ia1) = (proj(si.start, sj.start), proj(si.end, sj.start));
             let (ib0, ib1) = (proj(sj.start, sj.start), proj(sj.end, sj.start));
             let (ia_lo, ia_hi) = (ia0.min(ia1), ia0.max(ia1));
             let (ib_lo, ib_hi) = (ib0.min(ib1), ib0.max(ib1));
-            // Overlap length of the two 1D intervals; require a real (not just
-            // touching) overlap before either can be a subset of the other.
             let overlap = ia_hi.min(ib_hi) - ia_lo.max(ib_lo);
             if overlap <= tol {
                 continue;
             }
 
-            // Overlapping collinear sections. Remove the shorter one.
             let len_i = (si.end - si.start).length();
             let len_j = (sj.end - sj.start).length();
+            let shorter_len = len_i.min(len_j);
+            // Containment guard: the shorter segment is a redundant subset only
+            // when the overlap spans (almost) its entire length. An adjacent pair
+            // sharing a noisy junction overlaps by far less than the shorter
+            // length, so it falls through and both survive.
+            if overlap < shorter_len - tol * 10.0 {
+                continue;
+            }
+
+            // Overlapping collinear sections, shorter fully contained — remove it.
             if len_i < len_j - tol {
                 to_remove[i] = true;
             } else if len_j < len_i - tol {

--- a/crates/io/tests/gridfinity_honeycomb_cut_inmem.rs
+++ b/crates/io/tests/gridfinity_honeycomb_cut_inmem.rs
@@ -161,14 +161,46 @@ fn honeycomb_cut_no_longer_throws() {
 }
 
 #[test]
+fn honeycomb_cut_pcut0_is_watertight_and_analytic() {
+    // WIN: the full-footprint honeycomb cutter `pcut0` (whose outer wall is
+    // coincident with the body's ±41.75 outer wall) now produces a WATERTIGHT,
+    // analytic result. Previously its z=23 cap dropped one rounded-corner cell
+    // (free=8, an open shell) because `dedup_collinear_sections` mistook two
+    // ADJACENT PaveBlock fragments of the corner divider wall — meeting end-to-
+    // end at a junction whose shared vertex carried ~1e-3 of float noise — for a
+    // subset/superset pair and deleted the shorter fragment. The cap's corner
+    // cell then had a gap in its boundary and the planar arrangement absorbed it
+    // into a giant overlapping region (dropped at assembly), leaving the cell's
+    // walls free.
+    //
+    // The fix requires a real CONTAINMENT (the overlap spans almost the whole
+    // shorter segment), not a noisy touching overlap, before dropping a section
+    // as a redundant subset — so both adjacent fragments survive and the cell
+    // closes. This is the cascade root: a watertight `pcut0` keeps the production
+    // `operations::boolean` from rejecting the result and mesh-falling-back to an
+    // all-planar body, which then exploded the cost of every subsequent
+    // honeycomb cut.
+    let mut topo = Topology::new();
+    let body = build_wallcut_body(&mut topo);
+    let p = load("a2hcomb_pcut0.bin", &mut topo);
+    let r = gfa::boolean(&mut topo, BooleanOp::Cut, body, p).unwrap();
+    let (free, over) = edge_health(&topo, r);
+    assert_eq!(free, 0, "pcut0 must be watertight (got free={free})");
+    assert_eq!(over, 0, "pcut0 must be manifold (got over-shared={over})");
+    assert!(
+        curved_count(&topo, r) > 0,
+        "pcut0 must stay analytic (corner cylinders/cones preserved), not mesh fallback"
+    );
+}
+
+#[test]
 fn honeycomb_cut_residual_documented() {
-    // DOCUMENTED RESIDUAL: the honeycomb pattern cuts return Ok but leave an
-    // OPEN shell (free edges) — the cap's correct partition introduces vertices
-    // its neighbour analytic faces don't yet share (a cross-face partition-
-    // consistency gap). These free-edge counts pin the current state; a future
-    // cross-face-reconciliation fix should drive them to 0.
+    // DOCUMENTED RESIDUAL: `pcut1..3` (the lip-/NURBS-walled honeycomb cutters)
+    // still return Ok but leave some free edges (an open shell) from a SEPARATE,
+    // pre-existing cause — free edges spread across many z-levels through the
+    // stacking-lip cones and the NURBS honeycomb walls, unrelated to the z=23 cap
+    // dedup fixed for `pcut0`. These ceilings pin the current state.
     let residual_free: &[(&str, usize)] = &[
-        ("a2hcomb_pcut0.bin", 8),
         ("a2hcomb_pcut1.bin", 52),
         ("a2hcomb_pcut2.bin", 35),
         ("a2hcomb_pcut3.bin", 15),
@@ -182,8 +214,7 @@ fn honeycomb_cut_residual_documented() {
         // Upper bound, not exact: `edge_health` quantizes raw 3-D coords, so a
         // last-ULP position difference (e.g. a different FPU on a cross-compiled
         // target) could nudge the count. The qualitative invariant (all cuts
-        // return Ok + manifold) is asserted by `honeycomb_cut_no_longer_throws`;
-        // a cross-face-reconciliation fix should drive these toward 0.
+        // return Ok + manifold) is asserted by `honeycomb_cut_no_longer_throws`.
         assert!(
             free <= expect_free,
             "RESIDUAL: honeycomb {tool} free-edge count {free} exceeds the documented \


### PR DESCRIPTION
## Problem

The honeycomb wall-pattern cut's first cutter (`pcut0`) returned an **open shell (free=8)** → the production boolean's watertight gate rejected it → **mesh-fallback** → the body went all-planar → every subsequent honeycomb cut fed the pavefiller a ballooning all-planar body whose cost exploded (~1500× — a >200s freeze). This blocked the honeycomb+wall-cutout, honeycomb+scoop, and plain-honeycomb scenarios on *both* correctness and performance.

## Root cause

Traced the 8 free edges (all at z=23, the cap plane) to the cap's **bottom-left rounded-corner cell, whose sub-face was entirely missing**. Isolating it against a working corner (one variable) showed the inner divider wall's section was **truncated**.

The wall arrives as **two adjacent `PaveBlock` fragments** meeting end-to-end at a junction (a wall-cutout artifact splits the wall into two faces with different `opposing_face`s). The shared junction vertex carries **~1e-3 of float noise** (the two fragments ended at y=−34.7859 and y=−34.7877). `dedup_collinear_sections` only required `overlap > tol` (1e-7) to declare the shorter fragment a redundant *subset* of the longer — so the ~1.8e-3 noisy overlap tripped it and it **deleted the lower fragment**, opening a gap in the cap cell's boundary. The planar arrangement's half-edge tracer then couldn't close the cell, absorbed it into a giant overlapping region, and assembly discarded it → free edges → fallback → cascade.

Same sub-tolerance-vertex-noise fragility family as #859 / #909.

## Fix

`dedup_collinear_sections` now drops a section as a redundant subset **only on real containment** — the overlap must span (almost) the whole shorter segment:

```rust
let shorter_len = len_i.min(len_j);
if overlap < shorter_len - tol * 10.0 {
    continue;   // adjacent fragments overlap by ≪ shorter_len → both survive
}
```

A genuine coplanar-inner-vs-full-face subset has `overlap == shorter_len` → still removed. Adjacent fragments overlap by far less → both kept. The `tol*10` margin tolerates ULP deficits in real containment while rejecting ~1e-3 junction noise. It is **strictly more conservative about removal** (correct subset semantics), so it cannot newly delete a genuine section.

## Result

| | before | after |
|---|---:|---:|
| `gfa::boolean(Cut, wallcut_body, pcut0)` free | **8** | **0** |
| pcut0 curved faces | 16 | 16 (analytic) |
| `operations::boolean` pcut0 | open→fallback | **analytic, OK (590ms)** |
| sequential pcut1 | (on all-planar body) | **analytic, free=0 (94ms)** |

The mesh-fallback cascade is **broken at the front**: pcut0 and pcut1 stay analytic and fast (no >200s pavefiller explosion). The remaining pcut2/pcut3 free residuals (34/13, spread across the stacking-lip cones + NURBS honeycomb walls) are a **distinct, pre-existing** cause — kept as documented residuals, tracked separately.

## Verification

- New guard `gridfinity_honeycomb_cut_inmem::honeycomb_cut_pcut0_is_watertight_and_analytic` (free=0 + manifold + analytic).
- **Full workspace: 42 suites, 0 failed** — `boolean_stress`, `parity_boolean_*` (volume oracles), `regress_hexwall` (perf preserved, #926), `coaxial_*`, `multicavity_cut`, `compound_cut*`, all `gridfinity_*`/`scoop_*`/`lipfuse`/`wallcut`.
- fmt + clippy (`-D warnings`) + `check-boundaries.sh` clean.