### PR TITLE
feat(operations): support non-planar profiles in sweep and pipe

### DIFF
--- a/crates/operations/src/cap.rs
+++ b/crates/operations/src/cap.rs
@@ -1,0 +1,163 @@
+//! Shared loft/sweep/pipe/revolve end-cap construction.
+//!
+//! A swept/lofted/revolved end is closed by filling its section *boundary* — a
+//! ring of chord edges — rather than by reusing the section's own surface.
+//! brepkit tessellates and integrates a non-planar face over its full u/v
+//! extent rather than clipping to a chord-polygon wire, so a reused parent
+//! surface would overfill past the section. Instead: a planar ring gets an exact
+//! `Plane` cap (the planar tessellator clips it to the polygon), and a
+//! non-planar 4-sided ring is filled by a bilinear patch whose boundary
+//! iso-curves are exactly the ring chords (`domain == wire`, so it can't
+//! overfill).
+
+use brepkit_math::nurbs::surface::NurbsSurface;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::face::{Face, FaceId, FaceSurface};
+use brepkit_topology::vertex::VertexId;
+use brepkit_topology::wire::{OrientedEdge, Wire, WireId};
+
+use crate::dot_normal_point;
+
+/// Collect the 3D positions of a ring of vertices (a cap's outer boundary).
+///
+/// # Errors
+///
+/// Returns an error if a vertex id is missing from the arena.
+pub fn ring_point_positions(
+    topo: &Topology,
+    ring: &[VertexId],
+) -> Result<Vec<Point3>, crate::OperationsError> {
+    ring.iter()
+        .map(|&vid| -> Result<Point3, crate::OperationsError> { Ok(topo.vertex(vid)?.point()) })
+        .collect()
+}
+
+/// A cap ring whose vertices deviate from their best-fit plane by less than this
+/// fraction of the ring's size is treated as planar (capped by an exact
+/// `Plane`); a larger deviation is filled by a bilinear patch.
+const CAP_PLANARITY_TOL: f64 = 1e-6;
+
+/// Characteristic size of a cap ring: the largest distance from its first
+/// vertex to any other, used to scale the planarity test.
+fn ring_scale(verts: &[Point3]) -> f64 {
+    let c = verts[0];
+    verts.iter().map(|p| (*p - c).length()).fold(0.0, f64::max)
+}
+
+/// Whether the ring lies (within tolerance) in the plane through `cap_verts[0]`
+/// with normal `outward`.
+fn ring_is_planar(cap_verts: &[Point3], outward: Vec3) -> bool {
+    let plane_pt = cap_verts[0];
+    let max_dev = cap_verts
+        .iter()
+        .map(|p| (*p - plane_pt).dot(outward).abs())
+        .fold(0.0, f64::max);
+    max_dev <= CAP_PLANARITY_TOL * ring_scale(cap_verts)
+}
+
+/// Bilinear (degree-1) NURBS patch through a 4-corner ring, in ring order.
+///
+/// Its four boundary iso-curves are the straight segments between consecutive
+/// corners — exactly the ring's chord edges — so the cap shares its boundary
+/// with the side faces and tessellates/integrates clipped to the section.
+fn bilinear_cap_patch(corners: &[Point3]) -> Result<NurbsSurface, brepkit_math::MathError> {
+    NurbsSurface::new(
+        1,
+        1,
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![vec![corners[0], corners[1]], vec![corners[3], corners[2]]],
+        vec![vec![1.0, 1.0], vec![1.0, 1.0]],
+    )
+}
+
+/// The ring's outward cap normal: its Newell normal, flipped to agree with
+/// `toward` (the side the cap should face, e.g. away from the swept body).
+///
+/// # Errors
+///
+/// Returns an error if the ring is degenerate (zero-area Newell normal).
+pub fn outward_normal(verts: &[Point3], toward: Vec3) -> Result<Vec3, crate::OperationsError> {
+    let n = crate::winding::newell_normal(verts).normalize()?;
+    Ok(if n.dot(toward) < 0.0 { -n } else { n })
+}
+
+/// Build one end-cap face that fills the ring boundary (and any holes).
+///
+/// `outer_ring_edges` is the section's outer boundary in ring order;
+/// `inner_wires` are pre-built hole loops (empty for hole-free sections, and
+/// only supported on a planar cap). `outward` is the section's outward normal;
+/// `start_role` builds the reversed-ring wire so the cap faces away from the
+/// body.
+///
+/// A planar ring → exact `Plane` cap. A non-planar 4-sided hole-free ring →
+/// bilinear patch. A non-planar ring with more than four edges, or with holes,
+/// is unsupported.
+///
+/// # Errors
+///
+/// Returns an error if the wire is invalid, the bilinear patch cannot be built,
+/// or the ring is an unsupported non-planar shape.
+pub fn build_cap_face(
+    topo: &mut Topology,
+    outer_ring_edges: &[EdgeId],
+    inner_wires: Vec<WireId>,
+    cap_verts: &[Point3],
+    outward: Vec3,
+    start_role: bool,
+) -> Result<FaceId, crate::OperationsError> {
+    let n = outer_ring_edges.len();
+    // `cap_verts` must be one position per ring edge (and a ring needs ≥ 3) —
+    // later indexing (`cap_verts[0]`, the 4 bilinear corners) relies on this.
+    if n < 3 || cap_verts.len() != n {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "cap ring must have at least 3 vertices matching its edge count".into(),
+        });
+    }
+    let edges: Vec<OrientedEdge> = if start_role {
+        (0..n)
+            .rev()
+            .map(|i| OrientedEdge::new(outer_ring_edges[i], false))
+            .collect()
+    } else {
+        (0..n)
+            .map(|i| OrientedEdge::new(outer_ring_edges[i], true))
+            .collect()
+    };
+    let wid = topo.add_wire(Wire::new(edges, true).map_err(crate::OperationsError::Topology)?);
+
+    if ring_is_planar(cap_verts, outward) {
+        let surface = FaceSurface::Plane {
+            normal: outward,
+            d: dot_normal_point(outward, cap_verts[0]),
+        };
+        return Ok(topo.add_face(Face::new(wid, inner_wires, surface)));
+    }
+
+    if !inner_wires.is_empty() {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "cap with holes on a non-planar section boundary is not supported".into(),
+        });
+    }
+    if n != 4 {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "cap for a non-planar section boundary with more than 4 edges is not supported"
+                .into(),
+        });
+    }
+
+    let surf = bilinear_cap_patch(cap_verts).map_err(crate::OperationsError::Math)?;
+    // A near-flat bilinear lid: its center normal is stable and aligned with the
+    // ring axis, so probe there and flip if it opposes `outward`.
+    let reversed = surf
+        .normal(0.5, 0.5)
+        .map(|nrm| nrm.dot(outward) < 0.0)
+        .unwrap_or(false);
+    let mut face = Face::new(wid, vec![], FaceSurface::Nurbs(surf));
+    if reversed {
+        face.set_reversed(true);
+    }
+    Ok(topo.add_face(face))
+}

