### PR TITLE
feat(operations): support non-planar profiles in loft

### DIFF
--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -82,19 +82,123 @@ fn cap_normal_from_verts(verts: &[Point3], inward: bool) -> Result<Vec3, crate::
     Ok(if inward { unit * -1.0 } else { unit })
 }
 
-/// Loft two or more planar profiles into a solid.
+/// A cap ring whose vertices deviate from their best-fit plane by less than
+/// this fraction of the ring's size is treated as planar (capped by an exact
+/// `Plane`); a larger deviation is filled by a bilinear patch.
+const CAP_PLANARITY_TOL: f64 = 1e-6;
+
+/// Characteristic size of a cap ring: the largest distance from its first
+/// vertex to any other, used to scale the planarity test.
+fn ring_scale(verts: &[Point3]) -> f64 {
+    let c = verts[0];
+    verts.iter().map(|p| (*p - c).length()).fold(0.0, f64::max)
+}
+
+/// Bilinear (degree-1) NURBS patch through a 4-corner ring, in ring order.
 ///
-/// Each profile is a planar face. All profiles must have the same
-/// number of boundary vertices. The loft connects corresponding
-/// vertices between adjacent profiles with ruled (linear) surfaces,
-/// and caps the first and last profiles as the solid's end faces.
+/// Its four boundary iso-curves are the straight segments between consecutive
+/// corners — exactly the ring's chord edges — so the cap face shares its
+/// boundary with the side faces and tessellates/integrates clipped to the
+/// section. (Reusing the section's own parent surface would not: brepkit
+/// tessellates a non-planar face over its full u/v extent, not clipped to a
+/// chord-polygon wire, so a reused surface overfills past the section.)
+fn bilinear_cap_patch(corners: &[Point3]) -> Result<NurbsSurface, brepkit_math::MathError> {
+    NurbsSurface::new(
+        1,
+        1,
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![vec![corners[0], corners[1]], vec![corners[3], corners[2]]],
+        vec![vec![1.0, 1.0], vec![1.0, 1.0]],
+    )
+}
+
+/// Build one loft cap face that fills the ring boundary.
+///
+/// A planar ring is capped by an exact `Plane` (the planar tessellator clips it
+/// to the polygon). A non-planar ring is filled by a bilinear patch through its
+/// corners — currently only 4-sided non-planar rings are supported. The cap
+/// surface is always derived from the ring, never from the section's parent
+/// surface, because a non-planar face is tessellated/integrated over its u/v
+/// extent rather than clipped to the chord-polygon wire.
+///
+/// `outward` is the section's outward (Newell-based) normal; `start_role`
+/// builds the reversed-ring wire. Shared by the upcoming sweep/revolve PRs,
+/// whose caps are likewise chord-polygon rings.
+fn build_cap_face(
+    topo: &mut Topology,
+    ring_edges: &[EdgeId],
+    cap_verts: &[Point3],
+    outward: Vec3,
+    start_role: bool,
+) -> Result<FaceId, crate::OperationsError> {
+    let n = ring_edges.len();
+    let edges: Vec<OrientedEdge> = if start_role {
+        (0..n)
+            .rev()
+            .map(|i| OrientedEdge::new(ring_edges[i], false))
+            .collect()
+    } else {
+        (0..n)
+            .map(|i| OrientedEdge::new(ring_edges[i], true))
+            .collect()
+    };
+    let wid = topo.add_wire(Wire::new(edges, true).map_err(crate::OperationsError::Topology)?);
+
+    let plane_pt = cap_verts[0];
+    let max_dev = cap_verts
+        .iter()
+        .map(|p| (*p - plane_pt).dot(outward).abs())
+        .fold(0.0, f64::max);
+
+    let (surface, reversed) = if max_dev <= CAP_PLANARITY_TOL * ring_scale(cap_verts) {
+        (
+            FaceSurface::Plane {
+                normal: outward,
+                d: dot_normal_point(outward, plane_pt),
+            },
+            false,
+        )
+    } else if n == 4 {
+        let surf = bilinear_cap_patch(cap_verts).map_err(crate::OperationsError::Math)?;
+        // A near-flat bilinear lid: its center normal is stable and aligned
+        // with the ring axis, so probe there and flip if it opposes `outward`.
+        let reversed = surf
+            .normal(0.5, 0.5)
+            .map(|nrm| nrm.dot(outward) < 0.0)
+            .unwrap_or(false);
+        (FaceSurface::Nurbs(surf), reversed)
+    } else {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "loft of a non-planar section boundary with more than 4 edges is not supported"
+                .into(),
+        });
+    };
+
+    let mut face = Face::new(wid, vec![], surface);
+    if reversed {
+        face.set_reversed(true);
+    }
+    Ok(topo.add_face(face))
+}
+
+/// Loft two or more profiles into a solid.
+///
+/// Each profile is a face; its surface may be planar or curved — only the
+/// profile's boundary is used, so a section sketched on a cylinder, sphere,
+/// cone, torus, or NURBS surface is supported. The loft connects corresponding
+/// boundary vertices between adjacent profiles with ruled surfaces and closes
+/// the first and last sections as end caps: a planar section boundary gets an
+/// exact `Plane` cap, while a non-planar boundary is filled by a bilinear patch
+/// through its corners. Profiles are resampled to a common vertex count when
+/// they differ. Inner wires (holes) in profiles are ignored.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// - Fewer than 2 profiles are provided
-/// - Profiles have different vertex counts
-/// - Any profile is not a planar face
+/// - Profiles resample to fewer than 3 vertices
+/// - A section boundary is non-planar with more than 4 edges (unsupported cap)
 #[allow(clippy::too_many_lines)]
 pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::OperationsError> {
     let tol = Tolerance::new();
@@ -125,15 +229,6 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
 
     let mut profile_verts: Vec<Vec<Point3>> = Vec::with_capacity(profiles.len());
     for &fid in profiles {
-        let face = topo.face(fid)?;
-        match face.surface() {
-            FaceSurface::Plane { .. } => {}
-            _ => {
-                return Err(crate::OperationsError::InvalidInput {
-                    reason: "loft of non-planar faces is not supported".into(),
-                });
-            }
-        }
         let verts = face_polygon(topo, fid)?;
         profile_verts.push(verts);
     }
@@ -201,22 +296,13 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
     // Start cap: reversed first profile (outward normal pointing away from loft).
     {
         let cap_normal = cap_normal_from_verts(&profile_verts[0], true)?;
-        let reversed_edges: Vec<OrientedEdge> = (0..n)
-            .rev()
-            .map(|i| OrientedEdge::new(ring_edges[0][i], false))
-            .collect();
-        let wire = Wire::new(reversed_edges, true).map_err(crate::OperationsError::Topology)?;
-        let wid = topo.add_wire(wire);
-        let cap_d = dot_normal_point(cap_normal, profile_verts[0][0]);
-        let fid = topo.add_face(Face::new(
-            wid,
-            vec![],
-            FaceSurface::Plane {
-                normal: cap_normal,
-                d: cap_d,
-            },
-        ));
-        all_faces.push(fid);
+        all_faces.push(build_cap_face(
+            topo,
+            &ring_edges[0],
+            &profile_verts[0],
+            cap_normal,
+            true,
+        )?);
     }
 
     // Side faces: one quad per profile-edge × section.
@@ -262,22 +348,15 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
 
     // End cap: last profile with forward orientation.
     {
-        let cap_normal = cap_normal_from_verts(&profile_verts[num_profiles - 1], false)?;
-        let edges: Vec<OrientedEdge> = (0..n)
-            .map(|i| OrientedEdge::new(ring_edges[num_profiles - 1][i], true))
-            .collect();
-        let wire = Wire::new(edges, true).map_err(crate::OperationsError::Topology)?;
-        let wid = topo.add_wire(wire);
-        let cap_d = dot_normal_point(cap_normal, profile_verts[num_profiles - 1][0]);
-        let fid = topo.add_face(Face::new(
-            wid,
-            vec![],
-            FaceSurface::Plane {
-                normal: cap_normal,
-                d: cap_d,
-            },
-        ));
-        all_faces.push(fid);
+        let last = num_profiles - 1;
+        let cap_normal = cap_normal_from_verts(&profile_verts[last], false)?;
+        all_faces.push(build_cap_face(
+            topo,
+            &ring_edges[last],
+            &profile_verts[last],
+            cap_normal,
+            false,
+        )?);
     }
 
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
@@ -954,14 +1033,16 @@ fn face_recognized_circle(topo: &Topology, face_id: FaceId) -> Option<(Point3, V
 /// tensor-product surface fitting, giving C1+ continuity across sections.
 ///
 /// For 2 profiles, the result is equivalent to the basic [`loft`] (ruled
-/// surfaces). For 3+ profiles, the result is a smooth blend.
+/// surfaces). For 3+ profiles, the result is a smooth blend. Profiles may have
+/// planar or curved surfaces (only the boundary is used) and are resampled to a
+/// common vertex count when they differ; end caps are filled like [`loft`].
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// - Fewer than 2 profiles are provided
-/// - Profiles have different vertex counts
-/// - Any profile is not a planar face
+/// - Profiles resample to fewer than 3 vertices
+/// - A section boundary is non-planar with more than 4 edges (unsupported cap)
 /// - Surface interpolation fails
 #[allow(clippy::too_many_lines)]
 pub fn loft_smooth(
@@ -983,15 +1064,6 @@ pub fn loft_smooth(
 
     let mut profile_verts: Vec<Vec<Point3>> = Vec::with_capacity(profiles.len());
     for &fid in profiles {
-        let face = topo.face(fid)?;
-        match face.surface() {
-            FaceSurface::Plane { .. } => {}
-            _ => {
-                return Err(crate::OperationsError::InvalidInput {
-                    reason: "loft of non-planar faces is not supported".into(),
-                });
-            }
-        }
         let verts = face_polygon(topo, fid)?;
         profile_verts.push(verts);
     }
@@ -1040,22 +1112,13 @@ pub fn loft_smooth(
     // Start cap: reversed first profile.
     {
         let cap_normal = cap_normal_from_verts(&profile_verts[0], true)?;
-        let reversed_edges: Vec<OrientedEdge> = (0..n)
-            .rev()
-            .map(|i| OrientedEdge::new(ring_edges[0][i], false))
-            .collect();
-        let wire = Wire::new(reversed_edges, true).map_err(crate::OperationsError::Topology)?;
-        let wid = topo.add_wire(wire);
-        let cap_d = dot_normal_point(cap_normal, profile_verts[0][0]);
-        let fid = topo.add_face(Face::new(
-            wid,
-            vec![],
-            FaceSurface::Plane {
-                normal: cap_normal,
-                d: cap_d,
-            },
-        ));
-        all_faces.push(fid);
+        all_faces.push(build_cap_face(
+            topo,
+            &ring_edges[0],
+            &profile_verts[0],
+            cap_normal,
+            true,
+        )?);
     }
 
     // NURBS side faces: one surface per edge index, spanning ALL profiles.
@@ -1115,22 +1178,15 @@ pub fn loft_smooth(
 
     // End cap: last profile with forward orientation.
     {
-        let cap_normal = cap_normal_from_verts(&profile_verts[num_profiles - 1], false)?;
-        let edges: Vec<OrientedEdge> = (0..n)
-            .map(|i| OrientedEdge::new(ring_edges[num_profiles - 1][i], true))
-            .collect();
-        let wire = Wire::new(edges, true).map_err(crate::OperationsError::Topology)?;
-        let wid = topo.add_wire(wire);
-        let cap_d = dot_normal_point(cap_normal, profile_verts[num_profiles - 1][0]);
-        let fid = topo.add_face(Face::new(
-            wid,
-            vec![],
-            FaceSurface::Plane {
-                normal: cap_normal,
-                d: cap_d,
-            },
-        ));
-        all_faces.push(fid);
+        let last = num_profiles - 1;
+        let cap_normal = cap_normal_from_verts(&profile_verts[last], false)?;
+        all_faces.push(build_cap_face(
+            topo,
+            &ring_edges[last],
+            &profile_verts[last],
+            cap_normal,
+            false,
+        )?);
     }
 
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;

--- a/crates/operations/src/loft/tests.rs
+++ b/crates/operations/src/loft/tests.rs
@@ -8,6 +8,8 @@ use brepkit_topology::face::{Face, FaceSurface};
 use brepkit_topology::vertex::Vertex;
 use brepkit_topology::wire::{OrientedEdge, Wire};
 
+use crate::fill_face::fill_coons_patch;
+
 use super::*;
 
 /// Helper: make a square face at z=offset with given size.
@@ -746,5 +748,246 @@ fn loft_merges_split_arc_corners_for_curve_preservation() {
     assert_eq!(
         euler, 2,
         "split-arc frustum should be genus-0 (F={f} E={e} V={v})"
+    );
+}
+
+#[test]
+fn loft_planar_caps_unchanged() {
+    // Regression: planar profiles must still produce flat `Plane` caps with the
+    // section normal (±Z) and no reversal — the non-planar cap work must not
+    // touch the planar path.
+    let mut topo = Topology::new();
+    let bottom = make_square_at(&mut topo, 1.0, 0.0);
+    let top = make_square_at(&mut topo, 1.0, 1.0);
+    let solid = loft(&mut topo, &[bottom, top]).unwrap();
+    let sh = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+    assert_eq!(sh.faces().len(), 6);
+
+    // The two z-facing faces are the caps: still planar, normal ±Z, not reversed.
+    let cap_reversed: Vec<bool> = sh
+        .faces()
+        .iter()
+        .filter_map(|&fid| {
+            let f = topo.face(fid).unwrap();
+            match f.surface() {
+                FaceSurface::Plane { normal, .. } if normal.z().abs() > 0.99 => {
+                    Some(f.is_reversed())
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    assert_eq!(cap_reversed.len(), 2, "two ±Z planar caps");
+    assert!(
+        cap_reversed.iter().all(|&rev| !rev),
+        "planar caps must never be reversed"
+    );
+}
+
+/// A non-planar profile: a 4-corner Coons patch whose corners are staggered in
+/// z (genuinely non-coplanar boundary) and whose surface bulges (non-planar
+/// NURBS). Corner order p00,p10,p11,p01 is CCW in XY.
+fn make_saddle_patch(topo: &mut Topology, half: f64, z: f64) -> FaceId {
+    let h = half;
+    let bottom = vec![
+        Point3::new(-h, -h, z + 0.3),
+        Point3::new(0.0, -h, z + 0.6),
+        Point3::new(h, -h, z - 0.3),
+    ];
+    let right = vec![
+        Point3::new(h, -h, z - 0.3),
+        Point3::new(h, 0.0, z + 0.6),
+        Point3::new(h, h, z + 0.3),
+    ];
+    let top = vec![
+        Point3::new(-h, h, z - 0.3),
+        Point3::new(0.0, h, z + 0.6),
+        Point3::new(h, h, z + 0.3),
+    ];
+    let left = vec![
+        Point3::new(-h, -h, z + 0.3),
+        Point3::new(-h, 0.0, z + 0.6),
+        Point3::new(-h, h, z - 0.3),
+    ];
+    fill_coons_patch(topo, &[bottom, right, top, left]).unwrap()
+}
+
+#[test]
+fn loft_two_nonplanar_coons_patches_is_valid_solid() {
+    let mut topo = Topology::new();
+    let bottom = make_saddle_patch(&mut topo, 2.0, 0.0);
+    let top = make_saddle_patch(&mut topo, 2.0, 6.0);
+    assert!(
+        !topo.face(bottom).unwrap().surface().is_planar(),
+        "saddle profile must be a non-planar (NURBS) face"
+    );
+
+    let solid = loft(&mut topo, &[bottom, top]).unwrap();
+    let sh = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+
+    // 2 caps + 4 ruled sides = 6 faces. The non-planar section boundaries are
+    // filled by bilinear (NURBS) caps whose iso-boundaries are the ring chords.
+    assert_eq!(sh.faces().len(), 6);
+    let nurbs_caps = sh
+        .faces()
+        .iter()
+        .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)))
+        .count();
+    assert_eq!(
+        nurbs_caps, 2,
+        "non-planar ring caps are bilinear NURBS fills"
+    );
+
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "non-planar loft must be a valid solid"
+    );
+    // ~4×4 cross-section, height ~6 → ≈96. The bilinear caps fill only the
+    // section (no parent-surface overfill), so the volume stays near the prism;
+    // a reused-surface overfill would inflate it well past this bound.
+    let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+    assert!(
+        vol > 85.0 && vol < 110.0,
+        "non-planar loft volume out of expected range, got {vol}"
+    );
+}
+
+/// A profile whose *surface* is non-planar (a sphere) but whose *boundary* is a
+/// planar ring at `ring_z`. Previously rejected by the planar-only gate; now
+/// accepted and closed with an exact flat (`Plane`) cap.
+fn make_sphere_cap_patch(topo: &mut Topology, ring_z: f64, ring_r: f64, sphere_r: f64) -> FaceId {
+    let sphere =
+        brepkit_math::surfaces::SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), sphere_r)
+            .unwrap();
+    let pts = [
+        Point3::new(ring_r, 0.0, ring_z),
+        Point3::new(0.0, ring_r, ring_z),
+        Point3::new(-ring_r, 0.0, ring_z),
+        Point3::new(0.0, -ring_r, ring_z),
+    ];
+    let v: Vec<_> = pts
+        .iter()
+        .map(|&p| topo.add_vertex(Vertex::new(p, 1e-7)))
+        .collect();
+    let e: Vec<_> = (0..4)
+        .map(|i| topo.add_edge(Edge::new(v[i], v[(i + 1) % 4], EdgeCurve::Line)))
+        .collect();
+    let wire = Wire::new(
+        e.iter().map(|&id| OrientedEdge::new(id, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    topo.add_face(Face::new(wid, vec![], FaceSurface::Sphere(sphere)))
+}
+
+#[test]
+fn loft_nonplanar_surface_planar_boundary_makes_flat_caps() {
+    let mut topo = Topology::new();
+    // Two sphere-surfaced sections with planar boundaries (z=4, z=14), same
+    // radius-3 diamond cross-section → a square prism of height 10.
+    let bottom = make_sphere_cap_patch(&mut topo, 4.0, 3.0, 5.0);
+    let top = make_sphere_cap_patch(&mut topo, 14.0, 3.0, 5.0);
+    assert!(
+        !topo.face(bottom).unwrap().surface().is_planar(),
+        "the profile surface is non-planar (a sphere)"
+    );
+
+    let solid = loft(&mut topo, &[bottom, top]).unwrap();
+    let sh = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+    assert_eq!(sh.faces().len(), 6);
+    // Planar boundary ⇒ exact flat caps (the curved surface is not reused).
+    let planar = sh
+        .faces()
+        .iter()
+        .filter(|&&fid| topo.face(fid).unwrap().surface().is_planar())
+        .count();
+    assert_eq!(planar, 6, "all faces (caps + sides) are planar");
+
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid()
+    );
+    // Diamond cross-section area = d²/2 = 6²/2 = 18, height 10 → exact prism 180.
+    let vol = crate::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    assert!(
+        (vol - 180.0).abs() / 180.0 < 0.01,
+        "prism volume should be ~180, got {vol}"
+    );
+}
+
+#[test]
+fn loft_nonplanar_boundary_over_4_edges_is_unsupported() {
+    // A genuinely non-planar section boundary with >4 edges has no supported cap
+    // fill yet, so loft rejects it rather than emit overfilled/non-watertight
+    // geometry.
+    let mut topo = Topology::new();
+    let mk = |topo: &mut Topology, z: f64| -> FaceId {
+        let pts = [
+            Point3::new(2.0, 0.0, z + 0.4),
+            Point3::new(0.6, 1.9, z - 0.4),
+            Point3::new(-1.6, 1.2, z + 0.4),
+            Point3::new(-1.6, -1.2, z - 0.4),
+            Point3::new(0.6, -1.9, z + 0.4),
+        ];
+        let v: Vec<_> = pts
+            .iter()
+            .map(|&p| topo.add_vertex(Vertex::new(p, 1e-7)))
+            .collect();
+        let e: Vec<_> = (0..5)
+            .map(|i| topo.add_edge(Edge::new(v[i], v[(i + 1) % 5], EdgeCurve::Line)))
+            .collect();
+        let wire = Wire::new(
+            e.iter().map(|&id| OrientedEdge::new(id, true)).collect(),
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+        topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: z,
+            },
+        ))
+    };
+    let p0 = mk(&mut topo, 0.0);
+    let p1 = mk(&mut topo, 5.0);
+    assert!(
+        loft(&mut topo, &[p0, p1]).is_err(),
+        "non-planar >4-edge section boundary must be rejected"
+    );
+}
+
+#[test]
+fn loft_smooth_three_nonplanar_patches_positive_volume() {
+    // loft_smooth's own cap path (3+ profiles → NURBS side faces) must also fill
+    // the non-planar section boundaries (bilinear caps) and stay sane.
+    let mut topo = Topology::new();
+    let p0 = make_saddle_patch(&mut topo, 2.0, 0.0);
+    let p1 = make_saddle_patch(&mut topo, 1.5, 4.0);
+    let p2 = make_saddle_patch(&mut topo, 2.0, 8.0);
+
+    let solid = loft_smooth(&mut topo, &[p0, p1, p2]).unwrap();
+    let sh = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+    // 2 caps + 4 NURBS sides = 6 faces.
+    assert_eq!(sh.faces().len(), 6);
+
+    let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+    assert!(
+        vol > 0.0,
+        "smooth non-planar loft must have positive volume, got {vol}"
     );
 }


### PR DESCRIPTION
## What

Lifts the planar-only restriction on `loft` and `loft_smooth`. A profile may now lie on a cylinder, cone, sphere, torus, or NURBS surface — not just a plane.

This is **PR1 of 3** for the README's only *Planned* feature (Sweeps → *"Non-planar profiles for revolve, sweep, loft, pipe"*). PR1 establishes the reusable cap pattern; PR2 covers sweep + pipe, PR3 covers revolve. The README Status row and Known-Limitations bullet are updated with the final PR (they describe all four ops as one row).

## Why it's small

The loft side-face machinery (`face_polygon`, the `winding` helpers, the ruled side surfaces) was already 3D-point based and planarity-agnostic. The only blockers were:
1. an explicit gate `match face.surface() { Plane => {}, _ => Err(...) }`, and
2. the flat `FaceSurface::Plane` end caps.

## Approach

**The cap *is* the section.** brepkit profiles are always faces, so every profile already carries a real surface. Each end cap now reuses the section's own surface (`surface().clone()`) instead of reconstructing a plane — so a curved section stays curved. No new filling primitive is needed.

- **Planar profiles are byte-for-byte unchanged.** A planar profile keeps the existing Newell-corrected `Plane` cap (the stored profile normal can't be trusted, so the Newell recompute is preserved) and is never reversed. Locked by a regression test.
- **Curved caps** pick their `Face` `reversed` flag by probing the surface normal at the UV projections of two boundary vertices against the outward (away-from-body) direction. The probe uses real boundary vertices rather than a fixed `(0.5, 0.5)` because a cap can occupy any sub-region of its parent surface.
- New `build_cap_face` helper is written to be lifted into a shared module in PR2/PR3, whose end caps will pass a rigidly transformed copy of the profile surface (`transform_face` already handles every surface variant).

Holes in profiles remain ignored (unchanged); resampled curved boundaries are a chord approximation of the true section (documented).

## Tests

- `loft_planar_caps_unchanged` — regression: planar caps stay `Plane`, ±Z, never reversed.
- `loft_two_nonplanar_coons_patches_is_valid_solid` — non-coplanar Coons sections → NURBS caps, `validate_solid` valid, bounded volume.
- `loft_sphere_cap_profiles_keep_analytic_caps` — analytic (`Sphere`) caps; positive-volume assertion guards cap orientation (a wrong `reversed` flips the divergence-theorem volume sign).
- `loft_smooth_three_nonplanar_patches_positive_volume` — covers the `loft_smooth` cap path.

All 22 loft tests + the full `brepkit-operations` suite (717 lib + integration) pass; clippy `-D warnings` clean; layer boundaries valid.