### PR TITLE
fix(offset): assemble torus offsets analytically (doubly-periodic seam wire)

### DIFF
--- a/crates/offset/src/loops.rs
+++ b/crates/offset/src/loops.rs
@@ -10,8 +10,8 @@ use std::collections::{HashMap, HashSet};
 use brepkit_math::vec::Point3;
 use brepkit_topology::Topology;
 use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
-use brepkit_topology::face::FaceId;
-use brepkit_topology::vertex::VertexId;
+use brepkit_topology::face::{FaceId, FaceSurface};
+use brepkit_topology::vertex::{Vertex, VertexId};
 use brepkit_topology::wire::{OrientedEdge, Wire, WireId};
 
 use crate::data::{OffsetData, OffsetStatus, find_or_create_vertex};
@@ -71,6 +71,16 @@ fn build_loops_for_face(
     data: &OffsetData,
     face_id: FaceId,
 ) -> Result<Vec<WireId>, OffsetError> {
+    // Doubly-periodic torus face: its offset is a concentric torus with the
+    // same seam structure, so rebuild the fundamental-polygon wire directly.
+    // The generic strategies below can't handle its degenerate v0->v0 seam
+    // edges (they look for circle edges or chainable line corners).
+    if let Some(off) = data.offset_faces.get(&face_id)
+        && let FaceSurface::Torus(tor) = &off.surface
+    {
+        return build_torus_wire(topo, tor, data.options.tolerance.linear);
+    }
+
     let mut face_edges: Vec<EdgeId> = Vec::new();
     for intersection in &data.intersections {
         if intersection.face_a != face_id && intersection.face_b != face_id {
@@ -157,6 +167,29 @@ fn try_circle_seam_wire(
 
     // Mixed circle + non-circle: not handled by this strategy.
     Ok(None)
+}
+
+/// Build the fundamental-polygon wire for a torus face: 1 seam vertex, two
+/// degenerate seam edges, wire `a -> b -> a^-1 -> b^-1` (mirrors `make_torus`).
+fn build_torus_wire(
+    topo: &mut Topology,
+    tor: &brepkit_math::surfaces::ToroidalSurface,
+    tol: f64,
+) -> Result<Vec<WireId>, OffsetError> {
+    let seam = tor.evaluate(0.0, 0.0);
+    let v0 = topo.add_vertex(Vertex::new(seam, tol));
+    let ea = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Line));
+    let eb = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Line));
+    let wire = Wire::new(
+        vec![
+            OrientedEdge::new(ea, true),
+            OrientedEdge::new(eb, true),
+            OrientedEdge::new(ea, false),
+            OrientedEdge::new(eb, false),
+        ],
+        true,
+    )?;
+    Ok(vec![topo.add_wire(wire)])
 }
 
 /// Try to chain edges into closed loops using vertex adjacency.

--- a/crates/offset/tests/integration.rs
+++ b/crates/offset/tests/integration.rs
@@ -3,7 +3,7 @@
 
 use brepkit_offset::{OffsetOptions, offset_solid};
 use brepkit_operations::measure::solid_volume;
-use brepkit_operations::primitives::{make_box, make_cylinder, make_sphere};
+use brepkit_operations::primitives::{make_box, make_cylinder, make_sphere, make_torus};
 use brepkit_topology::Topology;
 
 fn offset_opts() -> OffsetOptions {
@@ -209,4 +209,33 @@ fn offset_sphere_outward_produces_solid() {
         .shell(topo.solid(result).unwrap().outer_shell())
         .unwrap();
     assert!(!shell.faces().is_empty(), "offset sphere should have faces");
+}
+
+#[test]
+fn offset_torus_stays_analytic() {
+    // Regression: a torus face is doubly-periodic (a fundamental-polygon wire
+    // with degenerate v0->v0 seam edges). The offset wire-builder's circle/seam
+    // and chaining strategies couldn't rebuild it, so the offset solid ended up
+    // with no faces ("no faces could be assembled"). The offset of a torus is a
+    // concentric torus, so its fundamental-polygon wire is now rebuilt directly.
+    for distance in [0.5_f64, -0.5, 1.0] {
+        let mut topo = Topology::new();
+        let solid = make_torus(&mut topo, 10.0, 3.0, 32).unwrap();
+        let result = offset_solid(&mut topo, solid, distance, offset_opts()).unwrap();
+        let shell = topo
+            .shell(topo.solid(result).unwrap().outer_shell())
+            .unwrap();
+        assert_eq!(
+            shell.faces().len(),
+            1,
+            "offset torus by {distance} should be a single torus face"
+        );
+        assert!(
+            matches!(
+                topo.face(shell.faces()[0]).unwrap().surface(),
+                brepkit_topology::face::FaceSurface::Torus(_)
+            ),
+            "offset torus by {distance} must stay analytic (Torus surface)"
+        );
+    }
 }


### PR DESCRIPTION
## What

Fixes the torus-offset failure the approximation census surfaced: `offset(torus)` errored with **"no faces could be assembled for the offset solid"**. Offsetting a torus now produces a clean analytic torus.

## Root cause

A torus face is doubly-periodic — it has a *fundamental-polygon* boundary wire (`a · b · a⁻¹ · b⁻¹`) built from **two degenerate `v0→v0` seam `Line` edges** and a single vertex (see `make_torus`). The offset wire-builder (`loops.rs::build_loops_for_face`) only knows three strategies — circle+seam (cylinder/cone/sphere), direct vertex chaining, and line-line corner intersection — none of which can reconstruct a wire from degenerate seam lines. So the torus face got **empty wires**, the assembler skipped it, and with no faces left it errored out.

Cylinder/cone/sphere offsets already worked because their lateral faces use Circle edges (handled by the circle+seam strategy); the torus is the only primitive with a doubly-periodic seam.

## Fix

The offset of a torus is a **concentric torus** (same center/major/axis, minor ± distance) with the identical seam structure. So `build_loops_for_face` now detects a torus offset face and rebuilds its fundamental-polygon wire directly from the offset `ToroidalSurface` — one seam vertex at `evaluate(0,0)`, two degenerate seam edges, wire `a · b · a⁻¹ · b⁻¹` — mirroring `make_torus`. ~25 lines in `loops.rs`, no change to the generic strategies.

## Verification

- New regression test `offset_torus_stays_analytic` (outward, inward, larger): asserts the result is a single analytic `Torus` face.
- Census: `offset torus` went from **error** to a **1-face analytic torus**.
- `cargo clippy --all-targets` clean; full `cargo test --workspace` green.
