### PR TITLE
fix(fillet): round a cylinder rim into an exact quarter-torus (#967)

### DIFF
--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -688,17 +688,29 @@ pub fn plane_cylinder_fillet(
     //      * reversed:     material is on the cylinder's *outward* side
     //        (a hole through a slab). Concave internal corner.
     let concave = topo.face(face_cyl)?.is_reversed();
+    let r_c = cyl.radius();
+
+    // 2b) Among the convex (non-reversed-cylinder) configurations, distinguish
+    //     the "post on a large plate" (the plate extends past the cylinder, so
+    //     the fillet flares OUTWARD with plate contact at `r_c + r`) from the
+    //     "rim of a bare disc cap bounded BY the cylinder" (e.g. a primitive
+    //     cylinder's bottom/top rim — the cap *is* the circle of radius `r_c`,
+    //     so the fillet rounds INWARD with plate contact at `r_c - r`). The
+    //     discriminator: a bounded disc cap has no inner wires and every
+    //     boundary vertex lies within `r_c` of the cylinder axis; a plate that
+    //     the post stands on has boundary vertices beyond `r_c`.
+    let rim = !concave && plane_is_bounded_disc(topo, face_plane, cyl, r_c)?;
 
     // 3) Radius bound depends on the case:
-    //    - Convex: major = `r_c + r`, always > minor = `r`, so the only
+    //    - Convex post: major = `r_c + r`, always > minor = `r`, so the only
     //      regime to reject is `r ≥ r_c` (rolling ball would encircle the
     //      cylinder axis).
-    //    - Concave: major = `r_c - r`; needs `r < r_c` to keep major
-    //      positive *and* `r ≤ r_c/2` to keep major ≥ minor. Past `r_c/2`
-    //      the construction becomes a spindle (self-intersecting) torus
+    //    - Concave hole / convex rim: major = `r_c - r`; needs `r < r_c` to
+    //      keep major positive *and* `r ≤ r_c/2` to keep major ≥ minor. Past
+    //      `r_c/2` the construction becomes a spindle (self-intersecting) torus
     //      which is invalid as a fillet surface.
-    let r_c = cyl.radius();
-    let max_radius = if concave { r_c * 0.5 } else { r_c };
+    let inward = concave || rim;
+    let max_radius = if inward { r_c * 0.5 } else { r_c };
     if radius <= tol_lin || radius >= max_radius {
         return Ok(None);
     }
@@ -711,14 +723,22 @@ pub fn plane_cylinder_fillet(
     let step = d_plane - n_p_inward.dot(Vec3::new(o_c.x(), o_c.y(), o_c.z()));
     let p_axis_on_plane = o_c + n_p_inward * step;
 
-    // 5) The torus center sits one fillet radius "above" the spine plane
-    //    along the side opposite the plane material (`-n_p_inward`) for
-    //    both convex and concave — the empty wedge is on the same side of
-    //    the plate in either case. Major radius differs: `r_c + r` for
-    //    convex (plate contact OUTSIDE the spine), `r_c - r` for concave
-    //    (plate contact INSIDE the spine).
-    let torus_center = p_axis_on_plane - n_p_inward * radius;
-    let major_radius = if concave { r_c - radius } else { r_c + radius };
+    // 5) Torus placement.
+    //    `z_axis_dir` is the side of the plate the rolling ball trajectory is
+    //    lifted toward (the cylinder-material side along the axis), and the
+    //    torus center sits one fillet radius along it.
+    //      - Concave hole / convex post: the empty wedge is on the plate side
+    //        opposite the cylinder material, so the ball lifts toward
+    //        `-n_p_inward` and the torus center is below the plate.
+    //      - Convex rim (disc bounded by the cylinder): the material *is* on
+    //        the `+n_p_inward` side, so the ball lifts INTO the material
+    //        (toward `+n_p_inward`) and the torus center sits one radius above
+    //        the plate; plate contact lands at `r_c - r`.
+    //    Major radius: `r_c + r` for a convex post (plate contact OUTSIDE the
+    //    spine), `r_c - r` for the inward cases (plate contact INSIDE).
+    let z_axis_dir = if rim { n_p_inward } else { -n_p_inward };
+    let torus_center = p_axis_on_plane + z_axis_dir * radius;
+    let major_radius = if inward { r_c - radius } else { r_c + radius };
     let minor_radius = radius;
 
     // 6) Spine must span an arc to be useful. `Spine::from_single_edge`
@@ -768,11 +788,10 @@ pub fn plane_cylinder_fillet(
     };
 
     // 9) 3D contact curves.
-    //    - On the plane: a circle of radius `R = r_c + r` around the cylinder
-    //      axis on the spine plane.
-    //    - On the cylinder: a circle of radius `r_c` at axial offset `r`
-    //      (the height of the ball trajectory above the plane).
-    let z_axis_dir = -n_p_inward; // Direction "out of the plate" along the cylinder axis side.
+    //    - On the plane: a circle of radius `major` (= `r_c ± r`) around the
+    //      cylinder axis on the spine plane.
+    //    - On the cylinder: a circle of radius `r_c` at axial offset `r` along
+    //      `z_axis_dir` (the height of the ball trajectory above the plane).
     let contact_plane_circle = brepkit_math::curves::Circle3D::with_axes(
         p_axis_on_plane,
         axis_c,
@@ -866,6 +885,45 @@ pub fn plane_cylinder_fillet(
         stripe,
         new_edges: Vec::new(),
     }))
+}
+
+/// Is the plane face a bounded disc cap whose rim is the cylinder (radius
+/// `r_c`), as opposed to a larger plate the cylinder stands on?
+///
+/// True when the face has no inner wires AND every outer-boundary vertex lies
+/// within `r_c` (plus a small tolerance) of the cylinder axis. For a primitive
+/// cylinder's end cap the only boundary is the rim circle of radius `r_c`, so
+/// all its vertices sit exactly on the axis-distance `r_c`; for a plate that a
+/// post stands on, the plate corners lie beyond `r_c`.
+fn plane_is_bounded_disc(
+    topo: &Topology,
+    face_plane: FaceId,
+    cyl: &brepkit_math::surfaces::CylindricalSurface,
+    r_c: f64,
+) -> Result<bool, BlendError> {
+    let face = topo.face(face_plane)?;
+    if !face.inner_wires().is_empty() {
+        return Ok(false);
+    }
+    let axis = cyl.axis();
+    let o_c = cyl.origin();
+    // Radial distance from the cylinder axis to a point: |(p − o_c) − ((p − o_c)·axis)·axis|.
+    let radial = |p: Point3| -> f64 {
+        let d = p - o_c;
+        let along = axis * axis.dot(d);
+        (d - along).length()
+    };
+    let tol = r_c * 1e-6 + ANALYTIC_TOL_LIN;
+    let wire = topo.wire(face.outer_wire())?;
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge())?;
+        let s = topo.vertex(edge.start())?.point();
+        let e = topo.vertex(edge.end())?.point();
+        if radial(s) > r_c + tol || radial(e) > r_c + tol {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 /// Recover the cylinder's axial v-parameter for a 3D point known to lie on

--- a/crates/blend/src/analytic/tests.rs
+++ b/crates/blend/src/analytic/tests.rs
@@ -325,13 +325,16 @@ fn plane_cylinder_fillet_concave_emits_torus_with_smaller_major() {
     );
 }
 
-/// Convex plane-cylinder fillet sanity check — the existing
-/// `fillet_cylinder_base_circle_produces_torus` integration test
-/// covers the convex path through `fillet_v2`, but adding a direct
-/// helper-level convex test alongside the concave one above guards
-/// against regression in the shared `major_radius` branch.
+/// A bare disc cap whose only boundary is the cylinder rim (no inner wires,
+/// all boundary vertices within `r_c` of the axis) is an INWARD rim — the
+/// fillet rounds the disc inward, with `major = r_c − r` and the torus centre
+/// one radius into the material (z = +r). This is the gh #967 geometry, and
+/// the direct analogue of the integration-level
+/// `fillet_cylinder_base_circle_produces_torus`. (A genuine post-on-a-plate,
+/// where the plate extends past the cylinder, instead keeps `major = r_c + r`;
+/// that configuration is not modelled by a bare disc.)
 #[test]
-fn plane_cylinder_fillet_convex_emits_torus_with_larger_major() {
+fn plane_cylinder_fillet_rim_emits_torus_with_smaller_major() {
     use brepkit_math::curves::Circle3D;
     use brepkit_math::surfaces::CylindricalSurface;
     use brepkit_topology::edge::{Edge, EdgeCurve};
@@ -358,7 +361,7 @@ fn plane_cylinder_fillet_convex_emits_torus_with_larger_major() {
         },
     ));
 
-    // NOT reversed — typical post-on-plate cylinder face.
+    // NOT reversed — the disc cap's rim borders a solid (post/cylinder body).
     let cyl_surface =
         CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), r_c).unwrap();
     let w2 = topo.add_wire(Wire::new(vec![OrientedEdge::new(eid, false)], true).unwrap());
