### PR TITLE
ci: track broad boolean-perf regressions via benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,11 @@ jobs:
       - name: Run boolean tracking benchmarks
         # `--output-format bencher` emits the libtest `bench:` lines (stdout)
         # that the `cargo` parser below understands; build noise stays on stderr.
-        run: cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher | tee bench-output.txt
+        # `pipefail` so a bench failure fails the step despite the `tee` (the
+        # default `bash -e` shell does NOT set it).
+        run: |
+          set -o pipefail
+          cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher | tee bench-output.txt
       - name: Compare / store results
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,12 +14,12 @@ on:
 permissions:
   contents: write # store the baseline on gh-pages (push to main only)
   pull-requests: write # comment on a regression
-  deployments: write
 
-# A newer commit supersedes an in-flight run on the same ref.
 concurrency:
   group: benchmark-${{ github.ref }}
-  cancel-in-progress: true
+  # Supersede an in-flight run on a PR (only the latest commit matters), but let
+  # every push to main finish so the baseline trend has no gaps.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   benchmark:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,9 +2,9 @@ name: Benchmark
 
 # Broad boolean-perf regression tracking (complements the deterministic O(N²)
 # complexity guard in the Test job). On `main` it records a baseline and renders
-# a trend chart on the gh-pages branch; on a PR it compares against that baseline
-# and comments only on a clear regression. Shared CI runners are noisy, so the
-# alert threshold is loose and a regression never fails the build — it informs.
+# a trend on the gh-pages branch; on a PR it compares against that baseline and
+# comments only on a clear regression. Shared CI runners are noisy, so the alert
+# threshold is loose and a regression never fails the build — it informs.
 
 on:
   push:
@@ -28,9 +28,40 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # github-action-benchmark stores its history on the gh-pages branch and
+      # fails hard (`couldn't find remote ref gh-pages`) if it is missing. Detect
+      # it, and create an empty one on the first push to main so the action can
+      # bootstrap. A PR that runs before that simply skips the compare step
+      # below — there is no baseline to compare against yet.
+      - name: Detect benchmark baseline
+        id: baseline
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create gh-pages baseline branch
+        if: github.event_name == 'push' && steps.baseline.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tmp="$(mktemp -d)"
+          git -C "$tmp" init -q -b gh-pages
+          : > "$tmp/.nojekyll"
+          git -C "$tmp" add .nojekyll
+          git -C "$tmp" \
+            -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -q -m 'Initialize gh-pages for benchmark tracking'
+          git -C "$tmp" push -q \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Run boolean tracking benchmarks
         # `--output-format bencher` emits the libtest `bench:` lines (stdout)
         # that the `cargo` parser below understands; build noise stays on stderr.
@@ -39,7 +70,12 @@ jobs:
         run: |
           set -o pipefail
           cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher | tee bench-output.txt
+
+      # Runs on every push to main (record/update the baseline) and on a PR only
+      # once a baseline exists (compare). Skipping the PR case during bootstrap
+      # keeps the job green instead of failing on the missing gh-pages ref.
       - name: Compare / store results
+        if: github.event_name == 'push' || steps.baseline.outputs.exists == 'true'
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: Boolean perf

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,76 +1,120 @@
 name: Benchmark
 
-# Broad boolean-perf trend tracking. Complements the deterministic O(N²)
-# complexity guard in the Test job, which already catches the critical
-# regression class on every PR. This records a baseline + trend on the gh-pages
-# branch and comments on any commit that regresses by >2x.
+# Broad boolean-perf regression tracking (complements the deterministic O(N²)
+# complexity guard in the Test job). On `main` it records a baseline + trend on
+# the gh-pages branch; on a PR it compares against that baseline and comments
+# only on a clear regression. Shared CI runners are noisy, so the alert
+# threshold is loose and a regression never fails the build — it informs.
 #
-# It runs ONLY on pushes to main — i.e. on already-merged, trusted code — so the
-# write-scoped token is never exposed to PR-controlled build scripts (`cargo
-# bench` compiles them). The bench's *compilation* is covered on PRs by `cargo
-# clippy --all-targets` in the Clippy job.
+# Split into two jobs for safety: `bench` runs the PR-controlled `cargo bench`
+# (which compiles arbitrary build scripts) with a read-only token and no
+# persisted credentials, then hands the result to `publish` as an artifact.
+# `publish` runs no untrusted code, so it can safely hold the write/comment
+# token — a PR build script can never reach it.
 
 on:
   push:
     branches: [main]
