### PR TITLE
fix(measure): clamp volume tessellation deflection for accurate curved-face volume

### DIFF
--- a/crates/operations/src/extrude/tests.rs
+++ b/crates/operations/src/extrude/tests.rs
@@ -497,6 +497,79 @@ fn extrude_face_with_ccw_circle_hole_volume() {
 }
 
 #[test]
+fn extrude_analytic_circle_hole_volume_is_exact() {
+    use brepkit_math::curves::Circle3D;
+
+    // 20×20 plate with a true (analytic) circular hole, radius 3, extruded by
+    // 10. The hole is four quarter-circle arc edges (how a full circle is
+    // lifted), so the extruded wall is four CylindricalSurface faces and the
+    // volume is exactly box − cylinder = 4000 − π·9·10. Tessellation (and a
+    // chord-polygonised cap) mis-count the curved boundary by ~1-2%; exact
+    // divergence-theorem integration over the analytic faces must hit it.
+    let mut topo = Topology::new();
+
+    let outer_pts = vec![
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(20.0, 0.0, 0.0),
+        Point3::new(20.0, 20.0, 0.0),
+        Point3::new(0.0, 20.0, 0.0),
+    ];
+    let outer_wire =
+        brepkit_topology::builder::make_polygon_wire(&mut topo, &outer_pts, 1e-7).unwrap();
+
+    let (cx, cy, r) = (10.0, 10.0, 3.0);
+    let mk = |topo: &mut Topology, x: f64, y: f64| {
+        topo.add_vertex(Vertex::new(Point3::new(x, y, 0.0), 1e-7))
+    };
+    let p = [
+        mk(&mut topo, cx + r, cy),
+        mk(&mut topo, cx, cy + r),
+        mk(&mut topo, cx - r, cy),
+        mk(&mut topo, cx, cy - r),
+    ];
+    let circ = || {
+        Circle3D::with_axes(
+            Point3::new(cx, cy, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            r,
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+        )
+        .unwrap()
+    };
+    let arcs: Vec<_> = (0..4)
+        .map(|i| {
+            let e = topo.add_edge(Edge::new(p[i], p[(i + 1) % 4], EdgeCurve::Circle(circ())));
+            OrientedEdge::new(e, true)
+        })
+        .collect();
+    let inner_wire = topo.add_wire(Wire::new(arcs, true).unwrap());
+
+    let face = topo.add_face(Face::new(
+        outer_wire,
+        vec![inner_wire],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 10.0).unwrap();
+    // Pass a deliberately COARSE deflection: solid_volume must internally clamp
+    // it fine enough to integrate the curved hole wall accurately. Without that
+    // clamp the inscribed mesh under-counts the wall and the volume is ~1-2% off.
+    let vol = crate::measure::solid_volume(&topo, solid, 0.5).unwrap();
+
+    let expected = 20.0 * 20.0 * 10.0 - std::f64::consts::PI * r * r * 10.0;
+    let rel_err = (vol - expected).abs() / expected;
+    assert!(
+        rel_err < 1e-3,
+        "analytic circular-hole volume should be ~{expected:.4}, got {vol:.4} \
+             (rel_err={rel_err:.2e}) — coarse deflection must be clamped fine"
+    );
+}
+
+#[test]
 fn extrude_cw_profile_produces_correct_solid() {
     crate::test_helpers::assert_cw_profile_produces_valid_solid(
         |topo, face| extrude(topo, face, Vec3::new(0.0, 0.0, 1.0), 2.0).unwrap(),

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -235,11 +235,19 @@ fn find_cap_circle(topo: &Topology, face_id: FaceId) -> Option<(Point3, f64)> {
 /// Clamp the tessellation deflection used for volume so curved faces are
 /// sampled finely enough for an accurate boundary integral.
 ///
-/// A coarse preview deflection inscribes too few facets in a curved analytic
-/// face and under-counts its volume; volume is a precise query, so cap the
-/// deflection at a small fraction of the solid's bounding-box diagonal. Never
-/// coarsens a finer request, and falls back to `requested` if the extent
-/// cannot be determined.
+/// A coarse preview deflection inscribes too few facets in a curved face and
+/// under-counts its volume; volume is a precise query, so cap the deflection at
+/// a small fraction of the solid's extent, estimated as the diagonal of the
+/// **vertex** bounding box. (Curvature can bulge slightly beyond the vertices,
+/// so this under-estimates the true AABB — but only by making the cap
+/// conservatively finer, which is safe.) Never coarsens a finer request, and
+/// falls back to `requested` if the extent cannot be determined.
+///
+/// A solid-extent scale (rather than per-curved-face curvature radius) is used
+/// deliberately: it keeps the deflection consistent between a sub-solid and a
+/// boolean result containing it, preserving the `volume(A ∪ B) == volume(A) +
+/// volume(B)` invariant for coincident-contact fuses. A curvature-radius cap
+/// would tessellate a shared face differently in each context and break it.
 fn volume_tessellation_deflection(topo: &Topology, solid: SolidId, requested: f64) -> f64 {
     let Ok(pts) = collect_solid_vertex_points(topo, solid) else {
         return requested;
@@ -281,12 +289,12 @@ pub fn solid_volume(
         return Ok(v);
     }
 
-    // Volume integrates the boundary, so curved analytic faces must be
-    // tessellated finely or the inscribed mesh under-counts them (a swept
-    // cylinder or a box with a cylindrical hole measures ~1-2% low at a coarse
-    // preview deflection). Clamp the deflection to a small fraction of the
-    // solid's extent — never coarsening a finer request — so the volume is
-    // accurate regardless of the (preview-tuned) deflection the caller passes.
+    // Volume integrates the boundary, so curved faces must be tessellated
+    // finely or the inscribed mesh under-counts them (a swept cylinder or a
+    // box with a cylindrical hole measures ~1-2% low at a coarse preview
+    // deflection). Clamp the deflection to a small fraction of the solid's
+    // extent — never coarsening a finer request — so the volume is accurate
+    // regardless of the (preview-tuned) deflection the caller passes.
     let deflection = volume_tessellation_deflection(topo, solid, deflection);
 
     // Fast path: for solids made entirely of planar triangular faces

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -232,6 +232,33 @@ fn find_cap_circle(topo: &Topology, face_id: FaceId) -> Option<(Point3, f64)> {
     None
 }
 
+/// Clamp the tessellation deflection used for volume so curved faces are
+/// sampled finely enough for an accurate boundary integral.
+///
+/// A coarse preview deflection inscribes too few facets in a curved analytic
+/// face and under-counts its volume; volume is a precise query, so cap the
+/// deflection at a small fraction of the solid's bounding-box diagonal. Never
+/// coarsens a finer request, and falls back to `requested` if the extent
+/// cannot be determined.
+fn volume_tessellation_deflection(topo: &Topology, solid: SolidId, requested: f64) -> f64 {
+    let Ok(pts) = collect_solid_vertex_points(topo, solid) else {
+        return requested;
+    };
+    let Some((&first, rest)) = pts.split_first() else {
+        return requested;
+    };
+    let (mut lo, mut hi) = (first, first);
+    for p in rest {
+        lo = Point3::new(lo.x().min(p.x()), lo.y().min(p.y()), lo.z().min(p.z()));
+        hi = Point3::new(hi.x().max(p.x()), hi.y().max(p.y()), hi.z().max(p.z()));
+    }
+    let diag = (hi - lo).length();
+    if !diag.is_finite() || diag <= 0.0 {
+        return requested;
+    }
+    requested.min((diag * 5e-5).max(1e-9))
+}
+
 /// Compute the volume of a solid using the signed tetrahedra method
 /// (divergence theorem on a surface tessellation).
 ///
@@ -253,6 +280,14 @@ pub fn solid_volume(
     if let Some(v) = try_analytic_solid_volume(topo, solid) {
         return Ok(v);
     }
+
+    // Volume integrates the boundary, so curved analytic faces must be
+    // tessellated finely or the inscribed mesh under-counts them (a swept
+    // cylinder or a box with a cylindrical hole measures ~1-2% low at a coarse
+    // preview deflection). Clamp the deflection to a small fraction of the
+    // solid's extent — never coarsening a finer request — so the volume is
+    // accurate regardless of the (preview-tuned) deflection the caller passes.
+    let deflection = volume_tessellation_deflection(topo, solid, deflection);
 
     // Fast path: for solids made entirely of planar triangular faces
     // (e.g. mesh imports), compute volume directly from face geometry.

--- a/tests/golden/data/boolean_box_minus_cylinder.golden
+++ b/tests/golden/data/boolean_box_minus_cylinder.golden
@@ -1,7 +1,7 @@
 # box 10x10x10 minus cylinder r=3 h=10 at center
 vertices: 46
 triangles: 88
-volume: 719.159002
+volume: 717.292793
 bbox_min: (0.000000, 0.000000, 0.000000)
 bbox_max: (10.000000, 10.000000, 10.000000)
 com: (5.000000, 5.000000, 5.000000)


### PR DESCRIPTION
## Summary

`solid_volume` tessellated curved analytic faces at whatever deflection the caller passed. A coarse **preview** deflection (brepjs passes `DEFAULT_DEFLECTION = 0.01`) inscribes too few facets in a cylinder/cone/sphere face, so the inscribed mesh **under-counts** the volume by ~1-2% — e.g. a swept cylinder, or a box with a cylindrical hole.

Volume is a precise query, not a preview, so it now clamps the tessellation deflection to a small fraction of the solid's bounding-box diagonal (never coarsening a finer request). Primitive solids are unaffected — the exact analytic fast path (`try_analytic_solid_volume`) runs first.

## Why this surfaced

This fixes three pre-existing `--project brepkit` failures in brepjs (`sweeps a circle along a straight spine`, `extrudes a compound sketch with a hole`, `sweep with transition mode`) — all swept/holed cylinders whose volume measured ~2% low at the preview deflection. Because the clamp is internal to the kernel, **no brepjs change is needed**: every consumer's `volume()` call gets an accurate result once this releases.

## Evidence

- New regression test `extrude_analytic_circle_hole_volume_is_exact`: a 20×20 plate with a true (4-arc) circular hole, extruded into four `CylindricalSurface` walls. It passes a deliberately **coarse** deflection (0.5) and asserts the volume is within 1e-3 of the exact `box − π·r²·h` — only possible if the clamp engages.
- Golden `boolean_box_minus_cylinder` volume improves **719.159 → 717.293** (true **717.257**): a ~50× accuracy gain. The mesh (46v/88t) is unchanged, confirming the change is isolated to volume accuracy.

## Tested

`cargo test` for `check`, `operations`, `io`, `wasm` all green (incl. the boolean/shell volume suites); `cargo fmt` + `clippy` clean; pre-commit hook passed.