@@ -383,7 +386,7 @@ fn plane_cylinder_fillet_convex_emits_torus_with_larger_major() {
         face_cyl,
     )
     .unwrap()
-    .expect("convex plane-cylinder fillet should produce a stripe");
+    .expect("rim plane-cylinder fillet should produce a stripe");
 
     let torus = match result.stripe.surface {
         FaceSurface::Torus(t) => t,
@@ -391,17 +394,16 @@ fn plane_cylinder_fillet_convex_emits_torus_with_larger_major() {
     };
 
     assert!(
-        (torus.major_radius() - (r_c + r_fillet)).abs() < 1e-9,
-        "torus major should be r_c + r_fillet = {} for convex, got {}",
-        r_c + r_fillet,
+        (torus.major_radius() - (r_c - r_fillet)).abs() < 1e-9,
+        "torus major should be r_c − r_fillet = {} for an inward rim, got {}",
+        r_c - r_fillet,
         torus.major_radius()
     );
-    // Convex case: torus center at z = -r (below plate, in empty wedge).
+    // Rim case: torus centre at z = +r (one radius into the material).
     let center = torus.center();
     assert!(
-        (center.z() - (-r_fillet)).abs() < 1e-9,
-        "convex torus center should sit at z = -r ({}), got {}",
-        -r_fillet,
+        (center.z() - r_fillet).abs() < 1e-9,
+        "rim torus centre should sit at z = +r ({r_fillet}), got {}",
         center.z()
     );
 }
@@ -491,24 +493,44 @@ fn plane_cylinder_fillet_concave_rejects_spindle_radius() {
         "concave fillet must reject r = r_c/2 (degenerate major = minor)"
     );
 
-    // Convex at r_c/2 < r < r_c is still fine — major = r_c + r > minor.
-    let mut topo_convex = Topology::new();
-    let (spine_convex, cyl_convex, fp_convex, fc_convex) = setup(&mut topo_convex, false);
-    let n_p_inward_convex = Vec3::new(0.0, 0.0, 1.0);
-    let result_convex = plane_cylinder_fillet(
-        n_p_inward_convex,
+    // The non-reversed cylinder face here borders a bare disc cap (the rim
+    // circle is the plate's only boundary), so it is an INWARD rim, not a
+    // post-on-a-plate. The rim shares the concave `major = r_c − r` formula, so
+    // it must reject r ≥ r_c/2 (spindle) too…
+    let mut topo_rim = Topology::new();
+    let (spine_rim, cyl_rim, fp_rim, fc_rim) = setup(&mut topo_rim, false);
+    let n_p_inward_rim = Vec3::new(0.0, 0.0, 1.0);
+    let result_rim_spindle = plane_cylinder_fillet(
+        n_p_inward_rim,
         0.0,
-        &cyl_convex,
-        &spine_convex,
-        &topo_convex,
+        &cyl_rim,
+        &spine_rim,
+        &topo_rim,
         1.5,
-        fp_convex,
-        fc_convex,
+        fp_rim,
+        fc_rim,
     )
     .unwrap();
     assert!(
-        result_convex.is_some(),
-        "convex fillet should accept r in (r_c/2, r_c)"
+        result_rim_spindle.is_none(),
+        "rim fillet must reject r > r_c/2 (spindle-torus regime)"
+    );
+
+    // …and accept a small radius (major = r_c − r > minor = r).
+    let result_rim_ok = plane_cylinder_fillet(
+        n_p_inward_rim,
+        0.0,
+        &cyl_rim,
+        &spine_rim,
+        &topo_rim,
+        0.5,
+        fp_rim,
+        fc_rim,
+    )
+    .unwrap();
+    assert!(
+        result_rim_ok.is_some(),
+        "rim fillet should accept r < r_c/2"
     );
 }
 

--- a/crates/blend/src/fillet_builder.rs
+++ b/crates/blend/src/fillet_builder.rs
@@ -6,11 +6,15 @@
 
 use std::collections::HashSet;
 
+use brepkit_math::curves::Circle3D;
+use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
-use brepkit_topology::edge::EdgeId;
-use brepkit_topology::face::FaceId;
+use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
+use brepkit_topology::face::{Face, FaceId, FaceSurface};
 use brepkit_topology::shell::Shell;
 use brepkit_topology::solid::{Solid, SolidId};
+use brepkit_topology::vertex::Vertex;
+use brepkit_topology::wire::{OrientedEdge, Wire};
 
 use crate::analytic;
 use crate::blend_func::{ConstRadBlend, EvolRadBlend};
@@ -139,7 +143,32 @@ impl<'a> FilletBuilder<'a> {
             });
         }
 
