### PR TITLE
fix(offset): restrict torus-wire rebuild to full untrimmed torus faces

### DIFF
--- a/crates/offset/src/loops.rs
+++ b/crates/offset/src/loops.rs
@@ -71,16 +71,6 @@ fn build_loops_for_face(
     data: &OffsetData,
     face_id: FaceId,
 ) -> Result<Vec<WireId>, OffsetError> {
-    // Doubly-periodic torus face: its offset is a concentric torus with the
-    // same seam structure, so rebuild the fundamental-polygon wire directly.
-    // The generic strategies below can't handle its degenerate v0->v0 seam
-    // edges (they look for circle edges or chainable line corners).
-    if let Some(off) = data.offset_faces.get(&face_id)
-        && let FaceSurface::Torus(tor) = &off.surface
-    {
-        return build_torus_wire(topo, tor, data.options.tolerance.linear);
-    }
-
     let mut face_edges: Vec<EdgeId> = Vec::new();
     for intersection in &data.intersections {
         if intersection.face_a != face_id && intersection.face_b != face_id {
@@ -91,6 +81,22 @@ fn build_loops_for_face(
 
     if let Some(boundary) = data.boundary_edges.get(&face_id) {
         face_edges.extend_from_slice(boundary);
+    }
+
+    // A full doubly-periodic torus offset face carries only degenerate v0->v0
+    // seam edges, which the generic strategies below can't use; rebuild its
+    // fundamental-polygon wire directly from the offset torus surface. Gate on
+    // the absence of any real (non-degenerate) edge so a TRIMMED torus patch
+    // (e.g. a fillet's torus face, which carries real boundary/intersection
+    // edges) still flows through the normal strategies.
+    let has_real_edge = face_edges
+        .iter()
+        .any(|&eid| topo.edge(eid).is_ok_and(|e| e.start() != e.end()));
+    if !has_real_edge
+        && let Some(off) = data.offset_faces.get(&face_id)
+        && let FaceSurface::Torus(tor) = &off.surface
+    {
+        return build_torus_wire(topo, tor, data.options.tolerance.linear);
     }
 
     if face_edges.is_empty() {


### PR DESCRIPTION
## What

Follow-up to #999 addressing a Copilot review finding: the torus-wire rebuild fired for **any** toroidal offset face, so a **trimmed torus patch** (e.g. a fillet/blend's torus face, which carries real boundary/intersection edges) would wrongly get the full fundamental-polygon seam wire instead of using its actual edges.

## Fix

Gate the rebuild on the face having **no real (non-degenerate) edge**. A full doubly-periodic torus offset face has only degenerate `v0→v0` seam edges (which the generic strategies can't use); a trimmed torus patch carries real edges. So the rebuild now fires only for the genuine full-torus case, and trimmed patches flow through the normal circle/seam, chaining, and line-intersection strategies as before.

Also moved the check to after `face_edges` collection (it now needs them to compute `has_real_edge`).

## Verification

- `offset_torus_stays_analytic` still passes (the full untrimmed torus has no real edges → still rebuilt → 1 analytic torus face).
- `cargo clippy --all-targets` clean; full `cargo test --workspace` green.
