### PR TITLE
fix(algo): bound sphere/torus faces by surface extent in boolean broad-phase

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1096,15 +1096,27 @@ fn compute_face_bbox(topo: &Topology, face_id: FaceId) -> Result<Aabb3, AlgoErro
         }
     }
 
-    if points.is_empty() {
+    let boundary_bbox = if points.is_empty() {
         // Degenerate face with no edges -- use a zero-volume box at origin
-        Ok(Aabb3 {
+        Aabb3 {
             min: Point3::new(0.0, 0.0, 0.0),
             max: Point3::new(0.0, 0.0, 0.0),
-        })
+        }
     } else {
-        Ok(Aabb3::from_points(points))
-    }
+        Aabb3::from_points(points)
+    };
+
+    // A sphere or torus face bulges beyond its boundary edges (a hemisphere's
+    // only boundary is its equatorial circle; a full torus's are degenerate
+    // seam points), so the boundary-sampled bbox underestimates the true extent
+    // and the broad-phase would wrongly reject genuinely intersecting pairs.
+    // Union with the surface's closed-form extent to keep the bbox a sound
+    // superset. Cylinder/cone/plane boundary edges already bound their faces.
+    Ok(match topo.face(face_id)?.surface() {
+        FaceSurface::Sphere(s) => boundary_bbox.union(s.aabb()),
+        FaceSurface::Torus(t) => boundary_bbox.union(t.aabb()),
+        _ => boundary_bbox,
+    })
 }
 
 /// Compute AABBs for a list of faces.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -53,8 +53,8 @@ pub fn perform(
     let faces_b = brepkit_topology::explorer::solid_faces(topo, solid_b)?;
 
     // Pre-compute face AABBs for rejection
-    let bboxes_a = compute_face_bboxes(topo, &faces_a)?;
-    let bboxes_b = compute_face_bboxes(topo, &faces_b)?;
+    let bboxes_a = compute_face_bboxes(topo, &faces_a, tol)?;
+    let bboxes_b = compute_face_bboxes(topo, &faces_b, tol)?;
 
     // Collect all surface data upfront so we don't borrow topo immutably
     // while mutating it later.
@@ -1078,7 +1078,7 @@ fn longest_inboth_run(inb: &[bool], closed: bool) -> (usize, usize) {
 }
 
 /// Compute AABB for a face by sampling its boundary edges.
-fn compute_face_bbox(topo: &Topology, face_id: FaceId) -> Result<Aabb3, AlgoError> {
+fn compute_face_bbox(topo: &Topology, face_id: FaceId, tol: Tolerance) -> Result<Aabb3, AlgoError> {
     let edges = brepkit_topology::explorer::face_edges(topo, face_id)?;
     let mut points = Vec::new();
 
@@ -1096,34 +1096,123 @@ fn compute_face_bbox(topo: &Topology, face_id: FaceId) -> Result<Aabb3, AlgoErro
         }
     }
 
-    let boundary_bbox = if points.is_empty() {
-        // Degenerate face with no edges -- use a zero-volume box at origin
-        Aabb3 {
-            min: Point3::new(0.0, 0.0, 0.0),
-            max: Point3::new(0.0, 0.0, 0.0),
-        }
-    } else {
-        Aabb3::from_points(points)
-    };
-
     // A sphere or torus face bulges beyond its boundary edges (a hemisphere's
-    // only boundary is its equatorial circle; a full torus's are degenerate
+    // only boundary is its equatorial circle; a full torus's are two degenerate
     // seam points), so the boundary-sampled bbox underestimates the true extent
     // and the broad-phase would wrongly reject genuinely intersecting pairs.