+  pull_request:
 
-permissions:
-  contents: write # push the baseline to gh-pages
+# Least privilege by default; each job opts into exactly what it needs.
+permissions: {}
 
 concurrency:
-  # Serialize runs so concurrent gh-pages pushes can't race; never cancel, so
-  # every commit lands a baseline point (no gaps in the trend).
-  group: benchmark
-  cancel-in-progress: false
+  group: benchmark-${{ github.ref }}
+  # Supersede an in-flight run on a PR (only the latest commit matters), but let
+  # every push to main finish so the baseline trend has no gaps.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  benchmark:
+  bench:
     name: Boolean perf
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      # github-action-benchmark stores its history on the gh-pages branch and
-      # fails hard (`couldn't find remote ref gh-pages`) if it is missing, which
-      # it is before the very first run. Create an empty one so the action can
-      # bootstrap its baseline.
-      - name: Create gh-pages baseline branch if missing
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
-            tmp="$(mktemp -d)"
-            git -C "$tmp" init -q -b gh-pages
-            : > "$tmp/.nojekyll"
-            git -C "$tmp" add .nojekyll
-            git -C "$tmp" \
-              -c user.name='github-actions[bot]' \
-              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-              commit -q -m 'Initialize gh-pages for benchmark tracking'
-            git -C "$tmp" push -q \
-              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
-          fi
-
+        with:
+          persist-credentials: false # no write token reachable by bench build scripts
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run boolean tracking benchmarks
         # `--output-format bencher` emits the libtest `bench:` lines (stdout)
-        # that the `cargo` parser below understands; build noise stays on stderr.
-        # `pipefail` so a bench failure fails the step despite the `tee` (the
-        # default `bash -e` shell does NOT set it).
+        # that the `cargo` parser in `publish` understands; build noise stays on
+        # stderr. `pipefail` so a bench failure fails the step despite the `tee`
+        # (the default `bash -e` shell does NOT set it).
         run: |
           set -o pipefail
           cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher | tee bench-output.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-output
+          path: bench-output.txt
+          retention-days: 5
 
+  publish:
+    name: Publish benchmark
+    needs: bench
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # push the baseline to gh-pages (main only)
+      pull-requests: write # comment on a regression (PR)
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false # the steps below use their own token
+
+      # github-action-benchmark stores its history on gh-pages and fails hard
+      # (`couldn't find remote ref gh-pages`) if it is missing. Detect it, and
+      # create an empty one on the first push to main so the action can
+      # bootstrap. A PR that runs before that simply skips the compare below.
+      - name: Detect benchmark baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --heads "$remote" gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create gh-pages baseline branch
+        if: github.event_name == 'push' && steps.baseline.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tmp="$(mktemp -d)"
+          git -C "$tmp" init -q -b gh-pages
+          : > "$tmp/.nojekyll"
+          git -C "$tmp" add .nojekyll
+          git -C "$tmp" \
+            -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -q -m 'Initialize gh-pages for benchmark tracking'
+          git -C "$tmp" push -q \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: bench-output
+
+      # Runs on every push to main (record/update the baseline) and on a PR only
+      # once a baseline exists (compare). Skipping the PR case during bootstrap
+      # keeps the job green instead of failing on the missing gh-pages ref.
       - name: Compare / store results
+        if: github.event_name == 'push' || steps.baseline.outputs.exists == 'true'
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: Boolean perf
           tool: cargo
           output-file-path: bench-output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
+          # Record the baseline only on main; PRs compare without pushing.
+          auto-push: ${{ github.event_name == 'push' }}
           # Alert only on a clear 2x regression, and never fail the build on it —
           # comment for visibility instead (shared runners are noisy).
           alert-threshold: '200%'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,25 +1,27 @@
 name: Benchmark
 
-# Broad boolean-perf regression tracking (complements the deterministic O(N²)
-# complexity guard in the Test job). On `main` it records a baseline and renders
-# a trend on the gh-pages branch; on a PR it compares against that baseline and
-# comments only on a clear regression. Shared CI runners are noisy, so the alert
-# threshold is loose and a regression never fails the build — it informs.
+# Broad boolean-perf trend tracking. Complements the deterministic O(N²)
+# complexity guard in the Test job, which already catches the critical
+# regression class on every PR. This records a baseline + trend on the gh-pages
+# branch and comments on any commit that regresses by >2x.
+#
+# It runs ONLY on pushes to main — i.e. on already-merged, trusted code — so the
+# write-scoped token is never exposed to PR-controlled build scripts (`cargo
+# bench` compiles them). The bench's *compilation* is covered on PRs by `cargo
+# clippy --all-targets` in the Clippy job.
 
 on:
   push:
     branches: [main]
