### PR TITLE
feat(algo): faithful shape-evolution via GFA face provenance

### DIFF
--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -124,6 +124,7 @@ pub(crate) fn select_faces(
             if keep {
                 Some(SelectedFace {
                     face_id: sf.face_id,
+                    source_face: sf.source_face,
                     reversed: op == BooleanOp::Cut && sf.rank == Rank::B,
                 })
             } else {
@@ -181,6 +182,7 @@ fn apply_sd_selection(
             if op == BooleanOp::Cut {
                 selected.push(SelectedFace {
                     face_id: sf_a.face_id,
+                    source_face: sf_a.source_face,
                     reversed: false,
                 });
                 continue;
@@ -215,6 +217,7 @@ fn apply_sd_selection(
             };
             selected.push(SelectedFace {
                 face_id: sub_faces[keep].face_id,
+                source_face: sub_faces[keep].source_face,
                 reversed: false,
             });
         } else {
@@ -242,6 +245,10 @@ fn apply_sd_selection(
 pub(crate) struct SelectedFace {
     /// The topology face to include.
     pub face_id: brepkit_topology::face::FaceId,
+    /// The original input face this selection derives from (shape-evolution
+    /// provenance). For a same-domain pair it is the kept representative's
+    /// source.
+    pub source_face: brepkit_topology::face::FaceId,
     /// Whether to reverse this face's orientation in the result.
     pub reversed: bool,
 }
@@ -277,8 +284,10 @@ mod tests {
 
     /// Helper to create a SubFace for testing.
     fn make_sub_face(topo: &mut Topology, rank: Rank, classification: FaceClass) -> SubFace {
+        let fid = dummy_face_id(topo);
         SubFace {
-            face_id: dummy_face_id(topo),
+            face_id: fid,
+            source_face: fid,
             classification,
             rank,
             interior_point: None,

--- a/crates/algo/src/builder/assemble.rs
+++ b/crates/algo/src/builder/assemble.rs
@@ -35,3 +35,19 @@ pub fn assemble_solid(
 ) -> Result<SolidId, AlgoError> {
     super::builder_solid::build_solid(topo, selected, cap_planes)
 }
+
+/// Like [`assemble_solid`], but also returns each result face's input-source
+/// provenance (store-local face IDs). See
+/// [`builder_solid::build_solid_with_origins`](super::builder_solid::build_solid_with_origins).
+///
+/// # Errors
+///
+/// Returns `AlgoError::AssemblyFailed` if no faces are selected or shell
+/// construction fails.
+pub fn assemble_solid_with_origins(
+    topo: &mut Topology,
+    selected: &[SelectedFace],
+    cap_planes: &[CapPlane],
+) -> Result<(SolidId, super::FaceProvenance), AlgoError> {
+    super::builder_solid::build_solid_with_origins(topo, selected, cap_planes)
+}

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -19,6 +19,8 @@ use brepkit_topology::shell::Shell;
 use brepkit_topology::solid::{Solid, SolidId};
 use brepkit_topology::wire::{OrientedEdge, WireId};
 
+use super::FaceProvenance;
+
 use crate::bop::SelectedFace;
 use crate::error::AlgoError;
 
@@ -41,6 +43,23 @@ pub fn build_solid(
     selected: &[SelectedFace],
     cap_planes: &[CapPlane],
 ) -> Result<SolidId, AlgoError> {
+    Ok(build_solid_with_origins(topo, selected, cap_planes)?.0)
+}
+
+/// Like [`build_solid`], but also returns each result face's provenance:
+/// `(result face, Some(input source face) | None for a synthesised face)`.
+///
+/// `face_origins` is maintained as a vector parallel to `face_ids` —
+/// the in-place edge/vertex rebuilds (`&mut [FaceId]`) replace faces by
+/// position so the parallel entries stay aligned; only the length-changing
+/// steps (sliver-retain, doubled-face removal, cap synthesis) sync it
+/// explicitly. This is purely additive: it never changes `face_ids`, so the
+/// assembled geometry is identical to [`build_solid`].
+pub fn build_solid_with_origins(
+    topo: &mut Topology,
+    selected: &[SelectedFace],
+    cap_planes: &[CapPlane],
+) -> Result<(SolidId, FaceProvenance), AlgoError> {
     if selected.is_empty() {
         return Err(AlgoError::AssemblyFailed("no faces selected".into()));
     }
@@ -48,6 +67,8 @@ pub fn build_solid(
 
     // Step 0: Create reversed copies for Cut B-faces
     let mut face_ids: Vec<FaceId> = Vec::with_capacity(selected.len());
+    // Provenance parallel to `face_ids`: the input face each entry derives from.
+    let mut sources: Vec<Option<FaceId>> = Vec::with_capacity(selected.len());
     for sf in selected {
         if sf.reversed {
             let face = topo.face(sf.face_id)?;
@@ -59,6 +80,7 @@ pub fn build_solid(
         } else {
             face_ids.push(sf.face_id);
         }
+        sources.push(Some(sf.source_face));
     }
 
     // Step 0a-pre: Drop degenerate sliver faces — all-Line outer wires with
@@ -67,7 +89,9 @@ pub fn build_solid(
     // Keeping them turns their edges non-manifold in an otherwise valid
     // result. Faces with curved edges are exempt (two half-circles bound a
     // real disc with only 2 vertices).
-    face_ids.retain(|&fid| !is_degenerate_line_sliver(topo, fid));
+    retain_aligned(&mut face_ids, &mut sources, |&fid| {
+        !is_degenerate_line_sliver(topo, fid)
+    });
     if face_ids.is_empty() {
         return Err(AlgoError::AssemblyFailed(
             "all faces degenerate slivers".into(),
@@ -117,7 +141,7 @@ pub fn build_solid(
     // both reference the same three edges). Keeping them makes every shared edge
     // incident to 3+ faces (non-manifold). Removing the whole group is sound:
     // coincident faces with one identical boundary cancel.
-    remove_doubled_faces(topo, &mut face_ids);
+    remove_doubled_faces(topo, &mut face_ids, &mut sources);
 
     if face_ids.is_empty() {
         return Err(AlgoError::AssemblyFailed(
@@ -131,7 +155,16 @@ pub fn build_solid(
     // discarded both faces of such an overlap, leaving a closed planar loop of
     // free edges where the larger face's overhang remainder should be. Cap each
     // such loop with a planar face that reuses the existing edges.
-    cap_partial_overlap_free_loops(topo, &mut face_ids, cap_planes)?;
+    cap_partial_overlap_free_loops(topo, &mut face_ids, &mut sources, cap_planes)?;
+
+    // Snapshot provenance now that face_ids / sources are final and parallel:
+    // map each result-bound face to the input face it derives from (None for a
+    // synthesised cap). Queried after assembly against the actual result faces.
+    let face_source: std::collections::HashMap<FaceId, Option<FaceId>> = face_ids
+        .iter()
+        .copied()
+        .zip(sources.iter().copied())
+        .collect();
 
     // Phase 2: Build shells via connectivity flood-fill
     let shells = perform_loops(topo, &face_ids)?;
@@ -150,7 +183,39 @@ pub fn build_solid(
     }
 
     // Phase 4: Assemble
-    assemble(topo, growth, holes)
+    let solid_id = assemble(topo, growth, holes)?;
+    let origins = brepkit_topology::explorer::solid_faces(topo, solid_id)
+        .map(|fids| {
+            fids.into_iter()
+                .map(|f| (f, face_source.get(&f).copied().flatten()))
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok((solid_id, origins))
+}
+
+/// Retain entries of `items` for which `keep` is true, dropping the same
+/// positions from the parallel `aligned` vector. The predicate runs exactly
+/// once per element (a precomputed mask), so side effects are not duplicated.
+fn retain_aligned<T, U>(
+    items: &mut Vec<T>,
+    aligned: &mut Vec<U>,
+    mut keep: impl FnMut(&T) -> bool,
+) {
+    debug_assert_eq!(items.len(), aligned.len());
+    let mask: Vec<bool> = items.iter().map(&mut keep).collect();
+    let mut idx = 0;
+    items.retain(|_| {
+        let k = mask.get(idx).copied().unwrap_or(true);
+        idx += 1;
+        k
+    });
+    let mut idx = 0;
+    aligned.retain(|_| {
+        let k = mask.get(idx).copied().unwrap_or(true);
+        idx += 1;
+        k
+    });
 }
 
 // ── Phase 1 ──────────────────────────────────────────────────────────
@@ -1969,7 +2034,11 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
 /// pair with one identical boundary always cancels, so dropping the whole group
 /// is sound. Inner wires are ignored — a doubled hole boundary is not a
 /// manifold defect on its own and removing the holed face would be unsafe.
-fn remove_doubled_faces(topo: &Topology, face_ids: &mut Vec<FaceId>) {
+fn remove_doubled_faces(
+    topo: &Topology,
+    face_ids: &mut Vec<FaceId>,
+    sources: &mut Vec<Option<FaceId>>,
+) {
     use brepkit_topology::edge::EdgeId;
     use brepkit_topology::wire::OrientedEdge;
 
@@ -2009,12 +2078,15 @@ fn remove_doubled_faces(topo: &Topology, face_ids: &mut Vec<FaceId>) {
         drop_idx.len()
     );
     let mut keep = Vec::with_capacity(face_ids.len() - drop_idx.len());
+    let mut keep_sources = Vec::with_capacity(keep.capacity());
     for (fi, &fid) in face_ids.iter().enumerate() {
         if !drop_idx.contains(&fi) {
             keep.push(fid);
+            keep_sources.push(sources.get(fi).copied().flatten());
         }
     }
     *face_ids = keep;
+    *sources = keep_sources;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -2129,6 +2201,7 @@ pub struct CapPlane {
 fn cap_partial_overlap_free_loops(
     topo: &mut Topology,
     face_ids: &mut Vec<FaceId>,
+    sources: &mut Vec<Option<FaceId>>,
     cap_planes: &[CapPlane],
 ) -> Result<(), AlgoError> {
     use brepkit_topology::edge::EdgeId;
@@ -2322,6 +2395,8 @@ fn cap_partial_overlap_free_loops(
     for f in new_faces {
         let fid = topo.add_face(f);
         face_ids.push(fid);
+        // A synthesised cap has no input source — it is a generated face.
+        sources.push(None);
     }
     Ok(())
 }

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -2079,7 +2079,9 @@ fn remove_doubled_faces(
     for (fi, &fid) in face_ids.iter().enumerate() {
         if !drop_idx.contains(&fi) {
             keep.push(fid);
-            keep_sources.push(sources.get(fi).copied().flatten());
+            // `sources` is parallel to `face_ids`, so `fi` is always in bounds;
+            // index directly (panics loudly in debug if the invariant breaks).
+            keep_sources.push(sources[fi]);
         }
     }
     *face_ids = keep;

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -184,13 +184,10 @@ pub fn build_solid_with_origins(
 
     // Phase 4: Assemble
     let solid_id = assemble(topo, growth, holes)?;
-    let origins = brepkit_topology::explorer::solid_faces(topo, solid_id)
-        .map(|fids| {
-            fids.into_iter()
-                .map(|f| (f, face_source.get(&f).copied().flatten()))
-                .collect()
-        })
-        .unwrap_or_default();
+    let origins = brepkit_topology::explorer::solid_faces(topo, solid_id)?
+        .into_iter()
+        .map(|f| (f, face_source.get(&f).copied().flatten()))
+        .collect();
     Ok((solid_id, origins))
 }
 

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -283,6 +283,7 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
                 rebuild_face_with_cb_edges(topo, expanded, &cb_qpair_edges, &vv_vertex_seed, tol);
             sub_faces.push(SubFace {
                 face_id: rebuilt.unwrap_or(expanded),
+                source_face: face_id,
                 classification: FaceClass::Unknown,
                 rank,
                 interior_point: None,
@@ -311,6 +312,7 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
                 rebuild_face_with_edge_images(topo, face_id, edge_images).unwrap_or(face_id);
             sub_faces.push(SubFace {
                 face_id: expanded,
+                source_face: face_id,
                 classification: FaceClass::Unknown,
                 rank,
                 interior_point: None,
@@ -342,6 +344,7 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
                 rebuild_face_with_edge_images(topo, face_id, edge_images).unwrap_or(face_id);
             sub_faces.push(SubFace {
                 face_id: expanded,
+                source_face: face_id,
                 classification: FaceClass::Unknown,
                 rank,
                 interior_point: None,
@@ -412,6 +415,7 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
 
             sub_faces.push(SubFace {
                 face_id: new_face_id.unwrap_or(face_id),
+                source_face: face_id,
                 classification: FaceClass::Unknown,
                 rank,
                 interior_point: Some(pt),

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -42,11 +42,18 @@ use crate::classifier;
 use crate::ds::{GfaArena, Rank};
 use crate::error::AlgoError;
 
+/// Provenance of result faces: for each face, the input source face it was
+/// derived from, or `None` for a synthesised face. Face IDs are store-local.
+pub type FaceProvenance = Vec<(FaceId, Option<FaceId>)>;
+
 /// A sub-face produced by the Builder after splitting.
 #[derive(Debug, Clone)]
 pub struct SubFace {
     /// The face entity in topology (same as parent if no split occurred).
     pub face_id: FaceId,
+    /// The original input face this sub-face was derived from. Provenance for
+    /// shape evolution — every sub-face traces back to one input argument face.
+    pub source_face: FaceId,
     /// Classification relative to the opposing solid.
     pub classification: FaceClass,
     /// Which boolean argument this face came from.
@@ -138,6 +145,26 @@ impl Builder {
         let cap_planes = self.partial_overlap_cap_planes(&selected);
         let solid_id = assemble::assemble_solid(&mut self.topo, &selected, &cap_planes)?;
         Ok((self.topo, solid_id))
+    }
+
+    /// Like [`Builder::build_result`], but also returns the provenance of each
+    /// result face: `(result face, Some(input source face) | None)`. The source
+    /// face IDs are in this builder's (store-local) topology — callers crossing
+    /// the GFA shape-store boundary must translate them to caller IDs.
+    pub fn build_result_with_origins(
+        mut self,
+        op: BooleanOp,
+    ) -> Result<(Topology, SolidId, FaceProvenance), AlgoError> {
+        let selected = bop::select_faces(
+            &self.sub_faces,
+            op,
+            &self.sd_pairs,
+            &self.sd_within_rank_dups,
+        );
+        let cap_planes = self.partial_overlap_cap_planes(&selected);
+        let (solid_id, origins) =
+            assemble::assemble_solid_with_origins(&mut self.topo, &selected, &cap_planes)?;
+        Ok((self.topo, solid_id, origins))
     }
 
     /// Candidate cap planes for partial coplanar same-domain overlaps.

--- a/crates/algo/src/builder/same_domain/tests.rs
+++ b/crates/algo/src/builder/same_domain/tests.rs
@@ -27,6 +27,7 @@ fn rect_sub_face(
     let face_id = make_face_from_wire(topo, wire).unwrap();
     SubFace {
         face_id,
+        source_face: face_id,
         classification: FaceClass::Unknown,
         rank,
         interior_point: Some(interior),
@@ -667,6 +668,7 @@ fn cylinder_patch(
     let zm = 0.5 * (z0 + z1);
     SubFace {
         face_id,
+        source_face: face_id,
         classification: FaceClass::Unknown,
         rank,
         interior_point: Some(pt(um, zm)),
@@ -738,6 +740,7 @@ fn cone_patch(
     let zm = 0.5 * (z0 + z1);
     SubFace {
         face_id,
+        source_face: face_id,
         classification: FaceClass::Unknown,
         rank,
         interior_point: Some(pt(um, zm)),

--- a/crates/algo/src/ds/shape_store.rs
+++ b/crates/algo/src/ds/shape_store.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use brepkit_topology::Topology;
 use brepkit_topology::edge::{Edge, EdgeId};
-use brepkit_topology::face::Face;
+use brepkit_topology::face::{Face, FaceId};
 use brepkit_topology::shell::Shell;
 use brepkit_topology::solid::{Solid, SolidId};
 use brepkit_topology::vertex::{Vertex, VertexId};
@@ -29,6 +29,9 @@ pub struct GfaShapeStore {
     pub solid_a: SolidId,
     /// Store-local SolidId for the deep-copied solid B.
     pub solid_b: SolidId,
+    /// Maps a store-local input face index back to the caller's original face
+    /// index, for both operands — shape-evolution provenance across the copy.
+    pub input_face_to_caller: HashMap<usize, usize>,
 }
 
 impl GfaShapeStore {
@@ -40,13 +43,21 @@ impl GfaShapeStore {
     pub fn new(source: &Topology, orig_a: SolidId, orig_b: SolidId) -> Result<Self, AlgoError> {
         let mut topo = Topology::default();
 
-        let solid_a = deep_copy_solid(source, &mut topo, orig_a)?;
-        let solid_b = deep_copy_solid(source, &mut topo, orig_b)?;
+        let (solid_a, map_a) = deep_copy_solid(source, &mut topo, orig_a)?;
+        let (solid_b, map_b) = deep_copy_solid(source, &mut topo, orig_b)?;
+
+        // Invert the caller-index -> store-face maps into store-face-index ->
+        // caller-face-index so a store input face resolves to its caller origin.
+        let mut input_face_to_caller = HashMap::new();
+        for (caller_idx, store_face) in map_a.into_iter().chain(map_b) {
+            input_face_to_caller.insert(store_face.index(), caller_idx);
+        }
 
         Ok(Self {
             topo,
             solid_a,
             solid_b,
+            input_face_to_caller,
         })
     }
 
@@ -63,6 +74,21 @@ impl GfaShapeStore {
         target: &mut Topology,
         solid_id: SolidId,
     ) -> Result<SolidId, AlgoError> {
+        Ok(deep_copy_solid(&self.topo, target, solid_id)?.0)
+    }
+
+    /// Like [`Self::export_solid`], but also returns the map from each store
+    /// result-face index to the new caller face it was copied to, for
+    /// translating shape-evolution provenance out of the store.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AlgoError`] if any topology lookup fails.
+    pub fn export_solid_with_face_map(
+        &self,
+        target: &mut Topology,
+        solid_id: SolidId,
+    ) -> Result<(SolidId, HashMap<usize, FaceId>), AlgoError> {
         deep_copy_solid(&self.topo, target, solid_id)
     }
 }
@@ -78,7 +104,7 @@ fn deep_copy_solid(
     source: &Topology,
     target: &mut Topology,
     solid_id: SolidId,
-) -> Result<SolidId, AlgoError> {
+) -> Result<(SolidId, HashMap<usize, FaceId>), AlgoError> {
     // ── Snapshot phase ──────────────────────────────────────────────
 
     let solid = source.solid(solid_id)?;
@@ -107,6 +133,7 @@ fn deep_copy_solid(
         closed: bool,
     }
     struct FaceSnap {
+        old_index: usize,
         outer_wire_index: usize,
         inner_wire_indices: Vec<usize>,
         surface: brepkit_topology::face::FaceSurface,
@@ -185,6 +212,7 @@ fn deep_copy_solid(
             }
 
             face_snaps.push(FaceSnap {
+                old_index: face_id.index(),
                 outer_wire_index,
                 inner_wire_indices,
                 surface,
@@ -228,6 +256,8 @@ fn deep_copy_solid(
     }
 
     let mut new_shell_ids = Vec::new();
+    // Provenance: source face index -> the new face it was copied to.
+    let mut face_map: HashMap<usize, FaceId> = HashMap::new();
     for ssnap in &shell_snaps {
         let mut new_face_ids = Vec::new();
         for fsnap in &ssnap.faces {
@@ -241,7 +271,9 @@ fn deep_copy_solid(
             if fsnap.reversed {
                 new_face.set_reversed(true);
             }
-            new_face_ids.push(target.add_face(new_face));
+            let new_fid = target.add_face(new_face);
+            face_map.insert(fsnap.old_index, new_fid);
+            new_face_ids.push(new_fid);
         }
         let new_shell = Shell::new(new_face_ids)?;
         new_shell_ids.push(target.add_shell(new_shell));
@@ -252,7 +284,7 @@ fn deep_copy_solid(
         .ok_or_else(|| AlgoError::AssemblyFailed("solid has no shells to copy".into()))?;
     let new_inner: Vec<_> = new_shell_ids[1..].to_vec();
 
-    Ok(target.add_solid(Solid::new(new_outer, new_inner)))
+    Ok((target.add_solid(Solid::new(new_outer, new_inner)), face_map))
 }
 
 #[cfg(test)]

--- a/crates/algo/src/gfa.rs
+++ b/crates/algo/src/gfa.rs
@@ -145,16 +145,25 @@ pub fn boolean_with_face_origins(
 
     let (result, export_map) = store.export_solid_with_face_map(topo, store_result)?;
 
-    // Translate store-space provenance to caller-space face indices.
-    let origins = store_origins
-        .into_iter()
-        .filter_map(|(store_out, store_src)| {
-            let caller_out = export_map.get(&store_out.index())?.index();
-            let caller_src =
-                store_src.and_then(|s| store.input_face_to_caller.get(&s.index()).copied());
-            Some((caller_out, caller_src))
-        })
-        .collect();
+    // Translate store-space provenance to caller-space face indices. The export
+    // map is total over result faces, so a miss is a real provenance desync and
+    // is surfaced as an error rather than silently dropped (which would mark a
+    // real input as `deleted`). A missing input source is `None` by design — a
+    // synthesised face with no input origin.
+    let mut origins = Vec::with_capacity(store_origins.len());
+    for (store_out, store_src) in store_origins {
+        let caller_out = export_map
+            .get(&store_out.index())
+            .ok_or_else(|| {
+                AlgoError::AssemblyFailed(
+                    "result face missing from export map (provenance desync)".into(),
+                )
+            })?
+            .index();
+        let caller_src =
+            store_src.and_then(|s| store.input_face_to_caller.get(&s.index()).copied());
+        origins.push((caller_out, caller_src));
+    }
 
     Ok((result, origins))
 }

--- a/crates/algo/src/gfa.rs
+++ b/crates/algo/src/gfa.rs
@@ -13,6 +13,10 @@ use crate::ds::GfaArena;
 use crate::error::AlgoError;
 use crate::pave_filler;
 
+/// Result-face provenance in caller-topology face indices:
+/// `(result face index, Some(input face index) | None)`.
+pub type FaceOriginIndices = Vec<(usize, Option<usize>)>;
+
 /// Run the complete GFA boolean operation with default tolerance.
 ///
 /// This is the single entry point for boolean operations via the GFA.
@@ -96,4 +100,61 @@ pub fn boolean_with_tolerance(
     let result = store.export_solid(topo, store_result)?;
 
     Ok(result)
+}
+
+/// Run a GFA boolean, also returning each result face's provenance.
+///
+/// Provenance is `(result face index, Some(input face index) | None)` in the
+/// **caller's** topology — the basis for faithful shape-evolution tracking.
+/// Indices are `FaceId::index()` values (matching the convention the evolution
+/// map uses). `None` marks a synthesised face with no input origin. Unlike
+/// [`boolean`], there is no identical-operand fast path; callers handle `A == B`.
+///
+/// # Errors
+///
+/// Returns [`AlgoError`] if any GFA stage fails.
+pub fn boolean_with_face_origins(
+    topo: &mut Topology,
+    op: BooleanOp,
+    solid_a: SolidId,
+    solid_b: SolidId,
+) -> Result<(SolidId, FaceOriginIndices), AlgoError> {
+    let tol = Tolerance::default();
+    let mut store = crate::ds::GfaShapeStore::new(topo, solid_a, solid_b)?;
+
+    let mut arena = GfaArena::new();
+    pave_filler::run_pave_filler(
+        &mut store.topo,
+        store.solid_a,
+        store.solid_b,
+        tol,
+        &mut arena,
+    )?;
+
+    let mut builder = Builder::with_tolerance(
+        std::mem::take(&mut store.topo),
+        arena,
+        store.solid_a,
+        store.solid_b,
+        tol,
+    );
+    builder.perform()?;
+
+    let (store_topo, store_result, store_origins) = builder.build_result_with_origins(op)?;
+    store.topo = store_topo;
+
+    let (result, export_map) = store.export_solid_with_face_map(topo, store_result)?;
+
+    // Translate store-space provenance to caller-space face indices.
+    let origins = store_origins
+        .into_iter()
+        .filter_map(|(store_out, store_src)| {
+            let caller_out = export_map.get(&store_out.index())?.index();
+            let caller_src =
+                store_src.and_then(|s| store.input_face_to_caller.get(&s.index()).copied());
+            Some((caller_out, caller_src))
+        })
+        .collect();
+
+    Ok((result, origins))
 }

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -893,12 +893,15 @@ pub fn compound_cut(
 /// Perform a boolean operation and return an [`crate::evolution::EvolutionMap`]
 /// tracking face provenance.
 ///
-/// Uses faithful provenance from the GFA builder — each result face records the
-/// input face it was split/derived from (`brepkit_algo::gfa::boolean_with_face_origins`).
-/// For operands handled by a non-GFA path (identical solids, AABB/containment
-/// fast paths), it falls back to the geometry heuristic (normal + centroid
-/// similarity). Unmatched input faces are classified as "deleted"; synthesised
-/// result faces with no input origin are left unattributed.
+/// Prefers **faithful** provenance from the GFA builder — each result face
+/// records the input face it was split/derived from
+/// (`brepkit_algo::gfa::boolean_with_face_origins`). Because that path runs the
+/// GFA directly, it can take a different route than [`boolean`] (which
+/// short-circuits some cases via AABB/containment fast paths), so its result is
+/// validated; on a GFA error or an invalid result — and for identical operands
+/// — it falls back to [`boolean`] with the geometry heuristic (normal +
+/// centroid). Either way, unmatched input faces are classified as "deleted";
+/// synthesised result faces with no input origin are left unattributed.
 ///
 /// # Errors
 ///
@@ -937,20 +940,26 @@ pub fn boolean_with_evolution(
             let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
             let _ = crate::heal::remove_wire_spurs(topo, result)?;
 
-            let mut evo = crate::evolution::EvolutionMap::new();
-            let mut sourced: std::collections::HashSet<usize> = std::collections::HashSet::new();
-            for (out_idx, src) in origins {
-                if let Some(in_idx) = src {
-                    evo.add_modified(in_idx, out_idx);
-                    sourced.insert(in_idx);
+            // Trust the faithful path only if its result is valid; otherwise
+            // fall through to boolean()'s full pipeline (fast paths + mesh
+            // fallback + validation), matching boolean()'s contract.
+            if validate_boolean_result(topo, result).is_ok() {
+                let mut evo = crate::evolution::EvolutionMap::new();
+                let mut sourced: std::collections::HashSet<usize> =
+                    std::collections::HashSet::new();
+                for (out_idx, src) in origins {
+                    if let Some(in_idx) = src {
+                        evo.add_modified(in_idx, out_idx);
+                        sourced.insert(in_idx);
+                    }
                 }
-            }
-            for in_idx in input_indices {
-                if !sourced.contains(&in_idx) {
-                    evo.add_deleted(in_idx);
+                for in_idx in input_indices {
+                    if !sourced.contains(&in_idx) {
+                        evo.add_deleted(in_idx);
+                    }
                 }
+                return Ok((result, evo));
             }
-            return Ok((result, evo));
         }
     }
 

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -890,13 +890,15 @@ pub fn compound_cut(
     Ok(result)
 }
 
-/// Perform a boolean operation and return an [`crate::evolution::EvolutionMap`] tracking face
-/// provenance.
+/// Perform a boolean operation and return an [`crate::evolution::EvolutionMap`]
+/// tracking face provenance.
 ///
-/// This wraps [`boolean`] and uses a heuristic (normal + centroid similarity)
-/// to match output faces back to their input faces. Faces whose best match
-/// score exceeds the similarity threshold are classified as "modified";
-/// unmatched input faces are classified as "deleted".
+/// Uses faithful provenance from the GFA builder — each result face records the
+/// input face it was split/derived from (`brepkit_algo::gfa::boolean_with_face_origins`).
+/// For operands handled by a non-GFA path (identical solids, AABB/containment
+/// fast paths), it falls back to the geometry heuristic (normal + centroid
+/// similarity). Unmatched input faces are classified as "deleted"; synthesised
+/// result faces with no input origin are left unattributed.
 ///
 /// # Errors
 ///
@@ -907,7 +909,52 @@ pub fn boolean_with_evolution(
     a: SolidId,
     b: SolidId,
 ) -> Result<(SolidId, crate::evolution::EvolutionMap), crate::OperationsError> {
-    // Collect input face normals + centroids before the operation mutates topology.
+    use brepkit_topology::explorer::solid_faces;
+
+    // Faithful path: the GFA reports each result face's true input source.
+    // Identical operands take a non-GFA fast path, so skip them here.
+    if a != b {
+        let input_indices: Vec<usize> = solid_faces(topo, a)?
+            .into_iter()
+            .chain(solid_faces(topo, b)?)
+            .map(brepkit_topology::arena::Id::index)
+            .collect();
+        let algo_op = match op {
+            BooleanOp::Fuse => brepkit_algo::bop::BooleanOp::Fuse,
+            BooleanOp::Cut => brepkit_algo::bop::BooleanOp::Cut,
+            BooleanOp::Intersect => brepkit_algo::bop::BooleanOp::Intersect,
+        };
+        if let Ok((result, origins)) =
+            brepkit_algo::gfa::boolean_with_face_origins(topo, algo_op, a, b)
+        {
+            // Apply the face-id-preserving result heals so the evolution result
+            // is as correct as the standard boolean (manifold, no #801 wire
+            // spurs). These rewrite wires in place, so the provenance — keyed by
+            // face ID — survives. `unify_faces` is intentionally NOT run here:
+            // it merges coplanar faces into new entities, discarding the
+            // per-face provenance this path exists to track.
+            let tol = brepkit_math::tolerance::Tolerance::default();
+            let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
+            let _ = crate::heal::remove_wire_spurs(topo, result)?;
+
+            let mut evo = crate::evolution::EvolutionMap::new();
+            let mut sourced: std::collections::HashSet<usize> = std::collections::HashSet::new();
+            for (out_idx, src) in origins {
+                if let Some(in_idx) = src {
+                    evo.add_modified(in_idx, out_idx);
+                    sourced.insert(in_idx);
+                }
+            }
+            for in_idx in input_indices {
+                if !sourced.contains(&in_idx) {
+                    evo.add_deleted(in_idx);
+                }
+            }
+            return Ok((result, evo));
+        }
+    }
+
+    // Fallback: geometry heuristic over the standard boolean result.
     let input_faces_a = collect_face_signatures(topo, a)?;
     let input_faces_b = collect_face_signatures(topo, b)?;
 

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -936,14 +936,17 @@ pub fn boolean_with_evolution(
             // face ID — survives. `unify_faces` is intentionally NOT run here:
             // it merges coplanar faces into new entities, discarding the
             // per-face provenance this path exists to track.
+            // A heal failure here is not fatal: fall through to boolean()'s
+            // full pipeline rather than propagating (the result solid stays as
+            // orphaned topology, which is harmless in the arena).
             let tol = brepkit_math::tolerance::Tolerance::default();
-            let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
-            let _ = crate::heal::remove_wire_spurs(topo, result)?;
+            let healed_ok = crate::heal::remove_degenerate_edges(topo, result, tol.linear).is_ok()
+                && crate::heal::remove_wire_spurs(topo, result).is_ok();
 
             // Trust the faithful path only if its result is valid; otherwise
             // fall through to boolean()'s full pipeline (fast paths + mesh
             // fallback + validation), matching boolean()'s contract.
-            if validate_boolean_result(topo, result).is_ok() {
+            if healed_ok && validate_boolean_result(topo, result).is_ok() {
                 let mut evo = crate::evolution::EvolutionMap::new();
                 let mut sourced: std::collections::HashSet<usize> =
                     std::collections::HashSet::new();
@@ -963,7 +966,10 @@ pub fn boolean_with_evolution(
         }
     }
 
-    // Fallback: geometry heuristic over the standard boolean result.
+    // Fallback: geometry heuristic over the standard boolean result. Reached
+    // for identical operands, a GFA error, or a GFA result that failed
+    // validation — the EvolutionMap is then approximate, not faithful.
+    log::debug!("boolean_with_evolution: faithful GFA provenance unavailable, using heuristic");
     let input_faces_a = collect_face_signatures(topo, a)?;
     let input_faces_b = collect_face_signatures(topo, b)?;
 

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -596,6 +596,65 @@ fn fuse_overlapping_3d() {
 }
 
 #[test]
+fn fuse_evolution_is_faithful() {
+    use brepkit_topology::explorer::solid_faces;
+    use std::collections::HashSet;
+
+    let mut topo = Topology::new();
+    let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut topo, 0.5, 0.5, 0.5);
+
+    // Partial overlap → not a fast-path box; the fuse runs through the GFA, so
+    // provenance is the faithful builder map, not the geometry heuristic.
+    let input_set: HashSet<usize> = solid_faces(&topo, a)
+        .unwrap()
+        .into_iter()
+        .chain(solid_faces(&topo, b).unwrap())
+        .map(brepkit_topology::arena::Id::index)
+        .collect();
+    assert_eq!(
+        input_set.len(),
+        12,
+        "two cubes have 12 distinct input faces"
+    );
+
+    let (result, evo) =
+        crate::boolean::boolean_with_evolution(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+
+    let result_faces: HashSet<usize> = solid_faces(&topo, result)
+        .unwrap()
+        .into_iter()
+        .map(brepkit_topology::arena::Id::index)
+        .collect();
+
+    // Every modified mapping is input-face → result-face, both real entities.
+    assert!(!evo.modified.is_empty(), "fuse must track modified faces");
+    let mut attributed: HashSet<usize> = HashSet::new();
+    for (&in_idx, outs) in &evo.modified {
+        assert!(
+            input_set.contains(&in_idx),
+            "modified key {in_idx} is not one of the input faces"
+        );
+        for &out in outs {
+            assert!(
+                result_faces.contains(&out),
+                "modified output {out} is not a face of the result"
+            );
+            attributed.insert(out);
+        }
+    }
+    for &d in &evo.deleted {
+        assert!(input_set.contains(&d), "deleted {d} is not an input face");
+    }
+    // Faithful tracking attributes every result face to an input here — the
+    // overlapping cubes produce no synthesised (cap) faces.
+    assert_eq!(
+        attributed, result_faces,
+        "every result face should trace to an input face"
+    );
+}
+
+#[test]
 fn intersect_overlapping_3d() {
     let mut topo = Topology::new();
     let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);


### PR DESCRIPTION
## Summary

Implements the one genuinely-remaining item in #863: **faithful shape-evolution** (persistent face identity through booleans), replacing the geometry heuristic that left the ~12 brepjs `shapeRef`/`shapeRefIntegration` tests skipped.

`boolean_with_evolution` previously matched each output face back to an input by **normal + centroid similarity** — fine for a single fillet, but unable to resolve ambiguous multi-step splits. Now each result face carries its **true input source**, threaded through the GFA.

## How the provenance flows

```
fill_images_faces: SubFace.source_face = the input face being split
        │
BOP select_faces: SelectedFace.source_face forwarded (kept rep for SD pairs)
        │
build_solid_with_origins: (result face → source) pairs, a vector PARALLEL to
        face_ids — in-place edge/vertex rebuilds preserve position; only the
        length-changing steps (sliver retain, doubled-face removal, cap
        synthesis) sync explicitly. **Purely additive: face_ids handling is
        unchanged, so the assembled geometry is identical.**
        │
GfaShapeStore (deep_copy_solid now returns its source→target face map):
        input remap retained + result remap exported
        │
gfa::boolean_with_face_origins: translates store-local provenance to CALLER
        face indices (the convention EvolutionMap uses)
        │
boolean_with_evolution: builds EvolutionMap (modified / deleted)
```

The faithful path applies the **id-preserving** result heals (`remove_degenerate_edges` + `remove_wire_spurs` for #801) so the result is as correct as the standard boolean; `unify_faces` is intentionally skipped — it merges coplanar faces into new entities, discarding per-face provenance. Non-GFA paths (identical operands) fall back to the geometry heuristic.

## Validation

New `fuse_evolution_is_faithful`: an overlapping two-cube fuse — **every** result face traces to a real input face (no geometry guessing). Full `algo`, `operations`, `io`, `wasm` suites green; `clippy`/`fmt` clean.

The wasm `fuseWithEvolution` / `cutWithEvolution` / `intersectWithEvolution` bindings pick this up automatically. The brepjs `shapeRef` un-skip + the stale `kernelDivergences.ts` reason refresh follow once `brepkit-wasm` releases and re-syncs.

## Known follow-ups (documented on #863)

- Same-domain merges record the kept representative's source only (the merged-away operand maps to `deleted`); dual-origin tracking is a refinement.
- A face synthesised with no input (rare partial-overlap cap) is left unattributed (`None`).

Refs #863