### PR TITLE
fix(fillet): reject degenerate cylinder-rim fillet instead of silent volume corruption

### DIFF
--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -2155,6 +2155,30 @@ pub fn fillet_rolling_ball(
     // the mesh boolean fallback on moderate-complexity filleted solids.
     let _ = crate::heal::unify_faces(topo, solid_id);
 
+    // Reject a geometrically-degenerate assembly. This engine is built around
+    // polygonal wires with distinct corner vertices; a closed circular edge
+    // (a cylinder/cone rim, where start vertex == end vertex) collapses its
+    // blend strip and the adjacent disc cap to zero-area faces while still
+    // passing the manifold check. Such a result is silently wrong (it drops
+    // the caps and shrinks the wall), so surface it as an error and let the
+    // caller fall through to the walking blend engine, which handles closed
+    // spines. The guard is keyed on actual face area, not edge topology, so a
+    // valid fillet (every face has real area) is never rejected.
+    let faces = brepkit_topology::explorer::solid_faces(topo, solid_id)
+        .map_err(crate::OperationsError::Topology)?;
+    let area_floor = (radius * radius) * 1e-6;
+    for fid in faces {
+        let area = crate::measure::face_area(topo, fid, radius * 0.1)?;
+        if area <= area_floor {
+            return Err(crate::OperationsError::InvalidInput {
+                reason: format!(
+                    "fillet produced a degenerate face (area {area:.3e} <= {area_floor:.3e}); \
+                     closed circular edges are not supported by the rolling-ball engine"
+                ),
+            });
+        }
+    }
+
     Ok(solid_id)
 }
 

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -923,9 +923,16 @@ fn fillet_radius_just_fits() {
 
 #[test]
 fn fillet_plane_cylinder_edge() {
-    // A cylinder has planar top/bottom and a cylindrical lateral face.
-    // The edges between the planar caps and the cylindrical face should
-    // now be filleted (previously silently skipped).
+    // A cylinder's rim edges are CLOSED circles (start vertex == end vertex).
+    // The rolling-ball engine is built around polygonal wires with distinct
+    // corner vertices; a closed circular edge collapses its blend strip and the
+    // adjacent disc cap to zero-area faces (the result is manifold but
+    // geometrically degenerate — it silently drops the caps and shrinks the
+    // wall, removing ~37% of the volume; see gh #967). The engine must reject
+    // this rather than return the broken solid, so the caller falls through to
+    // the walking blend engine (which handles closed spines). Rim fillets on a
+    // primitive cylinder therefore route through `blend_ops::fillet_v2`, not
+    // this deprecated path.
     let mut topo = Topology::new();
     let solid = crate::primitives::make_cylinder(&mut topo, 2.0, 4.0).unwrap();
 
@@ -972,26 +979,19 @@ fn fillet_plane_cylinder_edge() {
         "cylinder should have plane-cylinder edges"
     );
 
-    // Fillet the first plane-cylinder edge. This should succeed now
-    // (previously it would have been silently skipped).
+    // Filleting the closed rim circle must be REJECTED (not return a degenerate
+    // solid). The rejection lets the dispatcher fall through to the walking
+    // engine.
     let result = fillet_rolling_ball(&mut topo, solid, &plane_cyl_edges[..1], 0.3);
     assert!(
-        result.is_ok(),
-        "plane-cylinder fillet should succeed: {:?}",
-        result.err()
+        result.is_err(),
+        "rolling-ball fillet of a closed cylinder-rim edge must be rejected as \
+         degenerate, not return a silently-broken solid"
     );
-
-    // Verify the result has a NURBS fillet face.
-    let result_solid = result.unwrap();
-    let rs = topo.solid(result_solid).unwrap();
-    let rsh = topo.shell(rs.outer_shell()).unwrap();
-    let has_nurbs = rsh
-        .faces()
-        .iter()
-        .any(|&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)));
+    let msg = format!("{}", result.err().unwrap());
     assert!(
-        has_nurbs,
-        "plane-cylinder fillet should produce a NURBS face"
+        msg.contains("degenerate"),
+        "expected a degenerate-face rejection, got: {msg}"
     );
 }
 
@@ -1239,11 +1239,17 @@ fn adjacent_fillet_overlap_curved_face_detected() {
             assert!(vol > 0.0);
         }
         Err(e) => {
-            // Overlap or curvature error is expected for large radius
+            // A large radius on the closed cylinder rim is expected to fail.
+            // Acceptable reasons: overlap / curvature bound, or the degenerate
+            // closed-circular-edge rejection (the rim collapses the blend strip;
+            // see gh #967). The key is that it must NOT panic.
             let msg = format!("{e}");
             assert!(
-                msg.contains("overlap") || msg.contains("curvature") || msg.contains("exceeds"),
-                "expected overlap/curvature error, got: {msg}"
+                msg.contains("overlap")
+                    || msg.contains("curvature")
+                    || msg.contains("exceeds")
+                    || msg.contains("degenerate"),
+                "expected overlap/curvature/degenerate error, got: {msg}"
             );
         }
     }

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -172,13 +172,19 @@ pub fn try_fillet(
     }
     let edges = edges.as_slice();
 
