### PR TITLE
fix(operations): reverse periodic-curve parameterization for reversed extrude edges

### DIFF
--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -353,7 +353,16 @@ fn extrude_wire_vertices_with(
     for i in 0..n {
         let next = (i + 1) % n;
         let bottom_curve = topo.edge(edge_ids[i])?.curve().clone();
-        let top_curve = translate_edge_curve(&bottom_curve, offset)?;
+        let mut top_curve = translate_edge_curve(&bottom_curve, offset)?;
+        // The top edge's stored vertices (top_verts[i], top_verts[next]) follow
+        // wire-traversal order. For a reversed edge those are swapped relative
+        // to the curve's parameterization, so a periodic curve (ellipse/circle)
+        // would resolve to the complementary sub-arc — and a NURBS curve's
+        // endpoints would not match the stored vertices. Reverse the
+        // translated curve's parameterization so it stays consistent.
+        if !oriented[i].is_forward() {
+            top_curve = reverse_edge_curve(&top_curve)?;
+        }
         let top_edge = topo.add_edge(Edge::new(top_verts[i], top_verts[next], top_curve));
         top_edge_ids.push(top_edge);
     }
@@ -944,6 +953,58 @@ fn translate_edge_curve(
                     nc.knots().to_vec(),
                     translated_cps,
                     nc.weights().to_vec(),
+                )
+                .map_err(crate::OperationsError::Math)?,
+            )
+        }
+    })
+}
+
+/// Reverse a curve's intrinsic parameterization while preserving its geometry
+/// (same point set, opposite direction).
+///
+/// For a periodic analytic curve (circle/ellipse) the parameter direction is
+/// set by the binormal frame, so negating `normal` and `v_axis` flips
+/// `project` to `-θ`; for a NURBS curve the control net, weights, and (mirrored)
+/// knot vector are reversed. Used when copying an edge whose wire-traversal
+/// order is opposite its stored direction, so the copied edge's endpoints stay
+/// consistent with its curve.
+fn reverse_edge_curve(curve: &EdgeCurve) -> Result<EdgeCurve, crate::OperationsError> {
+    Ok(match curve {
+        EdgeCurve::Line => EdgeCurve::Line,
+        EdgeCurve::Circle(c) => EdgeCurve::Circle(
+            brepkit_math::curves::Circle3D::with_axes(
+                c.center(),
+                -c.normal(),
+                c.radius(),
+                c.u_axis(),
+                -c.v_axis(),
+            )
+            .map_err(crate::OperationsError::Math)?,
+        ),
+        EdgeCurve::Ellipse(e) => EdgeCurve::Ellipse(
+            brepkit_math::curves::Ellipse3D::with_axes(
+                e.center(),
+                -e.normal(),
+                e.semi_major(),
+                e.semi_minor(),
+                e.u_axis(),
+                -e.v_axis(),
+            )
+            .map_err(crate::OperationsError::Math)?,
+        ),
+        EdgeCurve::NurbsCurve(nc) => {
+            let knots = nc.knots();
+            let span = knots[0] + knots[knots.len() - 1];
+            let new_knots: Vec<f64> = knots.iter().rev().map(|&k| span - k).collect();
+            let new_cps: Vec<Point3> = nc.control_points().iter().rev().copied().collect();
+            let new_weights: Vec<f64> = nc.weights().iter().rev().copied().collect();
+            EdgeCurve::NurbsCurve(
+                brepkit_math::nurbs::curve::NurbsCurve::new(
+                    nc.degree(),
+                    new_knots,
+                    new_cps,
+                    new_weights,
                 )
                 .map_err(crate::OperationsError::Math)?,
             )

--- a/crates/operations/src/extrude/tests.rs
+++ b/crates/operations/src/extrude/tests.rs
@@ -997,6 +997,59 @@ fn extrude_half_circle_reversed_edge_volume() {
     );
 }
 
+#[test]
+fn extrude_half_disc_reversed_nurbs_edge_volume() {
+    use brepkit_math::nurbs::fitting::interpolate;
+    use brepkit_math::vec::{Point3, Vec3};
+
+    // Upper half-disc whose arc boundary is a NURBS (interpolated semicircle),
+    // used REVERSED in the wire. Guards the NURBS arm of `reverse_edge_curve`:
+    // a reversed NURBS edge would otherwise leave the translated top edge's
+    // endpoints inconsistent with its curve (the swept side then degenerates).
+    let mut topo = Topology::new();
+    let tol = Tolerance::new();
+    let r = 5.0_f64;
+    let cx = 5.0_f64;
+    // Upper semicircle (0,0) -> (5,5) -> (10,0): angle PI down to 0.
+    let n_pts = 24;
+    let pts: Vec<Point3> = (0..=n_pts)
+        .map(|i| {
+            let angle = std::f64::consts::PI * (1.0 - f64::from(i) / f64::from(n_pts));
+            Point3::new(cx + r * angle.cos(), r * angle.sin(), 0.0)
+        })
+        .collect();
+    let nurbs = interpolate(&pts, 3).unwrap();
+    let v0 = topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 0.0), tol.linear));
+    let v1 = topo.add_vertex(Vertex::new(Point3::new(10.0, 0.0, 0.0), tol.linear));
+    // arc stored (0,0)->(10,0) bulging +y; used reversed so the loop walks
+    // (10,0)->(5,5)->(0,0)->(10,0): the upper half-disc wound CCW.
+    let arc = topo.add_edge(Edge::new(v0, v1, EdgeCurve::NurbsCurve(nurbs)));
+    let line = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+    let wire = Wire::new(
+        vec![OrientedEdge::new(arc, false), OrientedEdge::new(line, true)],
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let face = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    // NURBS interpolation of the semicircle carries a small fitting error, so
+    // allow 2% (the bug otherwise degenerates the solid, not a 2% shift).
+    let expected = 0.5 * std::f64::consts::PI * r * r;
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+    let vol = crate::measure::solid_volume(&topo, solid, 0.001).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 0.02,
+        "reversed-edge half-disc (NURBS) volume {vol:.4} != {expected:.4}"
+    );
+}
+
 /// Regression for #869: extruding an `EdgeCurve::Ellipse` arc must build the
 /// ruled side surface from the edge's TRIMMED arc, not the full ellipse, so
 /// the solid volume matches the half-ellipse swept area (not the full ellipse).

