### PR TITLE
fix(operations): sweep profiles perpendicular to the path regardless of orientation

### DIFF
--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -111,6 +111,24 @@ fn compute_frames(
     Ok(frames)
 }
 
+/// The profile's own orthonormal basis `(right, up, tangent)` for mapping its 2D
+/// shape onto the path's perpendicular plane.
+///
+/// `tangent` is the profile normal, so a planar profile has ~zero tangent
+/// component and is mapped entirely into `right`/`up`; the profile is then swept
+/// perpendicular to the path regardless of how its plane was oriented relative
+/// to the path (an edge-on profile no longer collapses to a flat ribbon). For a
+/// profile already perpendicular to the path this equals the path frame's basis,
+/// leaving such sweeps unchanged.
+fn profile_basis(input_normal: Vec3) -> (Vec3, Vec3, Vec3) {
+    let tangent = input_normal
+        .normalize()
+        .unwrap_or_else(|_| Vec3::new(0.0, 0.0, 1.0));
+    let up = orthogonalize(pick_reference_axis(tangent), tangent);
+    let right = tangent.cross(up);
+    (right, up, tangent)
+}
+
 /// Project `v` to be perpendicular to `tangent`, then normalize.
 ///
 /// Falls back to a world-axis-based vector if the projection is degenerate.
@@ -622,9 +640,10 @@ pub fn sweep(
 
     // The first frame's basis vectors define the local coordinate system
     // in which profile vertex offsets are expressed.
-    let initial_right = frames[0].right;
-    let initial_up = frames[0].up;
-    let initial_tangent = frames[0].tangent;
+    // Map the profile's 2D shape onto the path's perpendicular plane using the
+    // profile's own basis, so a profile whose plane is not perpendicular to the
+    // path is still swept perpendicular (rather than collapsing to a ribbon).
+    let (initial_right, initial_up, initial_tangent) = profile_basis(input_normal);
 
     // ring_verts[k][i] = vertex at path sample k, profile vertex i.
     // For closed paths, frames has num_segments entries; we append a copy
@@ -897,9 +916,10 @@ pub fn sweep_smooth(
     let up_hint = orthogonalize(input_normal, path_tangent_0);
     let frames = compute_frames(path, num_segments, up_hint, is_closed)?;
 
-    let initial_right = frames[0].right;
-    let initial_up = frames[0].up;
-    let initial_tangent = frames[0].tangent;
+    // Map the profile's 2D shape onto the path's perpendicular plane using the
+    // profile's own basis, so a profile whose plane is not perpendicular to the
+    // path is still swept perpendicular (rather than collapsing to a ribbon).
+    let (initial_right, initial_up, initial_tangent) = profile_basis(input_normal);
 
     // Compute all ring positions (without allocating vertices yet).
     let num_rings = frames.len();
@@ -1336,9 +1356,10 @@ pub fn sweep_with_options(
         }
     };
 
-    let initial_right = frames[0].right;
-    let initial_up = frames[0].up;
-    let initial_tangent = frames[0].tangent;
+    // Map the profile's 2D shape onto the path's perpendicular plane using the
+    // profile's own basis, so a profile whose plane is not perpendicular to the
+    // path is still swept perpendicular (rather than collapsing to a ribbon).
+    let (initial_right, initial_up, initial_tangent) = profile_basis(input_normal);
 
     let mut ring_verts: Vec<Vec<VertexId>> = Vec::with_capacity(num_segments + 1);
 

--- a/crates/operations/src/sweep/tests.rs
+++ b/crates/operations/src/sweep/tests.rs
@@ -621,8 +621,15 @@ fn sweep_smooth_curved_path() {
         "smooth curved sweep should have 6 faces"
     );
 
+    // A unit square swept along a quarter circle of radius 5: the swept volume
+    // is ~ profile area (1) × arc length (π/2 × 5 ≈ 7.85). Before profile
+    // auto-orientation the XY-plane profile was edge-on to the +X start tangent
+    // and collapsed to a ~zero-volume ribbon that still satisfied `vol > 0`.
     let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
-    assert!(vol > 0.0, "curved smooth sweep should have positive volume");
+    assert!(
+        vol > 7.0 && vol < 8.5,
+        "curved smooth sweep volume should be ~7.85, got {vol}"
+    );
 }
 
 /// Helper: create a closed circular NURBS path (full circle in XZ plane).
