### PR TITLE
fix(algo): harden periodic-face arc splitting (shorter-arc convention + analytic-face v-band clip)

### DIFF
--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -5,11 +5,10 @@ use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::face::FaceSurface;
 
 use super::super::pcurve_compute::{
-    compute_pcurve_on_surface, evaluate_edge_at_t, project_point_on_surface,
+    compute_pcurve_on_surface, evaluate_edge_at_t, project_point_on_surface, shorter_arc_delta,
 };
 use super::super::plane_frame::PlaneFrame;
 use super::super::split_types::OrientedPCurveEdge;
-use super::sampling::normalize_angle_in_span;
 
 /// Split boundary edges at 3D points where section edges start/end.
 ///
@@ -111,13 +110,124 @@ pub(super) fn find_splits_on_line(
     splits
 }
 
-/// Find split parameters on a circle edge. Uses `Circle3D::project` for angular
-/// projection, then normalizes into the edge's `[0, 1]` parameter range.
+/// Map an angular crossing on an arc edge to the edge's `[0, 1]` parameter using
+/// the SAME shorter-arc convention as `evaluate_edge_at_t`, then validate the
+/// result in 3D so a crossing is accepted only if it actually lies on this
+/// edge's trimmed span.
 ///
-/// Note: `domain_with_endpoints` for full circles (start approx end) returns the
-/// full `(-pi, pi]` domain. For true arcs, it uses endpoint projection -- this
-/// is correct for the boundary edges produced by `make_cylinder`/`make_cone`.
+/// Why this and not `normalize_angle_in_span(angle, t0, span)` with `span` from
+/// `domain_with_endpoints`: `domain_with_endpoints` reports the CCW (positive,
+/// `0..2π`) arc from start to end, but `evaluate_edge_at_t` traces the SHORTER
+/// arc (signed delta in `(-π, π]`). When the CCW arc is the long one the two
+/// disagree — a `t` computed under the CCW convention is then evaluated
+/// downstream against the shorter arc and lands at the wrong 3D point. Worse,
+/// when one `Circle3D` is shared by two complementary arc edges (e.g. the two
+/// halves of a z-step rim), a genuine crossing projects onto both arcs: the arc
+/// it does NOT belong to either gets a spurious split at a bogus point, or
+/// returns a just-negative `t` for the real split and rejects it.
+///
+/// Computing `t` under the shorter-arc convention and round-tripping it through
+/// `evaluate_edge_at_t` selects the arc the crossing truly belongs to: the 3D
+/// round-trip only matches on the correct arc, so the right edge splits and the
+/// wrong one does not. `a_start` is the curve angle of `start`, `a_cross` the
+/// angle of the candidate crossing.
+fn split_param_on_arc(
+    curve: &EdgeCurve,
+    start: Point3,
+    end: Point3,
+    a_start: f64,
+    a_cross: f64,
+    sp: Point3,
+    tol: f64,
+) -> Option<f64> {
+    // Shorter-arc delta from start to end (the edge's full traced span) and
+    // from start to the crossing — both under the same convention used by
+    // `evaluate_edge_at_t`.
+    let span = shorter_arc_delta_for_endpoints(curve, start, end);
+    if span.abs() < 1e-14 {
+        return None;
+    }
+    let delta = shorter_arc_delta(a_cross - a_start);
+    let t = delta / span;
+    if t <= tol || t >= 1.0 - tol {
+        return None;
+    }
+    // Self-consistency: the point this `t` maps to (under the downstream
+    // `evaluate_edge_at_t` convention) must coincide with the crossing. This is
+    // the decisive arc selector — when one `Circle3D` is shared by two
+    // complementary arc edges and the crossing projects onto both, the arc the
+    // point does NOT belong to maps `t` to a different 3D location and is
+    // rejected here.
+    let back = evaluate_edge_at_t(curve, start, end, t);
+    if (back - sp).length() > tol {
+        return None;
+    }
+    // Reject a split that lands on (or numerically on top of) an endpoint: it
+    // makes a zero-length sub-edge that downstream over-shares the boundary.
+    // The split point is a section endpoint which is itself only vertex-snapped
+    // (≈1e-6 noise here), so a hair-past-endpoint crossing yields `t` just
+    // inside `(0, 1)` (e.g. `t ≈ 1.3e-7` against a 1e-7 tol). Test the actual
+    // mapped 3D point against the endpoints with a snap-scale tolerance so the
+    // degenerate split is dropped regardless of the crossing's own noise.
+    let snap = (tol * 100.0).max(1e-6);
+    if (back - start).length() <= snap || (back - end).length() <= snap {
+        return None;
+    }
+    Some(t)
+}
+
+/// Shorter-arc angular span from `start` to `end` for a Circle/Ellipse edge,
+/// matching `evaluate_edge_at_t`'s open-arc tracing.
+fn shorter_arc_delta_for_endpoints(curve: &EdgeCurve, start: Point3, end: Point3) -> f64 {
+    match curve {
+        EdgeCurve::Circle(c) => shorter_arc_delta(c.project(end) - c.project(start)),
+        EdgeCurve::Ellipse(e) => shorter_arc_delta(e.project(end) - e.project(start)),
+        _ => 0.0,
+    }
+}
+
+/// Find split parameters on a circle edge. Uses `Circle3D::project` for angular
+/// projection, then maps into `[0, 1]` via `split_param_on_arc` (shorter-arc
+/// convention + 3D self-consistency check).
 pub(super) fn find_splits_on_circle(
+    circle: &brepkit_math::curves::Circle3D,
+    edge: &OrientedPCurveEdge,
+    split_pts_3d: &[Point3],
+    tol: f64,
+) -> Vec<(f64, Point3)> {
+    // Closed full circle (start == end): no shorter-arc span; the legacy
+    // domain-based mapping is correct because span is the full 2π.
+    if (edge.start_3d - edge.end_3d).length() < 1e-9 {
+        return find_splits_on_closed_circle(circle, edge, split_pts_3d, tol);
+    }
+    let a_start = circle.project(edge.start_3d);
+    let mut splits = Vec::new();
+    for &sp in split_pts_3d {
+        let angle = circle.project(sp);
+        let closest = circle.evaluate(angle);
+        if (sp - closest).length() > tol {
+            continue;
+        }
+        if let Some(t) = split_param_on_arc(
+            &edge.curve_3d,
+            edge.start_3d,
+            edge.end_3d,
+            a_start,
+            angle,
+            sp,
+            tol,
+        ) {
+            splits.push((t, sp));
+        }
+    }
+    splits.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    splits.dedup_by(|a, b| (a.0 - b.0).abs() < tol);
+    splits
+}
+
+/// Split mapping for a closed full-circle edge (start == end). The edge spans
+/// the full domain; map each crossing's angle to `[0, 1]` via the curve domain.
+fn find_splits_on_closed_circle(
     circle: &brepkit_math::curves::Circle3D,
     edge: &OrientedPCurveEdge,
     split_pts_3d: &[Point3],
@@ -137,7 +247,7 @@ pub(super) fn find_splits_on_circle(
         if (sp - closest).length() > tol {
             continue;
         }
-        let t_norm = normalize_angle_in_span(angle, t0, span);
+        let t_norm = super::sampling::normalize_angle_in_span(angle, t0, span);
         if t_norm <= tol || t_norm >= 1.0 - tol {
             continue;
         }
@@ -148,8 +258,43 @@ pub(super) fn find_splits_on_circle(
     splits
 }
 
-/// Find split parameters on an ellipse edge.
+/// Find split parameters on an ellipse edge. Mirrors `find_splits_on_circle`.
 pub(super) fn find_splits_on_ellipse(
+    ellipse: &brepkit_math::curves::Ellipse3D,
+    edge: &OrientedPCurveEdge,
+    split_pts_3d: &[Point3],
+    tol: f64,
+) -> Vec<(f64, Point3)> {
+    if (edge.start_3d - edge.end_3d).length() < 1e-9 {
+        return find_splits_on_closed_ellipse(ellipse, edge, split_pts_3d, tol);
+    }
+    let a_start = ellipse.project(edge.start_3d);
+    let mut splits = Vec::new();
+    for &sp in split_pts_3d {
+        let angle = ellipse.project(sp);
+        let closest = ellipse.evaluate(angle);
+        if (sp - closest).length() > tol {
+            continue;
+        }
+        if let Some(t) = split_param_on_arc(
+            &edge.curve_3d,
+            edge.start_3d,
+            edge.end_3d,
+            a_start,
+            angle,
+            sp,
+            tol,
+        ) {
+            splits.push((t, sp));
+        }
+    }
+    splits.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    splits.dedup_by(|a, b| (a.0 - b.0).abs() < tol);
+    splits
+}
+
+/// Split mapping for a closed full-ellipse edge (start == end).
+fn find_splits_on_closed_ellipse(
     ellipse: &brepkit_math::curves::Ellipse3D,
     edge: &OrientedPCurveEdge,
     split_pts_3d: &[Point3],
@@ -169,7 +314,7 @@ pub(super) fn find_splits_on_ellipse(
         if (sp - closest).length() > tol {
             continue;
         }
-        let t_norm = normalize_angle_in_span(angle, t0, span);
+        let t_norm = super::sampling::normalize_angle_in_span(angle, t0, span);
         if t_norm <= tol || t_norm >= 1.0 - tol {
             continue;
         }
@@ -178,4 +323,86 @@ pub(super) fn find_splits_on_ellipse(
     splits.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
     splits.dedup_by(|a, b| (a.0 - b.0).abs() < tol);
     splits
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use brepkit_math::curves::Circle3D;
+    use brepkit_math::curves2d::{Curve2D, Line2D};
+    use brepkit_math::vec::{Point2, Vec2, Vec3};
+    use std::f64::consts::PI;
+
+    fn arc_edge(circle: &Circle3D, a0: f64, a1: f64) -> OrientedPCurveEdge {
+        let start_3d = circle.evaluate(a0);
+        let end_3d = circle.evaluate(a1);
+        OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Circle(circle.clone()),
+            pcurve: Curve2D::Line(Line2D::new(Point2::new(0.0, 0.0), Vec2::new(1.0, 0.0)).unwrap()),
+            start_uv: Point2::new(0.0, 0.0),
+            end_uv: Point2::new(1.0, 0.0),
+            start_3d,
+            end_3d,
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: None,
+        }
+    }
+
+    /// Two complementary arcs of ONE circle: the upper semicircle (angle 0→π,
+    /// through the top) and the lower semicircle (angle π→2π, through the
+    /// bottom). A split point on the top must split ONLY the upper arc; a point
+    /// on the bottom must split ONLY the lower arc. The old CCW-span mapping
+    /// mis-assigned these because both arcs project the same circle.
+    #[test]
+    fn co_circular_arcs_split_only_the_owning_arc() {
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let tol = 1e-9;
+
+        // Upper arc: start at angle 0 = (1,0,0), end at angle π = (-1,0,0),
+        // through the top (0,1,0).
+        let upper = arc_edge(&circle, 0.0, PI);
+        // Lower arc edge of the SAME circle: start angle π, end angle 2π,
+        // through the bottom (0,-1,0).
+        let lower = arc_edge(&circle, PI, 2.0 * PI);
+
+        let top = circle.evaluate(PI / 2.0); // (0,1,0)
+        let bottom = circle.evaluate(3.0 * PI / 2.0); // (0,-1,0)
+
+        // Top point splits the upper arc near its midpoint, not the lower.
+        let up_top = find_splits_on_circle(&circle, &upper, &[top], tol);
+        let lo_top = find_splits_on_circle(&circle, &lower, &[top], tol);
+        assert_eq!(up_top.len(), 1, "top point must split the upper arc");
+        assert!((up_top[0].0 - 0.5).abs() < 1e-6, "split at arc midpoint");
+        assert!(lo_top.is_empty(), "top point must NOT split the lower arc");
+
+        // Bottom point splits the lower arc, not the upper.
+        let up_bot = find_splits_on_circle(&circle, &upper, &[bottom], tol);
+        let lo_bot = find_splits_on_circle(&circle, &lower, &[bottom], tol);
+        assert!(
+            up_bot.is_empty(),
+            "bottom point must NOT split the upper arc"
+        );
+        assert_eq!(lo_bot.len(), 1, "bottom point must split the lower arc");
+        assert!((lo_bot[0].0 - 0.5).abs() < 1e-6, "split at arc midpoint");
+    }
+
+    /// A crossing that coincides with an arc's endpoint (within vertex-snap
+    /// noise) must not produce a degenerate zero-length split.
+    #[test]
+    fn endpoint_coincident_crossing_is_not_split() {
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+        let tol = 1e-7;
+        let arc = arc_edge(&circle, 0.0, PI / 2.0);
+        // A point a hair off the start vertex (≈1e-8 noise), on the circle.
+        let near_start = Point3::new(circle.evaluate(0.0).x(), 1e-8, 0.0);
+        let splits = find_splits_on_circle(&circle, &arc, &[near_start], tol);
+        assert!(
+            splits.is_empty(),
+            "near-endpoint crossing must not create a degenerate split, got {splits:?}"
+        );
+    }
 }

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1376,6 +1376,34 @@ fn build_section_edges(
                     None => (curve_ds.curve.clone(), start, end),
                 };
 
+                // Clip an OPEN arc section to an analytic (cylinder/cone) face's
+                // axial v-range. An exact faceted-ramp arc (a tread × corner
+                // cylinder ellipse, see phase_ff::trim_ellipse_to_boundary_crossings)
+                // is trimmed only to the PLANAR tread's boundary crossings — its
+                // endpoints can overshoot the cylinder face's own v-band when the
+                // tread straddles the band's top/bottom (the scoop+label lip-foot
+                // staircase: the topmost tread spans z 12.9→13.9 but the corner
+                // cylinder face stops at z 13.3). The dangling endpoint above the
+                // top boundary leaves the staircase chain unable to close a
+                // boundary-to-boundary cut, so the splitter returns one whole
+                // sub-face and the cylinder is classified by a single sample and
+                // dropped, orphaning the tread arcs. Clipping the arc to the
+                // band's v-range lands its endpoint exactly on the face's top/
+                // bottom circle, restoring the cut. Only the analytic side is
+                // clipped; the planar tread keeps the full arc.
+                let is_open = (start - end).length() >= tol * 100.0;
+                let (start, end) = if is_open
+                    && !matches!(curve_3d, EdgeCurve::Line)
+                    && matches!(
+                        face.surface(),
+                        FaceSurface::Cylinder(_) | FaceSurface::Cone(_)
+                    ) {
+                    clip_arc_to_face_v_range(topo, face_id, &curve_3d, start, end, tol)
+                        .unwrap_or((start, end))
+                } else {
+                    (start, end)
+                };
+
                 let pcurve = super::pcurve_compute::compute_pcurve_on_surface(
                     &curve_3d,
                     start,
@@ -1894,6 +1922,110 @@ fn curve_endpoints(
     let start_3d = curve_ds.curve.evaluate_with_endpoints(t0, dummy, dummy);
     let end_3d = curve_ds.curve.evaluate_with_endpoints(t1, dummy, dummy);
     (Some(start_3d), Some(end_3d))
+}
+
+/// Clip an open arc section to the analytic face's axial `v` range.
+///
+/// Projects the arc's endpoints and a dense sample set onto the face surface to
+/// find the face's `v` band, then clamps each end of the arc that overshoots the
+/// band to the parameter where the arc crosses the band boundary (found by
+/// bisection on the monotone-in-`v` arc). Returns `None` when no clip is needed
+/// (both ends already inside) or the geometry can't be resolved, so the caller
+/// keeps the original endpoints.
+fn clip_arc_to_face_v_range(
+    topo: &Topology,
+    face_id: FaceId,
+    curve: &EdgeCurve,
+    start: Point3,
+    end: Point3,
+    tol: f64,
+) -> Option<(Point3, Point3)> {
+    let face = topo.face(face_id).ok()?;
+    let surface = face.surface();
+
+    // Face v-band from its boundary vertices (the trimmed extent in v).
+    let wire = topo.wire(face.outer_wire()).ok()?;
+    let mut v_min = f64::MAX;
+    let mut v_max = f64::MIN;
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge()).ok()?;
+        for vid in [edge.start(), edge.end()] {
+            if let Ok(vtx) = topo.vertex(vid)
+                && let Some((_, v)) = surface.project_point(vtx.point())
+            {
+                v_min = v_min.min(v);
+                v_max = v_max.max(v);
+            }
+        }
+    }
+    if v_min > v_max {
+        return None;
+    }
+    // A small margin decides whether to clip at all (only on a real overshoot),
+    // matching the FaceExtent analytic margin. The clip itself targets the EXACT
+    // band edge (v_min / v_max), so the clipped endpoint lands on the face's
+    // top/bottom boundary circle — not inside the margin, where the wire builder
+    // can't connect it to the boundary edge.
+    let margin = (v_max - v_min).abs() * 0.01 + tol;
+    let over_hi = v_max + margin;
+    let over_lo = v_min - margin;
+
+    let (t0, t1) = curve.domain_with_endpoints(start, end);
+    let v_at = |t: f64| -> Option<f64> {
+        let p = curve.evaluate_with_endpoints(t, start, end);
+        surface.project_point(p).map(|(_, v)| v)
+    };
+
+    let v_start = v_at(t0)?;
+    let v_end = v_at(t1)?;
+    let overshoots = |v: f64| v > over_hi || v < over_lo;
+    // Neither end overshoots the band — nothing to clip.
+    if !overshoots(v_start) && !overshoots(v_end) {
+        return None;
+    }
+
+    // Target v for an overshooting end: the band edge it crossed.
+    let target_v = |v: f64| if v > over_hi { v_max } else { v_min };
+    // Bisection: walk `t_far` (the overshooting end) toward `t_near` (the other
+    // end, deeper into the band) until the arc's v reaches the band edge. The
+    // staircase arcs are monotone in v, so v(t) crosses `target` exactly once;
+    // keep the half-interval whose far end is still beyond the target.
+    let bisect_to = |t_far: f64, t_near: f64, target: f64| -> Option<f64> {
+        let v_far = v_at(t_far)?;
+        // Sign convention: are we above or below the target at the far end?
+        let far_above = v_far > target;
+        let mut lo = t_far;
+        let mut hi = t_near;
+        for _ in 0..60 {
+            let tm = 0.5 * (lo + hi);
+            let vm = v_at(tm)?;
+            // `tm` is still beyond the target on the far side?
+            let beyond = if far_above { vm > target } else { vm < target };
+            if beyond { lo = tm } else { hi = tm }
+        }
+        Some(0.5 * (lo + hi))
+    };
+
+    let mut nt0 = t0;
+    let mut nt1 = t1;
+    if overshoots(v_start) {
+        nt0 = bisect_to(t0, t1, target_v(v_start))?;
+    }
+    if overshoots(v_end) {
+        nt1 = bisect_to(t1, t0, target_v(v_end))?;
+    }
+    if (nt0 - t0).abs() < f64::EPSILON && (nt1 - t1).abs() < f64::EPSILON {
+        return None;
+    }
+
+    let new_start = curve.evaluate_with_endpoints(nt0, start, end);
+    let new_end = curve.evaluate_with_endpoints(nt1, start, end);
+    // Reject a clip that collapses the arc (the band barely clips a sliver and
+    // the two ends meet) — a zero-length section corrupts the wire.
+    if (new_start - new_end).length() < tol * 100.0 {
+        return None;
+    }
+    Some((new_start, new_end))
 }
 
 /// Remove section edges that are subsets of longer collinear edges.

--- a/crates/io/tests/scooplabel_ef_margin_inmem.rs
+++ b/crates/io/tests/scooplabel_ef_margin_inmem.rs
@@ -86,6 +86,34 @@ fn over_shared_edges(topo: &Topology, solid: SolidId) -> usize {
         .count()
 }
 
+/// Count geometrically free edges (a quantized endpoint pair bordered by a
+/// single face) — the open-shell witness.
+fn free_edges(topo: &Topology, solid: SolidId) -> usize {
+    type QPoint = (i64, i64, i64);
+    let scale = 1.0e5;
+    let q = |p: brepkit_math::vec::Point3| -> QPoint {
+        (
+            (p.x() * scale).round() as i64,
+            (p.y() * scale).round() as i64,
+            (p.z() * scale).round() as i64,
+        )
+    };
+    let mut counts: HashMap<(QPoint, QPoint), usize> = HashMap::new();
+    for fid in solid_faces(topo, solid).unwrap() {
+        let face = topo.face(fid).unwrap();
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).unwrap().edges() {
+                let e = topo.edge(oe.edge()).unwrap();
+                let a = q(topo.vertex(e.start()).unwrap().point());
+                let b = q(topo.vertex(e.end()).unwrap().point());
+                let key = if a <= b { (a, b) } else { (b, a) };
+                *counts.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+    counts.values().filter(|&&c| c == 1).count()
+}
+
 /// Count faces whose outer wire is a pure out-and-back spur (collapses to
 /// nothing after stripping consecutive same-endpoint opposite-direction
 /// pairs) — i.e. degenerate zero-area "ribbon" faces.
@@ -173,4 +201,37 @@ fn scooplabel_bracket_fuse_has_no_degenerate_sections() {
         curved >= 36,
         "expected the body's analytic corner surfaces preserved, got {curved} curved"
     );
+}
+
+/// TARGET (currently failing): the full scoop+label bracket fuse must be
+/// watertight (free edges = 0), analytic (curved ≥ 36), with the lip-foot cone
+/// present. This is the 4-part close: Part 1 (#936, bounded oblique plane-cone
+/// conic) and Part 3 (co-circular arc split convention, this PR) are landed.
+/// Parts 2 (phase_ff cone-hyperbola section weld) and 4 (multi-surface
+/// lip-foot z-stack section chaining + z-step ring reconciliation) are not yet
+/// implemented, so the lip-foot stack still leaves free edges. Ignored until
+/// Parts 2+4 land; remove `#[ignore]` then.
+#[test]
+#[ignore = "needs Parts 2+4 (cone-hyperbola weld + z-stack section chaining)"]
+fn scooplabel_bracket_fuse_is_watertight() {
+    let mut topo = Topology::new();
+    let body = load("scooplabel_inmem_body.bin", &mut topo);
+    let bracket = load("scooplabel_inmem_bracket.bin", &mut topo);
+
+    let result = gfa::boolean(&mut topo, BooleanOp::Fuse, body, bracket).unwrap();
+
+    let free = free_edges(&topo, result);
+    let curved = solid_faces(&topo, result)
+        .unwrap()
+        .iter()
+        .filter(|&&f| topo.face(f).unwrap().surface().type_tag() != "plane")
+        .count();
+    let cone_present = solid_faces(&topo, result)
+        .unwrap()
+        .iter()
+        .any(|&f| topo.face(f).unwrap().surface().type_tag() == "cone");
+
+    assert_eq!(free, 0, "scoop+label fuse must be watertight (free edges)");
+    assert!(curved >= 36, "analytic surfaces preserved, got {curved}");
+    assert!(cone_present, "lip-foot cone must survive the fuse");
 }


### PR DESCRIPTION
Two correct, general soundness fixes for periodic-face arc splitting in the GFA builder, discovered while driving the gridfinity scoop+label fuse close. Net effect on that fuse: free edges 21→20 (the bin corner cylinder now splits per z-band; 6 of 8 staircase ellipse arcs gain partners). All guards green; the remaining residual is a separate, precisely-localized z=13.3 ring-closure (tracked for a follow-up).

## Fix 1 — shorter-arc co-circular split convention (`face_splitter/edge_splitting.rs`)
`find_splits_on_circle`/`find_splits_on_ellipse` mapped a candidate split angle to `[0,1]` via `normalize_angle_in_span` over the CCW span from `domain_with_endpoints` (always positive 0..2π), but `evaluate_edge_at_t` traces the **shorter arc** (signed −π..π). On a circle whose two arcs are split, the genuine crossing projects onto both arcs and the old convention assigned it to the wrong one → a bogus 3D split point. Compute `t` under the shorter-arc convention (matching the existing `split_plane_boundary_arcs_at_points` precedent + `evaluate_edge_at_t`), select the owning arc by a 3D round-trip, and reject endpoint-coincident crossings within a snap tolerance. Two unit tests added. (Reconciled the honeycomb near-endpoint regression via the snap-tol guard.)

## Fix 2 — clip analytic-face section arcs to their v-band (`builder/fill_images_faces.rs`)
A plane×cylinder/cone section arc could be emitted with an endpoint **overshooting the analytic face's v-range** (e.g. v=13.912 on a face whose top is z=13.3). The dangling endpoint above the boundary circle prevented `split_face_2d` from closing a boundary-to-boundary cut, so the face stayed whole and was dropped by a single interior-sample classification. New `clip_arc_to_face_v_range` bisects the monotone-in-v arc to land the overshooting endpoint exactly on the face's v_min/v_max boundary circle (analytic side only; the planar partner keeps its full arc). Load-bearing detail: clip to the **exact** band edge, not the containment margin.

## Verification
`brepkit-algo` (137), `brepkit-io` (incl. scoop_fix_inmem, scooplabel_ef_margin_inmem, gridfinity_honeycomb_cut_inmem, gridfinity_lipfuse_dividers_inmem, scoop_corner_cylinder_fuse, dovetail_groove_cut_inmem, cavitycut, wallcut_seq), `brepkit-operations` (705+) — all green, 0 failed. clippy + fmt + layer-boundaries clean. Builds on #936 (oblique plane-cone conic, already in main).