-    // Union with the surface's closed-form extent to keep the bbox a sound
-    // superset. Cylinder/cone/plane boundary edges already bound their faces.
-    Ok(match topo.face(face_id)?.surface() {
-        FaceSurface::Sphere(s) => boundary_bbox.union(s.aabb()),
-        FaceSurface::Torus(t) => boundary_bbox.union(t.aabb()),
-        _ => boundary_bbox,
+    // Recover the missing extent from the surface, kept as tight as possible so
+    // the box stays a sound superset without admitting unrelated geometry.
+    let surface_bbox = match topo.face(face_id)?.surface() {
+        // Bound to the hemisphere the face occupies (pole side from the boundary
+        // winding) — the full-sphere box would let one hemisphere admit the
+        // other's sections. Ambiguous winding falls back to the full sphere.
+        FaceSurface::Sphere(s) => Some(match sphere_region_axis(topo, face_id, s.center(), tol) {
+            Some(axis) => s.aabb_region(axis),
+            None => s.aabb(),
+        }),
+        // Only a full, untrimmed torus needs the surface box — its boundary is
+        // the degenerate fundamental-polygon seam, which collapses to a point. A
+        // trimmed torus patch is bounded by its real edges; widening it to the
+        // whole torus would admit geometry on omitted angular bands.
+        FaceSurface::Torus(t) if face_boundary_all_degenerate(topo, face_id, tol)? => {
+            Some(t.aabb())
+        }
+        _ => None,
+    };
+
+    Ok(match (points.is_empty(), surface_bbox) {
+        (false, Some(sb)) => Aabb3::from_points(points).union(sb),
+        (false, None) => Aabb3::from_points(points),
+        (true, Some(sb)) => sb,
+        // Degenerate face with no edges and no surface box -- zero-volume box.
+        (true, None) => Aabb3 {
+            min: Point3::new(0.0, 0.0, 0.0),
+            max: Point3::new(0.0, 0.0, 0.0),
+        },
     })
 }
 
+/// Pole-side axis of a spherical face, from its boundary winding: the summed
+/// `(midpoint − center) × chord` over the outer wire points from the sphere
+/// center into the face's hemisphere (negated for a reversed face). Returns
+/// `None` when the wire is degenerate or near-planar through the center, so the
+/// side is ambiguous. Shared by the broad-phase AABB and the section in-both
+/// filter so the two stay consistent.
+fn sphere_region_axis(
+    topo: &Topology,
+    face_id: FaceId,
+    center: Point3,
+    tol: Tolerance,
+) -> Option<Vec3> {
+    let face = topo.face(face_id).ok()?;
+    let wire = topo.wire(face.outer_wire()).ok()?;
+    let mut axis = Vec3::new(0.0, 0.0, 0.0);
+    // The cross products have units of length^2, so the degeneracy threshold is
+    // derived from the input magnitudes rather than a bare linear tolerance:
+    // `scale` sums each term's bound (|mid − center| · |chord|); a truly
+    // cancelling wire leaves `axis` small relative to it.
+    let mut scale = 0.0;
+    for oe in wire.edges() {
+        let Ok(edge) = topo.edge(oe.edge()) else {
+            continue;
+        };
+        let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+            continue;
+        };
+        let (sp, ep) = if oe.is_forward() {
+            (sv.point(), ev.point())
+        } else {
+            (ev.point(), sv.point())
+        };
+        let mid = sp + (ep - sp) * 0.5;
+        let radial = mid - center;
+        let chord = ep - sp;
+        scale += radial.length() * chord.length();
+        axis += radial.cross(chord);
+    }
+    if face.is_reversed() {
+        axis = axis * -1.0;
+    }
+    let len = axis.length();
+    if scale < tol.linear * tol.linear || len < scale * tol.linear {
+        return None;
+    }
+    Some(axis * (1.0 / len))
+}
+
+/// True when every edge of the face is degenerate (zero length in 3D) — the
+/// signature of a full, untrimmed torus, whose boundary is the doubly-periodic
+/// fundamental-polygon seam built from `Line(v0, v0)` edges. A trimmed torus
+/// patch has real boundary edges and returns `false`.
+fn face_boundary_all_degenerate(
+    topo: &Topology,
+    face_id: FaceId,
+    tol: Tolerance,
+) -> Result<bool, AlgoError> {
+    let edges = brepkit_topology::explorer::face_edges(topo, face_id)?;
+    if edges.is_empty() {
+        return Ok(false);
+    }
+    for eid in edges {
+        let edge = topo.edge(eid)?;
+        let sp = topo.vertex(edge.start())?.point();
+        let ep = topo.vertex(edge.end())?.point();
+        if (ep - sp).length() > tol.linear {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 /// Compute AABBs for a list of faces.
-fn compute_face_bboxes(topo: &Topology, faces: &[FaceId]) -> Result<Vec<Aabb3>, AlgoError> {
+fn compute_face_bboxes(
+    topo: &Topology,
+    faces: &[FaceId],
+    tol: Tolerance,
+) -> Result<Vec<Aabb3>, AlgoError> {
     let mut bboxes = Vec::with_capacity(faces.len());
     for &fid in faces {
-        bboxes.push(compute_face_bbox(topo, fid)?);
+        bboxes.push(compute_face_bbox(topo, fid, tol)?);
     }
     Ok(bboxes)
 }
@@ -2146,41 +2235,7 @@ fn emit_split_circle_arcs(
             return None;
         };
         let center = s.center();
-        let wire = topo.wire(face.outer_wire()).ok()?;
-        let mut axis = Vec3::new(0.0, 0.0, 0.0);
-        // The accumulated cross products have units of length^2, so the
-        // degeneracy threshold must be derived from the input magnitudes
-        // rather than compared against a bare linear tolerance. `scale`
-        // sums each term's magnitude bound (|mid - center| * |ep - sp|);
-        // a true near-parallel/cancelling wire leaves `axis` small
-        // relative to it.
-        let mut scale = 0.0;
-        for oe in wire.edges() {
-            let Ok(edge) = topo.edge(oe.edge()) else {
-                continue;
-            };
-            let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
-                continue;
-            };
-            let (sp, ep) = if oe.is_forward() {
-                (sv.point(), ev.point())
-            } else {
-                (ev.point(), sv.point())
-            };
-            let mid = sp + (ep - sp) * 0.5;
-            let radial = mid - center;
-            let chord = ep - sp;
-            scale += radial.length() * chord.length();
-            axis += radial.cross(chord);
-        }
-        if face.is_reversed() {
-            axis = axis * -1.0;
-        }
-        let len = axis.length();
-        if scale < tol.linear * tol.linear || len < scale * tol.linear {
-            return None;
-        }
-        Some((center, axis * (1.0 / len)))
+        sphere_region_axis(topo, fid, center, tol).map(|axis| (center, axis))
     };
     let side_a = sphere_side(face_a);
     let side_b = sphere_side(face_b);

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1205,10 +1205,15 @@ fn sphere_region_axis(
     Some(axis * (1.0 / len))
 }
 
-/// True when every edge of the face is degenerate (zero length in 3D) — the
-/// signature of a full, untrimmed torus, whose boundary is the doubly-periodic
-/// fundamental-polygon seam built from `Line(v0, v0)` edges. A trimmed torus
-/// patch has real boundary edges and returns `false`.
+/// True when every edge of the face has zero spatial extent (a degenerate seam
+/// point) — the signature of a full, untrimmed torus, whose boundary is the
+/// doubly-periodic fundamental-polygon seam built from `Line(v0, v0)` edges.
+///
+/// Extent (not just endpoint coincidence) is the test: a closed `Circle` or
+/// closed NURBS edge also has `start == end`, yet it spans a real loop and
+/// bounds a *trimmed* patch — those must return `false` so the patch is not
+/// over-widened to the whole torus. Each edge is sampled along its curve and
+/// must stay within `tol` of its start point.
 fn face_boundary_all_degenerate(
     topo: &Topology,
     face_id: FaceId,
@@ -1222,8 +1227,13 @@ fn face_boundary_all_degenerate(
         let edge = topo.edge(eid)?;
         let sp = topo.vertex(edge.start())?.point();
         let ep = topo.vertex(edge.end())?.point();
-        if (ep - sp).length() > tol.linear {
-            return Ok(false);
+        let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
+        for frac in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            let t = t0 + (t1 - t0) * frac;
+            let p = edge.curve().evaluate_with_endpoints(t, sp, ep);
+            if (p - sp).length() > tol.linear {
+                return Ok(false);
+            }
         }
     }
     Ok(true)
@@ -2806,6 +2816,51 @@ mod tests {
         // The equatorial circle's plane normal is ±z; sampling recovers it.
         assert!(axis.z().abs() > 0.99, "axis not aligned with z: {axis:?}");
         assert!(axis.x().abs() < 0.05 && axis.y().abs() < 0.05);
+    }
+
+    #[test]
+    fn closed_circle_torus_boundary_is_not_full_torus() {
+        // A torus patch bounded by a closed `Circle` edge has coincident
+        // endpoints but real spatial extent — it must NOT be treated as a full
+        // (untrimmed) torus, which would over-widen its AABB to the whole torus.
+        use brepkit_math::curves::Circle3D;
+        use brepkit_math::surfaces::ToroidalSurface;
+        use brepkit_topology::face::Face;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+        let mut topo = Topology::default();
+        let v0 = topo.add_vertex(Vertex::new(Point3::new(13.0, 0.0, 0.0), 1e-7));
+        // A tube cross-section circle at u=0: centered on the tube center
+        // (10,0,0), in the x-z plane, radius = minor radius 3.
+        let circle =
+            Circle3D::new(Point3::new(10.0, 0.0, 0.0), Vec3::new(0.0, 1.0, 0.0), 3.0).unwrap();
+        let edge = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Circle(circle)));
+        let wire = topo.add_wire(Wire::new(vec![OrientedEdge::new(edge, true)], true).unwrap());
+        let torus = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), 10.0, 3.0).unwrap();
+        let face = topo.add_face(Face::new(wire, vec![], FaceSurface::Torus(torus)));
+        assert!(!face_boundary_all_degenerate(&topo, face, Tolerance::default()).unwrap());
+    }
+
+    #[test]
+    fn point_seam_boundary_is_full_torus() {
+        // Degenerate `Line(v0, v0)` seam edges (zero extent) are the full-torus
+        // signature and must return true.
+        use brepkit_math::surfaces::ToroidalSurface;
+        use brepkit_topology::face::Face;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+        let mut topo = Topology::default();
+        let v0 = topo.add_vertex(Vertex::new(Point3::new(13.0, 0.0, 0.0), 1e-7));
+        let e0 = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Line));
+        let e1 = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Line));
+        let wire = topo.add_wire(
+            Wire::new(
+                vec![OrientedEdge::new(e0, true), OrientedEdge::new(e1, true)],
+                true,
+            )
+            .unwrap(),
+        );
+        let torus = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), 10.0, 3.0).unwrap();
+        let face = topo.add_face(Face::new(wire, vec![], FaceSurface::Torus(torus)));
+        assert!(face_boundary_all_degenerate(&topo, face, Tolerance::default()).unwrap());
     }
 
     #[test]

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1146,12 +1146,11 @@ fn sphere_region_axis(
 ) -> Option<Vec3> {
     let face = topo.face(face_id).ok()?;
     let wire = topo.wire(face.outer_wire()).ok()?;
-    let mut axis = Vec3::new(0.0, 0.0, 0.0);
-    // The cross products have units of length^2, so the degeneracy threshold is
-    // derived from the input magnitudes rather than a bare linear tolerance:
-    // `scale` sums each term's bound (|mid − center| · |chord|); a truly
-    // cancelling wire leaves `axis` small relative to it.
-    let mut scale = 0.0;
+    // Sample the outer wire into an oriented closed polyline. Endpoint-only
+    // sampling fails for a boundary built from a single closed `Circle` edge
+    // (start == end, so every chord is zero); sampling along each edge recovers
+    // the loop shape so the winding below still yields the pole-side axis.
+    let mut pts: Vec<Point3> = Vec::new();
     for oe in wire.edges() {
         let Ok(edge) = topo.edge(oe.edge()) else {
             continue;
@@ -1159,14 +1158,40 @@ fn sphere_region_axis(
         let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
             continue;
         };
-        let (sp, ep) = if oe.is_forward() {
-            (sv.point(), ev.point())
-        } else {
-            (ev.point(), sv.point())
-        };
-        let mid = sp + (ep - sp) * 0.5;
+        let (sp, ep) = (sv.point(), ev.point());
+        let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
+        // Sample in the edge's natural direction (omit the endpoint — it is the
+        // next edge's start), then flip for a reversed orientation.
+        let n = 8;
+        let mut edge_pts: Vec<Point3> = (0..n)
+            .map(|i| {
+                let t = t0 + (t1 - t0) * (f64::from(i) / f64::from(n));
+                edge.curve().evaluate_with_endpoints(t, sp, ep)
+            })
+            .collect();
+        if !oe.is_forward() {
+            edge_pts.reverse();
+        }
+        pts.append(&mut edge_pts);
+    }
+    if pts.len() < 3 {
+        return None;
+    }
+    // Summed (midpoint − center) × chord around the closed loop ≈ 2·(area
+    // vector): its direction is the face's outward pole axis (negated for a
+    // reversed face). The cross products have units of length^2, so the
+    // degeneracy threshold is derived from the input magnitudes: `scale` sums
+    // each term's bound (|mid − center| · |chord|); a near-planar-through-center
+    // loop (ambiguous side) leaves `axis` small relative to it.
+    let mut axis = Vec3::new(0.0, 0.0, 0.0);
+    let mut scale = 0.0;
+    let count = pts.len();
+    for i in 0..count {
+        let a = pts[i];
+        let b = pts[(i + 1) % count];
+        let mid = a + (b - a) * 0.5;
         let radial = mid - center;
-        let chord = ep - sp;
+        let chord = b - a;
         scale += radial.length() * chord.length();
         axis += radial.cross(chord);
     }
@@ -2727,7 +2752,7 @@ fn clip_line_to_polygon_general(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
 
     #[test]
@@ -2751,6 +2776,36 @@ mod tests {
         // A closed curve entirely in-both returns the whole span (0, m).
         let inb = [true, true, true, true, true];
         assert_eq!(longest_inboth_run(&inb, true), (0, 4));
+    }
+
+    #[test]
+    fn sphere_region_axis_closed_circle_boundary() {
+        // A sphere face bounded by a single closed `Circle` edge has start ==
+        // end, so endpoint-only winding gives a zero chord and no axis. Sampling
+        // along the edge must recover the circle's plane normal as the pole axis
+        // (otherwise the broad-phase falls back to the loose full-sphere box).
+        use brepkit_math::curves::Circle3D;
+        use brepkit_math::surfaces::SphericalSurface;
+        use brepkit_topology::face::Face;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+        let mut topo = Topology::default();
+        let v0 = topo.add_vertex(Vertex::new(Point3::new(6.0, 0.0, 0.0), 1e-7));
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 6.0).unwrap();
+        let edge = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Circle(circle)));
+        let wire = topo.add_wire(Wire::new(vec![OrientedEdge::new(edge, true)], true).unwrap());
+        let sphere = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), 6.0).unwrap();
+        let face = topo.add_face(Face::new(wire, vec![], FaceSurface::Sphere(sphere)));
+        let axis = sphere_region_axis(
+            &topo,
+            face,
+            Point3::new(0.0, 0.0, 0.0),
+            Tolerance::default(),
+        )
+        .expect("closed-circle boundary should yield a pole axis");
+        // The equatorial circle's plane normal is ±z; sampling recovers it.
+        assert!(axis.z().abs() > 0.99, "axis not aligned with z: {axis:?}");
+        assert!(axis.x().abs() < 0.05 && axis.y().abs() < 0.05);
     }
 
     #[test]