@@ -1290,5 +1297,34 @@ fn sweep_smooth_gentle_curve_is_valid_with_sane_volume() {
     assert!(
         vol > 24.0 && vol < 26.0,
         "gently curved smooth-sweep volume should be ~25, got {vol}"
+    );
+}
+
+#[test]
+fn sweep_edge_on_profile_is_auto_oriented() {
+    // An XY-plane square (normal +Z) swept along a +X path is "edge-on": its
+    // plane contains the path tangent. Before profile auto-orientation this
+    // collapsed to a flat, zero-volume ribbon; now the profile's 2D shape is
+    // placed perpendicular to the path, giving a proper 1×1×5 prism (volume 5).
+    let mut topo = Topology::new();
+    let profile = make_square(&mut topo, 1.0);
+    let path = NurbsCurve::new(
+        1,
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![Point3::new(0.0, 0.0, 0.0), Point3::new(5.0, 0.0, 0.0)],
+        vec![1.0, 1.0],
+    )
+    .unwrap();
+    let solid = sweep(&mut topo, profile, &path).unwrap();
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "edge-on sweep must be a valid solid"
+    );
+    let vol = crate::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    assert!(
+        (vol - 5.0).abs() / 5.0 < 0.02,
+        "edge-on profile should sweep to a 1×1×5 prism (volume 5), got {vol}"
     );
 }


### PR DESCRIPTION
## What

Fixes the "quarter-turn degeneracy" flagged after the [sweep_smooth rail fix](https://github.com/andymai/brepkit/pull/981). The investigation showed it isn't a quarter-turn bug at all — it's a **profile-orientation** issue: a profile whose plane is *not perpendicular to the path* was swept **edge-on** and collapsed to a flat, zero-volume ribbon.

## Root cause

`sweep` placed the profile by seeding the transform with the **path frame's** basis (`frames[0].right/up/tangent`). When the profile plane contains the path tangent (e.g. an XY-plane square, normal +Z, swept along a +X path), the profile's 2D extent decomposes into the *right* and *tangent* directions and **zero** into *up* — so the swept cross-section perpendicular to the path is 1-D and the solid is flat. An XY square swept along +X measured **volume 0**; along an XZ quarter circle, **2.3e-10**.

The existing `sweep_smooth_curved_path` test **masked** this: it sweeps an edge-on profile and asserts only `vol > 0`, which a 2.3e-10 ribbon satisfies.

## Fix (chosen approach: auto-orient)

Seed the placement transform with the **profile's own** orthonormal basis (`tangent = profile normal`, `right`/`up` span the profile plane) via a new `profile_basis` helper. A planar profile then has ~zero tangent component and its 2D shape maps entirely onto the path's perpendicular plane — so it sweeps perpendicular to the path regardless of how its plane was originally oriented. **Crucially, for a profile already perpendicular to the path this basis equals the path frame's basis, so those (the common) sweeps are byte-for-byte unchanged.**

Applies to `sweep`, `sweep_smooth`, and the non-miter `sweep_with_options` path. The **miter** sweep keeps its per-segment sub-frame basis (its corner geometry depends on it; applying the fixed profile basis there regressed the L-shape volume, so it's intentionally left alone).

## Result

- Edge-on XY square swept along +X → proper **1×1×5 prism (volume 5)**, was 0.
- `sweep_smooth_curved_path` config → **7.85** (≈ profile area × arc length), was 2.3e-10.

## Tests

- New `sweep_edge_on_profile_is_auto_oriented` — exact prism volume 5.
- Strengthened `sweep_smooth_curved_path` from `vol > 0` to `vol ≈ 7.85`, so it can no longer pass on a collapsed ribbon.

Full `brepkit-operations` suite green (44 sweep tests); clippy `-D warnings` clean; layer boundaries valid.