### PR TITLE
feat(wasm): add fuseAll binding (batched balanced fuse + disjoint-merge)

### DIFF
--- a/crates/wasm/src/bindings/batch.rs
+++ b/crates/wasm/src/bindings/batch.rs
@@ -451,6 +451,28 @@ impl BrepKernel {
                 .map_err(|e| e.to_string())?;
                 Ok(serde_json::json!(solid_id_to_u32(result)))
             }
+            "fuseAll" => {
+                let solid_arr = args["solids"]
+                    .as_array()
+                    .ok_or("missing or invalid 'solids' array")?;
+                let solids: Vec<brepkit_topology::solid::SolidId> = solid_arr
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| {
+                        let h = v
+                            .as_u64()
+                            .ok_or_else(|| format!("solids[{i}] is not a number"))
+                            .map(|n| n as u32)?;
+                        self.resolve_solid(h).map_err(|e| e.to_string())
+                    })
+                    .collect::<Result<Vec<_>, String>>()?;
+                let compound = self
+                    .topo_mut()
+                    .add_compound(brepkit_topology::compound::Compound::new(solids));
+                let result = brepkit_operations::compound_ops::fuse_all(self.topo_mut(), compound)
+                    .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!(solid_id_to_u32(result)))
+            }
             "transform" => {
                 let s = get_u32(args, "solid")?;
                 let solid_id = self.resolve_solid(s).map_err(|e| e.to_string())?;

--- a/crates/wasm/src/bindings/booleans.rs
+++ b/crates/wasm/src/bindings/booleans.rs
@@ -5,6 +5,7 @@
 use wasm_bindgen::prelude::*;
 
 use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::compound_ops;
 
 use crate::handles::solid_id_to_u32;
 use crate::helpers::{build_triangle_mesh, panic_message, parse_boolean_op, triangle_mesh_to_js};
@@ -106,6 +107,31 @@ impl BrepKernel {
         )
         .map_err(|e| JsError::new(&format!("{e}")))?;
         Ok(coincident_face_pairs_to_json(&pairs).to_string())
+    }
+
+    /// Fuse (union) many solids into one in a single call.
+    ///
+    /// Faster than a left-fold over `fuse`: overlapping solids are reduced
+    /// pairwise in a balanced tree while disjoint groups are merged directly
+    /// without a boolean.
+    ///
+    /// Returns a new solid handle (`u32`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any solid handle is invalid, the list is empty,
+    /// or a boolean operation produces an empty or non-manifold result.
+    #[wasm_bindgen(js_name = "fuseAll")]
+    pub fn fuse_all(&mut self, solid_handles: Vec<u32>) -> Result<u32, JsError> {
+        let solid_ids = solid_handles
+            .iter()
+            .map(|&h| self.resolve_solid(h))
+            .collect::<Result<Vec<_>, _>>()?;
+        let compound = self
+            .topo_mut()
+            .add_compound(brepkit_topology::compound::Compound::new(solid_ids));
+        let result = compound_ops::fuse_all(self.topo_mut(), compound)?;
+        Ok(solid_id_to_u32(result))
     }
 
     /// Intersect two solids, keeping only their common volume.

--- a/crates/wasm/src/bindings/gridfinity_tests.rs
+++ b/crates/wasm/src/bindings/gridfinity_tests.rs
@@ -350,6 +350,45 @@ fn compound_cut_after_fuse() {
     assert_no_crash(&parsed, 7, "fuse + compoundCut");
 }
 
+/// Fuse many boxes at once via `fuseAll` (mix of overlapping + disjoint).
+///
+/// Exercises both `fuse_all` paths: boxes 0 and 2 overlap (pairwise boolean
+/// reduction) while box 3 is far away (disjoint-merge fast path).
+///
+/// Solids: 0=box, 2=overlapping copy, 3=disjoint copy, 4=fuseAll result.
+#[test]
+fn fuse_all_mixed_overlap_and_disjoint() {
+    let mut k = BrepKernel::new();
+    let result = k.execute_batch(
+        r#"[
+        {"op": "makeBox", "args": {"width": 10, "height": 10, "depth": 10}},
+        {"op": "makeBox", "args": {"width": 10, "height": 10, "depth": 10}},
+        {"op": "copyAndTransformSolid", "args": {"solid": 1, "matrix": [1,0,0,5, 0,1,0,0, 0,0,1,0, 0,0,0,1]}},
+        {"op": "copyAndTransformSolid", "args": {"solid": 1, "matrix": [1,0,0,50, 0,1,0,0, 0,0,1,0, 0,0,0,1]}},
+        {"op": "fuseAll", "args": {"solids": [0, 2, 3]}}
+    ]"#,
+    );
+    let parsed = parse_batch(&result);
+    assert_no_crash(&parsed, 4, "fuseAll mix of overlapping and disjoint boxes");
+    assert_ok(&parsed, 4);
+
+    let handle = parsed[4]["ok"]
+        .as_u64()
+        .expect("fuseAll should return a solid handle") as u32;
+    let counts = k
+        .get_entity_counts(handle)
+        .expect("fuseAll result should be a valid solid");
+    assert_eq!(
+        counts.len(),
+        3,
+        "entity counts are [faces, edges, vertices]"
+    );
+    assert!(
+        counts[0] > 0 && counts[1] > 0 && counts[2] > 0,
+        "fused solid should be non-empty, got {counts:?}"
+    );
+}
+
 /// Full pipeline: box + fuse + fillet + compoundCut.
 ///
 /// Uses `solidEdges` to get edge handles for the fillet step.


### PR DESCRIPTION
Exposes the existing `compound_ops::fuse_all` engine function to JS: balanced pairwise reduction within overlapping groups + a disjoint-merge fast path across spatially-separate groups (faster than a left-fold over individual `fuse` calls). Additive — no existing behavior changes.

- `fuseAll(solidHandles)` binding in `bindings/booleans.rs`
- `executeBatch` dispatch arm `fuseAll` (`{solids:[...]}`)
- contract test `fuse_all_mixed_overlap_and_disjoint` exercising both code paths (overlapping pair + disjoint box)

brepjs type re-sync needed downstream once republished. Full suite + clippy green.