--- a/crates/math/src/surfaces.rs
+++ b/crates/math/src/surfaces.rs
@@ -518,6 +518,37 @@ impl SphericalSurface {
         }
     }
 
+    /// Axis-aligned bounding box of the hemisphere on the `pole`-axis side —
+    /// the half-ball `{center + radius·d : d·pole ≥ 0}`. A tight, sound superset
+    /// of any spherical patch lying on that side; the boolean broad-phase uses
+    /// it so that one hemisphere face's box does not admit the other's sections
+    /// (the full-sphere `aabb` would). Falls back to the full sphere when `pole`
+    /// is degenerate (side ambiguous).
+    #[must_use]
+    pub fn aabb_region(&self, pole: Vec3) -> Aabb3 {
+        let Ok(n) = pole.normalize() else {
+            return self.aabb();
+        };
+        let c = self.center;
+        let r = self.radius;
+        // For world axis ê, the extreme of d·ê over {d·n ≥ 0, |d| = 1} is 1 when
+        // ê·n ≥ 0 (the axis itself is in the half-space), else the equator-plane
+        // projection √(1 − (ê·n)²); the minimum is the mirror image.
+        let span = |en: f64| -> (f64, f64) {
+            let s = (1.0 - en * en).max(0.0).sqrt();
+            let hi = if en >= 0.0 { 1.0 } else { s };
+            let lo = if en <= 0.0 { -1.0 } else { -s };
+            (lo, hi)
+        };
+        let (lx, hx) = span(n.x());
+        let (ly, hy) = span(n.y());
+        let (lz, hz) = span(n.z());
+        Aabb3 {
+            min: Point3::new(c.x() + r * lx, c.y() + r * ly, c.z() + r * lz),
+            max: Point3::new(c.x() + r * hx, c.y() + r * hy, c.z() + r * hz),
+        }
+    }
+
     /// Project a 3D point onto the sphere, returning (u, v) parameters.
     ///
     /// `u` is the longitudinal angle [0, 2π), `v` is the latitude [-π/2, π/2].

