### PR TITLE
chore(observability): report faces=1 for single-face offset_face in census

### DIFF
--- a/crates/operations/examples/approx_census.rs
+++ b/crates/operations/examples/approx_census.rs
@@ -565,7 +565,8 @@ fn remaining_paths() -> Result<(), Box<dyn Error>> {
                         let ms = t.elapsed().as_secs_f64() * 1000.0;
                         let mut ev = drain();
                         match res {
-                            Ok(_) => report("offset_face", label, ms, 0, &ev),
+                            // offset_face returns a single face (not a solid).
+                            Ok(_) => report("offset_face", label, ms, 1, &ev),
                             Err(e) => {
                                 ev.push(format!("err: {e}"));
                                 report("offset_face", &format!("{label} [ERR]"), ms, 0, &ev);


### PR DESCRIPTION
Addresses a Copilot review nit on #995: the census printed `faces=0` for `offset_face` success rows, which reads like an empty result. `offset_face` returns a single `FaceId` (not a solid), so report `faces=1` instead.

Example-only, one-line change. Verified: the `offset_face` rows now print `faces=1` on success; `cargo fmt`/`clippy` clean via pre-commit.