-        let stripes: Vec<Stripe> = stripe_results.iter().map(|sr| sr.stripe.clone()).collect();
+        // Partition out closed-revolution rim stripes (a full circular rim
+        // between a bounded disc cap and a cylinder/cone wall). These need an
+        // annular assembly that rebuilds the cap, shortens the wall, and emits
+        // a toroidal band — all sharing the two contact-circle edges — which
+        // the per-face line-based trimmer cannot produce (a closed interior
+        // contact circle crosses no boundary edge). Regular stripes still flow
+        // through the trim + corner + blend-face path below.
+        let mut blend_face_ids: Vec<FaceId> = Vec::new();
+        let mut face_replacements: std::collections::HashMap<FaceId, FaceId> =
+            std::collections::HashMap::new();
+        let mut regular_results: Vec<&StripeResult> = Vec::new();
+        for sr in &stripe_results {
+            if let Some(rim) = closed_rim_info(topo, &sr.stripe)? {
+                match assemble_closed_rim(topo, &sr.stripe, &rim, &mut face_replacements) {
+                    Ok(band) => blend_face_ids.push(band),
+                    Err(e) => {
+                        log::warn!("closed-rim assembly failed: {e}, falling back to trim path");
+                        regular_results.push(sr);
+                    }
+                }
+            } else {
+                regular_results.push(sr);
+            }
+        }
+
+        let stripes: Vec<Stripe> = regular_results.iter().map(|sr| sr.stripe.clone()).collect();
         let corner_results = match corner::compute_corners(topo, &stripes, self.solid) {
             Ok(results) => results,
             Err(e) => {
@@ -153,11 +182,7 @@ impl<'a> FilletBuilder<'a> {
             corner_face_ids.push(cr.face_id);
         }
 
-        // Map from original face ID to its latest trimmed replacement.
-        let mut face_replacements: std::collections::HashMap<FaceId, FaceId> =
-            std::collections::HashMap::new();
-
-        for sr in &stripe_results {
+        for sr in &regular_results {
             let stripe = &sr.stripe;
 
             let contact1_pts = sample_nurbs_endpoints(&stripe.contact1);
@@ -226,9 +251,7 @@ impl<'a> FilletBuilder<'a> {
             }
         }
 
-        let mut blend_face_ids: Vec<FaceId> = Vec::new();
-
-        for sr in &stripe_results {
+        for sr in &regular_results {
             let stripe = &sr.stripe;
 
             // For v1, we create a minimal wire from the contact curve endpoints.
@@ -265,6 +288,349 @@ impl<'a> FilletBuilder<'a> {
             is_partial,
         })
     }
+}
+
+/// Geometry of a full-revolution rim fillet (a closed circular edge between a
+/// bounded disc cap and an axisymmetric wall), recovered from a stripe whose
+/// blend surface is a torus.
+struct ClosedRimInfo {
+    /// The bounded disc cap face (a `Plane`).
+    plane_face: FaceId,
+    /// The axisymmetric wall face (`Cylinder` or `Cone`).
+    wall_face: FaceId,
+    /// The original closed rim edge on the wall, to be replaced by the
+    /// wall-contact circle.
+    rim_edge: EdgeId,
+    /// Contact circle on the plate (radius `r_c − r`), in the plane.
+    plate_circle: Circle3D,
+    /// Contact circle on the wall (radius `r_c` for a cylinder), one fillet
+    /// radius along the axis from the plate.
+    wall_circle: Circle3D,
+}
+
+/// Project a point onto the infinite axis line through `origin` with unit
+/// direction `axis`, returning the foot of the perpendicular.
+fn project_onto_axis(p: Point3, origin: Point3, axis: Vec3) -> Point3 {
+    let d = p - origin;
+    origin + axis * axis.dot(d)
+}
+
+/// Radial distance from a point to the axis line.
+fn radial_distance(p: Point3, origin: Point3, axis: Vec3) -> f64 {
+    let d = p - origin;
+    (d - axis * axis.dot(d)).length()
+}
+
+/// Detect a full-revolution rim-fillet stripe and recover its annular geometry.
+///
+/// Returns `Some` when the blend surface is a torus, the spine is a single
+/// closed circular edge (start vertex == end vertex), and the two adjacent
+/// faces are a plane (the disc cap) and a cylinder/cone (the wall). Returns
+/// `None` for every other configuration (so the caller uses the normal trim
+/// path).
+///
+/// # Errors
+///
+/// Returns [`BlendError`] if topology lookups or circle construction fail.
+fn closed_rim_info(topo: &Topology, stripe: &Stripe) -> Result<Option<ClosedRimInfo>, BlendError> {
+    if !matches!(stripe.surface, FaceSurface::Torus(_)) {
+        return Ok(None);
+    }
+
+    // Spine must be a single closed circular edge.
+    let edges = stripe.spine.edges();
+    if edges.len() != 1 {
+        return Ok(None);
+    }
+    let rim_edge = edges[0];
+    {
+        let e = topo.edge(rim_edge)?;
+        if e.start() != e.end() {
+            return Ok(None);
+        }
+        if !matches!(e.curve(), EdgeCurve::Circle(_)) {
+            return Ok(None);
+        }
+    }
+
+    // One side is the plane (cap), the other the cylinder/cone wall.
+    let s1 = topo.face(stripe.face1)?.surface().clone();
+    let s2 = topo.face(stripe.face2)?.surface().clone();
+    let (plane_face, wall_face) = match (&s1, &s2) {
+        (FaceSurface::Plane { .. }, FaceSurface::Cylinder(_) | FaceSurface::Cone(_)) => {
+            (stripe.face1, stripe.face2)
+        }
+        (FaceSurface::Cylinder(_) | FaceSurface::Cone(_), FaceSurface::Plane { .. }) => {
+            (stripe.face2, stripe.face1)
+        }
+        _ => return Ok(None),
+    };
+
+    // The annular rebuild replaces the cap's whole outer wire with the
+    // plate-contact circle, so it only applies when the cap is a bare disc
+    // whose sole boundary is this rim (no inner wires). A more complex cap
+    // falls back to the normal trim path.
+    {
+        let cap = topo.face(plane_face)?;
+        if !cap.inner_wires().is_empty() {
+            return Ok(None);
+        }
+        let cap_wire = topo.wire(cap.outer_wire())?;
+        let edges = cap_wire.edges();
+        if edges.len() != 1 || edges[0].edge() != rim_edge {
+            return Ok(None);
+        }
+    }
+
+    // The plane-side contact curve is the one whose face is the plane.
+    let (plate_contact, wall_contact) = if plane_face == stripe.face1 {
+        (&stripe.contact1, &stripe.contact2)
+    } else {
+        (&stripe.contact2, &stripe.contact1)
+    };
+
+    // Recover the wall axis line from the wall surface.
+    let wall_surf = topo.face(wall_face)?.surface().clone();
+    let (axis, axis_origin) = match &wall_surf {
+        FaceSurface::Cylinder(c) => (c.axis(), c.origin()),
+        FaceSurface::Cone(c) => (c.axis(), c.apex()),
+        _ => return Ok(None),
+    };
+
+    // Each contact is a full circle perpendicular to the axis; recover its
+    // centre (foot on the axis line) and radius (radial distance) from one
+    // sampled point.
+    let (pt0, _) = plate_contact.domain();
+    let plate_pt = plate_contact.evaluate(pt0);
+    let plate_center = project_onto_axis(plate_pt, axis_origin, axis);
+    let plate_radius = radial_distance(plate_pt, axis_origin, axis);
+
+    let (wt0, _) = wall_contact.domain();
+    let wall_pt = wall_contact.evaluate(wt0);
+    let wall_center = project_onto_axis(wall_pt, axis_origin, axis);
+    let wall_radius = radial_distance(wall_pt, axis_origin, axis);
+
+    let plate_circle = Circle3D::new(plate_center, axis, plate_radius)?;
+    let wall_circle = Circle3D::new(wall_center, axis, wall_radius)?;
+
+    Ok(Some(ClosedRimInfo {
+        plane_face,
+        wall_face,
+        rim_edge,
+        plate_circle,
+        wall_circle,
+    }))
+}
+
+/// Assemble a full-revolution rim fillet: rebuild the disc cap bounded by the
+/// plate-contact circle, shorten the wall to the wall-contact circle, and emit
+/// the toroidal band between them. The cap and wall edges are shared with the
+/// band so the result is watertight.
+///
+/// Updates `face_replacements` for the cap and wall (so a later stripe sees the
+/// shortened wall). Returns the new toroidal band face.
+///
+/// # Errors
+///
+/// Returns [`BlendError`] if topology lookups or wire/face construction fail.
+fn assemble_closed_rim(
+    topo: &mut Topology,
+    stripe: &Stripe,
+    rim: &ClosedRimInfo,
+    face_replacements: &mut std::collections::HashMap<FaceId, FaceId>,
+) -> Result<FaceId, BlendError> {
+    const TOL: f64 = 1e-7;
+
+    // Snapshot the cap and wall (resolving any prior replacement) before
+    // mutating the arena.
+    let plane_surf = topo.face(rim.plane_face)?.surface().clone();
+    let plane_reversed = topo.face(rim.plane_face)?.is_reversed();
+
+    let current_wall = face_replacements
+        .get(&rim.wall_face)
+        .copied()
+        .unwrap_or(rim.wall_face);
+    let wall_surf = topo.face(current_wall)?.surface().clone();
+    let wall_reversed = topo.face(current_wall)?.is_reversed();
+    let wall_outer_wire = topo.face(current_wall)?.outer_wire();
+    let wall_inner = topo.face(current_wall)?.inner_wires().to_vec();
+    let wall_oriented: Vec<OrientedEdge> = topo.wire(wall_outer_wire)?.edges().to_vec();
+
+    // Vertices for the two closed contact circles (start == end → degenerate).
+    let plate_v = topo.add_vertex(Vertex::new(rim.plate_circle.evaluate(0.0), TOL));
+    let wall_v = topo.add_vertex(Vertex::new(rim.wall_circle.evaluate(0.0), TOL));
+
+    // Shared contact-circle edges.
+    let plate_edge = topo.add_edge(Edge::new(
+        plate_v,
+        plate_v,
+        EdgeCurve::Circle(rim.plate_circle.clone()),
+    ));
+    let wall_edge = topo.add_edge(Edge::new(
+        wall_v,
+        wall_v,
+        EdgeCurve::Circle(rim.wall_circle.clone()),
+    ));
+    // Seam connecting the two circles (degenerate-seam band, as the primitive
+    // cylinder lateral uses).
+    let seam_edge = topo.add_edge(Edge::new(plate_v, wall_v, EdgeCurve::Line));
+
+    // --- Rebuild the disc cap bounded by the plate-contact circle. ---
+    // The cap originally borders the rim via a single closed-circle wire; the
+    // new cap reuses the plate-contact circle with the same orientation the cap
+    // had on the original rim edge.
+    let cap_orig_wire = topo.face(
+        face_replacements
+            .get(&rim.plane_face)
+            .copied()
+            .unwrap_or(rim.plane_face),
+    )?;
+    let cap_orig_wire_id = cap_orig_wire.outer_wire();
+    let cap_forward = topo
+        .wire(cap_orig_wire_id)?
+        .edges()
+        .iter()
+        .find(|oe| oe.edge() == rim.rim_edge)
+        .is_some_and(OrientedEdge::is_forward);
+    let cap_wire = Wire::new(vec![OrientedEdge::new(plate_edge, cap_forward)], true)?;
+    let cap_wire_id = topo.add_wire(cap_wire);
+    let mut cap_face = Face::new(cap_wire_id, Vec::new(), plane_surf);
+    cap_face.set_reversed(plane_reversed);
+    let cap_face_id = topo.add_face(cap_face);
+    face_replacements.insert(rim.plane_face, cap_face_id);
+
+    // --- Shorten the wall to the wall-contact circle. ---
+    // The wall's outer wire references the rim circle plus (for the cylinder /
+    // cone primitive) a degenerate seam line whose lower endpoint is the rim
+    // vertex. Replace the rim circle with the wall-contact circle, and rebuild
+    // any seam edge touching the old rim vertex so its lower endpoint becomes
+    // the new wall-circle vertex (otherwise the wire no longer closes — the
+    // seam would still start at the old rim height).
+    let old_rim_vertex = topo.edge(rim.rim_edge)?.start();
+    // A seam edge may appear twice in the wall wire (fwd + rev); rebuild each
+    // distinct edge once so both references share the new edge (otherwise the
+    // two copies each become a free edge).
+    let mut rebuilt: std::collections::HashMap<EdgeId, EdgeId> = std::collections::HashMap::new();
+    let mut new_wall_edges: Vec<OrientedEdge> = Vec::with_capacity(wall_oriented.len());
+    let mut replaced = false;
+    for oe in &wall_oriented {
+        if oe.edge() == rim.rim_edge {
+            new_wall_edges.push(OrientedEdge::new(wall_edge, oe.is_forward()));
+            replaced = true;
+            continue;
+        }
+        let e = topo.edge(oe.edge())?;
+        let touches_rim = e.start() == old_rim_vertex || e.end() == old_rim_vertex;
+        if touches_rim {
+            let new_eid = if let Some(&id) = rebuilt.get(&oe.edge()) {
+                id
+            } else {
+                // Rebuild this edge with `wall_v` substituted for the old rim vertex.
+                let curve = e.curve().clone();
+                let new_start = if e.start() == old_rim_vertex {
+                    wall_v
+                } else {
+                    e.start()
+                };
+                let new_end = if e.end() == old_rim_vertex {
+                    wall_v
+                } else {
+                    e.end()
+                };
+                let id = topo.add_edge(Edge::new(new_start, new_end, curve));
+                rebuilt.insert(oe.edge(), id);
+                id
+            };
+            new_wall_edges.push(OrientedEdge::new(new_eid, oe.is_forward()));
+        } else {
+            new_wall_edges.push(*oe);
+        }
+    }
+    if !replaced {
+        return Err(BlendError::TrimmingFailure {
+            face: rim.wall_face,
+        });
+    }
+    let new_wall_wire = Wire::new(new_wall_edges, true)?;
+    let new_wall_wire_id = topo.add_wire(new_wall_wire);
+    let mut new_wall_face = Face::new(new_wall_wire_id, wall_inner, wall_surf);
+    new_wall_face.set_reversed(wall_reversed);
+    let new_wall_face_id = topo.add_face(new_wall_face);
+    face_replacements.insert(rim.wall_face, new_wall_face_id);
+
+    // --- Toroidal band between the two contact circles. ---
+    // Degenerate-seam wire (plate circle, seam up, wall circle reversed, seam
+    // down). The seam runs plate_v → wall_v, so this fixed order always closes
+    // (plate_v → plate_v → wall_v → wall_v → plate_v). The shared circle edges
+    // are used opposite to the standard-wound cap and wall, keeping the shell
+    // manifold.
+    let torus = match &stripe.surface {
+        FaceSurface::Torus(t) => t.clone(),
+        _ => {
+            return Err(BlendError::TrimmingFailure {
+                face: rim.wall_face,
+            });
+        }
+    };
+    let band_wire = Wire::new(
+        vec![
+            OrientedEdge::new(plate_edge, true),
+            OrientedEdge::new(seam_edge, true),
+            OrientedEdge::new(wall_edge, false),
+            OrientedEdge::new(seam_edge, false),
+        ],
+        true,
+    )?;
+    let band_wire_id = topo.add_wire(band_wire);
+    let mut band_face = Face::new(band_wire_id, Vec::new(), stripe.surface.clone());
+    // Orient the band so its outward normal points away from the solid. The
+    // solid tessellator orients a torus band's triangles from the surface's
+    // intrinsic (u, v) frame, then applies the face `reversed` flag; pick the
+    // flag that makes the geometric normal at the band's mid-arc point outward.
+    // Outward at a rim fillet points away from the cylinder axis (positive
+    // radial) and away from the material along the axis; the torus geometric
+    // normal at the mid-arc already has the correct radial sign, so we compare
+    // its axial component against the material side.
+    if torus_band_needs_reversal(&torus, rim) {
+        band_face.set_reversed(true);
+    }
+    let band_face_id = topo.add_face(band_face);
+
+    Ok(band_face_id)
+}
+
+/// Decide whether a rim-fillet torus band must carry `reversed` so its outward
+/// normal points away from the solid.
+///
+/// The band's mid-arc geometric normal points radially out from the tube; we
+/// need it to also point to the *empty* side along the axis. The empty side is
+/// opposite the wall material: for a non-reversed cylinder/cone wall the
+/// material is on the axis-interior side, and the band sits one fillet radius
+/// from the plate toward the material — so the band's outward axial direction is
+/// the one pointing from the wall-contact circle back toward the plate.
+fn torus_band_needs_reversal(
+    torus: &brepkit_math::surfaces::ToroidalSurface,
+    rim: &ClosedRimInfo,
+) -> bool {
+    // The torus geometric normal at the mid-arc point (halfway between the two
+    // contacts) should point away from the segment plate→wall along the axis.
+    // The "away from material" axial direction is plate_center → (plate_center −
+    // wall_center) i.e. from the wall contact toward the plate.
+    let axis = torus.z_axis();
+    let to_plate = rim.plate_circle.center() - rim.wall_circle.center();
+    let outward_axial = axis * axis.dot(to_plate); // component along the axis toward the plate
+    // Mid-arc point and its geometric normal.
+    let v_plate = torus.project_point(rim.plate_circle.evaluate(0.0)).1;
+    let v_wall = torus.project_point(rim.wall_circle.evaluate(0.0)).1;
+    // Shortest signed mid-angle between the two contact v-parameters (periodic):
+    // reduce the raw difference into (−π, π].
+    let dv = (v_wall - v_plate + std::f64::consts::PI).rem_euclid(std::f64::consts::TAU)
+        - std::f64::consts::PI;
+    let v_mid = v_plate + dv * 0.5;
+    let n = torus.normal(0.0, v_mid);
+    // If the geometric normal's axial part opposes the outward axial direction,
+    // the band must be reversed.
+    n.dot(outward_axial) < 0.0
 }
 
 /// Compute a stripe for a single edge using the adjacency index.

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -2155,6 +2155,31 @@ pub fn fillet_rolling_ball(
     // the mesh boolean fallback on moderate-complexity filleted solids.
     let _ = crate::heal::unify_faces(topo, solid_id);
 
+    // Reject a geometrically-degenerate assembly. This engine is built around
+    // polygonal wires with distinct corner vertices; a closed circular edge
+    // (a cylinder/cone rim, where start vertex == end vertex) collapses its
+    // blend strip and the adjacent disc cap to zero-area faces while still
+    // passing the manifold check, silently dropping the caps and shrinking the
+    // wall. Surface it as an error so the dispatcher (`try_fillet`) falls
+    // through to the walking blend engine (`blend_ops::fillet_v2`), which
+    // rounds a closed rim correctly. The guard is keyed on actual face area,
+    // not edge topology, so a valid fillet (every face has real area) is never
+    // rejected.
+    let faces = brepkit_topology::explorer::solid_faces(topo, solid_id)
+        .map_err(crate::OperationsError::Topology)?;
+    let area_floor = (radius * radius) * 1e-6;
+    for fid in faces {
+        let area = crate::measure::face_area(topo, fid, radius * 0.1)?;
+        if area <= area_floor {
+            return Err(crate::OperationsError::InvalidInput {
+                reason: format!(
+                    "fillet produced a degenerate face (area {area:.3e} <= {area_floor:.3e}); \
+                     closed circular edges are not supported by the rolling-ball engine"
+                ),
+            });
+        }
+    }
+
     Ok(solid_id)
 }
 

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -923,9 +923,15 @@ fn fillet_radius_just_fits() {
 
 #[test]
 fn fillet_plane_cylinder_edge() {
-    // A cylinder has planar top/bottom and a cylindrical lateral face.
-    // The edges between the planar caps and the cylindrical face should
-    // now be filleted (previously silently skipped).
+    // A cylinder's rim edges are CLOSED circles (start vertex == end vertex).
+    // The rolling-ball engine is built around polygonal wires with distinct
+    // corner vertices; a closed circular edge collapses its blend strip and the
+    // adjacent disc cap to zero-area faces (the result is manifold but
+    // geometrically degenerate — it silently drops the caps and shrinks the
+    // wall, removing ~35% of the volume; see gh #967). The engine must reject
+    // this rather than return the broken solid, so the dispatcher
+    // (`wasm::try_fillet`) falls through to the walking blend engine
+    // (`blend_ops::fillet_v2`), which rounds a closed rim correctly.
     let mut topo = Topology::new();
     let solid = crate::primitives::make_cylinder(&mut topo, 2.0, 4.0).unwrap();
 
@@ -972,26 +978,19 @@ fn fillet_plane_cylinder_edge() {
         "cylinder should have plane-cylinder edges"
     );
 
-    // Fillet the first plane-cylinder edge. This should succeed now
-    // (previously it would have been silently skipped).
+    // Filleting the closed rim circle must be REJECTED (not return a degenerate
+    // solid). The rejection lets the dispatcher fall through to the walking
+    // engine, which rounds the rim into an exact quarter-torus (gh #967).
     let result = fillet_rolling_ball(&mut topo, solid, &plane_cyl_edges[..1], 0.3);
     assert!(
-        result.is_ok(),
-        "plane-cylinder fillet should succeed: {:?}",
-        result.err()
+        result.is_err(),
+        "rolling-ball fillet of a closed cylinder-rim edge must be rejected as \
+         degenerate, not return a silently-broken solid"
     );
-
-    // Verify the result has a NURBS fillet face.
-    let result_solid = result.unwrap();
-    let rs = topo.solid(result_solid).unwrap();
-    let rsh = topo.shell(rs.outer_shell()).unwrap();
-    let has_nurbs = rsh
-        .faces()
-        .iter()
-        .any(|&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)));
+    let msg = format!("{}", result.err().unwrap());
     assert!(
-        has_nurbs,
-        "plane-cylinder fillet should produce a NURBS face"
+        msg.contains("degenerate"),
+        "expected a degenerate-face rejection, got: {msg}"
     );
 }
 
@@ -1239,11 +1238,17 @@ fn adjacent_fillet_overlap_curved_face_detected() {
             assert!(vol > 0.0);
         }
         Err(e) => {
-            // Overlap or curvature error is expected for large radius
+            // A large radius on the closed cylinder rim is expected to fail.
+            // Acceptable reasons: overlap / curvature bound, or the degenerate
+            // closed-circular-edge rejection (the rim collapses the blend strip;
+            // see gh #967). The key is that it must NOT panic.
             let msg = format!("{e}");
             assert!(
-                msg.contains("overlap") || msg.contains("curvature") || msg.contains("exceeds"),
-                "expected overlap/curvature error, got: {msg}"
+                msg.contains("overlap")
+                    || msg.contains("curvature")
+                    || msg.contains("exceeds")
+                    || msg.contains("degenerate"),
+                "expected overlap/curvature/degenerate error, got: {msg}"
             );
         }
     }