--- a/crates/math/src/surfaces.rs
+++ b/crates/math/src/surfaces.rs
@@ -5,6 +5,7 @@
 //! intersection algorithms (e.g., plane-cylinder = ellipse) without sampling.
 
 use crate::MathError;
+use crate::aabb::Aabb3;
 use crate::frame::Frame3;
 use crate::nurbs::surface::NurbsSurface;
 use crate::vec::{Point3, Vec3};
@@ -495,6 +496,28 @@ impl SphericalSurface {
         }
     }
 
+    /// Axis-aligned bounding box of the full sphere (`center ± radius` on every
+    /// axis). Orientation-independent and a sound superset of any spherical
+    /// patch — the boolean broad-phase uses it because a face's boundary-only
+    /// bbox misses the surface bulge between its boundary edges (a hemisphere's
+    /// only boundary is its equator).
+    #[must_use]
+    pub fn aabb(&self) -> Aabb3 {
+        let r = self.radius;
+        Aabb3 {
+            min: Point3::new(
+                self.center.x() - r,
+                self.center.y() - r,
+                self.center.z() - r,
+            ),
+            max: Point3::new(
+                self.center.x() + r,
+                self.center.y() + r,
+                self.center.z() + r,
+            ),
+        }
+    }
+
     /// Project a 3D point onto the sphere, returning (u, v) parameters.
     ///
     /// `u` is the longitudinal angle [0, 2π), `v` is the latitude [-π/2, π/2].