--- a/crates/operations/src/lib.rs
+++ b/crates/operations/src/lib.rs
@@ -69,6 +69,7 @@ pub mod validate;
 pub mod tessellate;
 
 pub mod assembly;
+pub(crate) mod cap;
 pub mod compound_ops;
 pub mod evolution;
 pub mod sketch;

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -82,106 +82,6 @@ fn cap_normal_from_verts(verts: &[Point3], inward: bool) -> Result<Vec3, crate::
     Ok(if inward { unit * -1.0 } else { unit })
 }
 
-/// A cap ring whose vertices deviate from their best-fit plane by less than
-/// this fraction of the ring's size is treated as planar (capped by an exact
-/// `Plane`); a larger deviation is filled by a bilinear patch.
-const CAP_PLANARITY_TOL: f64 = 1e-6;
-
-/// Characteristic size of a cap ring: the largest distance from its first
-/// vertex to any other, used to scale the planarity test.
-fn ring_scale(verts: &[Point3]) -> f64 {
-    let c = verts[0];
-    verts.iter().map(|p| (*p - c).length()).fold(0.0, f64::max)
-}
-
-/// Bilinear (degree-1) NURBS patch through a 4-corner ring, in ring order.
-///
-/// Its four boundary iso-curves are the straight segments between consecutive
-/// corners — exactly the ring's chord edges — so the cap face shares its
-/// boundary with the side faces and tessellates/integrates clipped to the
-/// section. (Reusing the section's own parent surface would not: brepkit
-/// tessellates a non-planar face over its full u/v extent, not clipped to a
-/// chord-polygon wire, so a reused surface overfills past the section.)
-fn bilinear_cap_patch(corners: &[Point3]) -> Result<NurbsSurface, brepkit_math::MathError> {
-    NurbsSurface::new(
-        1,
-        1,
-        vec![0.0, 0.0, 1.0, 1.0],
-        vec![0.0, 0.0, 1.0, 1.0],
-        vec![vec![corners[0], corners[1]], vec![corners[3], corners[2]]],
-        vec![vec![1.0, 1.0], vec![1.0, 1.0]],
-    )
-}
-
-/// Build one loft cap face that fills the ring boundary.
-///
-/// A planar ring is capped by an exact `Plane` (the planar tessellator clips it
-/// to the polygon). A non-planar ring is filled by a bilinear patch through its
-/// corners — currently only 4-sided non-planar rings are supported. The cap
-/// surface is always derived from the ring, never from the section's parent
-/// surface, because a non-planar face is tessellated/integrated over its u/v
-/// extent rather than clipped to the chord-polygon wire.
-///
-/// `outward` is the section's outward (Newell-based) normal; `start_role`
-/// builds the reversed-ring wire. Shared by the upcoming sweep/revolve PRs,
-/// whose caps are likewise chord-polygon rings.
-fn build_cap_face(
-    topo: &mut Topology,
-    ring_edges: &[EdgeId],
-    cap_verts: &[Point3],
-    outward: Vec3,
-    start_role: bool,
-) -> Result<FaceId, crate::OperationsError> {
-    let n = ring_edges.len();
-    let edges: Vec<OrientedEdge> = if start_role {
-        (0..n)
-            .rev()
-            .map(|i| OrientedEdge::new(ring_edges[i], false))
-            .collect()
-    } else {
-        (0..n)
-            .map(|i| OrientedEdge::new(ring_edges[i], true))
-            .collect()
-    };
-    let wid = topo.add_wire(Wire::new(edges, true).map_err(crate::OperationsError::Topology)?);
-
-    let plane_pt = cap_verts[0];
-    let max_dev = cap_verts
-        .iter()
-        .map(|p| (*p - plane_pt).dot(outward).abs())
-        .fold(0.0, f64::max);
-
-    let (surface, reversed) = if max_dev <= CAP_PLANARITY_TOL * ring_scale(cap_verts) {
-        (
-            FaceSurface::Plane {
-                normal: outward,
-                d: dot_normal_point(outward, plane_pt),
-            },
-            false,
-        )
-    } else if n == 4 {
-        let surf = bilinear_cap_patch(cap_verts).map_err(crate::OperationsError::Math)?;
-        // A near-flat bilinear lid: its center normal is stable and aligned
-        // with the ring axis, so probe there and flip if it opposes `outward`.
-        let reversed = surf
-            .normal(0.5, 0.5)
-            .map(|nrm| nrm.dot(outward) < 0.0)
-            .unwrap_or(false);
-        (FaceSurface::Nurbs(surf), reversed)
-    } else {
-        return Err(crate::OperationsError::InvalidInput {
-            reason: "loft of a non-planar section boundary with more than 4 edges is not supported"
-                .into(),
-        });
-    };
-
-    let mut face = Face::new(wid, vec![], surface);
-    if reversed {
-        face.set_reversed(true);
-    }
-    Ok(topo.add_face(face))
-}
-
 /// Loft two or more profiles into a solid.
 ///
 /// Each profile is a face; its surface may be planar or curved — only the
