### PR TITLE
chore(observability): probe analytic-fallback paths + prune dead constants

### DIFF
--- a/crates/blend/src/chamfer_builder.rs
+++ b/crates/blend/src/chamfer_builder.rs
@@ -344,6 +344,12 @@ fn compute_chamfer_stripe(
         return Ok(result);
     }
 
+    log::debug!(
+        target: "brepkit_approx",
+        "chamfer: analytic path unavailable for {}+{} — v1 has no walker fallback, returning UnsupportedSurface",
+        surf1.type_tag(),
+        surf2.type_tag()
+    );
     // v1: no walker fallback for non-analytic surface pairs.
     Err(BlendError::UnsupportedSurface {
         face: face1,

--- a/crates/blend/src/fillet_builder.rs
+++ b/crates/blend/src/fillet_builder.rs
@@ -697,6 +697,14 @@ fn compute_stripe_for_edge(
         }
     }
 
+    log::debug!(
+        target: "brepkit_approx",
+        "fillet: analytic fast-path unavailable for {}+{} ({} radius) — using Newton-Raphson walker (approximate NURBS blend surface)",
+        surf1.type_tag(),
+        surf2.type_tag(),
+        if matches!(law, RadiusLaw::Constant(_)) { "constant" } else { "variable" }
+    );
+
     // Build ParametricSurface references via PlaneAdapter for planes.
     // When a face is reversed, the outward normal is flipped. For PlaneAdapter,
     // we negate the normal. For analytic/NURBS surfaces the ParametricSurface

--- a/crates/offset/Cargo.toml
+++ b/crates/offset/Cargo.toml
@@ -12,6 +12,7 @@ brepkit-geometry.workspace = true
 brepkit-math.workspace = true
 brepkit-topology.workspace = true
 
+log.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/offset/src/offset.rs
+++ b/crates/offset/src/offset.rs
@@ -133,6 +133,10 @@ pub fn build_offset_faces(
             }
 
             FaceSurface::Nurbs(nurbs) => {
+                log::debug!(
+                    target: "brepkit_approx",
+                    "offset: NURBS face {face_id:?} offset via {NURBS_GRID_SIZE}x{NURBS_GRID_SIZE} sampled-NURBS refit (degree {NURBS_DEGREE}) — not an exact analytic offset"
+                );
                 let (u_min, u_max) = nurbs.domain_u();
                 let (v_min, v_max) = nurbs.domain_v();
 

--- a/crates/operations/examples/approx_census.rs
+++ b/crates/operations/examples/approx_census.rs
@@ -1,0 +1,404 @@
+//! Approximation-path census.
+//!
+//! Reports, per operation, whether it produced an exact analytic B-Rep or
+//! degraded to an approximation — and which one: the boolean mesh (co-refinement)
+//! fallback, the fillet Newton-Raphson walker, the sampled-NURBS surface offset,
+//! the grid-sampling offset trim, or the rolling-ball planar corner patch.
+//!
+//! It installs an in-process logger that captures the `brepkit_approx` debug
+//! probes, so each row shows exactly which fallback (if any) fired during that
+//! single operation, alongside wall-clock and result face count.
+//!
+//! Run:
+//!   cargo run --release --example approx_census -p brepkit-operations
+//!
+//! The boolean matrix uses overlapping primitives; offset/fillet/chamfer run on
+//! every analytic primitive to show they stay exact (no probe fires). The
+//! NURBS-faced and non-analytic-pair fallbacks (sampled-NURBS offset, fillet
+//! walker, chamfer UnsupportedSurface) are exercised by the `brepkit-offset` and
+//! `brepkit-blend` test suites, not reproducible from primitives alone (no
+//! primitive has a NURBS face).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    deprecated,
+    missing_docs
+)]
+
+use std::sync::Mutex;
+use std::time::Instant;
+
+use brepkit_math::mat::Mat4;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::blend_ops::fillet_v2;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::chamfer::chamfer;
+use brepkit_operations::fillet::fillet_rolling_ball;
+use brepkit_operations::loft::loft_smooth;
+use brepkit_operations::offset_v2::{offset_solid_v2, shell_v2};
+use brepkit_operations::primitives;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::edge::{Edge, EdgeCurve};
+use brepkit_topology::explorer::{solid_edges, solid_faces};
+use brepkit_topology::face::{Face, FaceId, FaceSurface};
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::vertex::Vertex;
+use brepkit_topology::wire::{OrientedEdge, Wire};
+
+static EVENTS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+struct CaptureLogger;
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _m: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record) {
+        if record.target() == "brepkit_approx"
+            && let Ok(mut ev) = EVENTS.lock()
+        {
+            ev.push(record.args().to_string());
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+fn drain() -> Vec<String> {
+    let mut ev = EVENTS.lock().unwrap();
+    let out = ev.clone();
+    ev.clear();
+    out
+}
+
+type PrimBuild = fn(&mut Topology) -> SolidId;
+
+fn face_count(topo: &Topology, s: SolidId) -> usize {
+    solid_faces(topo, s).map(|f| f.len()).unwrap_or(0)
+}
+
+fn report(family: &str, case: &str, ms: f64, faces: usize, events: &[String]) {
+    let path = if events.is_empty() {
+        "exact analytic".to_string()
+    } else {
+        // De-duplicate (per-corner probes can fire many times).
+        let mut uniq: Vec<&String> = Vec::new();
+        for e in events {
+            if !uniq.contains(&e) {
+                uniq.push(e);
+            }
+        }
+        let n = events.len();
+        format!("FALLBACK x{n}: {}", uniq[0])
+    };
+    println!("  {family:<9} {case:<30} {ms:>8.2}ms  faces={faces:<4}  {path}");
+}
+
+fn box_at(topo: &mut Topology, d: f64, x: f64, y: f64, z: f64) -> SolidId {
+    let s = primitives::make_box(topo, d, d, d).unwrap();
+    transform_solid(topo, s, &Mat4::translation(x, y, z)).unwrap();
+    s
+}
+
+fn bool_case(name: &str, op: BooleanOp, build: impl FnOnce(&mut Topology) -> (SolidId, SolidId)) {
+    let mut topo = Topology::new();
+    let (a, b) = build(&mut topo);
+    let _ = drain();
+    let t = Instant::now();
+    let res = boolean(&mut topo, op, a, b);
+    let ms = t.elapsed().as_secs_f64() * 1000.0;
+    let ev = drain();
+    match res {
+        Ok(s) => report("boolean", name, ms, face_count(&topo, s), &ev),
+        Err(e) => {
+            let mut ev = ev;
+            if ev.is_empty() {
+                ev.push(format!("err: {e}"));
+            }
+            report("boolean", &format!("{name} [ERR]"), ms, 0, &ev);
+        }
+    }
+}
+
+fn boolean_matrix() {
+    println!("BOOLEAN (overlapping primitives):");
+    bool_case("box ∪ box (overlap)", BooleanOp::Fuse, |t| {
+        (
+            box_at(t, 10.0, 0.0, 0.0, 0.0),
+            box_at(t, 10.0, 5.0, 5.0, 5.0),
+        )
+    });
+    bool_case("box ∪ box (flush coplanar)", BooleanOp::Fuse, |t| {
+        (
+            box_at(t, 10.0, 0.0, 0.0, 0.0),
+            box_at(t, 10.0, 10.0, 0.0, 0.0),
+        )
+    });
+    bool_case("box − cyl (through hole)", BooleanOp::Cut, |t| {
+        let b = box_at(t, 10.0, 0.0, 0.0, 0.0);
+        let c = primitives::make_cylinder(t, 3.0, 20.0).unwrap();
+        transform_solid(t, c, &Mat4::translation(5.0, 5.0, -5.0)).unwrap();
+        (b, c)
+    });
+    bool_case("box ∩ sphere", BooleanOp::Intersect, |t| {
+        let b = box_at(t, 10.0, 0.0, 0.0, 0.0);
+        let s = primitives::make_sphere(t, 6.0, 24).unwrap();
+        transform_solid(t, s, &Mat4::translation(5.0, 5.0, 5.0)).unwrap();
+        (b, s)
+    });
+    bool_case("sphere − cyl (3 pieces)", BooleanOp::Cut, |t| {
+        let s = primitives::make_sphere(t, 6.0, 24).unwrap();
+        transform_solid(t, s, &Mat4::translation(0.0, 0.0, 0.0)).unwrap();
+        let c = primitives::make_cylinder(t, 3.0, 30.0).unwrap();
+        transform_solid(t, c, &Mat4::translation(0.0, 0.0, -15.0)).unwrap();
+        (s, c)
+    });
+    bool_case("cyl ∪ cyl (perp cross)", BooleanOp::Fuse, |t| {
+        let c1 = primitives::make_cylinder(t, 3.0, 20.0).unwrap();
+        transform_solid(t, c1, &Mat4::translation(0.0, 0.0, -10.0)).unwrap();
+        let c2 = primitives::make_cylinder(t, 3.0, 20.0).unwrap();
+        // rotate c2 to lie along x
+        let rot = Mat4::rotation_y(std::f64::consts::FRAC_PI_2);
+        transform_solid(t, c2, &rot).unwrap();
+        transform_solid(t, c2, &Mat4::translation(-10.0, 0.0, 0.0)).unwrap();
+        (c1, c2)
+    });
+    bool_case("cyl ∩ cyl (coaxial)", BooleanOp::Intersect, |t| {
+        let c1 = primitives::make_cylinder(t, 5.0, 20.0).unwrap();
+        let c2 = primitives::make_cylinder(t, 5.0, 20.0).unwrap();
+        transform_solid(t, c2, &Mat4::translation(0.0, 0.0, 10.0)).unwrap();
+        (c1, c2)
+    });
+    bool_case("cone ∪ box", BooleanOp::Fuse, |t| {
+        let c = primitives::make_cone(t, 6.0, 2.0, 12.0).unwrap();
+        let b = box_at(t, 8.0, -4.0, -4.0, 6.0);
+        (c, b)
+    });
+    bool_case("torus − box", BooleanOp::Cut, |t| {
+        let tor = primitives::make_torus(t, 10.0, 3.0, 32).unwrap();
+        let b = box_at(t, 8.0, 6.0, -4.0, -4.0);
+        (tor, b)
+    });
+    bool_case("cyl − box (slot)", BooleanOp::Cut, |t| {
+        let c = primitives::make_cylinder(t, 6.0, 20.0).unwrap();
+        let b = box_at(t, 4.0, -2.0, -8.0, 5.0);
+        (c, b)
+    });
+}
+
+fn offset_matrix() {
+    println!("\nOFFSET / SHELL (each analytic primitive):");
+    let cases: [(&str, PrimBuild); 5] = [
+        ("box", |t| {
+            primitives::make_box(t, 10.0, 10.0, 10.0).unwrap()
+        }),
+        ("cylinder", |t| {
+            primitives::make_cylinder(t, 5.0, 12.0).unwrap()
+        }),
+        ("cone", |t| {
+            primitives::make_cone(t, 6.0, 2.0, 12.0).unwrap()
+        }),
+        ("sphere", |t| primitives::make_sphere(t, 6.0, 24).unwrap()),
+        ("torus", |t| {
+            primitives::make_torus(t, 10.0, 3.0, 32).unwrap()
+        }),
+    ];
+    for (name, build) in cases {
+        let mut topo = Topology::new();
+        let s = build(&mut topo);
+        let _ = drain();
+        let t = Instant::now();
+        let res = offset_solid_v2(&mut topo, s, 1.0);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let ev = drain();
+        match res {
+            Ok(r) => report("offset", name, ms, face_count(&topo, r), &ev),
+            Err(e) => report(
+                "offset",
+                &format!("{name} [ERR]"),
+                ms,
+                0,
+                &[format!("err: {e}")],
+            ),
+        }
+    }
+    // Shell (hollow) — excludes the first face.
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let f0 = solid_faces(&topo, s).unwrap()[0];
+        let _ = drain();
+        let t = Instant::now();
+        let res = shell_v2(&mut topo, s, 1.0, &[f0]);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let ev = drain();
+        match res {
+            Ok(r) => report("shell", "box (1 face open)", ms, face_count(&topo, r), &ev),
+            Err(e) => report("shell", "box [ERR]", ms, 0, &[format!("err: {e}")]),
+        }
+    }
+}
+
+fn blend_matrix() {
+    println!("\nFILLET / CHAMFER (box, all edges):");
+    // rolling-ball fillet
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edges(&topo, s).unwrap();
+        let _ = drain();
+        let t = Instant::now();
+        let res = fillet_rolling_ball(&mut topo, s, &edges, 1.0);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let ev = drain();
+        match res {
+            Ok(r) => report("fillet-rb", "box all edges", ms, face_count(&topo, r), &ev),
+            Err(e) => report("fillet-rb", "box [ERR]", ms, 0, &[format!("err: {e}")]),
+        }
+    }
+    // blend-v2 fillet
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edges(&topo, s).unwrap();
+        let _ = drain();
+        let t = Instant::now();
+        let res = fillet_v2(&mut topo, s, &edges, 1.0);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let ev = drain();
+        match res {
+            Ok(r) => report(
+                "fillet-v2",
+                "box all edges",
+                ms,
+                face_count(&topo, r.solid),
+                &ev,
+            ),
+            Err(e) => report("fillet-v2", "box [ERR]", ms, 0, &[format!("err: {e}")]),
+        }
+    }
+    // chamfer
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let edges = solid_edges(&topo, s).unwrap();
+        let _ = drain();
+        let t = Instant::now();
+        let res = chamfer(&mut topo, s, &edges, 1.0);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let ev = drain();
+        match res {
+            Ok(r) => report("chamfer", "box all edges", ms, face_count(&topo, r), &ev),
+            Err(e) => report("chamfer", "box [ERR]", ms, 0, &[format!("err: {e}")]),
+        }
+    }
+    // fillet_v2 on a torus — analytic fast-path declines Torus pairs → walker.
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_torus(&mut topo, 10.0, 3.0, 32).unwrap();
+        let edges = solid_edges(&topo, s).unwrap();
+        let _ = drain();
+        let t = Instant::now();
+        let res = fillet_v2(&mut topo, s, &edges, 0.5);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let ev = drain();
+        match res {
+            Ok(r) => report(
+                "fillet-v2",
+                "torus (walker)",
+                ms,
+                face_count(&topo, r.solid),
+                &ev,
+            ),
+            Err(e) => {
+                let mut ev = ev;
+                if ev.is_empty() {
+                    ev.push(format!("err: {e}"));
+                }
+                report("fillet-v2", "torus (walker) [ERR]", ms, 0, &ev);
+            }
+        }
+    }
+}
+
+fn make_square_at(topo: &mut Topology, size: f64, z: f64) -> FaceId {
+    let hs = size / 2.0;
+    let t = 1e-7;
+    let v0 = topo.add_vertex(Vertex::new(Point3::new(-hs, -hs, z), t));
+    let v1 = topo.add_vertex(Vertex::new(Point3::new(hs, -hs, z), t));
+    let v2 = topo.add_vertex(Vertex::new(Point3::new(hs, hs, z), t));
+    let v3 = topo.add_vertex(Vertex::new(Point3::new(-hs, hs, z), t));
+    let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
+    let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
+    let e2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
+    let e3 = topo.add_edge(Edge::new(v3, v0, EdgeCurve::Line));
+    let wire = Wire::new(
+        vec![
+            OrientedEdge::new(e0, true),
+            OrientedEdge::new(e1, true),
+            OrientedEdge::new(e2, true),
+            OrientedEdge::new(e3, true),
+        ],
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: z,
+        },
+    ))
+}
+
+fn nurbs_section() {
+    println!("\nNURBS-FACED solid (3-profile loft_smooth) — offset must sample+refit:");
+    let mut topo = Topology::new();
+    let p0 = make_square_at(&mut topo, 6.0, 0.0);
+    let p1 = make_square_at(&mut topo, 3.0, 5.0);
+    let p2 = make_square_at(&mut topo, 6.0, 10.0);
+    let solid = match loft_smooth(&mut topo, &[p0, p1, p2]) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("  loft_smooth construction failed: {e}");
+            return;
+        }
+    };
+    let _ = drain();
+    let t = Instant::now();
+    let res = offset_solid_v2(&mut topo, solid, 0.5);
+    let ms = t.elapsed().as_secs_f64() * 1000.0;
+    let ev = drain();
+    match res {
+        Ok(r) => report("offset", "nurbs-loft solid", ms, face_count(&topo, r), &ev),
+        Err(e) => {
+            let mut ev = ev;
+            if ev.is_empty() {
+                ev.push(format!("err: {e}"));
+            }
+            report("offset", "nurbs-loft [ERR]", ms, 0, &ev);
+        }
+    }
+}
+
+fn main() {
+    log::set_logger(&LOGGER).expect("set logger");
+    log::set_max_level(log::LevelFilter::Debug);
+
+    println!("=== brepkit approximation-path census ===");
+    println!("(a probe firing = that op degraded from exact analytic B-Rep)\n");
+
+    boolean_matrix();
+    offset_matrix();
+    nurbs_section();
+    blend_matrix();
+
+    println!("\nLegend: 'exact analytic' = no degradation; 'FALLBACK' = an");
+    println!("approximation path fired (see the brepkit_approx probe text).");
+}