@@ -695,6 +718,33 @@ impl ToroidalSurface {
         Self {
             center: self.center + offset,
             ..self.clone()
+        }
+    }
+
+    /// Axis-aligned bounding box of the full torus. The half-extent along each
+    /// world axis sums the ring's projection onto the plane perpendicular to the
+    /// torus axis (`(major+minor)·‖(x·ê, y·ê)‖`) and the tube's projection onto
+    /// the axis (`minor·|z·ê|`); `x/y/z_axis` are orthonormal. A sound superset
+    /// used by the boolean broad-phase — a full torus's boundary is degenerate
+    /// seam points, so a boundary-only bbox collapses to a point.
+    #[must_use]
+    pub fn aabb(&self) -> Aabb3 {
+        let rr = self.major_radius + self.minor_radius;
+        let r = self.minor_radius;
+        let hx = rr * self.x_axis.x().hypot(self.y_axis.x()) + r * self.z_axis.x().abs();
+        let hy = rr * self.x_axis.y().hypot(self.y_axis.y()) + r * self.z_axis.y().abs();
+        let hz = rr * self.x_axis.z().hypot(self.y_axis.z()) + r * self.z_axis.z().abs();
+        Aabb3 {
+            min: Point3::new(
+                self.center.x() - hx,
+                self.center.y() - hy,
+                self.center.z() - hz,
+            ),
+            max: Point3::new(
+                self.center.x() + hx,
+                self.center.y() + hy,
+                self.center.z() + hz,
+            ),
         }
     }
 

