### PR TITLE
test(algo): address review feedback on boolean complexity guard

### DIFF
--- a/crates/algo/src/perf.rs
+++ b/crates/algo/src/perf.rs
@@ -63,10 +63,12 @@ pub(crate) fn bump_ray_geom_build() {
     RAY_GEOM_BUILDS.fetch_add(1, Ordering::Relaxed);
 }
 
-/// Count one candidate endpoint examined by a face-splitter grid query (the
-/// per-section / per-loop "is there a point near this edge" scan). The grid
-/// returns only nearby points, so this is near-constant per query; a reverted
-/// full scan returns every endpoint per query → O(sections²). Crate-internal.
+/// Count one unit of face-splitter candidate work — either an endpoint examined
+/// by a per-section / per-loop grid query (the "is there a point near this edge"
+/// scan), or a chord pair that survives the arrangement's bbox broad-phase and
+/// runs the real crossing / T-junction test. Each broad-phase keeps its work
+/// near-constant per query/edge; reverting either makes it O(sections²).
+/// Crate-internal.
 #[inline]
 pub(crate) fn bump_face_split_probe() {
     #[cfg(feature = "perf-counters")]
@@ -96,7 +98,8 @@ pub struct PerfSnapshot {
     pub sd_poly_clips: u64,
     /// Ray-cast geometry collections (`collect_face_geoms` calls).
     pub ray_geom_builds: u64,
-    /// Face-splitter grid-query candidate endpoints examined.
+    /// Face-splitter candidate work: grid-query endpoints examined plus
+    /// arrangement chord pairs that survive the bbox broad-phase.
     pub face_split_probes: u64,
     /// Sub-face-local vertex materializations in `build_topology_face`.
     pub local_vertex_inserts: u64,

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5161,12 +5161,16 @@ fn scaling_perforated_cut_is_subquadratic() {
 
     let s1 = cut_counts(9); // 81 holes
     let s4 = cut_counts(18); // 324 holes (4× input)
+    // Assert the baseline is exercised rather than dividing by it: a 0→nonzero
+    // ratio would otherwise read as 0.0 and silently pass the bound, disabling
+    // the scaling guard if a fixture/instrumentation change stops hitting the
+    // path at the smaller size.
     let ratio = |a: u64, b: u64| {
-        if a == 0 {
-            f64::from(b == 0)
-        } else {
-            b as f64 / a as f64
-        }
+        assert!(
+            a > 0,
+            "scaling-ratio baseline counter was not exercised at g=9"
+        );
+        b as f64 / a as f64
     };
     let fsp_ratio = ratio(s1.face_split_probes, s4.face_split_probes);
     let lvi_ratio = ratio(s1.local_vertex_inserts, s4.local_vertex_inserts);


### PR DESCRIPTION
## Summary

Follow-up to #992, addressing the Copilot and Greptile review comments on that (auto-merged) PR.

## Changes

**1. Harden the scaling-ratio helper** (Greptile P2 + Copilot)
The `ratio` helper returned `0.0` for a `0→nonzero` ratio, which passes the `< 8.0` bound — so if a fixture or instrumentation change stopped exercising a path at the smaller size (`g=9`), the scaling guard for that counter would silently switch off. It now asserts the baseline is exercised:

```rust
let ratio = |a: u64, b: u64| {
    assert!(a > 0, "scaling-ratio baseline counter was not exercised at g=9");
    b as f64 / a as f64
};
```

(Copilot also flagged `f64::from(bool)` as non-compiling — that's been valid since Rust 1.68 and CI compiled/ran it on the 1.88 MSRV, but the masking concern was real and is now fixed by removing it.)

**2. Fix two docstrings** (Copilot)
`bump_face_split_probe` and `PerfSnapshot::face_split_probes` described the counter as only "grid-query candidate endpoints", but it is also bumped for arrangement chord pairs that survive the bbox broad-phase in `arrangement_regions_from_inputs`. Both docs now reflect that.

## Scope

Doc-only and test-only changes; the counters remain `perf-counters`-gated, so shipping builds are unaffected.

## Checks
- `scaling_perforated_cut_is_subquadratic` still passes (4.1× / 4.0×, baselines nonzero)
- `clippy --all-targets -D warnings` clean in default and `perf-counters` configs
- `cargo fmt` clean