### PR TITLE
docs(readme): refresh performance table with 2026-06-23 benchmark run

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,18 @@ Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs
 
 | Operation                | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
 | ------------------------ | -------------- | ----------- | ------- | ---------------- |
-| fuse(box, box)           | 0.6 ms         | 45.1 ms     | 75x     | 117 µs           |
-| cut(box, cylinder)       | 61.4 ms        | 71.2 ms     | 1.2x    | 24.8 ms          |
-| intersect(box, sphere)   | 0.3 ms         | 63.9 ms     | 210x    | 97 µs            |
-| box + chamfer            | 0.1 ms         | 6.5 ms      | 65x     | 45 µs            |
-| box + fillet             | 0.3 ms         | 6.2 ms      | 21x     | 74 µs            |
-| multi-boolean (16 holes) | 7.6 ms         | 30.7 ms     | 4.0x    | 4.1 ms           |
-| mesh sphere (tol=0.01)   | 34.8 ms        | 50.0 ms     | 1.4x    | 1.5 ms           |
-| exportSTEP (×10)         | 0.8 ms         | 14.6 ms     | 18x     | —                |
+| fuse(box, box)           | 0.5 ms         | 43.3 ms     | 87x     | 122 µs           |
+| cut(box, cylinder)       | 59.6 ms        | 72.0 ms     | 1.2x    | 24.1 ms          |
+| intersect(box, sphere)   | 0.3 ms         | 62.6 ms     | 209x    | 104 µs           |
+| box + chamfer            | 0.1 ms         | 5.6 ms      | 56x     | 44 µs            |
+| box + fillet             | 0.3 ms         | 6.3 ms      | 21x     | 73 µs            |
+| multi-boolean (16 holes) | 7.0 ms         | 31.2 ms     | 4.5x    | 4.1 ms           |
+| mesh sphere (tol=0.01)   | 33.4 ms        | 49.7 ms     | 1.5x    | 1.5 ms           |
+| exportSTEP (×10)         | 1.1 ms         | 18.6 ms     | 17x     | —                |
 
 Booleans preserve analytic surfaces, keeping face counts low (72 vs ~7,000 for a 9-step compound boolean).
 
-> OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. Native benchmarks: `cargo bench -p brepkit-operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-06-14.
+> OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. Native benchmarks: `cargo bench -p brepkit-operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-06-23.
 
 ## Data Exchange
 

--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ Layered Cargo workspace. Crates depend only on the same or lower layers. Boundar
 
 Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs/tree/main/benchmarks) (5 iterations, Node.js, Linux x86_64). WASM is single-threaded; native benchmarks use criterion.
 
-| Operation                | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
-| ------------------------ | -------------- | ----------- | ------- | ---------------- |
-| fuse(box, box)           | 0.5 ms         | 43.3 ms     | 87x     | 122 µs           |
-| cut(box, cylinder)       | 59.6 ms        | 72.0 ms     | 1.2x    | 24.1 ms          |
-| intersect(box, sphere)   | 0.3 ms         | 62.6 ms     | 209x    | 104 µs           |
-| box + chamfer            | 0.1 ms         | 5.6 ms      | 56x     | 44 µs            |
-| box + fillet             | 0.3 ms         | 6.3 ms      | 21x     | 73 µs            |
-| multi-boolean (16 holes) | 7.0 ms         | 31.2 ms     | 4.5x    | 4.1 ms           |
-| mesh sphere (tol=0.01)   | 33.4 ms        | 49.7 ms     | 1.5x    | 1.5 ms           |
-| exportSTEP (×10)         | 1.1 ms         | 18.6 ms     | 17x     | —                |
+| Operation                    | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
+| ---------------------------- | -------------- | ----------- | ------- | ---------------- |
+| fuse(box, box) (×10)         | 0.5 ms         | 43.3 ms     | 87x     | 122 µs           |
+| cut(box, cylinder) (×10)     | 59.6 ms        | 72.0 ms     | 1.2x    | 24.1 ms          |
+| intersect(box, sphere) (×10) | 0.3 ms         | 62.6 ms     | 209x    | 104 µs           |
+| box + chamfer                | 0.1 ms         | 5.6 ms      | 56x     | 44 µs            |
+| box + fillet                 | 0.3 ms         | 6.3 ms      | 21x     | 73 µs            |
+| multi-boolean (16 holes)     | 7.0 ms         | 31.2 ms     | 4.5x    | 4.1 ms           |
+| mesh sphere (tol=0.01)       | 33.4 ms        | 49.7 ms     | 1.5x    | 1.5 ms           |
+| exportSTEP (×10)             | 1.1 ms         | 18.6 ms     | 17x     | —                |
 
 Booleans preserve analytic surfaces, keeping face counts low (72 vs ~7,000 for a 9-step compound boolean).
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs
 
 Booleans preserve analytic surfaces, keeping face counts low (72 vs ~7,000 for a 9-step compound boolean).
 
-> OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. Native benchmarks: `cargo bench -p brepkit-operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-06-23.
+> OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. Native benchmarks: `cargo bench -p brepkit-operations --bench cad_operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-06-23.
 
 ## Data Exchange
 


### PR DESCRIPTION
## What

Refreshes the README Performance table with a fresh benchmark run (brepkit-wasm 2.115.8, was 2.112.0-era numbers dated 2026-06-14 → now 2026-06-23).

- **WASM + OCCT (WASM) columns:** medians from a rerun of the [brepjs kernel-comparison suite](https://github.com/andymai/brepjs/pull/1584) across occt-wasm and brepkit.
- **brepkit (native) column:** `cargo bench -p brepkit-operations --bench cad_operations` criterion medians.
- Speedups recomputed against the fresh occt-wasm numbers.

| Operation | Δ |
| --- | --- |
| fuse | 75x → **87x** (occt-wasm 45.1→43.3 ms, brepkit 0.6→0.5 ms) |
| intersect | 210x → **209x** |
| box+chamfer | 65x → **56x** (occt-wasm 6.5→5.6 ms) |
| multi-boolean | 4.0x → **4.5x** |
| exportSTEP | 18x → **17x** |

Native numbers are essentially unchanged (stable Rust core): fuse 122 µs, cut 24.1 ms, intersect 104 µs, chamfer 44 µs, fillet 73 µs, multi-boolean 4.1 ms, mesh sphere 1.5 ms.

Docs-only change. Pairs with brepjs#1584 (the harness rerun + `latest.md`).