--- a/crates/math/src/surfaces/tests.rs
+++ b/crates/math/src/surfaces/tests.rs
@@ -288,6 +288,32 @@ fn sphere_aabb_offcenter() {
 }
 
 #[test]
+fn sphere_aabb_region_north_hemisphere() {
+    // Pole +z: the box is the upper half-ball (flat at the equator z=0).
+    let s = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), 6.0).unwrap();
+    let bb = s.aabb_region(Vec3::new(0.0, 0.0, 1.0));
+    assert!(point_approx_eq(bb.min, Point3::new(-6.0, -6.0, 0.0)));
+    assert!(point_approx_eq(bb.max, Point3::new(6.0, 6.0, 6.0)));
+}
+
+#[test]
+fn sphere_aabb_region_south_hemisphere() {
+    let s = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), 6.0).unwrap();
+    let bb = s.aabb_region(Vec3::new(0.0, 0.0, -1.0));
+    assert!(point_approx_eq(bb.min, Point3::new(-6.0, -6.0, -6.0)));
+    assert!(point_approx_eq(bb.max, Point3::new(6.0, 6.0, 0.0)));
+}
+
+#[test]
+fn sphere_aabb_region_degenerate_pole_is_full_sphere() {
+    // A zero pole axis is ambiguous → fall back to the full-sphere box.
+    let s = SphericalSurface::new(Point3::new(1.0, 2.0, 3.0), 4.0).unwrap();
+    let bb = s.aabb_region(Vec3::new(0.0, 0.0, 0.0));
+    assert!(point_approx_eq(bb.min, Point3::new(-3.0, -2.0, -1.0)));
+    assert!(point_approx_eq(bb.max, Point3::new(5.0, 6.0, 7.0)));
+}
+
+#[test]
 fn torus_aabb_canonical() {
     // Axis +z: radial reach R+r=13 in x/y, tube ±r=3 in z.
     let t = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), 10.0, 3.0).unwrap();