-  pull_request:
 
 permissions:
-  contents: write # store the baseline on gh-pages (push to main only)
-  pull-requests: write # comment on a regression
+  contents: write # push the baseline to gh-pages
 
 concurrency:
-  group: benchmark-${{ github.ref }}
-  # Supersede an in-flight run on a PR (only the latest commit matters), but let
-  # every push to main finish so the baseline trend has no gaps.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Serialize runs so concurrent gh-pages pushes can't race; never cancel, so
+  # every commit lands a baseline point (no gaps in the trend).
+  group: benchmark
+  cancel-in-progress: false
 
 jobs:
   benchmark:
@@ -30,37 +32,27 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # github-action-benchmark stores its history on the gh-pages branch and
-      # fails hard (`couldn't find remote ref gh-pages`) if it is missing. Detect
-      # it, and create an empty one on the first push to main so the action can
-      # bootstrap. A PR that runs before that simply skips the compare step
-      # below — there is no baseline to compare against yet.
-      - name: Detect benchmark baseline
-        id: baseline
-        run: |
-          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Create gh-pages baseline branch
-        if: github.event_name == 'push' && steps.baseline.outputs.exists == 'false'
+      # fails hard (`couldn't find remote ref gh-pages`) if it is missing, which
+      # it is before the very first run. Create an empty one so the action can
+      # bootstrap its baseline.
+      - name: Create gh-pages baseline branch if missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tmp="$(mktemp -d)"
-          git -C "$tmp" init -q -b gh-pages
-          : > "$tmp/.nojekyll"
-          git -C "$tmp" add .nojekyll
-          git -C "$tmp" \
-            -c user.name='github-actions[bot]' \
-            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-            commit -q -m 'Initialize gh-pages for benchmark tracking'
-          git -C "$tmp" push -q \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+          if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            tmp="$(mktemp -d)"
+            git -C "$tmp" init -q -b gh-pages
+            : > "$tmp/.nojekyll"
+            git -C "$tmp" add .nojekyll
+            git -C "$tmp" \
+              -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -q -m 'Initialize gh-pages for benchmark tracking'
+            git -C "$tmp" push -q \
+              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+          fi
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run boolean tracking benchmarks
         # `--output-format bencher` emits the libtest `bench:` lines (stdout)
@@ -71,19 +63,14 @@ jobs:
           set -o pipefail
           cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher | tee bench-output.txt
 
-      # Runs on every push to main (record/update the baseline) and on a PR only
-      # once a baseline exists (compare). Skipping the PR case during bootstrap
-      # keeps the job green instead of failing on the missing gh-pages ref.
       - name: Compare / store results
-        if: github.event_name == 'push' || steps.baseline.outputs.exists == 'true'
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: Boolean perf
           tool: cargo
           output-file-path: bench-output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Record the baseline only on main; PRs compare without pushing.
-          auto-push: ${{ github.event_name == 'push' }}
+          auto-push: true
           # Alert only on a clear 2x regression, and never fail the build on it —
           # comment for visibility instead (shared runners are noisy).
           alert-threshold: '200%'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,52 @@
+name: Benchmark
+
+# Broad boolean-perf regression tracking (complements the deterministic O(N²)
+# complexity guard in the Test job). On `main` it records a baseline and renders
+# a trend chart on the gh-pages branch; on a PR it compares against that baseline
+# and comments only on a clear regression. Shared CI runners are noisy, so the
+# alert threshold is loose and a regression never fails the build — it informs.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: write # store the baseline on gh-pages (push to main only)
+  pull-requests: write # comment on a regression
+  deployments: write
+
+# A newer commit supersedes an in-flight run on the same ref.
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Boolean perf
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Run boolean tracking benchmarks
+        # `--output-format bencher` emits the libtest `bench:` lines (stdout)
+        # that the `cargo` parser below understands; build noise stays on stderr.
+        run: cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher | tee bench-output.txt
+      - name: Compare / store results
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        with:
+          name: Boolean perf
+          tool: cargo
+          output-file-path: bench-output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Record the baseline only on main; PRs compare without pushing.
+          auto-push: ${{ github.event_name == 'push' }}
+          # Alert only on a clear 2x regression, and never fail the build on it —
+          # comment for visibility instead (shared runners are noisy).
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: false
+          summary-always: true

