### PR TITLE
fix(operations): correct sweep_smooth side-face rails and orientation

### DIFF
--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -991,6 +991,13 @@ pub fn sweep_smooth(
     let degree_u = (num_rings - 1).min(3);
     let degree_v = 1;
 
+    // Rail edges, one per profile vertex (the swept-vertex path from the first
+    // to the last ring), shared between the two adjacent side faces so the shell
+    // is manifold.
+    let rail_edges: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(first_ring[i], last_ring[i], EdgeCurve::Line)))
+        .collect();
+
     for i in 0..n {
         let next_i = (i + 1) % n;
 
@@ -1002,26 +1009,41 @@ pub fn sweep_smooth(
         let surface =
             interpolate_surface(&grid, degree_u, degree_v).map_err(crate::OperationsError::Math)?;
 
-        let e_left_rail = topo.add_edge(Edge::new(first_ring[i], last_ring[i], EdgeCurve::Line));
-        let e_right_rail = topo.add_edge(Edge::new(
-            first_ring[next_i],
-            last_ring[next_i],
-            EdgeCurve::Line,
-        ));
-
         let side_wire = Wire::new(
             vec![
                 OrientedEdge::new(first_ring_edges[i], true),
-                OrientedEdge::new(e_right_rail, true),
+                OrientedEdge::new(rail_edges[next_i], true),
                 OrientedEdge::new(last_ring_edges[i], false),
-                OrientedEdge::new(e_left_rail, false),
+                OrientedEdge::new(rail_edges[i], false),
             ],
             true,
         )
         .map_err(crate::OperationsError::Topology)?;
 
         let side_wire_id = topo.add_wire(side_wire);
-        all_faces.push(topo.add_face(Face::new(side_wire_id, vec![], FaceSurface::Nurbs(surface))));
+        // The surface normal ∂u×∂v = path×edge points *into* the swept body for
+        // a CCW profile; reverse the face when it opposes the geometric outward
+        // so the solid's faces are consistently outward. Probe everything at the
+        // start ring (u=0), mid-edge (v=0.5): the edge tangent crossed with the
+        // local path direction *at the edge midpoint*. If they are parallel (the
+        // edge runs along the path) the cross product vanishes, so fall back to
+        // the radial direction from the ring centroid.
+        let mid0 = ring_positions[0][i] + (ring_positions[0][next_i] - ring_positions[0][i]) * 0.5;
+        let mid1 = ring_positions[1][i] + (ring_positions[1][next_i] - ring_positions[1][i]) * 0.5;
+        let edge_dir = ring_positions[0][next_i] - ring_positions[0][i];
+        let mut outward = edge_dir.cross(mid1 - mid0);
+        if outward.length() < tol.linear {
+            outward = mid0 - crate::winding::polygon_centroid(&ring_positions[0]);
+        }
+        let reversed = surface
+            .normal(0.0, 0.5)
+            .map(|nrm| nrm.dot(outward) < 0.0)
+            .unwrap_or(false);
+        let mut face = Face::new(side_wire_id, vec![], FaceSurface::Nurbs(surface));
+        if reversed {
+            face.set_reversed(true);
+        }
+        all_faces.push(topo.add_face(face));
     }
 
     for iwd in &inner_swept_smooth {

--- a/crates/operations/src/sweep/tests.rs
+++ b/crates/operations/src/sweep/tests.rs
@@ -1236,3 +1236,59 @@ fn sweep_nonplanar_saddle_profile_is_valid_solid() {
         "non-planar sweep volume out of expected range, got {vol}"
     );
 }
+
+#[test]
+fn sweep_smooth_straight_path_exact_volume() {
+    // Regression for the rail bug: sweep_smooth built per-face (duplicated)
+    // straight rails and left the NURBS side faces with inward normals, giving a
+    // non-manifold shell whose volume integrated to 1/3 of the true value. A
+    // 2×2 square swept 6 along +Z is an exact 24-volume prism.
+    let mut topo = Topology::new();
+    let profile = make_square(&mut topo, 2.0);
+    let solid = sweep_smooth(&mut topo, profile, &straight_z_path(6.0)).unwrap();
+
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "smooth sweep must be a valid (manifold) solid"
+    );
+    let vol = crate::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    assert!(
+        (vol - 24.0).abs() / 24.0 < 0.01,
+        "straight smooth-sweep prism volume should be 24, got {vol}"
+    );
+}
+
+#[test]
+fn sweep_smooth_gentle_curve_is_valid_with_sane_volume() {
+    // A gently curved path (initial tangent +Z, bending toward +X): the shared
+    // rails keep the shell manifold and the volume near the swept prism
+    // (~profile area 4 × arc length ~6.3 ≈ 25), not 1/3 of it.
+    let mut topo = Topology::new();
+    let profile = make_square(&mut topo, 2.0);
+    let path = NurbsCurve::new(
+        2,
+        vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(0.0, 0.0, 3.0),
+            Point3::new(1.5, 0.0, 6.0),
+        ],
+        vec![1.0, 1.0, 1.0],
+    )
+    .unwrap();
+    let solid = sweep_smooth(&mut topo, profile, &path).unwrap();
+
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "curved smooth sweep must be a valid solid"
+    );
+    let vol = crate::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    assert!(
+        vol > 24.0 && vol < 26.0,
+        "gently curved smooth-sweep volume should be ~25, got {vol}"
+    );
+}


### PR DESCRIPTION
## What

Fixes the `sweep_smooth` bug flagged during the non-planar sweep work ([#976](https://github.com/andymai/brepkit/pull/976)): it produced **non-manifold solids whose volume integrated to ⅓ of the true value** — for *every* profile, not just non-planar ones. The existing tests only asserted `vol > 0`, so it slipped through.

## Root cause (two compounding defects)

1. **Duplicated rails.** Each side face built its *own* left/right rail edge between the same two ring vertices, so adjacent faces never shared the rail → the shell was non-manifold (every rail edge belonged to a single face).
2. **Inward side-face normals.** The NURBS side surface's natural normal `∂u×∂v = path×edge` points *into* the swept body for a CCW profile, but the face was added without the `reversed` flag → the sides contributed inward-facing flux and cancelled most of the volume (the telltale ⅓).

A diagnostic made it concrete — a 2×2 square swept 6 along +Z gave **volume 8, invalid**; expected 24.

## Fix

- Build **one shared rail edge per profile vertex**, reused by both adjacent side faces → manifold shell.
- Set the face `reversed` flag when the surface normal opposes the geometric outward (`edge×path`), probed at a consistent `(u=0, v=0.5)` location so it stays correct as a curved path twists the normal along `u`.

## Result

- Straight 2×2×6 prism: **exact 24, valid** (was 8, invalid).
- Gently curved path: correct volume (~25) and valid.
- New regression tests assert both (the exact straight-path volume catches both the ⅓ and the invalidity).

## Out of scope (pre-existing, noted)

A path that turns sharply *toward* the profile's up-vector (e.g. a 90° quarter circle in the plane of the profile normal) still degenerates to ~0 volume — but **basic `sweep` does too**, so that's a separate pre-existing sweep degeneracy, not a rail issue. This fix neither introduces nor resolves it.

This unblocks adding non-planar profile support to `sweep_smooth` (the rail bug was the blocker) as a future follow-up.

Full `brepkit-operations` suite green (43 sweep tests); clippy `-D warnings` clean; layer boundaries valid.