### PR TITLE
feat(operations): non-planar profiles in smooth, options, and multi-section sweeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A few areas are still maturing. Worth knowing before you build on them:
 
 - **Boolean fallback.** Most booleans run on an exact path that preserves analytic and NURBS surfaces. Hard configurations fall back to a mesh-based boolean: coincident-face contact, coaxial analytic surfaces, razor-thin geometry, or very high face counts. The fallback returns a usable, non-degenerate solid, but it tessellates the curved faces and is not guaranteed watertight.
 - **Torus booleans.** Box-with-torus and coaxial-torus cases work and give correct volumes. General torus-to-torus and torus-with-other-surface intersections have known gaps and may fall back to meshing.
-- **Non-planar profiles.** Loft, sweep, and pipe accept profiles with non-planar surfaces, and close non-planar section boundaries with bilinear caps for four-sided rings (boundaries with more than four edges, or holes on a non-planar section, are not yet supported). Revolve accepts non-planar profile surfaces; a full revolution takes any boundary, but a partial revolution still requires a planar boundary for its caps. The advanced sweep variants (smooth, scaled/guided, miter, multi-section) still require planar profiles.
+- **Non-planar profiles.** Loft, sweep, and pipe accept profiles with non-planar surfaces, and close non-planar section boundaries with bilinear caps for four-sided rings (boundaries with more than four edges, or holes on a non-planar section, are not yet supported). Revolve accepts non-planar profile surfaces; a full revolution takes any boundary, but a partial revolution still requires a planar boundary for its caps. The smooth, scaled/guided, and multi-section sweep variants accept non-planar profiles too; only the miter-corner variant still requires planar profiles (its bisector-plane joint faces would otherwise be non-planar).
 - **IGES is experimental.** Export writes planar and NURBS surfaces but skips analytic surfaces and approximates circular and elliptical edges as polylines. Import reconstructs planar placeholder faces only. Use STEP for B-Rep exchange.
 - **Inertia tensor.** Volume, area, bounding box, and center of mass are computed for any solid. A full inertia tensor exists only as closed-form formulas for analytic primitives and is not exposed through the modeling or WASM API.
 - **Beta subsystems.** Feature recognition, assemblies, evolution tracking, and defeaturing work but are still maturing. Defeaturing handles planar faces only.
@@ -229,7 +229,7 @@ cargo doc --workspace --no-deps --open
 Broad directions, no dates.
 
 - **Boolean robustness.** Harden torus and mixed-surface booleans, and shrink the set of inputs that fall back to meshing.
-- **Sweep generalization.** Extend non-planar profile support to the advanced sweep variants (smooth, scaled/guided, miter, multi-section), to section boundaries with more than four edges, and to partial revolutions with non-planar boundaries.
+- **Sweep generalization.** Extend non-planar profile support to the miter-corner sweep, to section boundaries with more than four edges, and to partial revolutions with non-planar boundaries.
 - **Parallel tessellation in WASM.** Native builds already parallelize per-face meshing. Bring it to the WASM target via threads.
 - **Assembly metadata.** Colors, layers, materials, and PMI for richer data exchange.
 - **Lossless IGES.** Real B-Rep import and analytic-surface export.

