### PR TITLE
fix(tessellate): honor angularTolerance in meshEdges/meshEdgesAll

### DIFF
--- a/crates/operations/src/tessellate/mesh_ops.rs
+++ b/crates/operations/src/tessellate/mesh_ops.rs
@@ -287,7 +287,13 @@ pub fn sample_solid_edges(
     solid: SolidId,
     deflection: f64,
 ) -> Result<EdgeLines, crate::OperationsError> {
-    sample_solid_edges_filtered(topo, solid, deflection, true)
+    sample_solid_edges_filtered(
+        topo,
+        solid,
+        deflection,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+        true,
+    )
 }
 
 /// Sample edges of a solid, optionally filtering out smooth (co-surface) edges.
@@ -296,6 +302,10 @@ pub fn sample_solid_edges(
 /// underlying geometric surface are omitted. These edges arise from boolean
 /// face-splitting and add wireframe clutter without representing visible creases.
 ///
+/// `angular_tol` caps the per-segment turn angle when discretizing curved
+/// edges (circles, ellipses, NURBS); a smaller value yields smoother polylines.
+/// Pass [`brepkit_math::chord::DEFAULT_ANGULAR_TOL`] for the historical default.
+///
 /// # Errors
 ///
 /// Returns an error if topology traversal or edge sampling fails.
@@ -303,6 +313,7 @@ pub fn sample_solid_edges_filtered(
     topo: &Topology,
     solid: SolidId,
     deflection: f64,
+    angular_tol: f64,
     filter_smooth: bool,
 ) -> Result<EdgeLines, crate::OperationsError> {
     let edges = brepkit_topology::explorer::solid_edges(topo, solid)?;
@@ -332,13 +343,7 @@ pub fn sample_solid_edges_filtered(
 
         result.offsets.push(result.positions.len());
         let edge = topo.edge(*edge_id)?;
-        let points = sample_edge(
-            topo,
-            edge,
-            deflection,
-            brepkit_math::chord::DEFAULT_ANGULAR_TOL,
-            false,
-        )?;
+        let points = sample_edge(topo, edge, deflection, angular_tol, false)?;
         result.positions.extend(points);
     }
 

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -865,11 +865,40 @@ fn sample_solid_edges_cylinder() {
         edge_lines.positions.len()
     );
 
-    let all_edges = sample_solid_edges_filtered(&topo, solid, 0.1, false).unwrap();
+    let all_edges = sample_solid_edges_filtered(
+        &topo,
+        solid,
+        0.1,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+        false,
+    )
+    .unwrap();
     assert!(
         all_edges.offsets.len() >= 3,
         "unfiltered cylinder should have at least 3 edges, got {}",
         all_edges.offsets.len()
+    );
+}
+
+#[test]
+fn sample_solid_edges_angular_tolerance_densifies_curves() {
+    // A tighter angular tolerance must refine curved edges (the cylinder's two
+    // circle rims) even with the linear deflection held fixed. Regression guard:
+    // meshEdges() previously hardcoded DEFAULT_ANGULAR_TOL, so the caller's
+    // angular tolerance had no effect (brepkit#952).
+    let mut topo = Topology::new();
+    let solid = crate::primitives::make_cylinder(&mut topo, 1.0, 3.0).unwrap();
+
+    // Loose linear deflection so the angular criterion governs sample density.
+    let deflection = 1.0;
+    let coarse = sample_solid_edges_filtered(&topo, solid, deflection, 0.5, false).unwrap();
+    let fine = sample_solid_edges_filtered(&topo, solid, deflection, 0.05, false).unwrap();
+
+    assert!(
+        fine.positions.len() > coarse.positions.len(),
+        "finer angular tolerance must add edge samples: coarse={}, fine={}",
+        coarse.positions.len(),
+        fine.positions.len()
     );
 }
 
@@ -900,7 +929,14 @@ fn sample_solid_edges_boolean_filters_coplanar() {
     .unwrap();
 
     let filtered = sample_solid_edges(&topo, fused, 0.1).unwrap();
-    let all = sample_solid_edges_filtered(&topo, fused, 0.1, false).unwrap();
+    let all = sample_solid_edges_filtered(
+        &topo,
+        fused,
+        0.1,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+        false,
+    )
+    .unwrap();
 
     // Exactly the three coplanar seams (top, bottom, front) must be dropped — a bare
     // `filtered < unfiltered` would still pass if the boolean output drifted to a

--- a/crates/wasm/src/bindings/tessellate.rs
+++ b/crates/wasm/src/bindings/tessellate.rs
@@ -228,11 +228,18 @@ impl BrepKernel {
         &self,
         solid: u32,
         deflection: f64,
+        angular_tolerance: Option<f64>,
     ) -> Result<crate::shapes::JsEdgeLines, JsError> {
         validate_positive(deflection, "deflection")?;
+        let angular_tol = resolve_angular_tol(angular_tolerance)?;
         let solid_id = self.resolve_solid(solid)?;
-        let edge_lines =
-            tessellate::sample_solid_edges_filtered(&self.topo, solid_id, deflection, true)?;
+        let edge_lines = tessellate::sample_solid_edges_filtered(
+            &self.topo,
+            solid_id,
+            deflection,
+            angular_tol,
+            true,
+        )?;
         Ok(edge_lines.into())
     }
 
@@ -245,11 +252,18 @@ impl BrepKernel {
         &self,
         solid: u32,
         deflection: f64,
+        angular_tolerance: Option<f64>,
     ) -> Result<crate::shapes::JsEdgeLines, JsError> {
         validate_positive(deflection, "deflection")?;
+        let angular_tol = resolve_angular_tol(angular_tolerance)?;
         let solid_id = self.resolve_solid(solid)?;
-        let edge_lines =
-            tessellate::sample_solid_edges_filtered(&self.topo, solid_id, deflection, false)?;
+        let edge_lines = tessellate::sample_solid_edges_filtered(
+            &self.topo,
+            solid_id,
+            deflection,
+            angular_tol,
+            false,
+        )?;
         Ok(edge_lines.into())
     }
 }
@@ -362,7 +376,7 @@ mod tests {
     #[test]
     fn mesh_edges_all_box_produces_nonempty_edge_lines() {
         let (k, solid) = kernel_with_box();
-        let edge_lines = k.mesh_edges_all(solid, 0.1).unwrap();
+        let edge_lines = k.mesh_edges_all(solid, 0.1, None).unwrap();
         assert!(edge_lines.edge_count() > 0, "expected edges, got 0");
         assert!(
             !edge_lines.positions().is_empty(),
@@ -374,7 +388,7 @@ mod tests {
     fn mesh_edges_all_box_has_twelve_edges() {
         // A box has exactly 12 edges.
         let (k, solid) = kernel_with_box();
-        let edge_lines = k.mesh_edges_all(solid, 0.1).unwrap();
+        let edge_lines = k.mesh_edges_all(solid, 0.1, None).unwrap();
         assert_eq!(
             edge_lines.edge_count(),
             12,


### PR DESCRIPTION
## Summary

Fixes #952 — `meshEdges()` / `meshEdgesAll()` ignored the caller's angular tolerance, producing coarse curved edge-lines.

The bindings accepted only `deflection`, and the internal `sample_solid_edges_filtered()` hardcoded `DEFAULT_ANGULAR_TOL` (0.35 rad ≈ 20°) into `sample_edge`. So curved feature edges (circle rims, ellipse, NURBS) discretized at a fixed coarse angular density regardless of what the caller asked — unlike the `tessellate_solid*` bindings, which already forward an `angular_tolerance`. Downstream (Gridfinity Layout Tool draft previews) this rendered rounded corners / lip rims / scoop arcs as chunky polylines vs OCCT's smooth curves at the same tolerance.

## Changes

- `meshEdges` / `meshEdgesAll` gain an optional `angular_tolerance: Option<f64>`, resolved via the existing `resolve_angular_tol` (the same helper `tessellate_solid*` use).
- `sample_solid_edges_filtered` gains an `angular_tol: f64` param, threaded to `sample_edge` instead of the hardcoded default. The `edge_sample_count`/`sample_edge` layer already accepted `angular_tol` — only the wrapper and bindings needed it.
- `sample_solid_edges` (convenience wrapper) passes `DEFAULT_ANGULAR_TOL`, preserving its behavior.

**Backward compatible:** omitting `angularTolerance` resolves to `DEFAULT_ANGULAR_TOL`, so existing callers and the JSON batch path are byte-unchanged.

## Tests

- New `sample_solid_edges_angular_tolerance_densifies_curves`: with linear `deflection` held fixed, a tighter `angular_tol` (0.5 → 0.05) must add edge samples on a cylinder's circle rims — the regression guard for #952.
- Updated the two existing `sample_solid_edges_filtered` call sites and the two `mesh_edges_all` binding tests for the new arg.
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, and tessellate/wasm tests all pass (63 + 4 green).

## Follow-up (separate, brepjs repo)

The brepjs `BrepkitAdapter` edge path + TS types need to forward `angularTolerance` to `meshEdges` so consumers like the Gridfinity tool can actually pass it; the wasm-bindgen signature is now in place to receive it.