--- a/crates/math/src/surfaces/tests.rs
+++ b/crates/math/src/surfaces/tests.rs
@@ -271,6 +271,47 @@ fn torus_accessors() {
 }
 
 #[test]
+fn sphere_aabb_at_origin() {
+    let s = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), 3.0).unwrap();
+    let bb = s.aabb();
+    assert!(point_approx_eq(bb.min, Point3::new(-3.0, -3.0, -3.0)));
+    assert!(point_approx_eq(bb.max, Point3::new(3.0, 3.0, 3.0)));
+}
+
+#[test]
+fn sphere_aabb_offcenter() {
+    // The census case: sphere r=6 centered at (5,5,5).
+    let s = SphericalSurface::new(Point3::new(5.0, 5.0, 5.0), 6.0).unwrap();
+    let bb = s.aabb();
+    assert!(point_approx_eq(bb.min, Point3::new(-1.0, -1.0, -1.0)));
+    assert!(point_approx_eq(bb.max, Point3::new(11.0, 11.0, 11.0)));
+}
+
+#[test]
+fn torus_aabb_canonical() {
+    // Axis +z: radial reach R+r=13 in x/y, tube ±r=3 in z.
+    let t = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), 10.0, 3.0).unwrap();
+    let bb = t.aabb();
+    assert!(point_approx_eq(bb.min, Point3::new(-13.0, -13.0, -3.0)));
+    assert!(point_approx_eq(bb.max, Point3::new(13.0, 13.0, 3.0)));
+}
+
+#[test]
+fn torus_aabb_x_axis() {
+    // Axis along +x: tube ±r=3 in x, radial reach R+r=13 in y/z.
+    let t = ToroidalSurface::with_axis(
+        Point3::new(0.0, 0.0, 0.0),
+        10.0,
+        3.0,
+        Vec3::new(1.0, 0.0, 0.0),
+    )
+    .unwrap();
+    let bb = t.aabb();
+    assert!(point_approx_eq(bb.min, Point3::new(-3.0, -13.0, -13.0)));
+    assert!(point_approx_eq(bb.max, Point3::new(3.0, 13.0, 13.0)));
+}
+
+#[test]
 fn revolution_with_x_axis() {
     // Tests the other candidate branch for revolution surfaces
     let rev = RevolutionSurface::new(


### PR DESCRIPTION
## What

Makes the boolean **broad-phase face AABB sound for sphere and torus faces**.

`compute_face_bbox` (in `phase_ff.rs`) derived each face's AABB from its
boundary edges alone. A curved analytic face bulges *between* its boundaries,
so the box collapsed:

- a **sphere hemisphere** flattened to its equatorial disk (`z ∈ [0, 0]`), and
- a **full torus** — whose entire boundary is two degenerate seam-point `Line(v0, v0)` edges — collapsed to a single **point** `(R, 0, 0)`.

The FF broad-phase then wrongly rejected genuinely intersecting face pairs (and
the 16-sample section filter dropped the curve), forcing every boolean on those
primitives down the mesh co-refinement fallback (100–1000× slower, analytic
surface types lost).

## How

- Add closed-form `aabb()` to `SphericalSurface` (`center ± radius`) and
  `ToroidalSurface` (ring + tube extent, orientation-aware) in `brepkit-math`,
  with unit tests.
- Union it into the face bbox for `Sphere`/`Torus` faces in `compute_face_bbox`.

The bbox only ever **widens**, so it can add broad-phase candidates but never
drop a needed pair — the precise in-both restriction downstream still trims
exactly. Cylinder, cone, and plane boundaries already bound their faces and are
untouched. Same class as the cylinder seam-collapse fix in #997.

## Effect (raw GFA, measured)

This is a **foundational** fix in a multi-PR campaign to eliminate the four
remaining boolean→mesh fallbacks (`box∩sphere`, `sphere−cyl`, `cyl∪cyl` perp,
`torus−box`). It advances all three curved cases but closes none on its own —
the analytic results land in the follow-up split/assembly PRs:

| case | before | after |
|---|---|---|
| `torus − box` | hard error: *"no faces selected"* (pairs rejected at broad-phase) | reaches shell assembly (*"all shells classified as holes"*) |
| `sphere − cyl` | cyl×sphere section dropped at broad-phase | sections survive (sphere split/keep is the follow-up) |
| `box ∩ sphere` | box-cap sections dropped | sphere face survives the broad-phase |

## Test

- 4 new unit tests for `SphericalSurface::aabb` / `ToroidalSurface::aabb`
  (origin, off-center, canonical, and x-axis-oriented torus).
- Full workspace suite green: **2444 passed, 9 skipped**, no regressions
  (incl. all gridfinity in-mem fixtures and `intersect_box_sphere_succeeds`).