-    // A candidate is acceptable only if its outer shell is a manifold (no edge
-    // shared by more than two faces).
+    // A candidate is acceptable only if its outer shell is a CLOSED 2-manifold
+    // (every edge used by exactly two faces — no free/boundary edges). The
+    // weaker `validate_shell_manifold` (only rejects edges shared by 3+ faces)
+    // silently accepted open shells: e.g. a primitive cylinder's rim fillet,
+    // where the walking engine cannot trim the disc cap to the toroidal blend's
+    // contact circle and leaves 8 free edges at the cap/torus seams. An open
+    // shell measures a plausible-but-wrong volume, so it must be rejected so the
+    // next engine (or the unchanged input) is used instead.
     let is_valid =
         |topo: &brepkit_topology::Topology, s: brepkit_topology::solid::SolidId| -> bool {
             topo.solid(s)
                 .and_then(|sd| topo.shell(sd.outer_shell()))
-                .map(|sh| brepkit_topology::validation::validate_shell_manifold(sh, topo).is_ok())
+                .map(|sh| brepkit_topology::validation::validate_shell_closed(sh, topo).is_ok())
                 .unwrap_or(false)
         };
 
@@ -549,6 +555,36 @@ mod fillet_tests {
         assert!(
             vol > 970.0 && vol < 1000.0,
             "filleted box volume should be ≈975.6, got {vol}"
+        );
+    }
+
+    // gh #967: filleting a plain cylinder's circular rim used to silently
+    // remove ~37% of the volume — the deprecated rolling-ball engine collapses
+    // a closed circular edge's blend strip and caps to zero-area faces, and the
+    // walking engine leaves an open shell. Both are now rejected, so `try_fillet`
+    // falls back to returning the input unchanged: a VALID solid with the raw
+    // volume, never the silently-corrupt one. (Genuine rim rounding — occt's
+    // ~0.1% reduction — is a separate blend-engine feature.)
+    #[test]
+    fn try_fillet_cylinder_rim_does_not_corrupt_volume() {
+        let mut topo = Topology::new();
+        let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, 10.0, 20.0).unwrap();
+        let raw = brepkit_operations::measure::solid_volume(&topo, cyl, 0.01).unwrap();
+        let edges = solid_edge_ids(&topo, cyl);
+
+        let result = try_fillet(&mut topo, cyl, &edges, 0.5).expect("rim fillet must not error");
+        let vol = brepkit_operations::measure::solid_volume(&topo, result, 0.01).unwrap();
+
+        // Must NOT be the corrupt ~3978 (−37%); a no-op keeps the raw volume.
+        assert!(
+            (vol - raw).abs() / raw < 0.02,
+            "cylinder rim fillet must keep raw volume {raw:.1} (no-op), got {vol:.1}"
+        );
+        assert!(
+            brepkit_operations::validate::validate_solid(&topo, result)
+                .unwrap()
+                .is_valid(),
+            "fillet result must be a valid solid"
         );
     }
 


### PR DESCRIPTION
## Summary

Filleting a plain cylinder's circular rim silently removed **37–47% of the solid** (#967) — a *valid-but-wrong* result that every cheap check accepted. A cylinder/cone rim is a **closed** circular edge (start vertex == end vertex), unlike a box's open line edges, which triggered two layered defects:

1. The deprecated **rolling-ball** engine (tried first) assumes polygonal wires with distinct corner vertices. On a closed circular edge it collapses the blend strip and the disc caps to **zero-area faces** while staying manifold — shrinking the wall and dropping the caps (−37% at r=0.5).
2. The walking **fillet_v2** engine (fallback) can't trim a disc cap to an interior contact circle, so it leaves an **open shell** (free edges) that tessellates to a plausible-but-wrong volume.
3. The dispatch gate `validate_shell_manifold` only forbids edges shared by 3+ faces, so it accepted **both**.

## Fix

- **`rolling_ball.rs`** — reject an assembly with any near-zero-area face (keyed on area, not topology, so a correct fillet is never rejected).
- **`wasm/helpers.rs`** — `try_fillet` now requires a **closed** shell (`validate_shell_closed`), not just a manifold one, rejecting open-shell results.
- **`fillet/tests.rs`** — corrected two tests that asserted the buggy rolling-ball output (whose "NURBS faces" were zero-area).

With both broken engine outputs rejected, `try_fillet` falls back to returning the input unchanged: the cylinder rim fillet is now a **valid no-op** (raw volume `6283.185`, **0% change**, within 0.1% of occt's `6276.519`) instead of silently-corrupt geometry. New regression test `try_fillet_cylinder_rim_does_not_corrupt_volume`.

## Scope — this stops the corruption, it does NOT yet round the rim

This fix eliminates the **reported defect** (the silent 37–47% volume loss). It does **not** implement genuine rim rounding (occt removes ~0.1% and yields 5 faces). That is a separate blend-engine **feature**, blocked on:
- `blend/src/analytic.rs::plane_cylinder_fillet` keying the blend side only on `is_reversed()` — wrong for a bare disc cap; the inward geometry is `major = r_c − r` (derived + prototyped), and
- `FilletBuilder`'s line-based trimmer being unable to rebuild a disc cap bounded by an interior contact circle.

Left as a follow-up; `Refs #967` (not `Closes`) so the rounding feature stays tracked.

## Verification

- `cargo test -p brepkit-operations -p brepkit-wasm -p brepkit-blend` — **1236 pass, 0 fail** (incl. the gridfinity fillet suite and the box `try_fillet` tests, proving the stricter gate rejects no legitimate fillet)
- clippy clean; pre-commit hooks passed

Refs #967