--- a/crates/operations/src/measure/area.rs
+++ b/crates/operations/src/measure/area.rs
@@ -303,8 +303,8 @@ fn analytic_torus_face_area(
     if v_vals.is_empty() {
         return Ok(0.0);
     }
-    let v_min = v_vals.iter().copied().fold(f64::INFINITY, f64::min);
-    let v_max = v_vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let mut v_min = v_vals.iter().copied().fold(f64::INFINITY, f64::min);
+    let mut v_max = v_vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
     if (v_max - v_min).abs() < 1e-15 {
         // Full torus: v wraps from 0 to 2pi, all boundary v-vals are the same.
         // Use full v-range.
@@ -315,6 +315,17 @@ fn analytic_torus_face_area(
         let dv = std::f64::consts::TAU;
         let area = small_r * (u1 - u0) * (big_r * dv + small_r * 0.0);
         return Ok(area.abs());
+    }
+
+    // A toroidal band (e.g. a rim fillet) is bounded by two rims at distinct v,
+    // and v is periodic: the raw [v_min, v_max] may be the long (bulge) arc
+    // rather than the short fillet arc. If the naive span exceeds π, take the
+    // complementary (wrapped) arc instead.
+    if v_max - v_min > std::f64::consts::PI {
+        let new_min = v_max;
+        let new_max = v_min + std::f64::consts::TAU;
+        v_min = new_min;
+        v_max = new_max;
     }
 
     let u_range = compute_angular_range(&mut u_vals);

--- a/crates/operations/src/tessellate/face.rs
+++ b/crates/operations/src/tessellate/face.rs
@@ -8,8 +8,8 @@ use super::AnalyticKind;
 use super::TriangleMeshUV;
 use super::edge_sampling::{plane_axes, segments_for_chord_deviation_a};
 use super::nurbs::{
-    compute_angular_range, compute_axial_range, compute_sphere_v_range, compute_v_param_range,
-    sphere_analytic_kind, tessellate_nurbs,
+    compute_angular_range, compute_axial_range, compute_sphere_v_range, compute_torus_v_range,
+    compute_v_param_range, sphere_analytic_kind, tessellate_nurbs,
 };
 use super::planar::{tessellate_analytic, tessellate_analytic_with_boundary, tessellate_planar};
 
@@ -179,7 +179,7 @@ pub fn tessellate_with_uvs_a(
         }
         FaceSurface::Torus(torus) => {
             let u_range = compute_angular_range(topo, face_data, |p| torus.project_point(p));
-            let v_range = (0.0, std::f64::consts::TAU);
+            let v_range = compute_torus_v_range(topo, face_data, torus);
             let nu = segments_for_chord_deviation_a(
                 torus.major_radius(),
                 u_range.1 - u_range.0,

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -288,6 +288,24 @@ pub(super) fn tessellate_nonplanar_cdt(
                 }
             }
         }
+
+        // The tube angle (v) is periodic on a torus too. A toroidal band (a rim
+        // fillet) is bounded by two rims at distinct v, joined by a seam where v
+        // jumps by nearly a full turn; without unwrapping, the v-bbox spans the
+        // long arc (the bulging 270° of the tube) instead of the short fillet
+        // arc, and the interior CDT samples cover the wrong side. Unwrap v the
+        // same way u is unwrapped so consecutive boundary points stay within
+        // half a turn, collapsing the band to its true (short-arc) v-extent.
+        if matches!(face_data.surface(), FaceSurface::Torus(_)) && !boundary_uv.is_empty() {
+            for i in 1..boundary_uv.len() {
+                let prev_v = boundary_uv[i - 1].1;
+                let mut v = boundary_uv[i].1;
+                let diff = v - prev_v;
+                let shifts = (diff / std::f64::consts::TAU + 0.5).floor();
+                v -= shifts * std::f64::consts::TAU;
+                boundary_uv[i].1 = v;
+            }
+        }
     }
 
     // Compute (u,v) bounding box from a set of UV pairs.

--- a/crates/operations/src/tessellate/nurbs.rs
+++ b/crates/operations/src/tessellate/nurbs.rs
@@ -56,6 +56,54 @@ pub(super) fn compute_v_param_range(
     }
 }
 
