### PR TITLE
fix(algo): keep cylinder slot-cut analytic (closed-circle section AABB)

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -2076,15 +2076,25 @@ fn emit_split_circle_arcs(
         let mut any = false;
         for oe in wire.edges() {
             if let Ok(edge) = topo.edge(oe.edge()) {
-                for vid in [edge.start(), edge.end()] {
-                    if let Ok(v) = topo.vertex(vid) {
-                        let p = v.point();
-                        min =
-                            Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
-                        max =
-                            Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
-                        any = true;
-                    }
+                let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+                    continue;
+                };
+                let (sp, ep) = (sv.point(), ev.point());
+                let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
+                // Sample along the curve, not just endpoints: a cylinder/cone
+                // lateral face's circular edges are closed (start == end at the
+                // seam vertex), so endpoint-only bounds collapse to a line at
+                // the seam and the face's radial extent is lost — which then
+                // wrongly rejects every in-face section-arc midpoint.
+                for i in 0..=8 {
+                    let p = edge.curve().evaluate_with_endpoints(
+                        t0 + (t1 - t0) * (f64::from(i) / 8.0),
+                        sp,
+                        ep,
+                    );
+                    min = Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
+                    max = Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
+                    any = true;
                 }
             }
         }

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -2086,12 +2086,12 @@ fn emit_split_circle_arcs(
                 // seam vertex), so endpoint-only bounds collapse to a line at
                 // the seam and the face's radial extent is lost — which then
                 // wrongly rejects every in-face section-arc midpoint.
-                for i in 0..=8 {
-                    let p = edge.curve().evaluate_with_endpoints(
-                        t0 + (t1 - t0) * (f64::from(i) / 8.0),
-                        sp,
-                        ep,
-                    );
+                let n = 8;
+                for i in 0..=n {
+                    let frac = f64::from(i) / f64::from(n);
+                    let p = edge
+                        .curve()
+                        .evaluate_with_endpoints(t0 + (t1 - t0) * frac, sp, ep);
                     min = Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
                     max = Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
                     any = true;

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5238,3 +5238,69 @@ fn scaling_perforated_cut_is_subquadratic() {
         s4.local_vertex_inserts
     );
 }
+
+#[test]
+fn cut_cylinder_by_box_slot_perpendicular_walls_is_watertight() {
+    // Regression: a box cutting a slot into a cylinder's side has two faces
+    // PERPENDICULAR to the cylinder axis (the slot's z=5 / z=9 top/bottom
+    // walls). Each intersects the cylinder in a closed circle, and the in-face
+    // arc of that circle was dropped because `emit_split_circle_arcs`'s face
+    // AABB used endpoint-only bounds — collapsing the cylinder lateral face to
+    // its seam line, so every arc midpoint fell outside the AABB. The two slot
+    // walls were then never created, leaving 8 free edges and forcing the mesh
+    // fallback. Now the face AABB samples the curved edges, so the result is
+    // analytic and watertight.
+    let mut topo = Topology::new();
+    let cyl = crate::primitives::make_cylinder(&mut topo, 6.0, 20.0).unwrap();
+    let bx = crate::primitives::make_box(&mut topo, 4.0, 4.0, 4.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        bx,
+        &brepkit_math::mat::Mat4::translation(-2.0, -8.0, 5.0),
+    )
+    .unwrap();
+
+    let result = boolean(&mut topo, BooleanOp::Cut, cyl, bx).unwrap();
+
+    assert!(
+        is_closed_manifold(&topo, result).unwrap(),
+        "cyl - box slot must be closed-manifold"
+    );
+    assert!(
+        !has_free_edges(&topo, result).unwrap(),
+        "cyl - box slot must be watertight (no free edges)"
+    );
+    // Analytic: the cylinder lateral face survives. A mesh fallback leaves 0
+    // cylinder faces and hundreds of planar facets.
+    assert!(
+        count_cylinder_faces(&topo, result) >= 1,
+        "cyl - box slot must keep the analytic cylinder face (no mesh fallback)"
+    );
+    let faces = brepkit_topology::explorer::solid_faces(&topo, result)
+        .unwrap()
+        .len();
+    assert!(
+        faces < 20,
+        "expected a compact analytic result, got {faces} faces (mesh fallback?)"
+    );
+    // The slot material is actually carved out: a point inside the slot
+    // classifies Outside while the cylinder body classifies Inside. (Volume
+    // measure is tessellation-based and unreliable on arc-edged faces, so the
+    // cut is verified geometrically via the robust ray-cast classifier.)
+    let slot_pt = Point3::new(0.0, -5.0, 7.0);
+    let body_pt = Point3::new(0.0, 0.0, 10.0);
+    assert!(
+        matches!(
+            crate::classify::classify_point(&topo, result, slot_pt, 0.01, 1e-7).unwrap(),
+            crate::classify::PointClassification::Outside
+        ),
+        "a point inside the carved slot must be Outside the result"
+    );
+    assert!(
+        matches!(
+            crate::classify::classify_point(&topo, result, body_pt, 0.01, 1e-7).unwrap(),
+            crate::classify::PointClassification::Inside
+        ),
+        "the cylinder body must remain Inside the result"
+    );
+}


### PR DESCRIPTION
## What

Fixes the first of the boolean→mesh fallbacks surfaced by the approximation census: **a box cutting a slot into a cylinder's side** now stays analytic and watertight instead of dropping to a 62-facet mesh.

## Root cause

A box has two faces **perpendicular to the cylinder axis** (the slot's top/bottom walls). Each intersects the cylinder lateral surface in a **closed circle**; only a small arc of that circle lies within the box face, so phase_ff splits the closed circle at its boundary crossings and emits the in-face arc (`emit_split_circle_arcs`).

That emit step rejects each candidate arc whose midpoint falls outside *either* face's AABB. The face-AABB helper built its bounds from edge **endpoint vertices only** — but a cylinder lateral face's circular edges are *closed* (start == end at the seam vertex), so its AABB collapsed to a thin line at the seam. Every slot-arc midpoint then tested "outside" the cylinder AABB → **all arcs dropped → the perpendicular box faces were never created → 8 free edges → mesh fallback.**

(The box faces *parallel* to the axis intersect in line segments via a different, correct path, which is why only the perpendicular walls were lost.)

## Fix

`emit_split_circle_arcs`'s face-AABB now **samples along each edge curve** (8 points), exactly as the engine's primary `compute_face_bbox` already does, so a closed circular edge contributes its full radial extent instead of just the seam point. One-function change in `phase_ff.rs`; the sphere-hemisphere surface-union path is untouched.

## Verification

- New regression test `cut_cylinder_by_box_slot_perpendicular_walls_is_watertight`: asserts the result is closed-manifold, free-edge-free, keeps the analytic cylinder face, is compact (<20 faces), **and** — via the robust ray-cast classifier — that a point in the slot is `Outside` and the cylinder body is `Inside` (the cut geometry is correct, not just topologically closed).
- Census: `cyl − box (slot)` went from **62 faces / mesh fallback** to **8 faces / exact analytic / 0.71 ms**. No other census case changed (box∩sphere, sphere−cyl, cyl∪cyl still fall back — separate root causes).
- `cargo clippy --all-targets` clean; full `cargo test --workspace` green.

## Note

The tessellation-based volume measure reads ~+1.4% high on the resulting arc-edged notched cylinder (a known, separate limitation — it diverges upward with finer deflection), so the test verifies the cut geometrically via classification rather than by volume.
