### PR TITLE
fix(operations): exact analytic volume for swept circles and extruded circular holes

### DIFF
--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -105,6 +105,39 @@ fn curve_is_analytic_circle(curve: &EdgeCurve) -> bool {
     }
 }
 
+/// Whether an inner (hole) wire is a single closed *circle* — a true circle or
+/// a rational NURBS recognized as one. This is the only hole the extrude path
+/// turns into a single exact cylinder wall (with a known inward orientation).
+///
+/// Ellipses and generic closed curves are deliberately excluded: their
+/// single-face pass-through wall is a ruled NURBS whose orientation can't be
+/// derived from the degenerate `start==end` endpoints, so they keep the
+/// chord-split path, which stays correct (if faceted).
+fn inner_wire_is_single_circle(topo: &Topology, wire_id: WireId) -> bool {
+    let Ok(wire) = topo.wire(wire_id) else {
+        return false;
+    };
+    let edges = wire.edges();
+    if edges.len() != 1 {
+        return false;
+    }
+    let Ok(edge) = topo.edge(edges[0].edge()) else {
+        return false;
+    };
+    if edge.start() != edge.end() {
+        return false; // not a closed loop
+    }
+    let tol = Tolerance::new().linear;
+    match edge.curve() {
+        EdgeCurve::Circle(_) => true,
+        EdgeCurve::NurbsCurve(nc) => matches!(
+            brepkit_geometry::convert::recognize_curve(nc, tol * 100.0),
+            brepkit_geometry::convert::RecognizedCurve::Circle { .. }
+        ),
+        _ => false,
+    }
+}
+
 /// Compute the number of segments for splitting a closed edge based on
 /// the chord-height deviation bound.
 ///