+/// Compute the tube-angle (v) range for a toroidal face from its wire boundary.
+///
+/// A full torus has no boundary constraint on v, so the default is the full
+/// tube `(0, TAU)`. A toroidal *band* (e.g. a rim-fillet quarter-torus) is
+/// bounded by two closed circle edges sitting at distinct constant v; the band
+/// fills the arc between them. v is periodic, so two arcs are possible — the
+/// fillet band is the shorter one (a 90° rim corner spans π/2; we accept up to
+/// just under π). Returns `(0, TAU)` whenever the boundary doesn't clearly
+/// describe such a band (preserving full-tube tessellation for every other
+/// toroidal face).
+pub(super) fn compute_torus_v_range(
+    topo: &Topology,
+    face_data: &brepkit_topology::face::Face,
+    torus: &brepkit_math::surfaces::ToroidalSurface,
+) -> (f64, f64) {
+    use brepkit_topology::edge::EdgeCurve;
+    use std::f64::consts::{PI, TAU};
+
+    // Collect the (constant) v of each closed circular boundary edge.
+    let mut circle_vs: Vec<f64> = Vec::new();
+    if let Ok(wire) = topo.wire(face_data.outer_wire()) {
+        for oe in wire.edges() {
+            if let Ok(edge) = topo.edge(oe.edge())
+                && matches!(edge.curve(), EdgeCurve::Circle(_))
+                && edge.start() == edge.end()
+                && let Ok(vertex) = topo.vertex(edge.start())
+            {
+                circle_vs.push(torus.project_point(vertex.point()).1.rem_euclid(TAU));
+            }
+        }
+    }
+
+    if circle_vs.len() != 2 {
+        return (0.0, TAU);
+    }
+    let (va, vb) = (circle_vs[0], circle_vs[1]);
+
+    // Two candidate arcs between the circles; the band is the shorter one.
+    let (lo, hi) = if va <= vb { (va, vb) } else { (vb, va) };
+    let forward_span = hi - lo; // arc lo -> hi without wrap
+    if forward_span <= PI {
+        (lo, hi)
+    } else {
+        // The wrapped arc hi -> lo + TAU is the shorter one.
+        (hi, lo + TAU)
+    }
+}
+
 /// Compute the v-range (axial extent) for an analytic surface from its face
 /// wire boundary vertices.
 ///