@@ -296,9 +196,10 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
     // Start cap: reversed first profile (outward normal pointing away from loft).
     {
         let cap_normal = cap_normal_from_verts(&profile_verts[0], true)?;
-        all_faces.push(build_cap_face(
+        all_faces.push(crate::cap::build_cap_face(
             topo,
             &ring_edges[0],
+            vec![],
             &profile_verts[0],
             cap_normal,
             true,
@@ -350,9 +251,10 @@ pub fn loft(topo: &mut Topology, profiles: &[FaceId]) -> Result<SolidId, crate::
     {
         let last = num_profiles - 1;
         let cap_normal = cap_normal_from_verts(&profile_verts[last], false)?;
-        all_faces.push(build_cap_face(
+        all_faces.push(crate::cap::build_cap_face(
             topo,
             &ring_edges[last],
+            vec![],
             &profile_verts[last],
             cap_normal,
             false,
@@ -1112,9 +1014,10 @@ pub fn loft_smooth(
     // Start cap: reversed first profile.
     {
         let cap_normal = cap_normal_from_verts(&profile_verts[0], true)?;
-        all_faces.push(build_cap_face(
+        all_faces.push(crate::cap::build_cap_face(
             topo,
             &ring_edges[0],
+            vec![],
             &profile_verts[0],
             cap_normal,
             true,
@@ -1180,9 +1083,10 @@ pub fn loft_smooth(
     {
         let last = num_profiles - 1;
         let cap_normal = cap_normal_from_verts(&profile_verts[last], false)?;
-        all_faces.push(build_cap_face(
+        all_faces.push(crate::cap::build_cap_face(
             topo,
             &ring_edges[last],
+            vec![],
             &profile_verts[last],
             cap_normal,
             false,

--- a/crates/operations/src/pipe.rs
+++ b/crates/operations/src/pipe.rs
@@ -34,10 +34,15 @@ struct InnerPipeData {
 ///
 /// If no guide is provided, this behaves identically to a regular sweep.
 ///
+/// The profile surface may be planar or curved — only its boundary is used, and
+/// the end caps are filled from that boundary (a planar ring gets a `Plane`
+/// cap, a non-planar 4-sided ring a bilinear patch).
+///
 /// # Errors
 ///
-/// Returns an error if the profile is not planar, the path is too short,
-/// or the guide curve produces degenerate scaling.
+/// Returns an error if the path is too short, the guide curve produces
+/// degenerate scaling, or a section boundary is non-planar with more than four
+/// edges or with holes (unsupported cap).
 #[allow(clippy::too_many_lines)]
 pub fn pipe(
     topo: &mut Topology,
@@ -54,14 +59,6 @@ pub fn pipe(
     }
 
     let face_data = topo.face(profile)?;
-    let mut input_normal = match face_data.surface() {
-        FaceSurface::Plane { normal, .. } => *normal,
-        _ => {
-            return Err(crate::OperationsError::InvalidInput {
-                reason: "pipe of non-planar faces is not supported".into(),
-            });
-        }
-    };
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids: Vec<brepkit_topology::wire::WireId> = face_data.inner_wires().to_vec();
 
@@ -81,6 +78,12 @@ pub fn pipe(
         let vid = oe.oriented_start(edge);
         input_verts.push(topo.vertex(vid)?.point());
     }
+
+    // Up-hint for the profile frame: the section boundary's own normal (Newell),
+    // which works for planar and non-planar profiles alike.
+    let mut input_normal = crate::winding::newell_normal(&input_verts)
+        .normalize()
+        .unwrap_or(Vec3::new(0.0, 0.0, 1.0));
 
     // Ensure CCW winding relative to path direction at t=0.
     // CW-wound profiles make `edge_dir.cross(path_dir)` point inward.
@@ -230,14 +233,6 @@ pub fn pipe(
 
     let mut all_faces = Vec::with_capacity(num_segments * n + 2);
 
-    let start_reversed: Vec<OrientedEdge> = (0..n)
-        .rev()
-        .map(|i| OrientedEdge::new(ring_edges[0][i], false))
-        .collect();
-    let start_wire = Wire::new(start_reversed, true).map_err(crate::OperationsError::Topology)?;
-    let start_wire_id = topo.add_wire(start_wire);
-    let start_normal = -(path.tangent(0.0)?);
-    let start_d = dot_normal_point(start_normal, topo.vertex(ring_verts[0][0])?.point());
     let mut start_inner_wires = Vec::new();
     for ipd in &inner_pipe_data {
         let iw_edges: Vec<OrientedEdge> = (0..ipd.n)
@@ -247,15 +242,16 @@ pub fn pipe(
         let iw = Wire::new(iw_edges, true).map_err(crate::OperationsError::Topology)?;
         start_inner_wires.push(topo.add_wire(iw));
     }
-    let start_face = topo.add_face(Face::new(
-        start_wire_id,
+    let start_verts = crate::cap::ring_point_positions(topo, &ring_verts[0])?;
+    let start_outward = crate::cap::outward_normal(&start_verts, -(path.tangent(0.0)?))?;
+    all_faces.push(crate::cap::build_cap_face(
+        topo,
+        &ring_edges[0],
         start_inner_wires,
-        FaceSurface::Plane {
-            normal: start_normal,
-            d: start_d,
-        },
-    ));
-    all_faces.push(start_face);
+        &start_verts,
+        start_outward,
+        true,
+    )?);
 
     for seg in 0..num_segments {
         for i in 0..n {
@@ -332,11 +328,6 @@ pub fn pipe(
         }
     }
 
-    let end_edges: Vec<OrientedEdge> = (0..n)
-        .map(|i| OrientedEdge::new(ring_edges[num_segments][i], true))
-        .collect();
-    let end_wire = Wire::new(end_edges, true).map_err(crate::OperationsError::Topology)?;
-    let end_wire_id = topo.add_wire(end_wire);
     let mut end_inner_wires = Vec::new();
     for ipd in &inner_pipe_data {
         let iw_edges: Vec<OrientedEdge> = (0..ipd.n)
@@ -345,20 +336,16 @@ pub fn pipe(
         let iw = Wire::new(iw_edges, true).map_err(crate::OperationsError::Topology)?;
         end_inner_wires.push(topo.add_wire(iw));
     }
-    let end_normal = path.tangent(1.0)?;
-    let end_d = dot_normal_point(
-        end_normal,
-        topo.vertex(ring_verts[num_segments][0])?.point(),
-    );
-    let end_face = topo.add_face(Face::new(
-        end_wire_id,
+    let end_verts = crate::cap::ring_point_positions(topo, &ring_verts[num_segments])?;
+    let end_outward = crate::cap::outward_normal(&end_verts, path.tangent(1.0)?)?;
+    all_faces.push(crate::cap::build_cap_face(
+        topo,
+        &ring_edges[num_segments],
         end_inner_wires,
-        FaceSurface::Plane {
-            normal: end_normal,
-            d: end_d,
-        },
-    ));
-    all_faces.push(end_face);
+        &end_verts,
+        end_outward,
+        false,
+    )?);
 
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
@@ -571,6 +558,62 @@ mod tests {
             rel_err < 0.01,
             "CW pipe volumes should match: origin={vol1}, translated={vol2}, \
              rel_err={rel_err:.2e}"
+        );
+    }
+
+    #[test]
+    fn pipe_planar_profile_caps_are_planar() {
+        // Regression: a planar profile must still produce flat `Plane` caps
+        // (pipe has no straight-extrude fast path, so this exercises the cap
+        // code directly).
+        let mut topo = Topology::new();
+        let profile = make_unit_square_face(&mut topo);
+        let path = straight_z_path(3.0);
+        let solid = pipe(&mut topo, profile, &path, None).unwrap();
+        let sh = topo
+            .shell(topo.solid(solid).unwrap().outer_shell())
+            .unwrap();
+        let planar = sh
+            .faces()
+            .iter()
+            .filter(|&&fid| topo.face(fid).unwrap().surface().is_planar())
+            .count();
+        assert_eq!(planar, sh.faces().len(), "planar pipe stays all-planar");
+    }
+
+    #[test]
+    fn pipe_nonplanar_saddle_profile_is_valid_solid() {
+        // A non-planar (saddle) profile piped along a straight path: previously
+        // rejected by the planar-only gate, now closed with bilinear caps.
+        let mut topo = Topology::new();
+        let profile = crate::test_helpers::make_saddle_profile(&mut topo, 2.0);
+        assert!(!topo.face(profile).unwrap().surface().is_planar());
+        let path = straight_z_path(6.0);
+
+        let solid = pipe(&mut topo, profile, &path, None).unwrap();
+        let sh = topo
+            .shell(topo.solid(solid).unwrap().outer_shell())
+            .unwrap();
+        let nurbs_caps = sh
+            .faces()
+            .iter()
+            .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)))
+            .count();
+        assert_eq!(
+            nurbs_caps, 2,
+            "non-planar ring caps are bilinear NURBS fills"
+        );
+
+        assert!(
+            crate::validate::validate_solid(&topo, solid)
+                .unwrap()
+                .is_valid(),
+            "non-planar pipe must be a valid solid"
+        );
+        let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+        assert!(
+            vol > 85.0 && vol < 110.0,
+            "non-planar pipe volume out of expected range, got {vol}"
         );
     }
 }

--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -506,15 +506,18 @@ fn try_straight_extrude(
 
 /// Sweep a face along a path curve to produce a solid.
 ///
-/// Creates a solid by moving a planar profile along a NURBS curve, with the
-/// profile oriented perpendicular to the path tangent at each sample point.
-/// Side faces are planar quads connecting consecutive profile rings.
+/// Creates a solid by moving a profile along a NURBS curve, with the profile
+/// oriented perpendicular to the path tangent at each sample point. Side faces
+/// are planar quads connecting consecutive profile rings. The profile surface
+/// may be planar or curved — only its boundary is used; the end caps are filled
+/// from that boundary (a planar ring gets a `Plane` cap, a non-planar 4-sided
+/// ring a bilinear patch).
 ///
 /// # Errors
 ///
-/// Returns an error if the profile is not planar, has inner wires (holes),
-/// the path has fewer than 2 control points, or a degenerate tangent is
-/// encountered.
+/// Returns an error if the path has fewer than 2 control points, a degenerate
+/// tangent is encountered, or a section boundary is non-planar with more than
+/// four edges or with holes (unsupported cap).
 #[allow(clippy::too_many_lines)]
 pub fn sweep(
     topo: &mut Topology,
@@ -535,14 +538,6 @@ pub fn sweep(
     }
 
     let face_data = topo.face(profile)?;
-    let mut input_normal = match face_data.surface() {
-        FaceSurface::Plane { normal, .. } => *normal,
-        _ => {
-            return Err(crate::OperationsError::InvalidInput {
-                reason: "sweep of non-planar faces is not supported".into(),
-            });
-        }
-    };
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids: Vec<brepkit_topology::wire::WireId> = face_data.inner_wires().to_vec();
 
@@ -599,13 +594,19 @@ pub fn sweep(
         })
         .collect::<Result<_, _>>()?;
 
+    // Up-hint for the rotation-minimizing frame: the section boundary's own
+    // normal (Newell), which works for planar and non-planar profiles alike —
+    // a profile's stored surface is no longer required to be a plane.
+    let mut input_normal = crate::winding::newell_normal(&input_positions)
+        .normalize()
+        .unwrap_or(Vec3::new(0.0, 0.0, 1.0));
+
     // Ensure CCW winding relative to the path direction at t=0.
     // CW-wound profiles (e.g. from brepjs) make `edge_dir.cross(path_dir)` point
     // inward instead of outward, producing inside-out side faces.
     let path_tangent_0 = path.tangent(0.0)?;
     if crate::winding::ensure_ccw_positions(&mut input_positions, path_tangent_0) {
-        // Positions were reversed → stored face normal was from CW winding.
-        // Negate so the up-hint for frame computation is correct.
+        // Positions were reversed → boundary normal flips with them.
         input_normal = -input_normal;
     }
 
@@ -710,26 +711,17 @@ pub fn sweep(
 
     // Start cap (open paths only — closed paths have no caps).
     if !is_closed {
-        let start_reversed_edges: Vec<OrientedEdge> = (0..n)
-            .rev()
-            .map(|i| OrientedEdge::new(ring_edges[0][i], false))
-            .collect();
-        let start_wire =
-            Wire::new(start_reversed_edges, true).map_err(crate::OperationsError::Topology)?;
-        let start_wire_id = topo.add_wire(start_wire);
         let start_inner_wires = build_inner_cap_wires(topo, &inner_swept, 0, true)?;
-
-        let start_normal = -frames[0].tangent;
-        let start_d = dot_normal_point(start_normal, topo.vertex(ring_verts[0][0])?.point());
-        let start_face = topo.add_face(Face::new(
-            start_wire_id,
+        let start_verts = crate::cap::ring_point_positions(topo, &ring_verts[0])?;
+        let outward = crate::cap::outward_normal(&start_verts, -frames[0].tangent)?;
+        all_faces.push(crate::cap::build_cap_face(
+            topo,
+            &ring_edges[0],
             start_inner_wires,
-            FaceSurface::Plane {
-                normal: start_normal,
-                d: start_d,
-            },
-        ));
-        all_faces.push(start_face);
+            &start_verts,
+            outward,
+            true,
+        )?);
     }
 
     // Side faces: one quad per profile-edge × path-segment.
@@ -781,27 +773,17 @@ pub fn sweep(
 
     // End cap (open paths only).
     if !is_closed {
-        let end_edges: Vec<OrientedEdge> = (0..n)
-            .map(|i| OrientedEdge::new(ring_edges[num_segments][i], true))
-            .collect();
-        let end_wire = Wire::new(end_edges, true).map_err(crate::OperationsError::Topology)?;
-        let end_wire_id = topo.add_wire(end_wire);
         let end_inner_wires = build_inner_cap_wires(topo, &inner_swept, num_segments, false)?;
-
-        let end_normal = frames[num_segments].tangent;
-        let end_d = dot_normal_point(
-            end_normal,
-            topo.vertex(ring_verts[num_segments][0])?.point(),
-        );
-        let end_face = topo.add_face(Face::new(
-            end_wire_id,
+        let end_verts = crate::cap::ring_point_positions(topo, &ring_verts[num_segments])?;
+        let outward = crate::cap::outward_normal(&end_verts, frames[num_segments].tangent)?;
+        all_faces.push(crate::cap::build_cap_face(
+            topo,
+            &ring_edges[num_segments],
             end_inner_wires,
-            FaceSurface::Plane {
-                normal: end_normal,
-                d: end_d,
-            },
-        ));
-        all_faces.push(end_face);
+            &end_verts,
+            outward,
+            false,
+        )?);
     }
 
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;

--- a/crates/operations/src/sweep/tests.rs
+++ b/crates/operations/src/sweep/tests.rs
@@ -1166,3 +1166,73 @@ fn densify_short_input_is_identity() {
     let pts = vec![Point3::new(0.0, 0.0, 0.0), Point3::new(10.0, 0.0, 0.0)];
     assert_eq!(densify_path_points(&pts), pts);
 }
+
+#[test]
+fn sweep_planar_profile_caps_are_planar() {
+    // Regression: a planar profile must still produce flat `Plane` caps. The
+    // path is curved (but starts tangent +Z) so the general sweep runs — a
+    // straight path short-circuits to extrude and skips the cap code under test.
+    let mut topo = Topology::new();
+    let profile = make_square(&mut topo, 2.0);
+    let path = NurbsCurve::new(
+        2,
+        vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(0.0, 0.0, 3.0),
+            Point3::new(2.0, 0.0, 5.0),
+        ],
+        vec![1.0, 1.0, 1.0],
+    )
+    .unwrap();
+    let solid = sweep(&mut topo, profile, &path).unwrap();
+    let sh = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+    let planar = sh
+        .faces()
+        .iter()
+        .filter(|&&fid| topo.face(fid).unwrap().surface().is_planar())
+        .count();
+    assert_eq!(planar, sh.faces().len(), "planar sweep stays all-planar");
+}
+
+#[test]
+fn sweep_nonplanar_saddle_profile_is_valid_solid() {
+    // A non-planar (saddle) profile swept along a straight path: previously
+    // rejected by the planar-only gate, now closed with bilinear caps.
+    let mut topo = Topology::new();
+    let profile = crate::test_helpers::make_saddle_profile(&mut topo, 2.0);
+    assert!(
+        !topo.face(profile).unwrap().surface().is_planar(),
+        "saddle profile must be a non-planar face"
+    );
+    let path = straight_z_path(6.0);
+    let solid = sweep(&mut topo, profile, &path).unwrap();
+
+    let sh = topo
+        .shell(topo.solid(solid).unwrap().outer_shell())
+        .unwrap();
+    let nurbs_caps = sh
+        .faces()
+        .iter()
+        .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)))
+        .count();
+    assert_eq!(
+        nurbs_caps, 2,
+        "non-planar ring caps are bilinear NURBS fills"
+    );
+
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "non-planar sweep must be a valid solid"
+    );
+    // ~4×4 cross-section over a length-6 path → ≈96; bilinear caps don't overfill.
+    let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+    assert!(
+        vol > 85.0 && vol < 110.0,
+        "non-planar sweep volume out of expected range, got {vol}"
+    );
+}

--- a/crates/operations/src/test_helpers.rs
+++ b/crates/operations/src/test_helpers.rs
@@ -175,3 +175,31 @@ where
     let solid = build_solid(&mut topo, face);
     assert_volume_near(&topo, solid, expected_vol, rel_tol);
 }
+
+/// Build a non-planar test profile: a 4-corner Coons patch with z-staggered
+/// corners, so both its boundary (the four corners) and its surface are
+/// non-planar. Centered at the origin with half-extent `half`.
+pub fn make_saddle_profile(topo: &mut Topology, half: f64) -> FaceId {
+    let h = half;
+    let bottom = vec![
+        Point3::new(-h, -h, 0.3),
+        Point3::new(0.0, -h, 0.6),
+        Point3::new(h, -h, -0.3),
+    ];
+    let right = vec![
+        Point3::new(h, -h, -0.3),
+        Point3::new(h, 0.0, 0.6),
+        Point3::new(h, h, 0.3),
+    ];
+    let top = vec![
+        Point3::new(-h, h, -0.3),
+        Point3::new(0.0, h, 0.6),
+        Point3::new(h, h, 0.3),
+    ];
+    let left = vec![
+        Point3::new(-h, -h, 0.3),
+        Point3::new(-h, 0.0, 0.6),
+        Point3::new(-h, h, -0.3),
+    ];
+    crate::fill_face::fill_coons_patch(topo, &[bottom, right, top, left]).unwrap()
+}


### PR DESCRIPTION
## What

**PR2 of the non-planar sweep-family series** (PR1 = loft, [#974](https://github.com/andymai/brepkit/pull/974), merged). Extends non-planar profile support to the basic `sweep` and `pipe`, and lifts the cap logic into a shared `crate::cap` module that loft now also uses.

## Approach (same as PR1: fill the boundary)

The end caps are built by filling the section **boundary**, never by reusing the section's parent surface — brepkit tessellates/integrates a non-planar face over its full u/v extent rather than clipping to a chord-polygon wire, so a reused surface overfills. So:

- **planar ring** → exact `Plane` cap (CDT-clipped; planar profiles unchanged),
- **non-planar 4-sided ring** → bilinear patch whose four iso-curves *are* the ring chords (`domain == wire`, can't overfill),
- **non-planar >4 edges, or holes on a non-planar cap** → unsupported (clear error).

For sweep/pipe the cap's `outward` normal is the ring's Newell normal oriented along the path tangent, and the frame up-hint is derived from the section boundary (replacing the old `match surface { Plane }` gate). A planar perpendicular profile yields byte-for-byte the same `-tangent` cap as before.

`crate::cap::build_cap_face` threads pre-built inner-wire (hole) loops; holes are supported on planar caps, rejected on non-planar ones.

## Scope

Basic `sweep` and `pipe` (the canonical entry points). The specialised sweep variants — `sweep_smooth`, `sweep_with_options`, `sweep_miter`, `multi_section_sweep` — **keep their planar gate** for now: `sweep_smooth`'s NURBS rail interpolation (rails skip the middle rings) degrades to a ~3× volume undercount on a non-planar profile, which needs separate work. Revolve is the next PR. The README row is updated when the series completes.

## Tests

- `sweep_planar_profile_caps_are_planar` — planar regression.
- `sweep_nonplanar_saddle_profile_is_valid_solid` — non-planar (saddle) sweep → `validate_solid` valid, bilinear caps, volume bounded near the prism (overfill would fail).
- `pipe_nonplanar_saddle_profile_is_valid_solid` — same for pipe.

Full `brepkit-operations` suite (incl. loft's 23, sweep's 41, pipe's 8) green; clippy `-D warnings` clean; layer boundaries valid; `brepkit-wasm` builds.