### PR TITLE
fix(algo): coincident-coplanar classification for clipped-away corner wedges

### DIFF
--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -301,8 +301,31 @@ impl Builder {
 
             match sample {
                 Ok(point) => {
-                    sf.classification =
-                        classifier::classify_point(&self.topo, opposing_solid, point)?;
+                    // Coincident-coplanar fast path: a planar sub-face lying in
+                    // a plane coincident with an opposing-solid face cannot be
+                    // classified by ray-cast — its interior point sits on the
+                    // opposing plane and cardinal rays graze the coincident cap
+                    // (voting wrongly Inside). Classify by 2D containment in the
+                    // opposing face's region instead.
+                    let coincident =
+                        if let brepkit_topology::face::FaceSurface::Plane { normal, d } =
+                            self.topo.face(sf.face_id)?.surface()
+                        {
+                            classifier::classify_coincident_coplanar(
+                                &self.topo,
+                                opposing_solid,
+                                sf.face_id,
+                                *normal,
+                                *d,
+                                self.tol,
+                            )?
+                        } else {
+                            None
+                        };
+                    sf.classification = match coincident {
+                        Some(class) => class,
+                        None => classifier::classify_point(&self.topo, opposing_solid, point)?,
+                    };
                     log::trace!(
                         "classify_sub_faces: idx={idx} face={:?} rank={:?} pt={point:?} class={:?}",
                         sf.face_id,

--- a/crates/algo/src/classifier/mod.rs
+++ b/crates/algo/src/classifier/mod.rs
@@ -9,11 +9,15 @@ mod analytic;
 mod ray_cast;
 
 pub use analytic::{AnalyticClassifier, classify_analytic, try_build_analytic_classifier};
-pub use ray_cast::{classify_ray_cast, compute_solid_bbox, point_in_face_3d};
+pub use ray_cast::{
+    classify_ray_cast, compute_solid_bbox, planar_face_polygons, point_in_face_3d,
+    point_in_planar_region, ray_cast_inside_votes,
+};
 pub(crate) use ray_cast::{largest_u_gap, u_in_gap};
 
-use brepkit_math::vec::Point3;
+use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
+use brepkit_topology::face::FaceSurface;
 use brepkit_topology::solid::SolidId;
 
 use crate::builder::FaceClass;
@@ -39,4 +43,192 @@ pub fn classify_point(
     }
 
     classify_ray_cast(topo, solid, point)
+}
+
+/// Classify a planar sub-face that is coincident-coplanar with a face of the
+/// opposing solid by 2D containment, bypassing the unstable grazing ray-cast.
+///
+/// When a split sub-face's supporting plane is coincident (coplanar within
+/// `tol`, ignoring normal sign) with a planar face of the opposing solid, the
+/// sub-face's interior point necessarily lies *on* that opposing face's plane.
+/// A cardinal ray-cast from such a point grazes the coincident cap and its wall
+/// top-edges and can vote wrongly Inside (and a single interior sample is
+/// itself unreliable on a thin corner wedge).
+///
+/// The override fires only for the *wholly-exterior wedge* signature: the
+/// sub-face has at least one vertex strictly outside the opposing region and
+/// **no** vertex strictly inside it (every vertex is outside or on the shared
+/// boundary) — the clipped-away corner orphan whose only contact with the
+/// opposing region is along the shared boundary.
+///
+/// To stay sound it additionally runs a *depth probe* at the wedge tip: a 2D
+/// point outside the opposing face's region is outside the opposing *solid*
+/// only when this coincident plane is the local outer boundary there. Stepping
+/// off the plane to both sides of the tip and finding the solid absent on both
+/// sides confirms the plane is a local boundary → the wedge is exterior
+/// ([`FaceClass::Outside`]). If the solid persists on either side (a plane
+/// shared with an interior feature, e.g. the honeycomb's stacked caps), the
+/// genuinely-inside coincident face is left to the regular classifier.
+///
+/// Returns `None` when there is no coincident opposing face, the sub-face is
+/// not a wholly-exterior wedge, or the depth probe finds the plane is internal.
+///
+/// # Errors
+///
+/// Returns [`AlgoError`] on a topology lookup failure.
+pub fn classify_coincident_coplanar(
+    topo: &Topology,
+    opposing_solid: SolidId,
+    sub_face_id: brepkit_topology::face::FaceId,
+    sub_normal: Vec3,
+    sub_d: f64,
+    tol: brepkit_math::tolerance::Tolerance,
+) -> Result<Option<FaceClass>, AlgoError> {
+    let plane_tol = tol.linear.max(1e-7);
+    let n_tol = 1e-6_f64;
+    let faces = brepkit_topology::explorer::solid_faces(topo, opposing_solid)?;
+    for fid in faces {
+        let face = topo.face(fid)?;
+        let FaceSurface::Plane {
+            normal: fn_raw,
+            d: fd_raw,
+        } = face.surface()
+        else {
+            continue;
+        };
+        // The stored (normal, d) define the plane regardless of face
+        // orientation; coincidence is sign-agnostic.
+        let fnv = *fn_raw;
+        let coplanar_same =
+            (fnv - sub_normal).length() < n_tol && (fd_raw - sub_d).abs() < plane_tol;
+        let coplanar_flip =
+            (fnv + sub_normal).length() < n_tol && (fd_raw + sub_d).abs() < plane_tol;
+        if !(coplanar_same || coplanar_flip) {
+            continue;
+        }
+        let Some((outer, holes, region_normal)) = planar_face_polygons(topo, fid)? else {
+            continue;
+        };
+        let Some(sub_verts) = sub_face_outer_vertices(topo, sub_face_id)? else {
+            return Ok(None);
+        };
+
+        // Classify each sub-face vertex against the opposing region with a
+        // boundary band: a vertex on the shared boundary (within `plane_tol`)
+        // is neither strictly inside nor strictly outside. Track the deepest
+        // strictly-outside vertex (farthest from the opposing boundary) — that
+        // is the wedge tip, the most reliable place to probe.
+        let mut any_strictly_inside = false;
+        let mut deepest_outside: Option<(f64, Point3)> = None;
+        for &v in &sub_verts {
+            let dist = dist_to_polygon_boundary(v, &outer, &region_normal);
+            if dist <= plane_tol {
+                continue;
+            }
+            if point_in_planar_region(v, &outer, &holes, &region_normal) {
+                any_strictly_inside = true;
+            } else if deepest_outside.is_none_or(|(d, _)| dist > d) {
+                deepest_outside = Some((dist, v));
+            }
+        }
+
+        // Wholly-exterior wedge: outside-or-on everywhere, with real exterior
+        // extent. A straddler (any strictly-inside vertex) is deferred.
+        let Some((_, tip)) = deepest_outside else {
+            return Ok(None);
+        };
+        if any_strictly_inside {
+            return Ok(None);
+        }
+
+        // Depth probe: a 2D point outside the opposing face's region is outside
+        // the opposing *solid* only if this coincident plane is the local outer
+        // boundary there — i.e. stepping off the plane to *both* sides leaves
+        // the solid. (A plane shared with an interior feature, e.g. the
+        // honeycomb's stacked caps, has solid on one side → defer to ray-cast,
+        // which correctly keeps the genuinely-inside coincident face.)
+        //
+        // The wedge tip sits at the sub-face's outermost corner, which lies on
+        // the shared walls — ray-cast grazes there. Nudge the probe location
+        // off the tip toward the wedge centroid so it clears the walls, while
+        // keeping it strictly outside the opposing 2D region.
+        let nlen = region_normal.length();
+        if nlen < 1e-12 {
+            return Ok(None);
+        }
+        let np = region_normal * (1.0 / nlen);
+        let (mut cx, mut cy, mut cz) = (0.0, 0.0, 0.0);
+        for &v in &sub_verts {
+            cx += v.x();
+            cy += v.y();
+            cz += v.z();
+        }
+        let inv = 1.0 / sub_verts.len() as f64;
+        let centroid = Point3::new(cx * inv, cy * inv, cz * inv);
+        let probe = (100.0 * plane_tol).max(1e-3);
+        let mut decided: Option<FaceClass> = None;
+        for frac in [0.25_f64, 0.4, 0.55] {
+            let probe_xy = tip + (centroid - tip) * frac;
+            // Must still be strictly outside the opposing region and clear of
+            // its boundary, else the probe is meaningless.
+            if point_in_planar_region(probe_xy, &outer, &holes, &region_normal)
+                || dist_to_polygon_boundary(probe_xy, &outer, &region_normal) <= probe
+            {
+                continue;
+            }
+            let av = ray_cast_inside_votes(topo, opposing_solid, probe_xy + np * probe)?;
+            let bv = ray_cast_inside_votes(topo, opposing_solid, probe_xy - np * probe)?;
+            decided = Some(if av < 2 && bv < 2 {
+                FaceClass::Outside
+            } else {
+                // Solid persists on a side: internal plane → keep (defer).
+                return Ok(None);
+            });
+            break;
+        }
+        return Ok(decided);
+    }
+    Ok(None)
+}
+
+/// Minimum distance from `p` to the closed polyline `poly` (edges + wrap).
+fn dist_to_polygon_boundary(p: Point3, poly: &[Point3], _normal: &Vec3) -> f64 {
+    let n = poly.len();
+    if n < 2 {
+        return f64::INFINITY;
+    }
+    let mut best = f64::INFINITY;
+    for i in 0..n {
+        let a = poly[i];
+        let b = poly[(i + 1) % n];
+        let ab = b - a;
+        let len2 = ab.dot(ab);
+        let t = if len2 > 1e-18 {
+            ((p - a).dot(ab) / len2).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let proj = a + ab * t;
+        best = best.min((p - proj).length());
+    }
+    best
+}
+
+/// Collect a planar sub-face's outer-wire vertices (3D), de-duplicated.
+fn sub_face_outer_vertices(
+    topo: &Topology,
+    face_id: brepkit_topology::face::FaceId,
+) -> Result<Option<Vec<Point3>>, AlgoError> {
+    let face = topo.face(face_id)?;
+    let wire = topo.wire(face.outer_wire())?;
+    let mut verts = Vec::new();
+    for oe in wire.edges() {
+        let e = topo.edge(oe.edge())?;
+        verts.push(topo.vertex(e.start())?.point());
+        verts.push(topo.vertex(e.end())?.point());
+    }
+    if verts.len() < 3 {
+        return Ok(None);
+    }
+    Ok(Some(verts))
 }

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -60,6 +60,27 @@ pub fn classify_ray_cast(
     solid: SolidId,
     point: Point3,
 ) -> Result<FaceClass, AlgoError> {
+    let inside_votes = ray_cast_inside_votes(topo, solid, point)?;
+    if inside_votes >= 2 {
+        Ok(FaceClass::Inside)
+    } else {
+        Ok(FaceClass::Outside)
+    }
+}
+
+/// Number of cardinal rays (of three) reporting an odd crossing count.
+///
+/// A point is classified inside when 2+ of the three rays agree; the raw count
+/// distinguishes a confident 3-vote verdict from a grazing 2-vote tie.
+///
+/// # Errors
+///
+/// Returns [`AlgoError::ClassificationFailed`] if no face geometry is collected.
+pub fn ray_cast_inside_votes(
+    topo: &Topology,
+    solid: SolidId,
+    point: Point3,
+) -> Result<u8, AlgoError> {
     let face_data = collect_face_geoms(topo, solid)?;
 
     if face_data.is_empty() {
@@ -85,12 +106,7 @@ pub fn classify_ray_cast(
             inside_votes += 1;
         }
     }
-
-    if inside_votes >= 2 {
-        Ok(FaceClass::Inside)
-    } else {
-        Ok(FaceClass::Outside)
-    }
+    Ok(inside_votes)
 }
 
 /// Sample a wire into a polygon by geometrically chaining its edges.
@@ -552,6 +568,63 @@ pub fn point_in_face_3d(point: Point3, polygon: &[Point3], normal: &Vec3) -> boo
 /// Compute `n . p` treating a `Point3` as a direction vector.
 fn dot_normal_point(n: Vec3, p: Point3) -> f64 {
     n.dot(Vec3::new(p.x(), p.y(), p.z()))
+}
+
+/// A planar face's sampled boundary: `(outer_polygon, hole_polygons, normal)`.
+pub type FacePolygons = (Vec<Point3>, Vec<Vec<Point3>>, Vec3);
+
+/// Build a planar face's boundary as `(outer_polygon, hole_polygons, normal)`.
+///
+/// The outer wire and inner wires are sampled into polylines (arcs densified
+/// via [`wire_polygon`]) so a rounded-corner cap's true region is captured.
+/// Returns `None` if the outer polygon is degenerate (< 3 points).
+///
+/// # Errors
+///
+/// Returns [`AlgoError`] on a topology lookup failure.
+pub fn planar_face_polygons(
+    topo: &Topology,
+    face_id: brepkit_topology::face::FaceId,
+) -> Result<Option<FacePolygons>, AlgoError> {
+    let face = topo.face(face_id)?;
+    let verts = wire_polygon(topo, face.outer_wire())?;
+    if verts.len() < 3 {
+        return Ok(None);
+    }
+    let raw_normal =
+        if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = face.surface() {
+            *normal
+        } else {
+            newell_normal(&verts)
+        };
+    let normal = if face.is_reversed() {
+        -raw_normal
+    } else {
+        raw_normal
+    };
+    let mut holes = Vec::with_capacity(face.inner_wires().len());
+    for &iw in face.inner_wires() {
+        let hole = wire_polygon(topo, iw)?;
+        if hole.len() >= 3 {
+            holes.push(hole);
+        }
+    }
+    Ok(Some((verts, holes, normal)))
+}
+
+/// Test whether `point` lies inside the planar face's region (inside the outer
+/// polygon and outside every hole), projecting along the face normal.
+#[must_use]
+pub fn point_in_planar_region(
+    point: Point3,
+    outer: &[Point3],
+    holes: &[Vec<Point3>],
+    normal: &Vec3,
+) -> bool {
+    if !point_in_face_3d(point, outer, normal) {
+        return false;
+    }
+    !holes.iter().any(|h| point_in_face_3d(point, h, normal))
 }
 
 /// Compute the solid-level AABB from boundary vertices.

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -576,7 +576,7 @@ pub type FacePolygons = (Vec<Point3>, Vec<Vec<Point3>>, Vec3);
 /// Build a planar face's boundary as `(outer_polygon, hole_polygons, normal)`.
 ///
 /// The outer wire and inner wires are sampled into polylines (arcs densified
-/// via [`wire_polygon`]) so a rounded-corner cap's true region is captured.
+/// via `wire_polygon`) so a rounded-corner cap's true region is captured.
 /// Returns `None` if the outer polygon is degenerate (< 3 points).
 ///
 /// # Errors

--- a/crates/io/tests/dovetail_cornerclip_intersect_inmem.rs
+++ b/crates/io/tests/dovetail_cornerclip_intersect_inmem.rs
@@ -144,33 +144,36 @@ fn dovetail_corner_clip_intersect_is_watertight() {
     );
 }
 
-/// Layers 1+2 regression guard (raw GFA, no mesh fallback).
+/// Layers 1+2 + Stage 2 regression guard (raw GFA, no mesh fallback).
 ///
 /// The full operations `boolean()` above still falls back to a mesh because the
-/// raw GFA result is not yet watertight (a residual free=4 splitter defect — the
-/// Layer-3 follow-up). But the two independently-correct fixes that LAND here —
+/// raw GFA result is not yet fully watertight (a residual free=1 splitter
+/// defect). But three independently-correct fixes LAND here:
 ///
-///   Layer 1: `algo::classifier::analytic` now rejects an invalid PIPE
-///            classifier for a fillet-corner cylinder/cone (so the slab's
-///            sub-faces classify via the geometrically-exact ray-cast path
-///            instead of being wrongly called Outside), and
-///   Layer 2: `operations::boolean::flatten_planar_nurbs_faces` now aligns the
+///   Layer 1: `algo::classifier::analytic` rejects an invalid PIPE classifier
+///            for a fillet-corner cylinder/cone (so the slab's sub-faces
+///            classify via the geometrically-exact ray-cast path instead of
+///            being wrongly called Outside),
+///   Layer 2: `operations::boolean::flatten_planar_nurbs_faces` aligns the
 ///            flattened plane normal to the NURBS du×dv normal (so a coincident
 ///            wall's same-domain pair comes out same-orientation instead of
-///            being discarded) —
+///            being discarded), and
+///   Stage 2: `algo::classifier::classify_coincident_coplanar` drops a planar
+///            sub-face that is a wholly-exterior wedge coincident with an
+///            opposing outer face (the clipped-away corner orphan), via 2D
+///            containment + a depth probe — instead of the grazing ray-cast
+///            that wrongly keeps it.
 ///
-/// take the raw GFA intersect from an open shell (free≈74, ~9 faces, most
-/// boundary dropped) to free=4 with EVERY pocket wall present and zero
-/// over-shared edges. This test asserts that improved, measurable state on the
-/// raw `gfa::boolean` result (operands flattened exactly as the operations
-/// boolean flattens them).
+/// Together they take the raw GFA intersect from an open shell (free≈74, ~9
+/// faces) to free=1 with EVERY pocket wall present and zero over-shared edges.
 ///
-/// The residual free=4 (two free legs on each of the z=0 / z=-5 caps at the
-/// rounded corner) is the Layer-3 face-splitter co-circular-arc defect; closing
-/// it un-ignores `dovetail_corner_clip_intersect_is_watertight` above. It is NOT
-/// fixed here (a ray-cast direction change regresses the honeycomb guard).
+/// The residual free=1 (one chord-vs-arc leg on the z=-5 cap at the rounded
+/// corner) is the co-circular-arc section-generation defect (the cap adopts a
+/// straight chord where the corner cylinder uses the arc) — NOT a
+/// classification problem. Closing it un-ignores
+/// `dovetail_corner_clip_intersect_is_watertight` above.
 #[test]
-fn cornerclip_intersect_raw_gfa_reaches_free_le_4() {
+fn cornerclip_intersect_raw_gfa_reaches_free_le_1() {
     use brepkit_algo::bop::BooleanOp as RawOp;
     use brepkit_algo::gfa;
     use brepkit_operations::boolean::flatten_planar_nurbs_faces_for_tests;
@@ -196,12 +199,17 @@ fn cornerclip_intersect_raw_gfa_reaches_free_le_4() {
         "raw GFA must stay free of over-shared edges; got {} faces, {free} free",
         faces.len()
     );
-    // Layers 1+2: open shell (free≈74) → free=4. The residual 4 is the Layer-3
-    // splitter follow-up; do NOT tighten to 0 here.
+    // Layers 1+2: open shell (free≈74) → free=4 (two corner-triangle orphans on
+    // each of the z=0 / z=-5 caps). Stage 2 (coincident-coplanar classification)
+    // drops both orphans by 2D containment → free=1. The residual 1 is a chord-
+    // vs-arc section-generation defect on the bottom cap (the
+    // co-circular-arc-split family), NOT a classification problem — do not tighten
+    // to 0 here.
     assert!(
-        free <= 4,
-        "Layers 1+2 should bring the raw GFA intersect to free<=4; got free={free} \
-         over {} faces (regression — a pipe-classifier or plane-sign bug returned)",
+        free <= 1,
+        "Layers 1+2 + Stage 2 should bring the raw GFA intersect to free<=1; got free={free} \
+         over {} faces (regression — a pipe-classifier, plane-sign, or coincident-cap \
+         classification bug returned)",
         faces.len()
     );
 


### PR DESCRIPTION
Second piece of the same-domain coincident-contact rework (after #944/#946). Adds a classification path for split sub-faces that lie in a plane **coincident with an opposing solid's planar face** — where the cardinal ray-cast grazes the shared plane and votes wrongly.

## Problem
In the dovetail corner-clip `Intersect(slab, round)`, the slab's square-corner cap region (square minus the rounded-corner arc) lies in the plane coincident with the round box's cap. Its interior sample sits *on* that plane, so ray-cast grazes the coincident cap + wall top-edges and votes Inside → the wedge is KEPT when an Intersect requires it DROPPED (its 2D region is outside the round box's rounded boundary). Result: orphan corner triangles → open shell → mesh fallback.

## Fix
New `classifier::classify_coincident_coplanar`, routed from `classify_sub_faces` before the ray-cast fallback, for planar sub-faces whose plane is coincident (sign-agnostic) with an opposing-solid planar face. It returns `Outside` only for a **wholly-exterior wedge** (all vertices outside-or-on the opposing region's 2D boundary, none strictly inside) **confirmed by a two-sided depth probe** at the wedge tip (nudged toward the wedge centroid to clear the grazed shared walls, stepped ±plane-normal): the opposing solid absent on both sides ⇒ the plane is the local outer boundary ⇒ drop.

**The hard part:** honeycomb-cut coincident-cap sub-faces share the *same* 2D-containment and ray-cast-vote signatures as the dovetail orphan — neither test alone separates them. Only the two-sided depth probe distinguishes the dovetail's *outer* cap (solid neither side → drop) from honeycomb's *internal/stacked* planes (solid one side → defer to ray-cast). **Ray-cast directions are unchanged** (changing them regresses honeycomb).

## Effect
- Dovetail cornerclip raw GFA: free 4 → 1, over 0 (guarded by `cornerclip_intersect_raw_gfa_reaches_free_le_1`). The residual free=1 is a different family (z=−5 cap chord-vs-arc, co-circular section gen) — separate follow-up; the watertight target stays `#[ignore]`d.
- This is the coincident-cap classifier the scoop's buried-cone corner also needs.

## Verification
`cargo nextest run --workspace` 2406 passed, 0 failed. `gridfinity_honeycomb_cut_inmem` 4/4, `gridfinity_d1_lip_ring_loft_cut` (wasm) 27/27 — the two regression-prone guards explicitly green. clippy + fmt + layer-boundaries clean.