--- a/crates/operations/tests/blend_integration.rs
+++ b/crates/operations/tests/blend_integration.rs
@@ -149,29 +149,32 @@ fn fillet_empty_edges_error() {
     assert!(err.is_err(), "empty edges should return an error");
 }
 
-/// Plane-cylinder fillet on a primitive cylinder. The bottom-cap circle
-/// edge sits where the plane (cap) meets the cylinder lateral; the analytic
-/// dispatcher should produce an exact toroidal fillet face for the convex
-/// "post on plate" geometry.
+/// Plane-cylinder fillet on a primitive cylinder. The bottom-cap circle edge
+/// sits where the disc cap (a bare disc bounded by the cylinder) meets the
+/// lateral; the analytic dispatcher should produce an exact toroidal fillet
+/// that rounds the rim INWARD (gh #967): `major = r_c − r`, torus centre one
+/// fillet radius into the material (z = +r). The result must be a watertight
+/// solid that removes only the thin rim sliver.
 #[test]
 fn fillet_cylinder_base_circle_produces_torus() {
     let mut topo = Topology::new();
-    // Cylinder of radius 2, height 4 — convex base circle is the spine.
+    // Cylinder of radius 2, height 4 — a rim circle is the spine.
     let solid = make_cylinder(&mut topo, 2.0, 4.0).unwrap();
+    let base_vol = solid_volume(&topo, solid, 0.005).unwrap();
 
     // The two `EdgeCurve::Circle` edges on a primitive cylinder are the top
-    // and bottom rims; pick whichever the explorer surfaces first.
-    let circle_edges: Vec<_> = solid_edges(&topo, solid)
+    // and bottom rims; pick the bottom rim (z = 0).
+    let bottom_rim = solid_edges(&topo, solid)
         .unwrap()
         .into_iter()
-        .filter(|&eid| matches!(topo.edge(eid).unwrap().curve(), EdgeCurve::Circle(_)))
-        .collect();
-    assert!(
-        !circle_edges.is_empty(),
-        "cylinder must have at least one circular rim edge"
-    );
+        .find(|&eid| {
+            let e = topo.edge(eid).unwrap();
+            matches!(e.curve(), EdgeCurve::Circle(_))
+                && topo.vertex(e.start()).unwrap().point().z().abs() < 1e-9
+        })
+        .expect("cylinder must have a bottom rim circle edge");
 
-    let result = fillet_v2(&mut topo, solid, &circle_edges[..1], 0.3).unwrap();
+    let result = fillet_v2(&mut topo, solid, &[bottom_rim], 0.3).unwrap();
 
     assert!(
         !result.succeeded.is_empty(),
@@ -191,34 +194,30 @@ fn fillet_cylinder_base_circle_produces_torus() {
     });
     let torus = torus.expect("analytic fast path should produce a Torus face");
 
-    // Torus geometry: minor radius == fillet radius, major radius ==
-    // r_cylinder + r_fillet (convex case), axis parallel to cylinder axis.
+    let r_c = 2.0;
+    let r_fillet = 0.3;
+    // Torus geometry: minor radius == fillet radius; major radius == r_c − r
+    // (inward rim); axis parallel to the cylinder axis.
     assert!(
-        (torus.minor_radius() - 0.3).abs() < 1e-9,
-        "torus minor radius should equal fillet radius 0.3, got {}",
+        (torus.minor_radius() - r_fillet).abs() < 1e-9,
+        "torus minor radius should equal fillet radius {r_fillet}, got {}",
         torus.minor_radius()
     );
     assert!(
-        (torus.major_radius() - 2.3).abs() < 1e-9,
-        "torus major radius should equal cylinder radius + fillet radius (2.3), got {}",
+        (torus.major_radius() - (r_c - r_fillet)).abs() < 1e-9,
+        "torus major radius should equal r_c − r_fillet ({}), got {}",
+        r_c - r_fillet,
         torus.major_radius()
     );
 
-    // Stricter geometric assertion: the torus must actually be tangent to
-    // both surfaces at the predicted contact points. Sample the small-circle
-    // u-frame densely and check that the predicted plate-contact and
-    // cylinder-contact 3D positions are reproduced. Without this we'd accept
-    // any torus with the right radii regardless of placement.
-    let r_c = 2.0;
-    let r_fillet = 0.3;
-    // Plate contact = top-of-tube (z toward +axis_dir): radial = r_c + r at z=0.
-    // Cylinder contact = inner-equator: radial = r_c at z = -r (one fillet
-    // radius below the plate, since the rolling ball center sits at z=-r).
-    // Both contacts lie in the plane spanned by the cylinder's local x_axis
-    // direction; for the brepkit primitive `Frame3::from_normal(z)` picks
-    // `x_axis = (0, 1, 0)`, so contact points appear in the +y direction.
-    let want_plate = brepkit_math::vec::Point3::new(0.0, r_c + r_fillet, 0.0);
-    let want_cyl = brepkit_math::vec::Point3::new(0.0, r_c, -r_fillet);
+    // Stricter geometric assertion: the torus must actually be tangent to both
+    // surfaces at the predicted contact points. The rim rounds inward, so the
+    // plate contact is at radial r_c − r (z = 0, inside the rim) and the
+    // cylinder contact is at radial r_c, z = +r (one fillet radius up into the
+    // body). For the brepkit primitive, `Frame3::from_normal(z)` picks
+    // `x_axis = (0, 1, 0)`, so contacts appear in the +y direction.
+    let want_plate = brepkit_math::vec::Point3::new(0.0, r_c - r_fillet, 0.0);
+    let want_cyl = brepkit_math::vec::Point3::new(0.0, r_c, r_fillet);
     let mut closest_plate = f64::INFINITY;
     let mut closest_cyl = f64::INFINITY;
     for i in 0..1440 {
@@ -234,6 +233,20 @@ fn fillet_cylinder_base_circle_produces_torus() {
     assert!(
         closest_cyl < 1e-6,
         "torus should touch cylinder at {want_cyl:?}; closest sample was {closest_cyl:.6}"
+    );
+
+    // The assembled solid must be watertight and remove only the thin rim
+    // sliver — a small fraction of the cylinder volume.
+    let sd = topo.solid(result.solid).unwrap();
+    let sh = topo.shell(sd.outer_shell()).unwrap();
+    brepkit_topology::validation::validate_shell_closed(sh, &topo)
+        .expect("rim fillet result must be watertight");
+    brepkit_topology::validation::validate_shell_manifold(sh, &topo)
+        .expect("rim fillet result must be manifold");
+    let vol = solid_volume(&topo, result.solid, 0.005).unwrap();
+    assert!(
+        vol < base_vol && vol > base_vol * 0.99,
+        "rim fillet should remove only a thin sliver: base={base_vol:.3}, filleted={vol:.3}"
     );
 }
 

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -152,9 +152,9 @@ pub fn json_f64(val: &serde_json::Value, key: &str) -> Result<f64, JsError> {
 /// is watertight too (#834). It runs first; the `FilletBuilder` and a flat
 /// bevel are fallbacks.
 ///
-/// Every candidate is validated as a manifold solid before being accepted, so
-/// a malformed result is rejected in favour of the next engine and, if none
-/// qualifies, the solid is returned unchanged. This guard lets
+/// Every candidate is validated as a closed (watertight) solid before being
+/// accepted, so a malformed result is rejected in favour of the next engine
+/// and, if none qualifies, the solid is returned unchanged. This guard lets
 /// `filter_filletable_edges` be permissive about curved neighbours without ever
 /// returning a degenerate solid.
 #[allow(deprecated)]
@@ -172,13 +172,17 @@ pub fn try_fillet(
     }
     let edges = edges.as_slice();
 
-    // A candidate is acceptable only if its outer shell is a manifold (no edge
-    // shared by more than two faces).
+    // A candidate is acceptable only if its outer shell is a CLOSED 2-manifold
+    // (every edge used by exactly two faces — no free/boundary edges). The
+    // weaker manifold-only check silently accepted open shells (e.g. a fillet
+    // that leaves a cap untrimmed at a contact circle), which tessellate to a
+    // plausible-but-wrong volume; reject them so the next engine or the
+    // unchanged input is used.
     let is_valid =
         |topo: &brepkit_topology::Topology, s: brepkit_topology::solid::SolidId| -> bool {
             topo.solid(s)
                 .and_then(|sd| topo.shell(sd.outer_shell()))
-                .map(|sh| brepkit_topology::validation::validate_shell_manifold(sh, topo).is_ok())
+                .map(|sh| brepkit_topology::validation::validate_shell_closed(sh, topo).is_ok())
                 .unwrap_or(false)
         };
 
@@ -549,6 +553,47 @@ mod fillet_tests {
         assert!(
             vol > 970.0 && vol < 1000.0,
             "filleted box volume should be ≈975.6, got {vol}"
+        );
+    }
+
+    // gh #967: filleting a plain cylinder's circular rim used to remove ~37% of
+    // the volume (the rolling-ball engine collapses closed circular edges). The
+    // rim now rounds into an exact quarter-torus: the rolling-ball degenerate
+    // result is rejected, `try_fillet` falls through to the walking engine, and
+    // the watertight rounded solid (≈6275.7, a ~0.12% rim round) is accepted —
+    // never the corrupt ~3978.
+    #[test]
+    fn try_fillet_cylinder_rim_rounds_not_corrupts() {
+        use brepkit_topology::face::FaceSurface;
+
+        let mut topo = Topology::new();
+        let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, 10.0, 20.0).unwrap();
+        let raw = brepkit_operations::measure::solid_volume(&topo, cyl, 0.01).unwrap();
+        let edges = solid_edge_ids(&topo, cyl);
+
+        let result = try_fillet(&mut topo, cyl, &edges, 0.5).expect("rim fillet");
+        let vol = brepkit_operations::measure::solid_volume(&topo, result, 0.01).unwrap();
+
+        // A tiny rim round — well under 1% removed, never the −37% corruption.
+        assert!(
+            vol < raw && vol > raw * 0.99,
+            "cylinder rim fillet should round (~{:.0}), got {vol} vs raw {raw}",
+            raw * 0.999
+        );
+        let sh = topo
+            .shell(topo.solid(result).unwrap().outer_shell())
+            .unwrap();
+        let torus_count = sh
+            .faces()
+            .iter()
+            .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Torus(_)))
+            .count();
+        assert_eq!(torus_count, 2, "both rims round into toroidal bands");
+        assert!(
+            brepkit_operations::validate::validate_solid(&topo, result)
+                .unwrap()
+                .is_valid(),
+            "rounded rim solid must be watertight"
         );
     }
 


