### PR TITLE
fix(algo): orient partial-overlap cap wire by Newell normal

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -2285,6 +2285,26 @@ fn cap_partial_overlap_free_loops(
         if !build_ok {
             continue;
         }
+        // The walk order alone yields an arbitrary winding; orient the wire CCW
+        // around the cap's outward normal so the face winding matches its
+        // surface normal (otherwise a manifold-but-inside-out cap could corrupt
+        // a downstream boolean). Newell's method gives the loop's normal.
+        let (mut nx, mut ny, mut nz) = (0.0_f64, 0.0_f64, 0.0_f64);
+        let nverts = verts3d.len();
+        for i in 0..nverts {
+            let c = verts3d[i];
+            let np = verts3d[(i + 1) % nverts];
+            nx += (c.y() - np.y()) * (c.z() + np.z());
+            ny += (c.z() - np.z()) * (c.x() + np.x());
+            nz += (c.x() - np.x()) * (c.y() + np.y());
+        }
+        if Vec3::new(nx, ny, nz).dot(cap.out_normal) < 0.0 {
+            oriented = oriented
+                .into_iter()
+                .rev()
+                .map(|oe| OrientedEdge::new(oe.edge(), !oe.is_forward()))
+                .collect();
+        }
         let Ok(wire) = Wire::new(oriented, true) else {
             continue;
         };


### PR DESCRIPTION
Follow-up to #944 (Greptile review note). The synthesized partial-overlap cap face set its surface normal to the recorded `out_normal`, but built the **wire winding from edge-walk order**, which is arbitrary — so the cap could be manifold-but-inside-out (the manifold test wouldn't catch it) and corrupt a subsequent boolean on the fused solid.

Fix: compute the loop's Newell normal and reverse the oriented wire when it opposes `cap.out_normal`, so the winding is CCW around the surface normal.

Verification: `cargo nextest run --workspace` 2406 passed, 0 failed; the compartment repro stays manifold; clippy + fmt + layer-boundaries clean. Pure orientation determinism — no behavior change where the walk order already happened to be correct.