--- a/crates/operations/src/extrude/tests.rs
+++ b/crates/operations/src/extrude/tests.rs
@@ -949,6 +949,54 @@ fn extrude_half_circle_face_volume() {
     );
 }
 
+#[test]
+fn extrude_half_circle_reversed_edge_volume() {
+    use brepkit_math::curves::Circle3D;
+    use brepkit_math::vec::{Point3, Vec3};
+
+    // Same upper half-disc as `extrude_half_circle_face_volume`, but the arc is
+    // used REVERSED in the wire — guards the Circle arm of `reverse_edge_curve`
+    // (a reversed circle arc would otherwise sweep the complementary lower arc).
+    let mut topo = Topology::new();
+    let tol = Tolerance::new();
+    let r = 5.0_f64;
+    let v0 = topo.add_vertex(Vertex::new(Point3::new(0.0, 0.0, 0.0), tol.linear));
+    let v1 = topo.add_vertex(Vertex::new(Point3::new(10.0, 0.0, 0.0), tol.linear));
+    let circle = Circle3D::with_axes(
+        Point3::new(5.0, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+        r,
+        Vec3::new(-1.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+    )
+    .unwrap();
+    // arc stored (0,0)->(10,0) bulging +y; used reversed so the loop walks
+    // (10,0)->(5,5)->(0,0)->(10,0): the upper half-disc wound CCW.
+    let arc = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Circle(circle)));
+    let line = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+    let wire = Wire::new(
+        vec![OrientedEdge::new(arc, false), OrientedEdge::new(line, true)],
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let face = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    let expected = 0.5 * std::f64::consts::PI * r * r;
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+    let vol = crate::measure::solid_volume(&topo, solid, 0.001).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 0.01,
+        "reversed-edge half-circle volume {vol:.4} != {expected:.4}"
+    );
+}
+
 /// Regression for #869: extruding an `EdgeCurve::Ellipse` arc must build the
 /// ruled side surface from the edge's TRIMMED arc, not the full ellipse, so
 /// the solid volume matches the half-ellipse swept area (not the full ellipse).
@@ -1018,12 +1066,6 @@ fn extrude_half_ellipse_face_volume() {
 }
 
 #[test]
-#[ignore = "reversed periodic-edge extrude: the translated TOP edge (extrude.rs:357) \
-is built with wire-order vertices but a stored-order-parameterized curve, so a reversed \
-ellipse/circle arc samples the complementary sub-arc on the top boundary (vol 98.33 vs \
-65.45). side_face_surface already derives its domain from stored endpoints; the residual \
-top-edge fix is tracked separately (needs a curve-reversal primitive or a top-edge/side-wire \
-orientation rework)."]
 fn extrude_half_ellipse_reversed_edge_volume() {
     use brepkit_math::vec::{Point3, Vec3};
     use brepkit_topology::builder::make_ellipse_arc;
@@ -1031,8 +1073,8 @@ fn extrude_half_ellipse_reversed_edge_volume() {
     // Same upper-half-ellipse region as `extrude_half_ellipse_face_volume`, but
     // the arc is traversed REVERSED in the wire. The arc edge's stored start/end
     // then disagree with wire-traversal order. `side_face_surface` derives its
-    // domain from the stored endpoints (correct), but the translated top edge
-    // still mismatches — see the #[ignore] note above.
+    // swept-side domain from the stored endpoints, and the translated top edge
+    // is parameter-reversed to match — so the swept region is the upper arc.
     let mut topo = Topology::new();
     let center = Point3::new(5.0, 0.0, 0.0);
     let axis = Vec3::new(0.0, 0.0, -1.0);


### PR DESCRIPTION
## What

Follow-up to #930 (the reversed-edge limitation it documented). Extrude's translated **top** edge was built with wire-traversal-order vertices but a curve from `translate_edge_curve` that keeps the bottom edge's **stored** parameterization. For an edge used reversed in its wire those disagree:

- a periodic curve (ellipse/circle) resolves to the **complementary sub-arc** via `domain_with_endpoints`, and
- a NURBS curve's endpoints no longer match the stored vertices.

The swept side then sweeps the wrong arc — the reversed half-ellipse came out **98.33 vs 65.45**.

## Fix

Add `reverse_edge_curve` (flip `normal`+`v_axis` for circle/ellipse so `project` → `-θ`; reverse control net, weights, and mirrored knots for NURBS) and apply it to the translated top curve when the source edge is reversed. **No-op for forward edges**, so the common path (all gridfinity profiles, every existing test) is byte-identical.

Single fix site: the shared `extrude_wire_vertices_with` top-edge loop (covers both outer and inner wires).

## Verification

- Un-ignores `extrude_half_ellipse_reversed_edge_volume` (now passes) + adds `extrude_half_circle_reversed_edge_volume`.
- Full `brepkit-operations` suite green (704 passed, 0 failed); clippy clean.
- Forward path unchanged (guarded by `is_forward()`).

Closes the reversed-edge follow-up tracked from #930.