@@ -264,26 +297,6 @@ fn winding_sample_points(
 /// Returns: `(input_verts, input_positions, input_oriented, input_edge_ids,
 ///            top_verts, top_edge_ids, vertical_edge_ids)`
 #[allow(clippy::type_complexity)]
-fn extrude_wire_vertices(
-    topo: &mut Topology,
-    wire_id: WireId,
-    offset: Vec3,
-) -> Result<
-    (
-        Vec<VertexId>,
-        Vec<Point3>,
-        Vec<OrientedEdge>,
-        Vec<EdgeId>,
-        Vec<VertexId>,
-        Vec<EdgeId>,
-        Vec<EdgeId>,
-    ),
-    crate::OperationsError,
-> {
-    extrude_wire_vertices_with(topo, wire_id, offset, /*pass_through_circles=*/ false)
-}
-
-#[allow(clippy::type_complexity)]
 fn extrude_wire_vertices_with(
     topo: &mut Topology,
     wire_id: WireId,
@@ -308,9 +321,9 @@ fn extrude_wire_vertices_with(
     // Check for closed single-edge wires (e.g. a full circle) and split them
     // into multiple edges so that the extrusion can create proper side faces.
     // Closed circles/ellipses (incl. NURBS-recognized ones) optionally pass
-    // through unsplit when the caller can handle analytic side faces. Inner
-    // wires of an extrude DON'T pass through — the inner side face
-    // construction still expects the per-edge polyline layout.
+    // through unsplit when the caller can build analytic side faces: the outer
+    // wire always does, and a single-circle inner (hole) wire does too (one
+    // exact cylinder wall — see `inner_wire_is_single_circle`).
     let oriented = maybe_split_closed_wire_with(
         topo,
         &original_oriented,
@@ -705,7 +718,12 @@ pub fn extrude(
             _iw_top_verts,
             iw_top_edge_ids,
             iw_vert_edge_ids,
-        ) = extrude_wire_vertices(topo, iw_id, offset)?;
+        ) = extrude_wire_vertices_with(
+            topo,
+            iw_id,
+            offset,
+            inner_wire_is_single_circle(topo, iw_id),
+        )?;
 
         // Bottom inner wire: reversed winding (same as outer wire reversal).
         let reversed_inner_edges: Vec<OrientedEdge> = iw_oriented
@@ -841,6 +859,14 @@ pub fn extrude(
             let inner_is_cw = !is_cw;
             let (surface, reversed) =
                 side_face_surface(&edge_curve, p0, p1, cs, ce, offset, inner_is_cw)?;
+
+            // A full closed circle passed through unsplit becomes one exact
+            // cylinder wall, but its start==end vertex makes `edge_dir` zero, so
+            // `side_face_surface` cannot derive the outward direction. A hole
+            // wall always faces into the hole (toward the axis), i.e. opposite
+            // the cylinder's natural outward radial normal, so force the flip.
+            let reversed =
+                reversed || (e_start == e_end && matches!(surface, FaceSurface::Cylinder(_)));
 
             let side_face = if reversed {
                 topo.add_face(Face::new_reversed(side_wire_id, vec![], surface))

--- a/crates/operations/src/extrude/tests.rs
+++ b/crates/operations/src/extrude/tests.rs
@@ -45,6 +45,74 @@ fn extrude_triangle_creates_prism() {
 }
 
 #[test]
+fn extrude_rect_with_circular_hole_uses_exact_cylinder() {
+    // gh #966: a rectangle with a circular hole, extruded, must remove the
+    // exact analytic π·r²·h instead of an inscribed-polygon prism. The hole
+    // wall becomes ONE cylinder face, not a faceted ring, and the measured
+    // volume matches the analytic value.
+    use brepkit_math::vec::Point3;
+    use brepkit_topology::builder::{make_circle_edge, make_polygon_wire};
+    use brepkit_topology::face::Face;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    let tol = 1e-7;
+    let mut topo = Topology::new();
+
+    let outer = make_polygon_wire(
+        &mut topo,
+        &[
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(20.0, 0.0, 0.0),
+            Point3::new(20.0, 20.0, 0.0),
+            Point3::new(0.0, 20.0, 0.0),
+        ],
+        tol,
+    )
+    .unwrap();
+    let hole = make_circle_edge(
+        &mut topo,
+        Point3::new(10.0, 10.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+        3.0,
+        tol,
+    )
+    .unwrap();
+    let inner = topo.add_wire(Wire::new(vec![OrientedEdge::new(hole, false)], true).unwrap());
+    let face = topo.add_face(Face::new(
+        outer,
+        vec![inner],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 10.0).unwrap();
+
+    let shell = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+    let cyl_count = shell
+        .faces()
+        .iter()
+        .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Cylinder(_)))
+        .count();
+    assert_eq!(cyl_count, 1, "hole wall must be one exact cylinder face");
+
+    let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+    let expected = (400.0 - std::f64::consts::PI * 9.0) * 10.0;
+    assert!(
+        (vol - expected).abs() / expected < 1e-3,
+        "expected ~{expected}, got {vol}"
+    );
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid()
+    );
+}
+
+#[test]
 fn extrude_zero_direction_error() {
     let mut topo = Topology::new();
     let face = make_unit_square_face(&mut topo);

--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -397,6 +397,113 @@ pub fn densify_path_points(points: &[Point3]) -> Vec<Point3> {
     out
 }
 
+/// Interior samples used to confirm a path is a straight segment.
+const STRAIGHT_SAMPLES: usize = 8;
+
+/// Approximate the centroid of a planar profile's outer boundary by sampling
+/// its edges.
+///
+/// Sampling (rather than averaging stored vertices) is needed for a single
+/// closed circle, whose start and end vertex coincide at the seam — the seam
+/// point is not the center.
+fn profile_outer_centroid(
+    topo: &Topology,
+    profile: FaceId,
+) -> Result<Point3, crate::OperationsError> {
+    let face = topo.face(profile)?;
+    let wire = topo.wire(face.outer_wire())?;
+    let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+    let mut count = 0_usize;
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge())?;
+        let start = topo.vertex(edge.start())?.point();
+        let end = topo.vertex(edge.end())?.point();
+        let (t0, t1) = edge.curve().domain_with_endpoints(start, end);
+        // Four samples per edge span a closed circle's full sweep.
+        for k in 0..4 {
+            let t = t0 + (t1 - t0) * (f64::from(k) / 4.0);
+            let p = edge.curve().evaluate_with_endpoints(t, start, end);
+            sx += p.x();
+            sy += p.y();
+            sz += p.z();
+            count += 1;
+        }
+    }
+    if count == 0 {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "sweep profile has no outer-wire edges".into(),
+        });
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let n = count as f64;
+    Ok(Point3::new(sx / n, sy / n, sz / n))
+}
+
+/// Fast exact path for a straight, perpendicular sweep: it is a prism, so
+/// delegate to [`crate::extrude::extrude`], which builds exact analytic side
+/// faces (a circular profile becomes a true cylinder matching π·r²·L). The
+/// general sweep inscribes a curved profile as a polygon and undercounts its
+/// volume by ~2% (gh #965).
+///
+/// Returns `Ok(None)` — fall back to the general sweep — when the path is not
+/// straight or the profile plane is not perpendicular to it (an oblique sweep
+/// is not a prism and has different semantics).
+fn try_straight_extrude(
+    topo: &mut Topology,
+    profile: FaceId,
+    path: &NurbsCurve,
+) -> Result<Option<SolidId>, crate::OperationsError> {
+    let tol = Tolerance::new();
+
+    let normal = match topo.face(profile)?.surface() {
+        FaceSurface::Plane { normal, .. } => *normal,
+        _ => return Ok(None),
+    };
+
+    let start = path.evaluate(0.0);
+    let end = path.evaluate(1.0);
+    let chord = end - start;
+    let length = chord.length();
+    if length < tol.linear {
+        return Ok(None); // closed or degenerate path
+    }
+    let Ok(dir) = chord.normalize() else {
+        return Ok(None);
+    };
+
+    // Confirm straightness: every interior sample stays on the start→end line
+    // and advances monotonically along it.
+    for k in 1..STRAIGHT_SAMPLES {
+        #[allow(clippy::cast_precision_loss)]
+        let t = k as f64 / STRAIGHT_SAMPLES as f64;
+        let v = path.evaluate(t) - start;
+        let along = v.dot(dir);
+        let perp = (v - dir * along).length();
+        if perp > tol.linear * 100.0 || along < -tol.linear || along > length + tol.linear {
+            return Ok(None);
+        }
+    }
+
+    // The profile must be perpendicular to the path (normal parallel to the
+    // direction); an oblique profile is not a prism.
+    if normal.dot(dir).abs() < 1.0 - 1e-6 {
+        return Ok(None);
+    }
+
+    // Position a copy of the profile so its centroid lands on the path start —
+    // matching the general sweep's frame[0] placement — then extrude.
+    let centroid = profile_outer_centroid(topo, profile)?;
+    let moved = crate::copy::copy_face(topo, profile)?;
+    let shift = start - centroid;
+    crate::transform::transform_face(
+        topo,
+        moved,
+        &Mat4::translation(shift.x(), shift.y(), shift.z()),
+    )?;
+
+    Ok(Some(crate::extrude::extrude(topo, moved, dir, length)?))
+}
+
 /// Sweep a face along a path curve to produce a solid.
 ///
 /// Creates a solid by moving a planar profile along a NURBS curve, with the
@@ -420,6 +527,11 @@ pub fn sweep(
         return Err(crate::OperationsError::InvalidInput {
             reason: "sweep path must have at least 2 control points".into(),
         });
+    }
+
+    // A straight perpendicular sweep is a prism — build it exactly via extrude.
+    if let Some(solid) = try_straight_extrude(topo, profile, path)? {
+        return Ok(solid);
     }
 
     let face_data = topo.face(profile)?;
@@ -1085,6 +1197,16 @@ pub fn sweep_with_options(
             });
         }
         return sweep(topo, profile, path);