### PR DESCRIPTION
## Summary

A constant-radius fillet on a plain cylinder's circular rim silently removed **37–47%** of the solid (#967). A cylinder rim is a *closed* circular edge (start vertex == end vertex), which broke two engines: the deprecated rolling-ball engine collapsed the blend strip and caps to **zero-area faces**, and the walking engine left the disc cap **untrimmed** at the contact circle → an **open shell** that tessellated to a plausible-but-wrong volume. Both passed the weak manifold-only acceptance gate.

The rim now **rounds correctly into an exact quarter-torus**.

**Result** (cyl r=10 h=20, fillet r=0.5): a watertight **5-face** solid — wall + 2 caps + 2 toroidal bands (occt's structure) — volume **≈6275.7, a ~0.12% rim round** matching occt's ~0.1%, not the −37% corruption.

| | before | after | occt |
|---|---|---|---|
| volume | 3978.8 (−37%) / open shell | **6275.7** | 6276.5 |
| shell | corrupt / 8 free edges | **watertight, 5 faces** | watertight, 5 faces |

## How

- **`blend/analytic` `plane_cylinder_fillet`** — detect an inward rim (bare disc cap bounded by the cylinder: no inner wires, all boundary verts within `r_c`) and place the torus inward (`major = r_c − r`, center one radius into the material) instead of the outward post-on-plate placement.
- **`blend/fillet_builder`** — a dedicated closed-revolution assembly rebuilds the disc cap shrunk to the torus's plate-contact circle, shortens the wall to its cylinder-contact circle, and emits the toroidal band, all sharing the two contact-circle edges. (The line-based trimmer couldn't: an interior contact circle has no boundary crossings — this was the blocker.)
- **`tessellate` + `measure`** — a toroidal *band* spans a short tube-angle (v) arc, not the full tube. `compute_torus_v_range` derives it from the two closed-circle rims (full-tube `(0,TAU)` otherwise, **so the torus primitive is unchanged** — verified); the CDT path unwraps periodic v; `analytic_torus_face_area` takes the short arc.
- **`fillet/rolling_ball`** — reject a degenerate zero-area-face assembly so the dispatcher falls through.
- **wasm `try_fillet`** — require a **closed** shell (not just manifold), rejecting the old open-shell results.

## Scope / note

Cone-rim fillets are now watertight too, but `plane_cone_fillet` still uses the outward placement, so a frustum *bottom*-rim flares slightly outward rather than rounding inward — a follow-up if inward-cone-rim semantics are wanted.

## Verification

- `cargo test` across operations + blend + wasm + io + check: **1462 pass, 0 fail**. The torus primitive (`curved_properties`) and the gridfinity fillet suite are unaffected; the rim now rounds end-to-end through `try_fillet`.
- New/updated tests: `try_fillet_cylinder_rim_rounds_not_corrupts`, `fillet_cylinder_base_circle_produces_torus` (inward geometry + watertight asserts), the two analytic tests that baked in the old outward geometry, and the rolling-ball degenerate-rejection tests.
- clippy clean, fmt clean, layer boundaries pass.

**Supersedes #971** (which made the rim a validated no-op to stop the corruption); this PR actually rounds the rim, so #971 will be closed.

Closes #967