--- a/crates/operations/src/sweep.rs
+++ b/crates/operations/src/sweep.rs
@@ -823,10 +823,15 @@ pub fn sweep(
 /// `num_segments × n + 2` flat faces, making the topology significantly
 /// more compact while improving geometric quality.
 ///
+/// The profile surface may be planar or curved — only its boundary is used; the
+/// end caps are filled from that boundary (planar ring → `Plane`, non-planar
+/// 4-edge ring → bilinear patch).
+///
 /// # Errors
 ///
-/// Returns an error if the profile is not planar, has inner wires (holes),
-/// the path has fewer than 2 control points, or surface fitting fails.
+/// Returns an error if the path has fewer than 2 control points, surface
+/// fitting fails, or a section boundary is non-planar with more than four edges
+/// or with holes (unsupported cap).
 #[allow(clippy::too_many_lines)]
 pub fn sweep_smooth(
     topo: &mut Topology,
@@ -842,14 +847,6 @@ pub fn sweep_smooth(
     }
 
     let face_data = topo.face(profile)?;
-    let mut input_normal = match face_data.surface() {
-        FaceSurface::Plane { normal, .. } => *normal,
-        _ => {
-            return Err(crate::OperationsError::InvalidInput {
-                reason: "sweep of non-planar faces is not supported".into(),
-            });
-        }
-    };
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids_smooth: Vec<brepkit_topology::wire::WireId> =
         face_data.inner_wires().to_vec();
@@ -903,6 +900,12 @@ pub fn sweep_smooth(
                 .map(brepkit_topology::vertex::Vertex::point)
         })
         .collect::<Result<_, _>>()?;
+
+    // Profile normal from the section boundary (planar or non-planar alike); the
+    // gate that required a planar surface is gone.
+    let mut input_normal = crate::winding::newell_normal(&input_positions)
+        .normalize()
+        .unwrap_or(Vec3::new(0.0, 0.0, 1.0));
 
     // Ensure CCW winding relative to path direction (same fix as sweep()).
     let path_tangent_0 = path.tangent(0.0)?;
@@ -989,23 +992,16 @@ pub fn sweep_smooth(
 
     let mut all_faces = Vec::with_capacity(n + 2);
 
-    let start_reversed: Vec<OrientedEdge> = (0..n)
-        .rev()
-        .map(|i| OrientedEdge::new(first_ring_edges[i], false))
-        .collect();
-    let start_wire = Wire::new(start_reversed, true).map_err(crate::OperationsError::Topology)?;
-    let start_wire_id = topo.add_wire(start_wire);
     let start_inner_wires_smooth = build_inner_cap_wires(topo, &inner_swept_smooth, 0, true)?;
-    let start_normal = -frames[0].tangent;
-    let start_d = dot_normal_point(start_normal, ring_positions[0][0]);
-    all_faces.push(topo.add_face(Face::new(
-        start_wire_id,
+    let start_outward = crate::cap::outward_normal(&ring_positions[0], -frames[0].tangent)?;
+    all_faces.push(crate::cap::build_cap_face(
+        topo,
+        &first_ring_edges,
         start_inner_wires_smooth,
-        FaceSurface::Plane {
-            normal: start_normal,
-            d: start_d,
-        },
-    )));
+        &ring_positions[0],
+        start_outward,
+        true,
+    )?);
 
     // NURBS side faces: one surface per edge index spanning all rings.
     let degree_u = (num_rings - 1).min(3);
@@ -1071,23 +1067,18 @@ pub fn sweep_smooth(
         all_faces.extend(inner_faces);
     }
 
-    let end_edges: Vec<OrientedEdge> = (0..n)
-        .map(|i| OrientedEdge::new(last_ring_edges[i], true))
-        .collect();
-    let end_wire = Wire::new(end_edges, true).map_err(crate::OperationsError::Topology)?;
-    let end_wire_id = topo.add_wire(end_wire);
     let end_inner_wires_smooth =
         build_inner_cap_wires(topo, &inner_swept_smooth, num_segments, false)?;
-    let end_normal = frames[num_segments].tangent;
-    let end_d = dot_normal_point(end_normal, ring_positions[num_rings - 1][0]);
-    all_faces.push(topo.add_face(Face::new(
-        end_wire_id,
+    let end_outward =
+        crate::cap::outward_normal(&ring_positions[num_rings - 1], frames[num_segments].tangent)?;
+    all_faces.push(crate::cap::build_cap_face(
+        topo,
+        &last_ring_edges,
         end_inner_wires_smooth,
-        FaceSurface::Plane {
-            normal: end_normal,
-            d: end_d,
-        },
-    )));
+        &ring_positions[num_rings - 1],
+        end_outward,
+        false,
+    )?);
 
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
@@ -1195,14 +1186,6 @@ pub fn sweep_with_options(
     }
 
     let face_data = topo.face(profile)?;
-    let mut input_normal = match face_data.surface() {
-        FaceSurface::Plane { normal, .. } => *normal,
-        _ => {
-            return Err(crate::OperationsError::InvalidInput {
-                reason: "sweep of non-planar faces is not supported".into(),
-            });
-        }
-    };
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids_opts: Vec<brepkit_topology::wire::WireId> = face_data.inner_wires().to_vec();
 
@@ -1264,6 +1247,12 @@ pub fn sweep_with_options(
                 .map(brepkit_topology::vertex::Vertex::point)
         })
         .collect::<Result<_, _>>()?;
+
+    // Profile normal from the section boundary (planar or non-planar alike); the
+    // gate that required a planar surface is gone.
+    let mut input_normal = crate::winding::newell_normal(&input_positions)
+        .normalize()
+        .unwrap_or(Vec3::new(0.0, 0.0, 1.0));
 
     // Ensure CCW winding relative to path direction (same fix as sweep()).
     let path_tangent_0 = path.tangent(0.0)?;
@@ -1436,25 +1425,17 @@ pub fn sweep_with_options(
 
     let mut all_faces = Vec::with_capacity(num_segments * n + 2);
 
-    let start_reversed_edges: Vec<OrientedEdge> = (0..n)
-        .rev()
-        .map(|i| OrientedEdge::new(ring_edges[0][i], false))
-        .collect();
-    let start_wire =
-        Wire::new(start_reversed_edges, true).map_err(crate::OperationsError::Topology)?;
-    let start_wire_id = topo.add_wire(start_wire);
     let start_inner_wires_opts = build_inner_cap_wires(topo, &inner_swept_opts, 0, true)?;
-    let start_normal = -frames[0].tangent;
-    let start_d = dot_normal_point(start_normal, topo.vertex(ring_verts[0][0])?.point());
-    let start_face = topo.add_face(Face::new(
-        start_wire_id,
+    let start_verts = crate::cap::ring_point_positions(topo, &ring_verts[0])?;
+    let start_outward = crate::cap::outward_normal(&start_verts, -frames[0].tangent)?;
+    all_faces.push(crate::cap::build_cap_face(
+        topo,
+        &ring_edges[0],
         start_inner_wires_opts,
-        FaceSurface::Plane {
-            normal: start_normal,
-            d: start_d,
-        },
-    ));
-    all_faces.push(start_face);
+        &start_verts,
+        start_outward,
+        true,
+    )?);
 
     for seg in 0..num_segments {
         for i in 0..n {
@@ -1499,26 +1480,17 @@ pub fn sweep_with_options(
         all_faces.extend(inner_faces);
     }
 
-    let end_edges: Vec<OrientedEdge> = (0..n)
-        .map(|i| OrientedEdge::new(ring_edges[num_segments][i], true))
-        .collect();
-    let end_wire = Wire::new(end_edges, true).map_err(crate::OperationsError::Topology)?;
-    let end_wire_id = topo.add_wire(end_wire);
     let end_inner_wires_opts = build_inner_cap_wires(topo, &inner_swept_opts, num_segments, false)?;
-    let end_normal = frames[num_segments].tangent;
-    let end_d = dot_normal_point(
-        end_normal,
-        topo.vertex(ring_verts[num_segments][0])?.point(),
-    );
-    let end_face = topo.add_face(Face::new(
-        end_wire_id,
+    let end_verts = crate::cap::ring_point_positions(topo, &ring_verts[num_segments])?;
+    let end_outward = crate::cap::outward_normal(&end_verts, frames[num_segments].tangent)?;
+    all_faces.push(crate::cap::build_cap_face(
+        topo,
+        &ring_edges[num_segments],
         end_inner_wires_opts,
-        FaceSurface::Plane {
-            normal: end_normal,
-            d: end_d,
-        },
-    ));
-    all_faces.push(end_face);
+        &end_verts,
+        end_outward,
+        false,
+    )?);
 
     let shell = Shell::new(all_faces).map_err(crate::OperationsError::Topology)?;
     let shell_id = topo.add_shell(shell);
@@ -2057,8 +2029,9 @@ fn sweep_miter(
 /// # Errors
 ///
 /// Returns [`crate::OperationsError::InvalidInput`] for fewer than two
-/// sections, a parameter outside `[0, 1]`, a non-planar profile, or a spine
-/// with fewer than two control points; propagates loft errors otherwise.
+/// sections, a parameter outside `[0, 1]`, or a spine with fewer than two
+/// control points; propagates loft errors otherwise. Sections may be planar or
+/// non-planar (they are joined by [`crate::loft::loft`], which supports both).
 pub fn multi_section_sweep(
     topo: &mut Topology,
     spine: &NurbsCurve,
@@ -2132,23 +2105,15 @@ fn pick_reference_axis(dir: Vec3) -> Vec3 {
     }
 }
 
-/// Rigid transform placing a planar profile face into `frame`: centroid →
-/// `frame.origin`, normal → tangent, in-plane axes → right/up.
+/// Rigid transform placing a profile face into `frame`: centroid →
+/// `frame.origin`, normal → tangent, in-plane axes → right/up. A planar profile
+/// uses its stored plane normal; a non-planar section uses its boundary's
+/// Newell normal.
 fn profile_to_frame_matrix(
     topo: &Topology,
     face_id: FaceId,
     frame: &Frame,
 ) -> Result<Mat4, crate::OperationsError> {
-    let face = topo.face(face_id)?;
-    let normal = match face.surface() {
-        FaceSurface::Plane { normal, .. } => normal.normalize().unwrap_or(*normal),
-        _ => {
-            return Err(crate::OperationsError::InvalidInput {
-                reason: "multi-section sweep profiles must be planar".into(),
-            });
-        }
-    };
-
     // Centroid of the sampled boundary — robust for a circle profile whose
     // outer wire is a single closed edge (where averaging start vertices would
     // collapse to the seam point).
@@ -2158,6 +2123,16 @@ fn profile_to_frame_matrix(
             reason: "multi-section sweep profile has no boundary".into(),
         });
     }
+    // A planar profile uses its stored plane normal; a non-planar section's
+    // orientation normal is its boundary's Newell normal (the planar-only gate
+    // is gone — the placed sections are joined by `loft`, which handles
+    // non-planar profiles).
+    let normal = match topo.face(face_id)?.surface() {
+        FaceSurface::Plane { normal, .. } => normal.normalize().unwrap_or(*normal),
+        _ => crate::winding::newell_normal(&boundary)
+            .normalize()
+            .unwrap_or(Vec3::new(0.0, 0.0, 1.0)),
+    };
     let centroid = crate::winding::polygon_centroid(&boundary);
 
     // Profile in-plane basis from a consistent world reference, so all profiles
@@ -2210,8 +2185,8 @@ fn profile_to_frame_matrix(
 ///
 /// # Errors
 ///
-/// Propagates [`sweep_with_options`] errors (e.g. a non-planar profile or a
-/// degenerate path).
+/// Propagates [`sweep_with_options`] errors (e.g. a degenerate path or an
+/// unsupported non-planar cap).
 pub fn sweep_guided(
     topo: &mut Topology,
     profile: FaceId,

--- a/crates/operations/src/sweep/tests.rs
+++ b/crates/operations/src/sweep/tests.rs
@@ -1328,3 +1328,78 @@ fn sweep_edge_on_profile_is_auto_oriented() {
         "edge-on profile should sweep to a 1×1×5 prism (volume 5), got {vol}"
     );
 }
+
+#[test]
+fn sweep_smooth_nonplanar_saddle_is_valid_solid() {
+    // sweep_smooth previously gated non-planar profiles; with the rail fix,
+    // auto-orientation, and boundary-fill caps it now sweeps them. A saddle
+    // (~4×4) swept 6 along +Z is a prism of volume ~96 (the bilinear caps fill
+    // the non-planar end rings).
+    let mut topo = Topology::new();
+    let profile = crate::test_helpers::make_saddle_profile(&mut topo, 2.0);
+    assert!(!topo.face(profile).unwrap().surface().is_planar());
+    let solid = sweep_smooth(&mut topo, profile, &straight_z_path(6.0)).unwrap();
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "non-planar smooth sweep must be a valid solid"
+    );
+    let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+    assert!(
+        (vol - 96.0).abs() / 96.0 < 0.05,
+        "non-planar smooth sweep volume should be ~96, got {vol}"
+    );
+}
+
+#[test]
+fn sweep_with_options_nonplanar_saddle_is_valid_solid() {
+    let mut topo = Topology::new();
+    let profile = crate::test_helpers::make_saddle_profile(&mut topo, 2.0);
+    let solid = sweep_with_options(
+        &mut topo,
+        profile,
+        &straight_z_path(6.0),
+        &SweepOptions::default(),
+    )
+    .unwrap();
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "non-planar sweep_with_options must be a valid solid"
+    );
+    let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+    assert!(
+        (vol - 96.0).abs() / 96.0 < 0.05,
+        "non-planar sweep_with_options volume should be ~96, got {vol}"
+    );
+}
+
+#[test]
+fn multi_section_sweep_nonplanar_sections_is_valid_solid() {
+    // multi_section places each section perpendicular to the spine and lofts
+    // them; loft handles non-planar sections, so saddle sections now work
+    // (previously gated by "multi-section sweep profiles must be planar").
+    let mut topo = Topology::new();
+    let a = crate::test_helpers::make_saddle_profile(&mut topo, 2.0);
+    let b = crate::test_helpers::make_saddle_profile(&mut topo, 2.0);
+    let solid = multi_section_sweep(
+        &mut topo,
+        &straight_z_path(6.0),
+        &[(a, 0.0), (b, 1.0)],
+        true,
+    )
+    .unwrap();
+    assert!(
+        crate::validate::validate_solid(&topo, solid)
+            .unwrap()
+            .is_valid(),
+        "non-planar multi-section sweep must be a valid solid"
+    );
+    let vol = crate::measure::solid_volume(&topo, solid, 0.1).unwrap();
+    assert!(
+        vol > 80.0 && vol < 110.0,
+        "non-planar multi-section sweep volume should be ~96, got {vol}"
+    );
+}


### PR DESCRIPTION
## What

Extends non-planar profile support (loft [#974](https://github.com/andymai/brepkit/pull/974), sweep/pipe [#976](https://github.com/andymai/brepkit/pull/976)) to **three of the four advanced sweep variants**, using the shared `crate::cap` boundary-fill caps. Unblocked by the [sweep_smooth rail fix](https://github.com/andymai/brepkit/pull/981) and [sweep auto-orientation](https://github.com/andymai/brepkit/pull/985).

## Changes

- **`sweep_smooth`, `sweep_with_options`** — drop the planar gate, derive the frame up-hint from the section boundary's Newell normal, and route the end caps through `cap::build_cap_face` (planar ring → exact `Plane`; non-planar 4-edge ring → bilinear patch whose iso-curves are the ring chords). This is the identical conversion already shipped for the basic `sweep`/`pipe`.
- **`multi_section_sweep`** — it places each section perpendicular to the spine (`copy_face` + `transform_face`) and then **lofts** them, and `loft` already handles non-planar profiles. So the only change is `profile_to_frame_matrix`: a planar section keeps its stored plane normal; a non-planar one uses its boundary's Newell normal. Planar behavior is unchanged (the existing CCW-square tests use a stored normal that equals the Newell normal).

## Scope

The **miter-corner** variant (`sweep_miter`) still requires planar profiles — its joint faces lie on the bisector plane between legs and would become non-planar, which needs separate work (a follow-up). The README's Known-Limitations and Roadmap entries are updated to reflect that only miter remains.

## Tests

A non-planar (saddle) profile swept through `sweep_smooth`, `sweep_with_options`, and `multi_section_sweep` — each produces a `validate_solid`-valid solid with the expected ~96 prism volume (the bilinear caps fill the non-planar end rings without overfill).

Full `brepkit-operations` suite green (47 sweep tests); clippy `-D warnings` clean; layer boundaries valid.