+    }
+
+    // A straight perpendicular sweep is a prism — build it exactly via extrude.
+    // Only when no scale law or guide spine applies, since either makes the
+    // result non-prismatic.
+    if options.scale_law.is_none()
+        && options.aux_spine.is_none()
+        && let Some(solid) = try_straight_extrude(topo, profile, path)?
+    {
+        return Ok(solid);
     }
 
     let input_wire = topo.wire(input_wire_id)?;

--- a/crates/operations/src/sweep/tests.rs
+++ b/crates/operations/src/sweep/tests.rs
@@ -287,9 +287,57 @@ fn sweep_guided_handles_guide_meeting_spine() {
 }
 
 #[test]
+fn sweep_circle_along_straight_line_is_exact_cylinder() {
+    // gh #965: sweeping a circle along a straight spine must produce an exact
+    // cylinder (π·r²·L), not an inscribed polygonal prism (~2% low). The
+    // straight-sweep fast path delegates to extrude, which builds a true
+    // cylinder side face.
+    use brepkit_math::vec::Vec3;
+    use brepkit_topology::builder::make_circle_edge;
+    use brepkit_topology::face::Face;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    let tol = 1e-7;
+    let mut topo = Topology::new();
+    let circle = make_circle_edge(
+        &mut topo,
+        Point3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+        2.0,
+        tol,
+    )
+    .unwrap();
+    let wid = topo.add_wire(Wire::new(vec![OrientedEdge::new(circle, true)], true).unwrap());
+    let profile = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    let path = straight_z_path(20.0);
+
+    let solid = sweep(&mut topo, profile, &path).unwrap();
+
+    let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+    let expected = std::f64::consts::PI * 4.0 * 20.0;
+    assert!(
+        (vol - expected).abs() / expected < 1e-6,
+        "expected exact cylinder volume {expected}, got {vol}"
+    );
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid()
+    );
+}
+
+#[test]
 fn sweep_square_along_line() {
-    // Sweeping along a straight line should produce a box-like solid,
-    // similar to extrude.
+    // A straight perpendicular sweep is a prism: a unit square swept along a
+    // length-2 line is a 1×1×2 box — 6 planar faces, volume 2 — built exactly
+    // via the extrude fast path (not a faceted multi-ring solid).
     let mut topo = Topology::new();
     let face = make_unit_square_face(&mut topo);
     let path = straight_z_path(2.0);
@@ -299,20 +347,21 @@ fn sweep_square_along_line() {
     let solid_data = topo.solid(solid).unwrap();
     let shell = topo.shell(solid_data.outer_shell()).unwrap();
 
-    // 4 segments (from max(2*2, 4)) × 4 profile edges = 16 side faces
-    // + 2 caps = 18 faces total.
-    let num_segs = (path.control_points().len() * 2).max(4);
-    let expected_faces = num_segs * 4 + 2;
-    assert_eq!(shell.faces().len(), expected_faces);
+    assert_eq!(shell.faces().len(), 6, "a straight square sweep is a box");
 
-    // Verify all faces are planar.
     for &fid in shell.faces() {
         let f = topo.face(fid).unwrap();
         assert!(
             matches!(f.surface(), FaceSurface::Plane { .. }),
-            "all sweep V1 faces should be planar"
+            "all box faces should be planar"
         );
     }
+
+    let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+    assert!(
+        (vol - 2.0).abs() < 1e-9,
+        "expected box volume 2.0, got {vol}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two related "inscribed-circle approximation" volume bugs (#965, #966). Both still reproduced on `main` (the same-day #959 deflection clamp refines tessellation but cannot fix an inscribed *shape* — the error is geometric).

Shared root cause: a circular edge was **chorded into line segments** before the side surface was built, producing an inscribed ~18-gon prism (~98% of the true area).

### #965 — straight-spine sweep of a circle (~2% low → exact)

A straight perpendicular sweep is geometrically a prism, so `sweep` now detects that case and delegates to `extrude`, whose outer-wire path already builds an exact `Cylinder`. The profile is copied and translated so its centroid lands on the path start (matching the general sweep's `frame[0]` placement). Falls back to the general sweep for curved/oblique paths, and in `sweep_with_options` when a scale law or guide spine applies. Fixes all curved profiles (circle, ellipse), not just circles.

- circle r=2 along a length-20 spine: **246.2545 → 251.3274 (exact)**
- a swept square is now a clean 6-face box (was an 18-face faceted solid)

### #966 — extruded rectangle with a circular hole (~0.15% high → ~0.002%)

A single-circle inner (hole) wire now passes through unsplit to build **one exact `Cylinder` wall** (6 box planes + 1 cylinder) instead of a faceted ring. A full circle's `start==end` vertex makes the side-face edge direction degenerate, so the inward hole-wall orientation is forced explicitly. Ellipse / generic closed inner wires keep the existing chord-split path.

- 20×20 plate, r=3 hole, height 10: **3722.96 → 3717.32** (analytic 3717.26; residual ~0.002% is the planar cap's tessellated hole, bounded by the volume deflection clamp)
- watertight, validated

## Tests

- New regression tests: `sweep_circle_along_straight_line_is_exact_cylinder`, `extrude_rect_with_circular_hole_uses_exact_cylinder` (volume + validity)
- Updated `sweep_square_along_line` to assert the improved box result
- Full suite green: operations 919, io+check 226, wasm 227 (incl. gridfinity integration); clippy clean

Closes #965
Closes #966