### PR TITLE
test(algo): extend boolean complexity guard to all five #990 hot paths

### DIFF
--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -95,6 +95,7 @@ pub(super) fn find_splits_on_line(
     }
     let mut splits = Vec::new();
     for &sp in split_pts_3d {
+        crate::perf::bump_face_split_probe();
         let to_pt = sp - edge.start_3d;
         let t = to_pt.dot(edge_dir) / edge_len_sq;
         if t <= tol || t >= 1.0 - tol {
@@ -132,6 +133,7 @@ pub(super) fn find_splits_on_circle(
     }
     let mut splits = Vec::new();
     for &sp in split_pts_3d {
+        crate::perf::bump_face_split_probe();
         let angle = circle.project(sp);
         let closest = circle.evaluate(angle);
         if (sp - closest).length() > tol {
@@ -164,6 +166,7 @@ pub(super) fn find_splits_on_ellipse(
     }
     let mut splits = Vec::new();
     for &sp in split_pts_3d {
+        crate::perf::bump_face_split_probe();
         let angle = ellipse.project(sp);
         let closest = ellipse.evaluate(angle);
         if (sp - closest).length() > tol {

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -1260,6 +1260,9 @@ fn arrangement_regions_from_inputs(
                     continue; // chord boxes disjoint → no crossing, no T-junction
                 }
             }
+            // A pair that survives the broad-phase does the real crossing /
+            // T-junction work below — the cost the bbox prune keeps near-linear.
+            crate::perf::bump_face_split_probe();
             let (b0, b1) = (other.a, other.b);
             // Proper interior crossing. For an arc input, only honour the break
             // when the crossing point is on the real arc (not just its chord).
@@ -3055,10 +3058,13 @@ fn plane_internal_line_loops(
         for cx in lo.0..=hi.0 {
             for cy in lo.1..=hi.1 {
                 for cz in lo.2..=hi.2 {
-                    if let Some(pts) = ep_grid.get(&(cx, cy, cz))
-                        && pts.iter().copied().any(subdivided)
-                    {
-                        return false;
+                    if let Some(pts) = ep_grid.get(&(cx, cy, cz)) {
+                        for &p in pts {
+                            crate::perf::bump_face_split_probe();
+                            if subdivided(p) {
+                                return false;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2377,6 +2377,7 @@ fn layered_vertex(
         return v;
     }
     let v = fallback();
+    crate::perf::bump_local_vertex_insert();
     local.insert(key, v);
     v
 }

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -258,6 +258,7 @@ fn wire_polygon(
 
 /// Collect per-face ray-cast geometry from a solid.
 fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, AlgoError> {
+    crate::perf::bump_ray_geom_build();
     let faces = brepkit_topology::explorer::solid_faces(topo, solid)?;
     let mut result = Vec::with_capacity(faces.len());
 

--- a/crates/algo/src/perf.rs
+++ b/crates/algo/src/perf.rs
@@ -1,11 +1,20 @@
 //! Deterministic work counters for complexity-regression guards.
 //!
-//! These count the *inner work* of the boolean hot paths that were once
-//! O(N²) — the pave-vertex coincidence lookup and the same-domain polygon
-//! clip — so a test can assert the work grows sub-quadratically with input
-//! size. Counting work (not wall-clock) makes the guard deterministic: a
+//! These count the *inner work* of the boolean hot paths that issue #987 found
+//! to be O(N²) — so a test can assert the work grows sub-quadratically with
+//! input size. Counting work (not wall-clock) makes the guard deterministic: a
 //! reintroduced per-item full scan turns a linear count into a quadratic one,
 //! which trips the bound with no timing flakiness.
+//!
+//! Five hot paths were fixed in #990; each has a counter here:
+//!
+//! | Counter | Hot path | Bounded shape with the fix in |
+//! |---|---|---|
+//! | `pave_vertex_probes` | PaveFiller endpoint→vertex snap | spatial hash → near-constant per query |
+//! | `sd_poly_clips` | `detect_same_domain` polygon clip | bbox gate → ~0 clips |
+//! | `ray_geom_builds` | classify sub-faces | ray-cast geometry built once per solid, not per sub-face |
+//! | `face_split_probes` | face-splitter section/loop scans | grid index → near-constant candidates per query |
+//! | `local_vertex_inserts` | `build_topology_face` vertex pool | layered lookup → only genuinely-new vertices materialized |
 //!
 //! The counters are gated behind the `perf-counters` feature. With the feature
 //! off (every normal and release build) the `bump_*` calls are empty `#[inline]`
@@ -19,6 +28,12 @@ use core::sync::atomic::{AtomicU64, Ordering};
 static PAVE_VERTEX_PROBES: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "perf-counters")]
 static SD_POLY_CLIPS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-counters")]
+static RAY_GEOM_BUILDS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-counters")]
+static FACE_SPLIT_PROBES: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-counters")]
+static LOCAL_VERTEX_INSERTS: AtomicU64 = AtomicU64::new(0);
 
 /// Count one pave-vertex distance comparison (per candidate examined while
 /// snapping an intersection endpoint to a coincident vertex). Crate-internal:
@@ -37,20 +52,76 @@ pub(crate) fn bump_sd_poly_clip() {
     SD_POLY_CLIPS.fetch_add(1, Ordering::Relaxed);
 }
 
+/// Count one ray-cast geometry collection for a solid (`collect_face_geoms`).
+/// This is the O(faces) build the classify loop now does *once* per argument
+/// solid; rebuilding it per sub-face was the quadratic. A regression that
+/// classifies via the per-call (uncached) path inside the sub-face loop bumps
+/// this once per sub-face, so the count grows with the result's face count.
+#[inline]
+pub(crate) fn bump_ray_geom_build() {
+    #[cfg(feature = "perf-counters")]
+    RAY_GEOM_BUILDS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Count one candidate endpoint examined by a face-splitter grid query (the
+/// per-section / per-loop "is there a point near this edge" scan). The grid
+/// returns only nearby points, so this is near-constant per query; a reverted
+/// full scan returns every endpoint per query → O(sections²). Crate-internal.
+#[inline]
+pub(crate) fn bump_face_split_probe() {
+    #[cfg(feature = "perf-counters")]
+    FACE_SPLIT_PROBES.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Count one vertex materialized into a sub-face's local vertex map during
+/// `build_topology_face`. The layered lookup resolves existing vertices by
+/// reference from the shared seed/rank pools, so only genuinely-new vertices
+/// land here — O(new vertices), linear in the result. Re-seeding the per-sub-face
+/// map from the shared pools (the former clone) re-materializes pool-sized state
+/// per sub-face → O(pool · sub-faces), quadratic. Crate-internal.
+#[inline]
+pub(crate) fn bump_local_vertex_insert() {
+    #[cfg(feature = "perf-counters")]
+    LOCAL_VERTEX_INSERTS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// A snapshot of every work counter since the last [`reset`]. Only available
+/// with `perf-counters`.
+#[cfg(feature = "perf-counters")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PerfSnapshot {
+    /// Pave-vertex coincidence-lookup candidate comparisons.
+    pub pave_vertex_probes: u64,
+    /// Same-domain polygon-intersection clips (the expensive narrow-phase).
+    pub sd_poly_clips: u64,
+    /// Ray-cast geometry collections (`collect_face_geoms` calls).
+    pub ray_geom_builds: u64,
+    /// Face-splitter grid-query candidate endpoints examined.
+    pub face_split_probes: u64,
+    /// Sub-face-local vertex materializations in `build_topology_face`.
+    pub local_vertex_inserts: u64,
+}
+
 /// Reset all counters to zero. Only available with `perf-counters`.
 #[cfg(feature = "perf-counters")]
 pub fn reset() {
     PAVE_VERTEX_PROBES.store(0, Ordering::Relaxed);
     SD_POLY_CLIPS.store(0, Ordering::Relaxed);
+    RAY_GEOM_BUILDS.store(0, Ordering::Relaxed);
+    FACE_SPLIT_PROBES.store(0, Ordering::Relaxed);
+    LOCAL_VERTEX_INSERTS.store(0, Ordering::Relaxed);
 }
 
-/// `(pave_vertex_probes, sd_poly_clips)` since the last [`reset`]. Only
-/// available with `perf-counters`.
+/// Every work counter since the last [`reset`]. Only available with
+/// `perf-counters`.
 #[cfg(feature = "perf-counters")]
 #[must_use]
-pub fn snapshot() -> (u64, u64) {
-    (
-        PAVE_VERTEX_PROBES.load(Ordering::Relaxed),
-        SD_POLY_CLIPS.load(Ordering::Relaxed),
-    )
+pub fn snapshot() -> PerfSnapshot {
+    PerfSnapshot {
+        pave_vertex_probes: PAVE_VERTEX_PROBES.load(Ordering::Relaxed),
+        sd_poly_clips: SD_POLY_CLIPS.load(Ordering::Relaxed),
+        ray_geom_builds: RAY_GEOM_BUILDS.load(Ordering::Relaxed),
+        face_split_probes: FACE_SPLIT_PROBES.load(Ordering::Relaxed),
+        local_vertex_inserts: LOCAL_VERTEX_INSERTS.load(Ordering::Relaxed),
+    }
 }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5122,15 +5122,35 @@ fn build_perforated_panel(topo: &mut Topology, g: usize) -> (SolidId, SolidId) {
     (slab, tool)
 }
 
-/// Complexity-regression guard (issue #987): the boolean hot paths that were
-/// O(N²) must stay sub-quadratic. Counting *work* (not wall-clock) makes this
-/// deterministic — a reintroduced per-item full scan turns a linear count into
-/// a quadratic one, tripping the bound with no timing flakiness. Runs only with
+/// Complexity-regression guard (issue #987): the five boolean hot paths that
+/// PR #990 made near-linear must stay sub-quadratic. Counting *work* (not
+/// wall-clock) makes this deterministic — a reintroduced per-item full scan or
+/// per-sub-face rebuild turns a linear count into a quadratic (or constant into
+/// linear) one, tripping a bound with no timing flakiness. Runs only with
 /// `--features perf-counters`; a dedicated CI step exercises it.
+///
+/// Cutting a `g×g` grid of disjoint prisms through a slab. Going from `g=9`
+/// (81 holes) to `g=18` (324 holes) is a 4× input increase, so a linear path
+/// scales ~4× and a quadratic one ~16×. Each counter's bound was chosen by
+/// reverting the corresponding #990 fix and observing the counter explode:
+///
+/// | counter | fix in | fix reverted | bound |
+/// |---|---|---|---|
+/// | `pave_vertex_probes` | 0 | tens of thousands | absolute `< 5_000` |
+/// | `sd_poly_clips` | 0 | thousands | absolute `< 2_000` |
+/// | `ray_geom_builds` | 2 (once per solid) | 656 (per sub-face) | absolute `< 64` |
+/// | `face_split_probes` | ~4.1× | ~15.5× | ratio `< 8.0` |
+/// | `local_vertex_inserts` | ~4.0× | ~15.8× | ratio `< 8.0` |
+///
+/// `ray_geom_builds` regresses to O(N), not O(N²) — a *constant* becoming
+/// linear — so a ratio bound (still ~4×) would miss it; the absolute bound
+/// catches it. The two ratio-guarded paths conversely regress to O(N²), where
+/// a ratio bound is the sharp test. The `> 0` sanity checks ensure the path is
+/// actually exercised, so silently deleted instrumentation can't pass as 0→0.
 #[cfg(feature = "perf-counters")]
 #[test]
 fn scaling_perforated_cut_is_subquadratic() {
-    let cut_counts = |g: usize| -> (u64, u64) {
+    let cut_counts = |g: usize| -> brepkit_algo::perf::PerfSnapshot {
         let mut topo = Topology::new();
         let (slab, tool) = build_perforated_panel(&mut topo, g);
         brepkit_algo::perf::reset();
@@ -5139,27 +5159,78 @@ fn scaling_perforated_cut_is_subquadratic() {
         brepkit_algo::perf::snapshot()
     };
 
-    // The fixes make these once-O(N²) hot paths do near-constant work on this
-    // case: empty pave-vertex lookups examine no grid entries, and the bbox gate
-    // skips the polygon clip for every touching/side-by-side coplanar pair. A
-    // reintroduced per-item full scan turns each into O(N²) — many thousands of
-    // probes/clips at 324 holes — so a generous absolute bound at the larger
-    // size catches the regression with no timing flakiness. The smaller size is
-    // measured too, for the diagnostic trend.
-    let (probes_1x, clips_1x) = cut_counts(9); // 81 holes
-    let (probes_4x, clips_4x) = cut_counts(18); // 324 holes (4× input)
+    let s1 = cut_counts(9); // 81 holes
+    let s4 = cut_counts(18); // 324 holes (4× input)
+    let ratio = |a: u64, b: u64| {
+        if a == 0 {
+            f64::from(b == 0)
+        } else {
+            b as f64 / a as f64
+        }
+    };
+    let fsp_ratio = ratio(s1.face_split_probes, s4.face_split_probes);
+    let lvi_ratio = ratio(s1.local_vertex_inserts, s4.local_vertex_inserts);
     eprintln!(
-        "scaling guard @ 81→324 holes: pave_probes {probes_1x}->{probes_4x}, sd_clips {clips_1x}->{clips_4x}"
+        "scaling guard @ 81→324 holes (4× input → linear ~4×, quadratic ~16×): \
+         pave_probes {}->{}, sd_clips {}->{}, ray_geom_builds {}->{}, \
+         face_split_probes {}->{} ({fsp_ratio:.1}×), local_vtx_inserts {}->{} ({lvi_ratio:.1}×)",
+        s1.pave_vertex_probes,
+        s4.pave_vertex_probes,
+        s1.sd_poly_clips,
+        s4.sd_poly_clips,
+        s1.ray_geom_builds,
+        s4.ray_geom_builds,
+        s1.face_split_probes,
+        s4.face_split_probes,
+        s1.local_vertex_inserts,
+        s4.local_vertex_inserts,
     );
 
+    // PaveFiller endpoint→vertex snap: spatial hash keeps lookups near-constant;
+    // a per-pave-block linear scan would be tens of thousands of probes.
     assert!(
-        probes_4x < 5_000,
-        "pave-vertex lookup regressed to O(N²): {probes_4x} probes at 324 holes \
-         (current ~40; a per-pave-block linear scan would be tens of thousands+)"
+        s4.pave_vertex_probes < 5_000,
+        "pave-vertex lookup regressed to O(N²): {} probes at 324 holes",
+        s4.pave_vertex_probes
+    );
+    // Same-domain polygon clip: the bbox gate skips every disjoint coplanar
+    // pair; an ungated clip-every-pair would be thousands.
+    assert!(
+        s4.sd_poly_clips < 2_000,
+        "same-domain polygon clip regressed to O(N²): {} clips at 324 holes",
+        s4.sd_poly_clips
+    );
+    // Classify sub-faces: ray-cast geometry is built once per argument solid (2
+    // total). Rebuilding it per sub-face makes this O(sub-faces) — hundreds.
+    assert!(
+        s4.ray_geom_builds < 64,
+        "ray-cast geometry rebuilt per sub-face (was once per solid): {} builds at 324 holes",
+        s4.ray_geom_builds
+    );
+    // Face-splitter section/loop scans: grid pruning keeps per-section candidate
+    // work near-linear; a reverted full scan is O(sections²) (~16×).
+    assert!(
+        s4.face_split_probes > 0,
+        "face-split probe instrumentation not exercised"
     );
     assert!(
-        clips_4x < 2_000,
-        "same-domain polygon clip regressed to O(N²): {clips_4x} clips at 324 holes \
-         (current ~0; an ungated clip-every-candidate-pair would be thousands)"
+        fsp_ratio < 8.0,
+        "face-splitter candidate scan regressed toward O(N²): {fsp_ratio:.1}× for 4× input \
+         ({}->{} probes)",
+        s1.face_split_probes,
+        s4.face_split_probes
+    );
+    // build_topology_face vertex pool: layered lookup materializes only new
+    // vertices per sub-face; re-seeding from the shared pools is O(pool·sub-faces).
+    assert!(
+        s4.local_vertex_inserts > 0,
+        "vertex-insert instrumentation not exercised"
+    );
+    assert!(
+        lvi_ratio < 8.0,
+        "per-sub-face vertex materialization regressed toward O(N²): {lvi_ratio:.1}× for 4× input \
+         ({}->{} inserts)",
+        s1.local_vertex_inserts,
+        s4.local_vertex_inserts
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to #990. That PR fixed **five** independent O(N²) hot paths in the boolean `Cut` pipeline, but the deterministic work-counter guard (`scaling_perforated_cut_is_subquadratic`) only instrumented **two** of them — the pave-vertex probe and the same-domain polygon clip. The other three were watched only by the noisy wall-clock tracking bench (#991), so a regression in them could silently reintroduce a quadratic without tripping the sharp guard.

This adds work-counters for the remaining three paths and extends the guard to assert sub-quadratic scaling on all five.

## New counters (`algo::perf`)

Zero-cost `#[inline]` no-ops when `perf-counters` is off, so the instrumented hot loops pay nothing in normal/release builds.

| Counter | Path | Site |
|---|---|---|
| `ray_geom_builds` | classify sub-faces | `collect_face_geoms` (built once per solid) |
| `face_split_probes` | face-splitter scans | `find_splits_on_*`, arrangement pairwise, `plane_internal_line_loops` |
| `local_vertex_inserts` | `build_topology_face` vertex pool | `layered_vertex` materialization |

`snapshot()` now returns a `PerfSnapshot` struct instead of a 2-tuple.

## Verification — each counter catches its regression

Reverting each #990 fix in isolation makes the corresponding counter explode (81→324 holes, a 4× input step):

| Counter | fix in | fix reverted | bound |
|---|---|---|---|
| `ray_geom_builds` | **2→2** | **170→656** | absolute `< 64` |
| `face_split_probes` | **4.1×** | **15.5×** | ratio `< 8.0` |
| `local_vertex_inserts` | **4.0×** | **15.8×** | ratio `< 8.0` |

`ray_geom_builds` regresses to O(N) (a *constant* becoming linear), so a ratio bound would miss it — it uses an absolute bound. The other two regress to O(N²), where the scaling **ratio** is the sharp test. Counts are fully deterministic across runs, so the thresholds are tight with no timing flakiness.

## No residual quadratic found

All five paths measure linear (~4.0× for 4× input). The arrangement pass's `for i { for j }` pairwise loop is structurally O(N²) but bbox-pruned and cheap; on disjoint holes it stays linear (work partitions into small per-hole arrangements), matching #990's "diminishing returns" call. Left as-is.

## CI

The existing complexity-guard step (`cargo nextest run -p brepkit-operations --features perf-counters -E 'test(scaling_)'`) runs the extended guard — **no workflow change needed**.

## Checks
- Full workspace suite: **0 failures**
- `clippy --all-targets -D warnings`: clean in **both** default and `perf-counters` configs
- `cargo fmt`, `check-boundaries.sh`: clean