--- a/crates/operations/examples/approx_census.rs
+++ b/crates/operations/examples/approx_census.rs
@@ -19,20 +19,15 @@
 //! `brepkit-blend` test suites, not reproducible from primitives alone (no
 //! primitive has a NURBS face).
 
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::print_stdout,
-    clippy::print_stderr,
-    deprecated,
-    missing_docs
-)]
+#![allow(clippy::print_stdout, deprecated, missing_docs)]
 
+use std::error::Error;
 use std::sync::Mutex;
 use std::time::Instant;
 
 use brepkit_math::mat::Mat4;
 use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::OperationsError;
 use brepkit_operations::blend_ops::fillet_v2;
 use brepkit_operations::boolean::{BooleanOp, boolean};
 use brepkit_operations::chamfer::chamfer;
@@ -51,10 +46,13 @@ use brepkit_topology::wire::{OrientedEdge, Wire};
 
 static EVENTS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
+/// Captures only `brepkit_approx` probe records into `EVENTS`; everything else is
+/// cheaply ignored (filtered in `enabled` and again in `log`) so unrelated engine
+/// logging does not skew the per-op timings this example measures.
 struct CaptureLogger;
 impl log::Log for CaptureLogger {
-    fn enabled(&self, _m: &log::Metadata) -> bool {
-        true
+    fn enabled(&self, m: &log::Metadata) -> bool {
+        m.target() == "brepkit_approx"
     }
     fn log(&self, record: &log::Record) {
         if record.target() == "brepkit_approx"
@@ -68,14 +66,15 @@ impl log::Log for CaptureLogger {
 
 static LOGGER: CaptureLogger = CaptureLogger;
 
+/// Take and clear the captured probe messages (no clone; poisoned lock → empty).
 fn drain() -> Vec<String> {
-    let mut ev = EVENTS.lock().unwrap();
-    let out = ev.clone();
-    ev.clear();
-    out
+    EVENTS
+        .lock()
+        .map(|mut ev| std::mem::take(&mut *ev))
+        .unwrap_or_default()
 }
 
-type PrimBuild = fn(&mut Topology) -> SolidId;
+type PrimBuild = fn(&mut Topology) -> Result<SolidId, OperationsError>;
 
 fn face_count(topo: &Topology, s: SolidId) -> usize {
     solid_faces(topo, s).map(|f| f.len()).unwrap_or(0)
@@ -85,40 +84,53 @@ fn report(family: &str, case: &str, ms: f64, faces: usize, events: &[String]) {
     let path = if events.is_empty() {
         "exact analytic".to_string()
     } else {
-        // De-duplicate (per-corner probes can fire many times).
-        let mut uniq: Vec<&String> = Vec::new();
+        // Show every distinct probe (an op can hit more than one path), with the
+        // raw count so per-corner repeats stay visible.
+        let mut uniq: Vec<&str> = Vec::new();
         for e in events {
-            if !uniq.contains(&e) {
-                uniq.push(e);
+            if !uniq.contains(&e.as_str()) {
+                uniq.push(e.as_str());
             }
         }
-        let n = events.len();
-        format!("FALLBACK x{n}: {}", uniq[0])
+        format!("FALLBACK x{}: {}", events.len(), uniq.join(" | "))
     };
     println!("  {family:<9} {case:<30} {ms:>8.2}ms  faces={faces:<4}  {path}");
 }
 
-fn box_at(topo: &mut Topology, d: f64, x: f64, y: f64, z: f64) -> SolidId {
-    let s = primitives::make_box(topo, d, d, d).unwrap();
-    transform_solid(topo, s, &Mat4::translation(x, y, z)).unwrap();
-    s
+fn box_at(topo: &mut Topology, d: f64, x: f64, y: f64, z: f64) -> Result<SolidId, OperationsError> {
+    let s = primitives::make_box(topo, d, d, d)?;
+    transform_solid(topo, s, &Mat4::translation(x, y, z))?;
+    Ok(s)
 }
 
-fn bool_case(name: &str, op: BooleanOp, build: impl FnOnce(&mut Topology) -> (SolidId, SolidId)) {
+fn bool_case(
+    name: &str,
+    op: BooleanOp,
+    build: impl FnOnce(&mut Topology) -> Result<(SolidId, SolidId), OperationsError>,
+) {
     let mut topo = Topology::new();
-    let (a, b) = build(&mut topo);
+    let (a, b) = match build(&mut topo) {
+        Ok(v) => v,
+        Err(e) => {
+            report(
+                "boolean",
+                &format!("{name} [build ERR]"),
+                0.0,
+                0,
+                &[format!("err: {e}")],
+            );
+            return;
+        }
+    };
     let _ = drain();
     let t = Instant::now();
     let res = boolean(&mut topo, op, a, b);
     let ms = t.elapsed().as_secs_f64() * 1000.0;
-    let ev = drain();
+    let mut ev = drain();
     match res {
         Ok(s) => report("boolean", name, ms, face_count(&topo, s), &ev),
         Err(e) => {
-            let mut ev = ev;
-            if ev.is_empty() {
-                ev.push(format!("err: {e}"));
-            }
+            ev.push(format!("err: {e}"));
             report("boolean", &format!("{name} [ERR]"), ms, 0, &ev);
         }
     }
@@ -127,211 +139,133 @@ fn bool_case(name: &str, op: BooleanOp, build: impl FnOnce(&mut Topology) -> (So
 fn boolean_matrix() {
     println!("BOOLEAN (overlapping primitives):");
     bool_case("box ∪ box (overlap)", BooleanOp::Fuse, |t| {
-        (
-            box_at(t, 10.0, 0.0, 0.0, 0.0),
-            box_at(t, 10.0, 5.0, 5.0, 5.0),
-        )
+        Ok((
+            box_at(t, 10.0, 0.0, 0.0, 0.0)?,
+            box_at(t, 10.0, 5.0, 5.0, 5.0)?,
+        ))
     });
     bool_case("box ∪ box (flush coplanar)", BooleanOp::Fuse, |t| {
-        (
-            box_at(t, 10.0, 0.0, 0.0, 0.0),
-            box_at(t, 10.0, 10.0, 0.0, 0.0),
-        )
+        Ok((
+            box_at(t, 10.0, 0.0, 0.0, 0.0)?,
+            box_at(t, 10.0, 10.0, 0.0, 0.0)?,
+        ))
     });
     bool_case("box − cyl (through hole)", BooleanOp::Cut, |t| {
-        let b = box_at(t, 10.0, 0.0, 0.0, 0.0);
-        let c = primitives::make_cylinder(t, 3.0, 20.0).unwrap();
-        transform_solid(t, c, &Mat4::translation(5.0, 5.0, -5.0)).unwrap();
-        (b, c)
+        let b = box_at(t, 10.0, 0.0, 0.0, 0.0)?;
+        let c = primitives::make_cylinder(t, 3.0, 20.0)?;
+        transform_solid(t, c, &Mat4::translation(5.0, 5.0, -5.0))?;
+        Ok((b, c))
     });
     bool_case("box ∩ sphere", BooleanOp::Intersect, |t| {
-        let b = box_at(t, 10.0, 0.0, 0.0, 0.0);
-        let s = primitives::make_sphere(t, 6.0, 24).unwrap();
-        transform_solid(t, s, &Mat4::translation(5.0, 5.0, 5.0)).unwrap();
-        (b, s)
+        let b = box_at(t, 10.0, 0.0, 0.0, 0.0)?;
+        let s = primitives::make_sphere(t, 6.0, 24)?;
+        transform_solid(t, s, &Mat4::translation(5.0, 5.0, 5.0))?;
+        Ok((b, s))
     });
     bool_case("sphere − cyl (3 pieces)", BooleanOp::Cut, |t| {
-        let s = primitives::make_sphere(t, 6.0, 24).unwrap();
-        transform_solid(t, s, &Mat4::translation(0.0, 0.0, 0.0)).unwrap();
-        let c = primitives::make_cylinder(t, 3.0, 30.0).unwrap();
-        transform_solid(t, c, &Mat4::translation(0.0, 0.0, -15.0)).unwrap();
-        (s, c)
+        let s = primitives::make_sphere(t, 6.0, 24)?;
+        let c = primitives::make_cylinder(t, 3.0, 30.0)?;
+        transform_solid(t, c, &Mat4::translation(0.0, 0.0, -15.0))?;
+        Ok((s, c))
     });
     bool_case("cyl ∪ cyl (perp cross)", BooleanOp::Fuse, |t| {
-        let c1 = primitives::make_cylinder(t, 3.0, 20.0).unwrap();
-        transform_solid(t, c1, &Mat4::translation(0.0, 0.0, -10.0)).unwrap();
-        let c2 = primitives::make_cylinder(t, 3.0, 20.0).unwrap();
-        // rotate c2 to lie along x
-        let rot = Mat4::rotation_y(std::f64::consts::FRAC_PI_2);
-        transform_solid(t, c2, &rot).unwrap();
-        transform_solid(t, c2, &Mat4::translation(-10.0, 0.0, 0.0)).unwrap();
-        (c1, c2)
+        let c1 = primitives::make_cylinder(t, 3.0, 20.0)?;
+        transform_solid(t, c1, &Mat4::translation(0.0, 0.0, -10.0))?;
+        let c2 = primitives::make_cylinder(t, 3.0, 20.0)?;
+        transform_solid(t, c2, &Mat4::rotation_y(std::f64::consts::FRAC_PI_2))?;
+        transform_solid(t, c2, &Mat4::translation(-10.0, 0.0, 0.0))?;
+        Ok((c1, c2))
     });
     bool_case("cyl ∩ cyl (coaxial)", BooleanOp::Intersect, |t| {
-        let c1 = primitives::make_cylinder(t, 5.0, 20.0).unwrap();
-        let c2 = primitives::make_cylinder(t, 5.0, 20.0).unwrap();
-        transform_solid(t, c2, &Mat4::translation(0.0, 0.0, 10.0)).unwrap();
-        (c1, c2)
+        let c1 = primitives::make_cylinder(t, 5.0, 20.0)?;
+        let c2 = primitives::make_cylinder(t, 5.0, 20.0)?;
+        transform_solid(t, c2, &Mat4::translation(0.0, 0.0, 10.0))?;
+        Ok((c1, c2))
     });
     bool_case("cone ∪ box", BooleanOp::Fuse, |t| {
-        let c = primitives::make_cone(t, 6.0, 2.0, 12.0).unwrap();
-        let b = box_at(t, 8.0, -4.0, -4.0, 6.0);
-        (c, b)
+        let c = primitives::make_cone(t, 6.0, 2.0, 12.0)?;
+        let b = box_at(t, 8.0, -4.0, -4.0, 6.0)?;
+        Ok((c, b))
     });
     bool_case("torus − box", BooleanOp::Cut, |t| {
-        let tor = primitives::make_torus(t, 10.0, 3.0, 32).unwrap();
-        let b = box_at(t, 8.0, 6.0, -4.0, -4.0);
-        (tor, b)
+        let tor = primitives::make_torus(t, 10.0, 3.0, 32)?;
+        let b = box_at(t, 8.0, 6.0, -4.0, -4.0)?;
+        Ok((tor, b))
     });
     bool_case("cyl − box (slot)", BooleanOp::Cut, |t| {
-        let c = primitives::make_cylinder(t, 6.0, 20.0).unwrap();
-        let b = box_at(t, 4.0, -2.0, -8.0, 5.0);
-        (c, b)
+        let c = primitives::make_cylinder(t, 6.0, 20.0)?;
+        let b = box_at(t, 4.0, -2.0, -8.0, 5.0)?;
+        Ok((c, b))
     });
 }
 
-fn offset_matrix() {
+fn offset_matrix() -> Result<(), Box<dyn Error>> {
     println!("\nOFFSET / SHELL (each analytic primitive):");
     let cases: [(&str, PrimBuild); 5] = [
-        ("box", |t| {
-            primitives::make_box(t, 10.0, 10.0, 10.0).unwrap()
-        }),
-        ("cylinder", |t| {
-            primitives::make_cylinder(t, 5.0, 12.0).unwrap()
-        }),
-        ("cone", |t| {
-            primitives::make_cone(t, 6.0, 2.0, 12.0).unwrap()
-        }),
-        ("sphere", |t| primitives::make_sphere(t, 6.0, 24).unwrap()),
-        ("torus", |t| {
-            primitives::make_torus(t, 10.0, 3.0, 32).unwrap()
-        }),
+        ("box", |t| primitives::make_box(t, 10.0, 10.0, 10.0)),
+        ("cylinder", |t| primitives::make_cylinder(t, 5.0, 12.0)),
+        ("cone", |t| primitives::make_cone(t, 6.0, 2.0, 12.0)),
+        ("sphere", |t| primitives::make_sphere(t, 6.0, 24)),
+        ("torus", |t| primitives::make_torus(t, 10.0, 3.0, 32)),
     ];
     for (name, build) in cases {
         let mut topo = Topology::new();
-        let s = build(&mut topo);
+        let s = match build(&mut topo) {
+            Ok(s) => s,
+            Err(e) => {
+                report(
+                    "offset",
+                    &format!("{name} [build ERR]"),
+                    0.0,
+                    0,
+                    &[format!("err: {e}")],
+                );
+                continue;
+            }
+        };
         let _ = drain();
         let t = Instant::now();
         let res = offset_solid_v2(&mut topo, s, 1.0);
         let ms = t.elapsed().as_secs_f64() * 1000.0;
-        let ev = drain();
+        let mut ev = drain();
         match res {
             Ok(r) => report("offset", name, ms, face_count(&topo, r), &ev),
-            Err(e) => report(
-                "offset",
-                &format!("{name} [ERR]"),
-                ms,
-                0,
-                &[format!("err: {e}")],
-            ),
-        }
-    }
-    // Shell (hollow) — excludes the first face.
-    {
-        let mut topo = Topology::new();
-        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
-        let f0 = solid_faces(&topo, s).unwrap()[0];
-        let _ = drain();
-        let t = Instant::now();
-        let res = shell_v2(&mut topo, s, 1.0, &[f0]);
-        let ms = t.elapsed().as_secs_f64() * 1000.0;
-        let ev = drain();
-        match res {
-            Ok(r) => report("shell", "box (1 face open)", ms, face_count(&topo, r), &ev),
-            Err(e) => report("shell", "box [ERR]", ms, 0, &[format!("err: {e}")]),
-        }
-    }
-}
-
-fn blend_matrix() {
-    println!("\nFILLET / CHAMFER (box, all edges):");
-    // rolling-ball fillet
-    {
-        let mut topo = Topology::new();
-        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
-        let edges = solid_edges(&topo, s).unwrap();
-        let _ = drain();
-        let t = Instant::now();
-        let res = fillet_rolling_ball(&mut topo, s, &edges, 1.0);
-        let ms = t.elapsed().as_secs_f64() * 1000.0;
-        let ev = drain();
-        match res {
-            Ok(r) => report("fillet-rb", "box all edges", ms, face_count(&topo, r), &ev),
-            Err(e) => report("fillet-rb", "box [ERR]", ms, 0, &[format!("err: {e}")]),
-        }
-    }
-    // blend-v2 fillet
-    {
-        let mut topo = Topology::new();
-        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
-        let edges = solid_edges(&topo, s).unwrap();
-        let _ = drain();
-        let t = Instant::now();
-        let res = fillet_v2(&mut topo, s, &edges, 1.0);
-        let ms = t.elapsed().as_secs_f64() * 1000.0;
-        let ev = drain();
-        match res {
-            Ok(r) => report(
-                "fillet-v2",
-                "box all edges",
-                ms,
-                face_count(&topo, r.solid),
-                &ev,
-            ),
-            Err(e) => report("fillet-v2", "box [ERR]", ms, 0, &[format!("err: {e}")]),
-        }
-    }
-    // chamfer
-    {
-        let mut topo = Topology::new();
-        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
-        let edges = solid_edges(&topo, s).unwrap();
-        let _ = drain();
-        let t = Instant::now();
-        let res = chamfer(&mut topo, s, &edges, 1.0);
-        let ms = t.elapsed().as_secs_f64() * 1000.0;
-        let ev = drain();
-        match res {
-            Ok(r) => report("chamfer", "box all edges", ms, face_count(&topo, r), &ev),
-            Err(e) => report("chamfer", "box [ERR]", ms, 0, &[format!("err: {e}")]),
-        }
-    }
-    // fillet_v2 on a torus — analytic fast-path declines Torus pairs → walker.
-    {
-        let mut topo = Topology::new();
-        let s = primitives::make_torus(&mut topo, 10.0, 3.0, 32).unwrap();
-        let edges = solid_edges(&topo, s).unwrap();
-        let _ = drain();
-        let t = Instant::now();
-        let res = fillet_v2(&mut topo, s, &edges, 0.5);
-        let ms = t.elapsed().as_secs_f64() * 1000.0;
-        let ev = drain();
-        match res {
-            Ok(r) => report(
-                "fillet-v2",
-                "torus (walker)",
-                ms,
-                face_count(&topo, r.solid),
-                &ev,
-            ),
             Err(e) => {
-                let mut ev = ev;
-                if ev.is_empty() {
-                    ev.push(format!("err: {e}"));
-                }
-                report("fillet-v2", "torus (walker) [ERR]", ms, 0, &ev);
+                ev.push(format!("err: {e}"));
+                report("offset", &format!("{name} [ERR]"), ms, 0, &ev);
             }
         }
     }
+    // Shell (hollow) — excludes the first face.
+    let mut topo = Topology::new();
+    let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0)?;
+    let exclude = solid_faces(&topo, s)?
+        .first()
+        .copied()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let _ = drain();
+    let t = Instant::now();
+    let res = shell_v2(&mut topo, s, 1.0, &exclude);
+    let ms = t.elapsed().as_secs_f64() * 1000.0;
+    let mut ev = drain();
+    match res {
+        Ok(r) => report("shell", "box (1 face open)", ms, face_count(&topo, r), &ev),
+        Err(e) => {
+            ev.push(format!("err: {e}"));
+            report("shell", "box [ERR]", ms, 0, &ev);
+        }
+    }
+    Ok(())
 }
 
-fn make_square_at(topo: &mut Topology, size: f64, z: f64) -> FaceId {
+fn make_square_at(topo: &mut Topology, size: f64, z: f64) -> Result<FaceId, Box<dyn Error>> {
     let hs = size / 2.0;
-    let t = 1e-7;
-    let v0 = topo.add_vertex(Vertex::new(Point3::new(-hs, -hs, z), t));
-    let v1 = topo.add_vertex(Vertex::new(Point3::new(hs, -hs, z), t));
-    let v2 = topo.add_vertex(Vertex::new(Point3::new(hs, hs, z), t));
-    let v3 = topo.add_vertex(Vertex::new(Point3::new(-hs, hs, z), t));
+    let tol = 1e-7;
+    let v0 = topo.add_vertex(Vertex::new(Point3::new(-hs, -hs, z), tol));
+    let v1 = topo.add_vertex(Vertex::new(Point3::new(hs, -hs, z), tol));
+    let v2 = topo.add_vertex(Vertex::new(Point3::new(hs, hs, z), tol));
+    let v3 = topo.add_vertex(Vertex::new(Point3::new(-hs, hs, z), tol));
     let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
     let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
     let e2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
@@ -344,61 +278,148 @@ fn make_square_at(topo: &mut Topology, size: f64, z: f64) -> FaceId {
             OrientedEdge::new(e3, true),
         ],
         true,
-    )
-    .unwrap();
+    )?;
     let wid = topo.add_wire(wire);
-    topo.add_face(Face::new(
+    Ok(topo.add_face(Face::new(
         wid,
         vec![],
         FaceSurface::Plane {
             normal: Vec3::new(0.0, 0.0, 1.0),
             d: z,
         },
-    ))
+    )))
 }
 
-fn nurbs_section() {
+fn nurbs_section() -> Result<(), Box<dyn Error>> {
     println!("\nNURBS-FACED solid (3-profile loft_smooth) — offset must sample+refit:");
     let mut topo = Topology::new();
-    let p0 = make_square_at(&mut topo, 6.0, 0.0);
-    let p1 = make_square_at(&mut topo, 3.0, 5.0);
-    let p2 = make_square_at(&mut topo, 6.0, 10.0);
+    let p0 = make_square_at(&mut topo, 6.0, 0.0)?;
+    let p1 = make_square_at(&mut topo, 3.0, 5.0)?;
+    let p2 = make_square_at(&mut topo, 6.0, 10.0)?;
     let solid = match loft_smooth(&mut topo, &[p0, p1, p2]) {
         Ok(s) => s,
         Err(e) => {
             println!("  loft_smooth construction failed: {e}");
-            return;
+            return Ok(());
         }
     };
     let _ = drain();
     let t = Instant::now();
     let res = offset_solid_v2(&mut topo, solid, 0.5);
     let ms = t.elapsed().as_secs_f64() * 1000.0;
-    let ev = drain();
+    let mut ev = drain();
     match res {
         Ok(r) => report("offset", "nurbs-loft solid", ms, face_count(&topo, r), &ev),
         Err(e) => {
-            let mut ev = ev;
-            if ev.is_empty() {
-                ev.push(format!("err: {e}"));
-            }
+            ev.push(format!("err: {e}"));
             report("offset", "nurbs-loft [ERR]", ms, 0, &ev);
         }
     }
+    Ok(())
 }
 
-fn main() {
-    log::set_logger(&LOGGER).expect("set logger");
+fn blend_matrix() -> Result<(), Box<dyn Error>> {
+    println!("\nFILLET / CHAMFER (box, all edges):");
+    // rolling-ball fillet
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0)?;
+        let edges = solid_edges(&topo, s)?;
+        let _ = drain();
+        let t = Instant::now();
+        let res = fillet_rolling_ball(&mut topo, s, &edges, 1.0);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let mut ev = drain();
+        match res {
+            Ok(r) => report("fillet-rb", "box all edges", ms, face_count(&topo, r), &ev),
+            Err(e) => {
+                ev.push(format!("err: {e}"));
+                report("fillet-rb", "box [ERR]", ms, 0, &ev);
+            }
+        }
+    }
+    // blend-v2 fillet
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0)?;
+        let edges = solid_edges(&topo, s)?;
+        let _ = drain();
+        let t = Instant::now();
+        let res = fillet_v2(&mut topo, s, &edges, 1.0);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let mut ev = drain();
+        match res {
+            Ok(r) => report(
+                "fillet-v2",
+                "box all edges",
+                ms,
+                face_count(&topo, r.solid),
+                &ev,
+            ),
+            Err(e) => {
+                ev.push(format!("err: {e}"));
+                report("fillet-v2", "box [ERR]", ms, 0, &ev);
+            }
+        }
+    }
+    // chamfer
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_box(&mut topo, 10.0, 10.0, 10.0)?;
+        let edges = solid_edges(&topo, s)?;
+        let _ = drain();
+        let t = Instant::now();
+        let res = chamfer(&mut topo, s, &edges, 1.0);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let mut ev = drain();
+        match res {
+            Ok(r) => report("chamfer", "box all edges", ms, face_count(&topo, r), &ev),
+            Err(e) => {
+                ev.push(format!("err: {e}"));
+                report("chamfer", "box [ERR]", ms, 0, &ev);
+            }
+        }
+    }
+    // fillet_v2 on a torus — analytic fast-path declines Torus pairs → walker.
+    {
+        let mut topo = Topology::new();
+        let s = primitives::make_torus(&mut topo, 10.0, 3.0, 32)?;
+        let edges = solid_edges(&topo, s)?;
+        let _ = drain();
+        let t = Instant::now();
+        let res = fillet_v2(&mut topo, s, &edges, 0.5);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let mut ev = drain();
+        match res {
+            Ok(r) => report(
+                "fillet-v2",
+                "torus (walker)",
+                ms,
+                face_count(&topo, r.solid),
+                &ev,
+            ),
+            Err(e) => {
+                ev.push(format!("err: {e}"));
+                report("fillet-v2", "torus (walker) [ERR]", ms, 0, &ev);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    log::set_logger(&LOGGER)?;
     log::set_max_level(log::LevelFilter::Debug);
 
     println!("=== brepkit approximation-path census ===");
     println!("(a probe firing = that op degraded from exact analytic B-Rep)\n");
 
     boolean_matrix();
-    offset_matrix();
-    nurbs_section();
-    blend_matrix();
+    offset_matrix()?;
+    nurbs_section()?;
+    blend_matrix()?;
 
     println!("\nLegend: 'exact analytic' = no degradation; 'FALLBACK' = an");
     println!("approximation path fired (see the brepkit_approx probe text).");
+    Ok(())
 }

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -812,6 +812,10 @@ pub fn boolean(
     }
 
     // Mesh boolean fallback (no recursion).
+    log::debug!(
+        target: "brepkit_approx",
+        "boolean {op:?}: GFA unusable — using mesh (co-refinement) fallback; analytic surface types will be lost"
+    );
     let opts = BooleanOptions::default();
     let raw = match mesh_boolean_fallback(topo, op, a, b, opts.deflection, tol, &opts) {
         Ok(raw) => raw,

--- a/crates/operations/src/boolean/types.rs
+++ b/crates/operations/src/boolean/types.rs
@@ -33,22 +33,6 @@ pub(super) const DEFAULT_BOOLEAN_DEFLECTION: f64 = 0.1;
 /// sufficient for correct ray-crossing parity.
 pub(super) const CLASSIFIER_CYL_SEGMENTS: usize = 16;
 
-/// Per-solid face count above which the chord-based tessellated path is
-/// too expensive. If EITHER solid exceeds this, fall back to mesh boolean.
-///
-/// This catches individual complex solids (e.g. shelled geometry with merged
-/// faces from `unify_faces`) that would cause O(N²) intersection computation.
-/// Matches the v2.6.0 behavior that prevented hangs on gridfinity bins.
-pub(super) const MESH_BOOLEAN_PER_SOLID_THRESHOLD: usize = 100;
-
-/// Combined face count (A + B) above which the chord-based tessellated
-/// path is too expensive. Falls back to the mesh boolean (co-refinement
-/// on triangle meshes, O(N log N)).
-///
-/// Checked BEFORE `collect_face_data` to avoid expensive NURBS
-/// tessellation when the mesh boolean will be used anyway.
-pub(super) const MESH_BOOLEAN_FACE_THRESHOLD: usize = 500;
-
 /// Threshold: use CDT batch splitting for faces with this many or more chords.
 ///
 /// Below this threshold, the iterative approach is fast enough and avoids the

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -1960,6 +1960,10 @@ pub fn fillet_rolling_ball(
         }
 
         // Fallback: flat planar blend for non-triangular or degenerate cases.
+        log::debug!(
+            target: "brepkit_approx",
+            "fillet(rolling-ball): corner patch fell back to flat planar blend (non-triangular/degenerate corner)"
+        );
         let blend_d = dot_normal_point(blend_normal, ordered_points[0]);
         all_specs.push(FaceSpec::Planar {
             vertices: ordered_points,

--- a/crates/operations/src/offset_face.rs
+++ b/crates/operations/src/offset_face.rs
@@ -256,6 +256,10 @@ fn offset_nurbs_face(
     ) {
         Ok(trimmed) => trimmed,
         Err(e) => {
+            log::debug!(
+                target: "brepkit_approx",
+                "offset_face: raw-offset-surface fallback (SSI trim failed: {e})"
+            );
             log::warn!(
                 "offset_face: self-intersection trimming failed ({e}), \
                  using raw offset surface"

--- a/crates/operations/src/offset_trim.rs
+++ b/crates/operations/src/offset_trim.rs
@@ -76,6 +76,10 @@ pub fn trim_offset_self_intersections(
         return trim_via_ssi(original, offset, offset_distance, tolerance, &ssi_curves);
     }
 
+    log::debug!(
+        target: "brepkit_approx",
+        "offset_trim: SSI curve detection found nothing — falling back to grid-sampling trim ({DETECTION_GRID}x{DETECTION_GRID})"
+    );
     trim_via_sampling(original, offset, offset_distance, tolerance)
 }
 


### PR DESCRIPTION
## What

Two cleanups from an audit of every brepkit operation that can degrade from an exact analytic B-Rep to an approximation.

### 1. Observability probes — `chore(observability)`

Permanent `log::debug!(target: "brepkit_approx", …)` probes at all 7 approximation branches, so any run can report exactly where an op left the analytic path:

| Path | Site |
|------|------|
| Boolean → mesh (co-refinement) fallback — *the only path that loses analytic surface types* | `operations/boolean/mod.rs` |
| Fillet analytic → Newton-Raphson walker | `blend/fillet_builder.rs` |
| Chamfer analytic → `UnsupportedSurface` (no v1 walker) | `blend/chamfer_builder.rs` |
| Offset NURBS face → 16×16 sampled-NURBS refit | `offset/offset.rs` |
| Offset trim → grid-sampling | `operations/offset_trim.rs` |
| Offset face → raw untrimmed surface | `operations/offset_face.rs` |
| Rolling-ball fillet → flat planar corner | `operations/fillet/rolling_ball.rs` |

New `crates/operations/examples/approx_census.rs` installs an in-process logger that captures the probes and prints **path + wall-clock + face count** per op:

```
cargo run --release --example approx_census -p brepkit-operations
```

Sample output (overlapping primitives): boolean stays exact and sub-millisecond on `box−cyl` and coaxial `cyl∩cyl`, but `box∩sphere` (956 faces, 187 ms), `sphere−cyl` (1392 faces, 357 ms), and `torus−box` (1733 faces, 204 ms) drop to the mesh fallback — roughly 100–1000× slower with a 10–200× face explosion. Offset/fillet/chamfer stay exact on every analytic primitive.

`offset` gains a `log` dependency (used by the new probe).

### 2. Prune dead constants — `chore(boolean)`

`MESH_BOOLEAN_PER_SOLID_THRESHOLD` / `MESH_BOOLEAN_FACE_THRESHOLD` were unconsumed leftovers from the pre-GFA "chord-based tessellated" boolean pipeline (the `collect_face_data` face-count pre-gate). That pipeline is gone — the engine is GFA-primary with a mesh fallback decided by result validation, not a face-count threshold. Their doc comments held the last reference to the removed `collect_face_data`.

## Why

Pure observability + dead-code cleanup, no behavior change: the probes are `debug`-level (silent unless a logger opts in) and the removed constants had zero references.

## Verification

- `cargo test --workspace` green — probes regress nothing.
- `cargo clippy --all-targets` clean under `-D warnings`.
- The example empirically captures all three primary fallback families (boolean→mesh, fillet→walker, offset→sampled-NURBS).