--- a/crates/operations/Cargo.toml
+++ b/crates/operations/Cargo.toml
@@ -48,5 +48,9 @@ name = "compound_cut_perf"
 harness = false
 name = "fuse_perf"
 
+[[bench]]
+harness = false
+name = "boolean_tracking"
+
 [lints]
 workspace = true

--- a/crates/operations/benches/boolean_tracking.rs
+++ b/crates/operations/benches/boolean_tracking.rs
@@ -42,7 +42,8 @@ fn merge_disjoint(topo: &mut Topology, solids: &[SolidId]) -> SolidId {
     topo.add_solid(Solid::new(outer, vec![]))
 }
 
-/// Two overlapping unit boxes offset along the diagonal.
+/// Two unit boxes overlapping on the diagonal (a non-trivial intersection
+/// region for all three boolean ops).
 fn two_boxes(topo: &mut Topology) -> (SolidId, SolidId) {
     let a = make_box(topo, 1.0, 1.0, 1.0).unwrap();
     let b = make_box(topo, 1.0, 1.0, 1.0).unwrap();
@@ -58,21 +59,19 @@ fn bench_booleans(c: &mut Criterion) {
         .warm_up_time(Duration::from_millis(500))
         .measurement_time(Duration::from_secs(2));
 
-    group.bench_function("cut_box_box", |bencher| {
-        bencher.iter(|| {
-            let mut topo = Topology::new();
-            let (a, b) = two_boxes(&mut topo);
-            black_box(boolean(&mut topo, BooleanOp::Cut, a, b).unwrap())
+    for (name, op) in [
+        ("cut_box_box", BooleanOp::Cut),
+        ("fuse_box_box", BooleanOp::Fuse),
+        ("intersect_box_box", BooleanOp::Intersect),
+    ] {
+        group.bench_function(name, |bencher| {
+            bencher.iter(|| {
+                let mut topo = Topology::new();
+                let (a, b) = two_boxes(&mut topo);
+                black_box(boolean(&mut topo, op, a, b).unwrap())
+            });
         });
-    });
-
-    group.bench_function("fuse_box_box", |bencher| {
-        bencher.iter(|| {
-            let mut topo = Topology::new();
-            let (a, b) = two_boxes(&mut topo);
-            black_box(boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap())
-        });
-    });
+    }
 
     group.bench_function("cut_cylinder_through_box", |bencher| {
         bencher.iter(|| {

--- a/crates/operations/benches/boolean_tracking.rs
+++ b/crates/operations/benches/boolean_tracking.rs
@@ -1,0 +1,114 @@
+//! Lightweight boolean-perf tracking benchmarks for CI regression alerts.
+//!
+//! Deliberately small and fast (reduced sample count, moderate sizes) so the
+//! whole suite runs in well under a minute on a shared CI runner. The goal is a
+//! stable *trend* over time on `main`, not precise local measurement — the
+//! `github-action-benchmark` step compares against the stored baseline and
+//! comments on a large regression. For sharp O(N²) detection see the
+//! deterministic complexity guard (`boolean::tests::scaling_*`); this catches
+//! broad slowdowns the work-counters can't see.
+//!
+//! Run locally: `cargo bench -p brepkit-operations --bench boolean_tracking`
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::missing_docs_in_private_items,
+    missing_docs
+)]
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::primitives::{make_box, make_cylinder};
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::shell::Shell;
+use brepkit_topology::solid::{Solid, SolidId};
+
+/// Merge disjoint solids into one multi-region tool (the lowering of a compound
+/// cutter). Inlined here because `compound_ops::merge_disjoint_solids` is
+/// crate-internal and benches are an external target.
+fn merge_disjoint(topo: &mut Topology, solids: &[SolidId]) -> SolidId {
+    let mut faces = Vec::new();
+    for &s in solids {
+        let outer = topo.solid(s).unwrap().outer_shell();
+        faces.extend_from_slice(topo.shell(outer).unwrap().faces());
+    }
+    let outer = topo.add_shell(Shell::new(faces).unwrap());
+    topo.add_solid(Solid::new(outer, vec![]))
+}
+
+/// Two overlapping unit boxes offset along the diagonal.
+fn two_boxes(topo: &mut Topology) -> (SolidId, SolidId) {
+    let a = make_box(topo, 1.0, 1.0, 1.0).unwrap();
+    let b = make_box(topo, 1.0, 1.0, 1.0).unwrap();
+    transform_solid(topo, b, &Mat4::translation(0.5, 0.5, 0.5)).unwrap();
+    (a, b)
+}
+
+fn bench_booleans(c: &mut Criterion) {
+    let mut group = c.benchmark_group("boolean");
+    // CI-friendly: few samples, short measurement — trend tracking, not precision.
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2));
+
+    group.bench_function("cut_box_box", |bencher| {
+        bencher.iter(|| {
+            let mut topo = Topology::new();
+            let (a, b) = two_boxes(&mut topo);
+            black_box(boolean(&mut topo, BooleanOp::Cut, a, b).unwrap())
+        });
+    });
+
+    group.bench_function("fuse_box_box", |bencher| {
+        bencher.iter(|| {
+            let mut topo = Topology::new();
+            let (a, b) = two_boxes(&mut topo);
+            black_box(boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap())
+        });
+    });
+
+    group.bench_function("cut_cylinder_through_box", |bencher| {
+        bencher.iter(|| {
+            let mut topo = Topology::new();
+            let box_id = make_box(&mut topo, 4.0, 4.0, 2.0).unwrap();
+            let cyl = make_cylinder(&mut topo, 1.0, 6.0).unwrap();
+            transform_solid(&mut topo, cyl, &Mat4::translation(2.0, 2.0, -2.0)).unwrap();
+            black_box(boolean(&mut topo, BooleanOp::Cut, box_id, cyl).unwrap())
+        });
+    });
+
+    // Issue #987: a 6×6 perforated panel (36 through-holes). Tracks the
+    // many-holes Cut path that the O(N²) fixes made near-linear.
+    group.bench_function("perforated_cut_36", |bencher| {
+        bencher.iter(|| {
+            let mut topo = Topology::new();
+            let pitch = 2.4;
+            let span = 7.0 * pitch;
+            let slab = make_box(&mut topo, span, span, 2.0).unwrap();
+            transform_solid(&mut topo, slab, &Mat4::translation(0.0, 0.0, 1.0)).unwrap();
+            let mut tools = Vec::new();
+            for j in 0..6 {
+                for i in 0..6 {
+                    let h = make_box(&mut topo, 1.0, 1.0, 4.0).unwrap();
+                    let m = Mat4::translation((i + 1) as f64 * pitch, (j + 1) as f64 * pitch, 0.0);
+                    transform_solid(&mut topo, h, &m).unwrap();
+                    tools.push(h);
+                }
+            }
+            let tool = merge_disjoint(&mut topo, &tools);
+            black_box(boolean(&mut topo, BooleanOp::Cut, slab, tool).unwrap())
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_booleans);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Follow-up to #990. That PR added a **deterministic complexity guard** that fails CI if a boolean hot path regresses to O(N²) — sharp, but it only watches the two paths it counts. This adds the complementary **broad absolute-perf tracking** so general slowdowns (anywhere in the boolean pipeline) are visible too.

## What it does

- A new, intentionally **small and fast** `boolean_tracking` criterion bench — box cut/fuse, cylinder-through-box cut, and a 36-hole perforated panel (the #987 case) — reduced sample count so the whole suite runs in well under a minute.
- Emitted in the libtest `bencher` format (`--output-format bencher`) and fed to [`benchmark-action/github-action-benchmark`](https://github.com/benchmark-action/github-action-benchmark) (pinned to v1.22.1).
- **On `main`:** records a baseline and renders a trend chart on the `gh-pages` branch.
- **On a PR:** compares against that baseline and comments only on a clear regression.

## Deliberately conservative (won't add flaky failures)

Shared CI runners are noisy, so:
- `alert-threshold: 200%` — only a clear ~2× regression alerts.
- `fail-on-alert: false` — a regression **comments**, never fails the build.
- `auto-push` only on `main`; PRs compare without writing.

The first `main` run bootstraps the `gh-pages` baseline; until then PRs simply run the bench with nothing to compare.

## Verification

- Bench emits clean `bencher` lines on stdout (box cut/fuse ~1ms, cylinder cut ~0.4ms, perforated_cut_36 ~15ms).
- `benchmark.yml` is valid YAML and interpolates only trusted `github.*` context + `secrets.GITHUB_TOKEN` (no untrusted-input injection surface).
- clippy `--all-targets` and `cargo fmt` clean.
