### PR TITLE
fix(operations): assemble and render sphere−cyl Cut analytically

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -1869,7 +1869,16 @@ pub fn split_face_2d(
             // seam connections (e.g., torus), not true line boundaries.
             && (e.start_3d - e.end_3d).length() > tol.linear
     });
-    if all_boundary_line && !is_plane {
+    // `split_noseam_face_direct` carves cap+band from OPEN section arcs (it
+    // skips full-circle sections, relying on the FF boundary-crossing split to
+    // pre-open them). A hemisphere cut by a cylinder yields a CLOSED circle
+    // interior to the face (no equator crossing) — there are no open arcs, so
+    // that path would unsplit it. Defer those to the internal-loops path
+    // below, which carves the cap disc as a hole.
+    let has_open_section = sections
+        .iter()
+        .any(|s| (s.start - s.end).length() > tol.linear);
+    if all_boundary_line && !is_plane && has_open_section {
         return split_noseam_face_direct(
             &surface,
             &boundary_edges,
@@ -2857,13 +2866,37 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
             .fold(f64::NEG_INFINITY, f64::max);
         if (v_max - v_min) < 0.1 {
             let v_boundary = (v_min + v_max) * 0.5;
-            let v_pole = if v_boundary >= 0.0 {
-                std::f64::consts::FRAC_PI_2
-            } else {
-                -std::f64::consts::FRAC_PI_2
-            };
             let u_center = pts_2d.iter().map(|p| p.x()).sum::<f64>() / pts_2d.len() as f64;
-            interior_uv = Point2::new(u_center, (v_boundary + v_pole) * 0.5);
+
+            // A band sub-face's outer wire sits at the equator (v ≈ 0) for
+            // BOTH hemispheres, so its v-sign cannot say which hemisphere the
+            // band covers. The hole (the cut tunnel rim) carries that sign:
+            // aim the interior into the annular ring between the equator and
+            // the hole. Without a hole the strip is a polar cap whose own
+            // v-sign points at the enclosed pole.
+            let hole_v: Option<f64> = {
+                let vs: Vec<f64> = sub_face
+                    .inner_wires
+                    .iter()
+                    .flatten()
+                    .map(|e| 0.5 * (e.start_uv.y() + e.end_uv.y()))
+                    .collect();
+                vs.iter()
+                    .copied()
+                    .max_by(|a, b| a.abs().total_cmp(&b.abs()))
+            };
+            let target_v = match hole_v {
+                Some(hv) if (hv - v_boundary).abs() > 1e-9 => 0.5 * (v_boundary + hv),
+                _ => {
+                    let v_pole = if v_boundary >= 0.0 {
+                        std::f64::consts::FRAC_PI_2
+                    } else {
+                        -std::f64::consts::FRAC_PI_2
+                    };
+                    0.5 * (v_boundary + v_pole)
+                }
+            };
+            interior_uv = Point2::new(u_center, target_v);
         }
     }
 

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -200,6 +200,16 @@ pub fn detect_same_domain<S: BuildHasher>(
                 };
 
                 if let Some(same_dir) = surfaces_same_domain(surf_i, surf_j, tol) {
+                    // Two curved faces of the same underlying surface can share an
+                    // outer-wire edge set yet cover DIFFERENT regions — e.g. the
+                    // two hemisphere bands of a bored sphere share the equator
+                    // polygon but lie on opposite halves. A genuine same-domain
+                    // duplicate is coincident (same region → same interior
+                    // sample); distinct glued patches have far-apart interiors.
+                    // Skip the union when their interior samples disagree.
+                    if !planar(surf_i) && distinct_curved_regions(sub_faces, i, j, tol) {
+                        continue;
+                    }
                     uf.union(i, j);
                     let key = (i.min(j), i.max(j));
                     pair_data.insert(key, same_dir ^ (reversed[i] != reversed[j]));
@@ -1275,6 +1285,29 @@ impl UnionFind {
                 self.rank[rx] += 1;
             }
         }
+    }
+}
+
+/// Whether a surface is planar (the planar SD passes have their own geometric
+/// containment tests, so the curved-region guard only applies to non-planes).
+fn planar(surf: &FaceSurface) -> bool {
+    matches!(surf, FaceSurface::Plane { .. })
+}
+
+/// Whether two curved sub-faces of the same underlying surface, paired by a
+/// shared outer-wire edge set, actually cover DIFFERENT regions of that
+/// surface (so they are glued neighbours, not coincident duplicates).
+///
+/// The discriminator is their precomputed interior sample: a genuine
+/// same-domain duplicate is coincident (identical region → coincident
+/// interior), whereas the two hemisphere bands of a bored sphere share the
+/// equator boundary yet have interiors on opposite halves. Returns `false`
+/// (defer to the edge-set union) when either interior is unavailable, keeping
+/// the conservative pre-existing behaviour.
+fn distinct_curved_regions(sub_faces: &[SubFace], i: usize, j: usize, tol: Tolerance) -> bool {
+    match (sub_faces[i].interior_point, sub_faces[j].interior_point) {
+        (Some(pi), Some(pj)) => (pi - pj).length() > tol.linear * 100.0,
+        _ => false,
     }
 }
 

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1427,6 +1427,45 @@ fn compute_raw_curves(
             }
         }
 
+        (FaceSurface::Sphere(sphere), FaceSurface::Cylinder(cyl))
+        | (FaceSurface::Cylinder(cyl), FaceSurface::Sphere(sphere)) => {
+            // A coaxial sphere and cylinder meet at one or two circles (the
+            // tunnel rims of a sphere-with-bore). Emit them as exact Circles
+            // so the closed-circle FF split carves each hemisphere into a
+            // band-with-hole + cap; the marcher would return NURBS fragments
+            // the splitter cannot recognise, dropping the spherical faces.
+            // Non-coaxial (None) falls through to the general marcher.
+            match analytic_intersection::exact_sphere_cylinder(sphere, cyl)? {
+                Some(exacts) => {
+                    let mut results = Vec::new();
+                    for exact in exacts {
+                        if let analytic_intersection::ExactIntersectionCurve::Circle(circle) = exact
+                        {
+                            let bbox = circle_bbox(&circle);
+                            let domain = (0.0, std::f64::consts::TAU);
+                            let p_start = ParametricCurve::evaluate(&circle, domain.0);
+                            let p_end = ParametricCurve::evaluate(&circle, domain.1);
+                            results.push(RawCurve {
+                                curve: EdgeCurve::Circle(circle),
+                                bbox,
+                                t_range: domain,
+                                p_start,
+                                p_end,
+                            });
+                        }
+                    }
+                    Ok(results)
+                }
+                None => {
+                    if let (Some(aa), Some(ab)) = (surf_a.as_analytic(), surf_b.as_analytic()) {
+                        analytic_analytic_intersection(&aa, &ab, v_range_a, v_range_b)
+                    } else {
+                        Ok(Vec::new())
+                    }
+                }
+            }
+        }
+
         (a, b) if a.as_analytic().is_some() && b.as_analytic().is_some() => {
             if let (Some(aa), Some(ab)) = (a.as_analytic(), b.as_analytic()) {
                 analytic_analytic_intersection(&aa, &ab, v_range_a, v_range_b)

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -183,7 +183,14 @@ fn full_revolution_hole_vs<S: ParametricSurface>(
             let Ok(edge) = topo.edge(oe.edge()) else {
                 continue;
             };
-            let Ok(v) = topo.vertex(edge.start()) else {
+            // Oriented traversal: the wire-ordered start vertex is the edge's
+            // end when the oriented edge is reversed.
+            let vid = if oe.is_forward() {
+                edge.start()
+            } else {
+                edge.end()
+            };
+            let Ok(v) = topo.vertex(vid) else {
                 continue;
             };
             let (u, vv) = surface.project_point(v.point());
@@ -199,16 +206,16 @@ fn full_revolution_hole_vs<S: ParametricSurface>(
         if v_max - v_min > 1e-6 {
             continue;
         }
-        // Full revolution in u: unwrapped span ≈ TAU. A single-edge closed
-        // circle has one vertex, so also accept holes whose sole edge is a
-        // closed circle curve.
+        // Full revolution in u: the unwrapped per-vertex deltas around the
+        // CLOSED loop (including the closing step back to the first vertex) sum
+        // to ≈ TAU. A single-edge closed circle has one vertex, so also accept
+        // holes whose sole edge is a closed circle curve.
         let unwrapped_span = {
-            let mut prev = us.first().copied().unwrap_or(0.0);
+            let n = us.len();
             let mut acc = 0.0;
-            for &u in us.iter().skip(1) {
-                let d = u - prev;
+            for i in 0..n {
+                let d = us[(i + 1) % n] - us[i];
                 acc += d - TAU * ((d + std::f64::consts::PI) / TAU).floor();
-                prev = u;
             }
             acc.abs()
         };
@@ -618,9 +625,9 @@ fn integrate_with_trimming<S: ParametricSurface>(
         let v_far = hole_vs
             .iter()
             .copied()
-            .filter(|&hv| {
-                (hv - v_min).signum() == (v_pole - v_min).signum() && (hv - v_min).abs() > 1e-9
-            })
+            // Same side of v_min as the pole (strict same sign → positive
+            // product), and not coincident with v_min.
+            .filter(|&hv| (hv - v_min) * (v_pole - v_min) > 0.0 && (hv - v_min).abs() > 1e-9)
             .min_by(|a, b| (a - v_min).abs().total_cmp(&(b - v_min).abs()))
             .unwrap_or(v_pole);
         let v_dom = (v_min.min(v_far), v_min.max(v_far));

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -9,6 +9,7 @@ use brepkit_math::quadrature::gauss_legendre_points;
 use brepkit_math::traits::ParametricSurface;
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeCurve;
 use brepkit_topology::face::{FaceId, FaceSurface};
 
 use crate::CheckError;
@@ -75,6 +76,7 @@ pub fn integrate_face(
                 sign,
                 &uv_boundary,
                 true,
+                &[],
             ))
         }
         FaceSurface::Cone(s) => {
@@ -92,6 +94,7 @@ pub fn integrate_face(
                 sign,
                 &uv_boundary,
                 true,
+                &[],
             ))
         }
         FaceSurface::Sphere(s) => {
@@ -101,6 +104,7 @@ pub fn integrate_face(
             );
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, false, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
+            let hole_vs = full_revolution_hole_vs(topo, face_id, s);
             Ok(integrate_with_trimming(
                 s,
                 u_range,
@@ -109,6 +113,7 @@ pub fn integrate_face(
                 sign,
                 &uv_boundary,
                 true,
+                &hole_vs,
             ))
         }
         FaceSurface::Torus(s) => {
@@ -123,6 +128,7 @@ pub fn integrate_face(
                 sign,
                 &uv_boundary,
                 true,
+                &[],
             ))
         }
         FaceSurface::Nurbs(s) => {
@@ -141,6 +147,7 @@ pub fn integrate_face(
                 sign,
                 &uv_boundary,
                 periodic_u,
+                &[],
             ))
         }
     }
@@ -148,6 +155,74 @@ pub fn integrate_face(
 
 /// UV domain bounds as `((u_min, u_max), (v_min, v_max))`.
 type UvBounds = ((f64, f64), (f64, f64));
+
+/// The v-positions of a face's full-revolution inner wires (holes) on a
+/// surface periodic in u.
+///
+/// A boolean that drills a cylinder through a sphere leaves each spherical
+/// band bounded by a latitude circle hole (the tunnel rim). Such a hole wraps
+/// the full u-period and sits at a single v, so the band runs from its outer
+/// latitude to the hole — not on to the pole. Collecting these lets the
+/// integrator clip the band instead of over-integrating the polar cap the hole
+/// removed. Each entry is the mean projected v of one full-revolution hole.
+fn full_revolution_hole_vs<S: ParametricSurface>(
+    topo: &Topology,
+    face_id: FaceId,
+    surface: &S,
+) -> Vec<f64> {
+    use std::f64::consts::TAU;
+    let Ok(face) = topo.face(face_id) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for &wid in face.inner_wires() {
+        let Ok(wire) = topo.wire(wid) else { continue };
+        let mut us = Vec::new();
+        let mut vs = Vec::new();
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            let Ok(v) = topo.vertex(edge.start()) else {
+                continue;
+            };
+            let (u, vv) = surface.project_point(v.point());
+            us.push(u);
+            vs.push(vv);
+        }
+        if vs.is_empty() {
+            continue;
+        }
+        let v_min = vs.iter().copied().fold(f64::INFINITY, f64::min);
+        let v_max = vs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        // Constant-v latitude circle.
+        if v_max - v_min > 1e-6 {
+            continue;
+        }
+        // Full revolution in u: unwrapped span ≈ TAU. A single-edge closed
+        // circle has one vertex, so also accept holes whose sole edge is a
+        // closed circle curve.
+        let unwrapped_span = {
+            let mut prev = us.first().copied().unwrap_or(0.0);
+            let mut acc = 0.0;
+            for &u in us.iter().skip(1) {
+                let d = u - prev;
+                acc += d - TAU * ((d + std::f64::consts::PI) / TAU).floor();
+                prev = u;
+            }
+            acc.abs()
+        };
+        let single_closed_circle = wire.edges().len() == 1
+            && wire.edges().first().is_some_and(|oe| {
+                topo.edge(oe.edge())
+                    .is_ok_and(|e| matches!(e.curve(), EdgeCurve::Circle(_)))
+            });
+        if unwrapped_span >= TAU - 1e-3 || single_closed_circle {
+            out.push(0.5 * (v_min + v_max));
+        }
+    }
+    out
+}
 
 /// Compute UV bounds for a parametric face by projecting boundary vertices
 /// onto the surface and taking the min/max of the resulting parameters.
@@ -481,6 +556,7 @@ fn polygon_area(poly: &[(f64, f64)]) -> f64 {
 
 /// Dispatch to trimmed or untrimmed parametric integration based on whether
 /// a UV boundary polygon is available.
+#[allow(clippy::too_many_arguments)]
 fn integrate_with_trimming<S: ParametricSurface>(
     surface: &S,
     u_range: (f64, f64),
@@ -489,6 +565,7 @@ fn integrate_with_trimming<S: ParametricSurface>(
     sign: f64,
     uv_boundary: &[(f64, f64)],
     u_periodic: bool,
+    hole_vs: &[f64],
 ) -> FaceContribution {
     if uv_boundary.len() < 3 {
         return integrate_parametric(surface, u_range, v_range, gauss_order, sign);
@@ -535,7 +612,18 @@ fn integrate_with_trimming<S: ParametricSurface>(
         // (CCW vs CW boundary) selects which pole — the boundary's interior
         // side — so the two hemispheres do not both integrate the whole sphere.
         let v_pole = if winding >= 0.0 { v_range.1 } else { v_range.0 };
-        let v_dom = (v_min.min(v_pole), v_min.max(v_pole));
+        // A full-revolution hole at a latitude between the outer circle and the
+        // pole (the drilled-tunnel rim) clips the cap into a band: integrate
+        // only from the outer latitude to the hole, not on to the pole.
+        let v_far = hole_vs
+            .iter()
+            .copied()
+            .filter(|&hv| {
+                (hv - v_min).signum() == (v_pole - v_min).signum() && (hv - v_min).abs() > 1e-9
+            })
+            .min_by(|a, b| (a - v_min).abs().total_cmp(&(b - v_min).abs()))
+            .unwrap_or(v_pole);
+        let v_dom = (v_min.min(v_far), v_min.max(v_far));
         integrate_parametric(surface, (u_min, u_min + tau), v_dom, gauss_order, sign)
     } else if full_revolution {
         // Full-revolution band (cone/cylinder): integrate the whole revolution

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -1311,23 +1311,29 @@ fn algebraic_cone_cone(
     Ok(Some(curves))
 }
 
-/// Algebraic sphere-cylinder intersection.
+/// Exact coaxial sphere-cylinder intersection: returns the shared circle(s).
 ///
-/// For a sphere of radius R centered at C and a cylinder of radius r with
-/// axis through O in direction A, the intersection is found by:
+/// A sphere of radius `R` centered at `C` and a cylinder of radius `r` whose
+/// axis passes through `C` meet in concentric circles of radius `r` at the
+/// axial stations where `sqrt(R² − z²) = r`, i.e. `z = ±sqrt(R² − r²)`
+/// measured from `C` along the axis. A proper crossing yields two circles; a
+/// tangent contact (`r = R`) yields one; a cylinder wider than the sphere, or
+/// a non-coaxial configuration (quartic curve), yields none/defers.
 ///
-/// 1. Project the sphere center onto the cylinder axis.
-/// 2. Compute the perpendicular distance `d_perp` from center to axis.
-/// 3. If `d_perp + r > R` or `d_perp + R < r`: no intersection.
-/// 4. Otherwise, the intersection lies at axial positions where
-///    `sqrt(R² - z²) = r` for the coaxial case (d_perp = 0), giving
-///    two circles at `z = ±sqrt(R² - r²)`.
-/// 5. For the general case, solve a quartic for the axial position.
-///    Currently only handles the coaxial case analytically.
-fn algebraic_sphere_cylinder(
+/// Mirrors [`exact_cone_cylinder`] so phase FF can emit the section as an
+/// exact `Circle3D` (which the closed-circle split + seam adoption recognise)
+/// rather than the marcher's NURBS fragments.
+///
+/// Returns `Some(vec![..])` (0, 1, or 2 circles) for the coaxial case, and
+/// `None` (defer to the general marcher) when the axes are not coaxial.
+///
+/// # Errors
+///
+/// Returns [`MathError`] if a shared `Circle3D` cannot be constructed.
+pub fn exact_sphere_cylinder(
     sphere: &SphericalSurface,
     cyl: &CylindricalSurface,
-) -> Result<Option<Vec<IntersectionCurve>>, MathError> {
+) -> Result<Option<Vec<ExactIntersectionCurve>>, MathError> {
     let sc = sphere.center();
     let r_sphere = sphere.radius();
     let co = cyl.origin();
@@ -1341,65 +1347,72 @@ fn algebraic_sphere_cylinder(
     let perp_vec = delta_vec - axis * along;
     let d_perp = perp_vec.length();
 
-    // Separation check.
-    if d_perp > r_sphere + r_cyl + 1e-10 {
-        return Ok(Some(vec![])); // Too far apart
-    }
-
-    // Currently only handle the coaxial/near-coaxial case.
     // Non-coaxial sphere-cylinder intersections produce quartic curves;
-    // fall back to the general marching approach for those.
+    // defer those to the general marcher.
     if d_perp > 1e-7 {
-        return Ok(None); // Fall through to marching
+        return Ok(None);
     }
 
-    // Coaxial case: sphere center is on the cylinder axis.
-    // The intersection is at z = ±sqrt(R² - r²) relative to sphere center.
+    // Coaxial: the sphere center lies on the cylinder axis. No real circle
+    // when the cylinder is wider than the sphere or they are tangent-internal.
     if r_cyl > r_sphere + 1e-10 {
-        return Ok(Some(vec![])); // Cylinder larger than sphere
+        return Ok(Some(vec![]));
     }
-
     let z_sq = r_sphere * r_sphere - r_cyl * r_cyl;
     if z_sq < 0.0 {
-        return Ok(Some(vec![])); // No real intersection
+        return Ok(Some(vec![]));
     }
-
     let z = z_sq.sqrt();
 
-    // The intersection circles are centered on the axis at height ±z
-    // from the sphere center, with radius = r_cyl.
+    // The sphere center projected onto the axis is the midpoint of the two
+    // section circles, each offset by ±z along the axis with radius `r_cyl`.
     let center_axis_pt = Point3::new(
         co.x() + axis.x() * along,
         co.y() + axis.y() * along,
         co.z() + axis.z() * along,
     );
 
-    let mut curves = Vec::new();
-
-    // Build reference frame perpendicular to axis.
-    let basis = Frame3::from_normal(center_axis_pt, axis)?;
-    let u_dir = basis.x;
-    let v_dir = basis.y;
-
-    for &z_offset in &[z, -z] {
+    let mut circles = Vec::new();
+    let offsets: &[f64] = if z < 1e-10 { &[0.0] } else { &[z, -z] };
+    for &z_offset in offsets {
         let center = Point3::new(
             center_axis_pt.x() + axis.x() * z_offset,
             center_axis_pt.y() + axis.y() * z_offset,
             center_axis_pt.z() + axis.z() * z_offset,
         );
+        let circle = Circle3D::new(center, axis, r_cyl)?;
+        circles.push(ExactIntersectionCurve::Circle(circle));
+    }
+    Ok(Some(circles))
+}
 
+/// Algebraic sphere-cylinder intersection (NURBS form for the general bounded
+/// path). Delegates to [`exact_sphere_cylinder`] and samples each exact circle
+/// into an interpolated NURBS `IntersectionCurve`. phase FF prefers the exact
+/// circle form directly (so the section edge links to the coincident boundary
+/// and the closed-circle splitter can carve the spherical band), but a caller
+/// of `intersect_analytic_analytic_bounded` still gets clean curves instead of
+/// the marcher's fragments.
+fn algebraic_sphere_cylinder(
+    sphere: &SphericalSurface,
+    cyl: &CylindricalSurface,
+) -> Result<Option<Vec<IntersectionCurve>>, MathError> {
+    let Some(exacts) = exact_sphere_cylinder(sphere, cyl)? else {
+        return Ok(None);
+    };
+
+    let mut curves = Vec::new();
+    for exact in exacts {
+        let ExactIntersectionCurve::Circle(circle) = exact else {
+            continue;
+        };
         let n_samples = 33;
         let mut points = Vec::with_capacity(n_samples);
         let mut positions = Vec::with_capacity(n_samples);
         #[allow(clippy::cast_precision_loss)]
         for i in 0..n_samples {
             let theta = TAU * i as f64 / (n_samples - 1) as f64;
-            let (sin_t, cos_t) = theta.sin_cos();
-            let pt = Point3::new(
-                center.x() + (u_dir.x() * cos_t + v_dir.x() * sin_t) * r_cyl,
-                center.y() + (u_dir.y() * cos_t + v_dir.y() * sin_t) * r_cyl,
-                center.z() + (u_dir.z() * cos_t + v_dir.z() * sin_t) * r_cyl,
-            );
+            let pt = crate::traits::ParametricCurve::evaluate(&circle, theta);
             positions.push(pt);
             points.push(IntersectionPoint {
                 point: pt,
@@ -1407,15 +1420,9 @@ fn algebraic_sphere_cylinder(
                 param2: (0.0, 0.0),
             });
         }
-
         let degree = 3.min(positions.len() - 1);
         let curve = interpolate(&positions, degree)?;
         curves.push(IntersectionCurve { curve, points });
-    }
-
-    // If z is effectively 0, the two circles coincide (tangent case).
-    if z < 1e-10 {
-        curves.pop(); // Remove duplicate
     }
 
     Ok(Some(curves))
@@ -2146,6 +2153,50 @@ mod tests {
         // at the origin, should intersect (the cylinder passes through
         // the sphere).
         assert!(!curves.is_empty(), "sphere and cylinder should intersect");
+    }
+
+    #[test]
+    fn exact_sphere_cylinder_coaxial_two_circles() {
+        // Sphere r=6 at origin, coaxial cylinder r=3 along z: two latitude
+        // circles at z = ±sqrt(36-9) = ±sqrt(27), each of radius 3.
+        let sphere = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), 6.0).unwrap();
+        let cyl =
+            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        let circles = exact_sphere_cylinder(&sphere, &cyl)
+            .unwrap()
+            .expect("coaxial case returns Some");
+        assert_eq!(circles.len(), 2, "through-bore meets the sphere twice");
+        let mut zs: Vec<f64> = circles
+            .iter()
+            .filter_map(|c| match c {
+                ExactIntersectionCurve::Circle(circle) => {
+                    assert!(
+                        (circle.radius() - 3.0).abs() < 1e-9,
+                        "rim radius == cyl radius"
+                    );
+                    Some(circle.center().z())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(zs.len(), 2, "both sections must be exact circles");
+        zs.sort_by(f64::total_cmp);
+        let z = 27.0_f64.sqrt();
+        assert!((zs[0] + z).abs() < 1e-9 && (zs[1] - z).abs() < 1e-9);
+    }
+
+    #[test]
+    fn exact_sphere_cylinder_non_coaxial_defers() {
+        // Cylinder axis offset from the sphere center → quartic curve, deferred.
+        let sphere = SphericalSurface::new(Point3::new(0.0, 0.0, 0.0), 6.0).unwrap();
+        let cyl =
+            CylindricalSurface::new(Point3::new(2.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        assert!(
+            exact_sphere_cylinder(&sphere, &cyl).unwrap().is_none(),
+            "non-coaxial sphere/cylinder defers to the marcher"
+        );
     }
 
     #[test]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1142,6 +1142,78 @@ fn cut_box_by_sphere_succeeds() {
 }
 
 #[test]
+/// Cut a sphere (r=6) with a coaxial cylinder (r=3) passing all the way
+/// through: a sphere-with-tunnel. The intersection is two latitude circles, so
+/// the result must be EXACT ANALYTIC — two spherical bands (each carrying the
+/// tunnel-rim hole) plus the inner cylinder wall — and watertight, NOT a 1392-
+/// face mesh fallback.
+fn cut_sphere_by_through_cylinder_is_analytic_watertight() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let s = crate::primitives::make_sphere(&mut topo, 6.0, 24).unwrap();
+    let c = crate::primitives::make_cylinder(&mut topo, 3.0, 30.0).unwrap();
+    crate::transform::transform_solid(&mut topo, c, &Mat4::translation(0.0, 0.0, -15.0)).unwrap();
+
+    let res = boolean(&mut topo, BooleanOp::Cut, s, c).unwrap();
+
+    // Exact analytic surface mix: spheres + the cylinder tunnel wall, no
+    // mesh-fallback plane explosion.
+    let faces = brepkit_topology::explorer::solid_faces(&topo, res).unwrap();
+    let mut spheres = 0;
+    let mut cylinders = 0;
+    for &fid in &faces {
+        match topo.face(fid).unwrap().surface() {
+            FaceSurface::Sphere(_) => spheres += 1,
+            FaceSurface::Cylinder(_) => cylinders += 1,
+            other => panic!("unexpected non-analytic-tunnel face {other:?}"),
+        }
+    }
+    assert_eq!(spheres, 2, "expected two spherical bands, got {spheres}");
+    assert_eq!(cylinders, 1, "expected one tunnel wall, got {cylinders}");
+    assert!(
+        faces.len() <= 6,
+        "analytic result must be a handful of faces, not a mesh fallback (got {})",
+        faces.len()
+    );
+
+    // Watertight: every edge shared by exactly two faces.
+    let mut edge_use: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for &fid in &faces {
+        let f = topo.face(fid).unwrap();
+        let mut wires = vec![f.outer_wire()];
+        wires.extend(f.inner_wires().iter().copied());
+        for w in wires {
+            for oe in topo.wire(w).unwrap().edges() {
+                *edge_use.entry(oe.edge().index()).or_insert(0) += 1;
+            }
+        }
+    }
+    let free = edge_use.values().filter(|&&c| c == 1).count();
+    let over = edge_use.values().filter(|&&c| c > 2).count();
+    assert_eq!(free, 0, "result must be watertight (free edges = {free})");
+    assert_eq!(
+        over, 0,
+        "result must be manifold (over-shared edges = {over})"
+    );
+
+    // Volume = sphere − (sphere ∩ cylinder through-bore).
+    let r = 3.0_f64;
+    let rr = 6.0_f64;
+    let z = (rr * rr - r * r).sqrt();
+    let v_sphere = 4.0 / 3.0 * std::f64::consts::PI * rr.powi(3);
+    let h_cap = rr - z;
+    let v_cap = std::f64::consts::PI * h_cap * h_cap * (rr - h_cap / 3.0);
+    let v_removed = std::f64::consts::PI * r * r * (2.0 * z) + 2.0 * v_cap;
+    let v_expect = v_sphere - v_removed;
+    let vol = crate::measure::solid_volume(&topo, res, 0.001).unwrap();
+    assert!(
+        (vol - v_expect).abs() < v_expect * 0.01,
+        "tunnel volume {vol:.3} should match sphere − bore {v_expect:.3}"
+    );
+}
+
+#[test]
 fn cut_box_by_translated_sphere() {
     // Matches brepjs test: box(10,10,10), sphere(r=3) translated to (5,5,5).
     let mut topo = Topology::new();

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -36,9 +36,14 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         let face = topo.face(fid).ok()?;
         match face.surface() {
             FaceSurface::Nurbs(_) => return None,
-            FaceSurface::Sphere(_) | FaceSurface::Torus(_) if !face.inner_wires().is_empty() => {
+            // Sphere only: the per-face integrator's hole-clipping is wired up
+            // for spheres. A bored torus would pass `hole_vs = []` and
+            // over-integrate, so defer it to tessellation until torus
+            // hole-clipping lands (with the torus−box analytic split).
+            FaceSurface::Sphere(_) if !face.inner_wires().is_empty() => {
                 has_bored_quadric = true;
             }
+            FaceSurface::Torus(_) if !face.inner_wires().is_empty() => return None,
             _ => {}
         }
     }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -9,6 +9,53 @@ use crate::tessellate;
 
 use super::helpers::{collect_solid_vertex_points, compute_angular_range};
 
+/// Volume of a solid that contains a bored quadric — a sphere (or torus) face
+/// carrying a full-revolution latitude-circle hole (a drilled tunnel rim) — via
+/// exact per-face Gauss quadrature on the analytic surfaces.
+///
+/// The tessellation paths below cannot bound such an annular band: both of its
+/// boundary loops are constant-v latitude circles, so the band's UV outline is
+/// degenerate and the mesh fills the removed polar cap, over-counting. The
+/// per-face analytic integrator (orientation-aware, hole-clipped) is exact.
+///
+/// Scope is deliberately narrow — only solids whose tessellated volume is known
+/// to be wrong — so every other analytic solid keeps its existing
+/// tessellation-based volume. Returns `None` (defer to tessellation) when no
+/// bored quadric is present, when any face is NURBS, or when a face fails to
+/// integrate.
+fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
+    use brepkit_topology::explorer::solid_faces;
+
+    let faces = solid_faces(topo, solid).ok()?;
+    if faces.is_empty() {
+        return None;
+    }
+
+    let mut has_bored_quadric = false;
+    for &fid in &faces {
+        let face = topo.face(fid).ok()?;
+        match face.surface() {
+            FaceSurface::Nurbs(_) => return None,
+            FaceSurface::Sphere(_) | FaceSurface::Torus(_) if !face.inner_wires().is_empty() => {
+                has_bored_quadric = true;
+            }
+            _ => {}
+        }
+    }
+    if !has_bored_quadric {
+        return None;
+    }
+
+    let gauss_order = brepkit_check::properties::PropertiesOptions::default().gauss_order;
+    let mut total = 0.0;
+    for &fid in &faces {
+        total += brepkit_check::properties::face_integrator::integrate_face(topo, fid, gauss_order)
+            .ok()?
+            .volume;
+    }
+    Some(total.abs())
+}
+
 /// Try to compute the volume of a solid analytically by detecting known
 /// primitive shapes (sphere, cylinder, cone/frustum, torus).
 ///
@@ -286,6 +333,16 @@ pub fn solid_volume(
 ) -> Result<f64, crate::OperationsError> {
     // Fast path: exact analytic formula for known primitives.
     if let Some(v) = try_analytic_solid_volume(topo, solid) {
+        return Ok(v);
+    }
+
+    // Fast path: a solid whose faces are ALL analytic (planes + quadrics,
+    // no NURBS) integrates exactly via per-face Gauss quadrature on the
+    // analytic surfaces — orientation-aware and immune to the inscribed-mesh
+    // undercount and the degenerate-UV annular-band over-count that the
+    // tessellation paths below suffer on bored quadrics (e.g. a cylinder
+    // drilled through a sphere).
+    if let Some(v) = analytic_faces_solid_volume(topo, solid) {
         return Ok(v);
     }
 

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -11,6 +11,8 @@ use super::{MERGE_GRID, TriangleMesh, point_merge_key};
 
 /// Maps a 3D point to its `(u, v)` surface parameters.
 type ProjectFn = Box<dyn Fn(Point3) -> (f64, f64)>;
+/// Maps `(u, v)` surface parameters to a 3D surface point.
+type EvalFn = Box<dyn Fn(f64, f64) -> Point3>;
 /// Maps `(u, v)` surface parameters to the outward surface normal.
 type NormalFn = Box<dyn Fn(f64, f64) -> Vec3>;
 
@@ -148,6 +150,334 @@ pub(super) fn tessellate_revolution_band_shared(
     }
 
     Ok(true)
+}
+
+/// A boundary ring of a latitude band: each entry is `(u_angle, global_id)`,
+/// with `u_angle ∈ [0, 2π)`. Sorted ascending by angle so two rings align by
+/// longitude during stitching.
+type LatRing = Vec<(f64, u32)>;
+
+/// Tessellate a sphere/torus latitude band (the annular region between two
+/// constant-`v` full-revolution boundaries) as a structured UV grid.
+///
+/// The CDT path cannot bound this band: each constant-`v` latitude boundary
+/// projects to a back-and-forth horizontal segment of zero UV area, so the
+/// 2D polygon degenerates and the triangulation fills the removed polar cap
+/// (the tunnel mouth on a bored sphere is skinned over). Like the cylinder/cone
+/// `tessellate_revolution_band_shared`, this builds the band directly from the
+/// shared boundary vertices instead.
+///
+/// Unlike the ruled cylinder/cone band (whose two rims connect directly because
+/// the surface is straight in `v`), a sphere/torus band bulges between its two
+/// latitudes, so intermediate latitude rows are inserted until the chord error
+/// in `v` stays within `deflection`. The two boundary rows reuse the shared rim
+/// global vertex IDs (watertight by construction); interior-row vertices are new
+/// face-local points evaluated on the surface across the full `u` ring.
+///
+/// Returns `Ok(true)` when the face is such a band and was handled here, else
+/// `Ok(false)` (the caller then takes the CDT/snap path). Detection is
+/// deliberately conservative: a face qualifies only if its surface is a sphere
+/// or torus, it has exactly one inner wire, and both the outer and inner wires
+/// are closed full-revolution loops, each at a single constant `v`, built only
+/// from `Line`/`Circle` edges, at two distinct `v` levels.
+#[allow(clippy::too_many_lines)]
+pub(super) fn tessellate_latitude_band_shared(
+    topo: &Topology,
+    face_data: &brepkit_topology::face::Face,
+    deflection: f64,
+    angular_tol: f64,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
+    merged: &mut TriangleMesh,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
+) -> Result<bool, crate::OperationsError> {
+    if face_data.inner_wires().len() != 1 {
+        return Ok(false);
+    }
+
+    let (project, surf_eval, surf_normal): (ProjectFn, EvalFn, NormalFn) = match face_data.surface()
+    {
+        FaceSurface::Sphere(s) => {
+            let (s1, s2, s3) = (s.clone(), s.clone(), s.clone());
+            (
+                Box::new(move |p| s1.project_point(p)),
+                Box::new(move |u, v| s2.evaluate(u, v)),
+                Box::new(move |u, v| s3.normal(u, v)),
+            )
+        }
+        FaceSurface::Torus(t) => {
+            let (t1, t2, t3) = (t.clone(), t.clone(), t.clone());
+            (
+                Box::new(move |p| t1.project_point(p)),
+                Box::new(move |u, v| t2.evaluate(u, v)),
+                Box::new(move |u, v| t3.normal(u, v)),
+            )
+        }
+        _ => return Ok(false),
+    };
+
+    // Build one boundary ring per wire (outer first, then the single inner).
+    // Each must be a closed full-revolution loop at a single constant v.
+    let mut wire_ids = vec![face_data.outer_wire()];
+    wire_ids.extend_from_slice(face_data.inner_wires());
+    let mut rings: Vec<(f64, LatRing)> = Vec::with_capacity(2);
+    for &wid in &wire_ids {
+        let Some((v_level, ring)) =
+            collect_constant_v_ring(topo, wid, project.as_ref(), edge_global_indices, merged)?
+        else {
+            return Ok(false);
+        };
+        rings.push((v_level, ring));
+    }
+
+    // Order by v so we sweep from the lower latitude to the upper.
+    rings.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    let (v_lo, ring_lo) = &rings[0];
+    let (v_hi, ring_hi) = &rings[1];
+    let (v_lo, v_hi) = (*v_lo, *v_hi);
+    if (v_hi - v_lo).abs() < 1e-9 {
+        return Ok(false);
+    }
+
+    // Number of intermediate latitude rows from the chord error across the band
+    // in v. The bulge radius is the sphere radius (torus: minor radius).
+    let band_radius = match face_data.surface() {
+        FaceSurface::Sphere(s) => s.radius(),
+        FaceSurface::Torus(t) => t.minor_radius(),
+        _ => return Ok(false),
+    };
+    let n_v =
+        segments_for_chord_deviation_a(band_radius, v_hi - v_lo, deflection, angular_tol, true)
+            .max(1);
+
+    // Column count for the interior rows. Use the full-circle chord-deviation
+    // count at the band radius, but never fewer columns than the denser of the
+    // two boundary rings, so interior rows never undercut the boundary sampling.
+    let n_u_interior = ring_lo
+        .len()
+        .max(ring_hi.len())
+        .max(segments_for_chord_deviation_a(
+            band_radius,
+            std::f64::consts::TAU,
+            deflection,
+            angular_tol,
+            true,
+        ));
+
+    let emit = make_band_emit(project.as_ref(), surf_normal.as_ref());
+
+    // Build interior rows (new face-local vertices on the full u ring), then
+    // stitch boundary_lo -> interior rows... -> boundary_hi.
+    let mut prev_ring: LatRing = ring_lo.clone();
+    for iv in 1..n_v {
+        let t = iv as f64 / n_v as f64;
+        let v = v_lo + (v_hi - v_lo) * t;
+        let row = build_interior_row(
+            v,
+            n_u_interior,
+            surf_eval.as_ref(),
+            surf_normal.as_ref(),
+            merged,
+            point_to_global,
+        );
+        stitch_rings(merged, &prev_ring, &row, &emit);
+        prev_ring = row;
+    }
+    stitch_rings(merged, &prev_ring, ring_hi, &emit);
+
+    Ok(true)
+}
+
+/// Collect a wire's shared boundary vertices as a `(v_level, ring)` pair, or
+/// `None` if the wire is not a closed full-revolution loop at a single constant
+/// `v` (built only from `Line`/`Circle` edges).
+fn collect_constant_v_ring(
+    topo: &Topology,
+    wire_id: brepkit_topology::wire::WireId,
+    project: &dyn Fn(Point3) -> (f64, f64),
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
+    merged: &TriangleMesh,
+) -> Result<Option<(f64, LatRing)>, crate::OperationsError> {
+    let wire = topo.wire(wire_id)?;
+    let mut gids: Vec<u32> = Vec::new();
+    for oe in wire.edges() {
+        let e = topo.edge(oe.edge())?;
+        match e.curve() {
+            EdgeCurve::Line | EdgeCurve::Circle(_) => {}
+            _ => return Ok(None),
+        }
+        let Some(edge_gids) = edge_global_indices.get(&oe.edge().index()) else {
+            return Ok(None);
+        };
+        for &g in edge_gids {
+            gids.push(g);
+        }
+    }
+    if gids.len() < 3 {
+        return Ok(None);
+    }
+
+    // Deduplicate to unique global IDs and check they all sit at one constant v
+    // while their longitudes cover the full circle (a full revolution).
+    let mut seen: DetHashSet<u32> = DetHashSet::default();
+    let mut ring: LatRing = Vec::with_capacity(gids.len());
+    let mut v_sum = 0.0;
+    let mut v_min = f64::INFINITY;
+    let mut v_max = f64::NEG_INFINITY;
+    for g in gids {
+        if !seen.insert(g) {
+            continue;
+        }
+        let p = merged.positions[g as usize];
+        let (u, v) = project(p);
+        v_sum += v;
+        v_min = v_min.min(v);
+        v_max = v_max.max(v);
+        ring.push((u, g));
+    }
+    if ring.len() < 3 {
+        return Ok(None);
+    }
+    if (v_max - v_min) > 1e-6 {
+        return Ok(None);
+    }
+    ring.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Full-revolution check: the largest angular gap between consecutive
+    // longitudes (including the wrap-around) must be well under a full turn —
+    // otherwise this is a partial arc, not a closed latitude loop.
+    let max_gap = ring
+        .windows(2)
+        .map(|w| w[1].0 - w[0].0)
+        .chain(std::iter::once(
+            ring[0].0 + std::f64::consts::TAU - ring[ring.len() - 1].0,
+        ))
+        .fold(0.0_f64, f64::max);
+    if max_gap > std::f64::consts::PI {
+        return Ok(None);
+    }
+
+    let v_level = v_sum / ring.len() as f64;
+    Ok(Some((v_level, ring)))
+}
+
+/// Build an interior latitude row of `n` evenly-spaced new vertices at constant
+/// `v`, returning them as a ring sorted by longitude.
+fn build_interior_row(
+    v: f64,
+    n: usize,
+    surf_eval: &dyn Fn(f64, f64) -> Point3,
+    surf_normal: &dyn Fn(f64, f64) -> Vec3,
+    merged: &mut TriangleMesh,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
+) -> LatRing {
+    let mut row: LatRing = Vec::with_capacity(n);
+    for i in 0..n {
+        let u = std::f64::consts::TAU * (i as f64) / (n as f64);
+        let p = surf_eval(u, v);
+        let key = point_merge_key(p, MERGE_GRID);
+        let gid = *point_to_global.entry(key).or_insert_with(|| {
+            let idx = merged.positions.len() as u32;
+            merged.positions.push(p);
+            merged.normals.push(surf_normal(u, v));
+            idx
+        });
+        row.push((u, gid));
+    }
+    row
+}
+
+/// Emit a default-oriented (non-reversed) triangle, mirroring the orientation
+/// convention of [`tessellate_revolution_band_shared`]: the geometric normal is
+/// flipped to match the surface outward normal. The caller applies the global
+/// `is_reversed` winding flip afterward.
+fn make_band_emit<'a>(
+    project: &'a dyn Fn(Point3) -> (f64, f64),
+    surf_normal: &'a dyn Fn(f64, f64) -> Vec3,
+) -> impl Fn(&mut TriangleMesh, u32, u32, u32) + 'a {
+    move |merged: &mut TriangleMesh, a: u32, b: u32, c: u32| {
+        if a == b || b == c || a == c {
+            return;
+        }
+        let (pa, pb, pc) = (
+            merged.positions[a as usize],
+            merged.positions[b as usize],
+            merged.positions[c as usize],
+        );
+        let geo = (pb - pa).cross(pc - pa);
+        if geo.length() < 1e-20 {
+            return;
+        }
+        let (u, v) = project(pa);
+        let outward = surf_normal(u, v);
+        let mut tri = [a, b, c];
+        if geo.dot(outward) < 0.0 {
+            tri.swap(1, 2);
+        }
+        merged.indices.extend_from_slice(&tri);
+    }
+}
+
+/// Triangulate the band between two coaxial latitude rings, both sorted by
+/// longitude in `[0, 2π)`, whose vertex counts/phases may differ. Walks both
+/// rings forward in longitude, at each step advancing whichever ring's next
+/// vertex has the smaller longitude (relative to a monotonically increasing
+/// base) and emitting one triangle per advance. Watertight by construction:
+/// every interior quad diagonal is shared by exactly two triangles, and after
+/// `nl + nh` advances each ring has been traversed once back to its start.
+fn stitch_rings(
+    merged: &mut TriangleMesh,
+    lo: &LatRing,
+    hi: &LatRing,
+    emit: &impl Fn(&mut TriangleMesh, u32, u32, u32),
+) {
+    if lo.len() < 2 || hi.len() < 2 {
+        return;
+    }
+    let (nl, nh) = (lo.len(), hi.len());
+    // Precompute the unwrapped (strictly increasing) longitude reached after
+    // `k` forward steps on each ring, k = 0..=len. Step 0 is the ring's first
+    // longitude; step len returns to it plus one full turn.
+    let unwrap_ring = |ring: &LatRing| -> Vec<f64> {
+        let mut acc = Vec::with_capacity(ring.len() + 1);
+        let mut prev = ring[0].0;
+        acc.push(prev);
+        for k in 1..=ring.len() {
+            let raw = ring[k % ring.len()].0;
+            // Forward gap to the next vertex, in (0, 2π]: a full turn on the
+            // wrap-around step (k == len), the spacing otherwise.
+            let mut gap = (raw - prev).rem_euclid(std::f64::consts::TAU);
+            if gap <= 0.0 {
+                gap = std::f64::consts::TAU;
+            }
+            prev += gap;
+            acc.push(prev);
+        }
+        acc
+    };
+    let lo_ang = unwrap_ring(lo);
+    let hi_ang = unwrap_ring(hi);
+
+    // Each ring is advanced exactly once around (nl + nh advances total). Once a
+    // ring has completed its revolution (`i == nl` / `j == nh`) it must not
+    // advance again, so its "next longitude" is treated as +inf.
+    let (mut i, mut j) = (0usize, 0usize);
+    for _ in 0..(nl + nh) {
+        let li = lo[i % nl].1;
+        let hj = hi[j % nh].1;
+        let lo_next = if i < nl { lo_ang[i + 1] } else { f64::INFINITY };
+        let hi_next = if j < nh { hi_ang[j + 1] } else { f64::INFINITY };
+        // Advance whichever ring's next vertex comes first in longitude; the new
+        // triangle's apex stays on the ring that did not advance.
+        if lo_next <= hi_next {
+            let li_next = lo[(i + 1) % nl].1;
+            emit(merged, li, li_next, hj);
+            i += 1;
+        } else {
+            let hj_next = hi[(j + 1) % nh].1;
+            emit(merged, li, hj_next, hj);
+            j += 1;
+        }
+    }
 }
 
 /// CDT-based tessellation for non-planar faces with exact boundary constraints.

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -11,7 +11,8 @@ use super::TriangleMesh;
 use super::edge_sampling::{circle_param_range, sample_edge, segments_for_chord_deviation_a};
 use super::mesh_ops::{dedupe_coincident_triangles, weld_boundary_vertices};
 use super::nonplanar::{
-    tessellate_nonplanar_cdt, tessellate_nonplanar_snap, tessellate_revolution_band_shared,
+    tessellate_latitude_band_shared, tessellate_nonplanar_cdt, tessellate_nonplanar_snap,
+    tessellate_revolution_band_shared,
 };
 use super::nurbs::{compute_angular_range, compute_v_param_range};
 use super::planar::{
@@ -883,41 +884,63 @@ pub(super) fn tessellate_face_with_shared_edges(
             }
         }
     } else {
-        let pos_save = merged.positions.len();
-        let nrm_save = merged.normals.len();
-        let idx_save = merged.indices.len();
-        let ptg_count_save = point_to_global.len();
-
-        let cdt_ok = tessellate_nonplanar_cdt(
+        // A sphere/torus latitude band (the annular region between two
+        // constant-v full-revolution boundaries, e.g. a cylinder bored through a
+        // sphere) degenerates in UV: each latitude projects to a zero-area
+        // back-and-forth segment, so the CDT below cannot bound the band and
+        // fills the removed polar cap. Tessellate such bands structurally from
+        // the shared boundary vertices instead. Returns false for any other
+        // sphere/torus face, which then takes the CDT/snap path unchanged.
+        let handled_band = matches!(
+            face_data.surface(),
+            FaceSurface::Sphere(_) | FaceSurface::Torus(_)
+        ) && tessellate_latitude_band_shared(
             topo,
-            face_id,
             face_data,
             deflection,
             angular_tol,
-            circle_floor,
             edge_global_indices,
             merged,
             point_to_global,
-        );
-        let cdt_produced_tris = cdt_ok.is_ok() && merged.indices.len() > idx_save;
-        if !cdt_produced_tris {
-            merged.positions.truncate(pos_save);
-            merged.normals.truncate(nrm_save);
-            merged.indices.truncate(idx_save);
-            if point_to_global.len() > ptg_count_save {
-                point_to_global.retain(|_, v| (*v as usize) < pos_save);
-            }
+        )?;
 
-            tessellate_nonplanar_snap(
+        if !handled_band {
+            let pos_save = merged.positions.len();
+            let nrm_save = merged.normals.len();
+            let idx_save = merged.indices.len();
+            let ptg_count_save = point_to_global.len();
+
+            let cdt_ok = tessellate_nonplanar_cdt(
                 topo,
                 face_id,
                 face_data,
                 deflection,
                 angular_tol,
+                circle_floor,
                 edge_global_indices,
                 merged,
                 point_to_global,
-            )?;
+            );
+            let cdt_produced_tris = cdt_ok.is_ok() && merged.indices.len() > idx_save;
+            if !cdt_produced_tris {
+                merged.positions.truncate(pos_save);
+                merged.normals.truncate(nrm_save);
+                merged.indices.truncate(idx_save);
+                if point_to_global.len() > ptg_count_save {
+                    point_to_global.retain(|_, v| (*v as usize) < pos_save);
+                }
+
+                tessellate_nonplanar_snap(
+                    topo,
+                    face_id,
+                    face_data,
+                    deflection,
+                    angular_tol,
+                    edge_global_indices,
+                    merged,
+                    point_to_global,
+                )?;
+            }
         }
     }
 

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -630,6 +630,96 @@ fn tessellate_boolean_cut_cone_watertight() {
     );
 }
 
+/// A cylinder bored through a sphere yields two spherical latitude bands (each a
+/// `Sphere` face whose only inner wire is the tunnel rim, bounded by the equator)
+/// plus an inner cylinder wall. Those bands degenerate in UV (each constant-v
+/// latitude projects to a zero-area segment), so the CDT path used to fill the
+/// removed polar cap — skinning over the tunnel mouth and inflating the mesh area
+/// to ~648 vs the analytic band area ~587.67. The structured latitude-band path
+/// must instead leave the mouth open: area must approach the analytic value from
+/// below (inscribed), the mesh must be watertight, and no vertex may reach the
+/// sphere pole (|z| stays at the rim's z, ~5.196, well below the radius 6).
+#[test]
+fn bored_sphere_band_area_and_watertight() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let sphere = crate::primitives::make_sphere(&mut topo, 6.0, 24).unwrap();
+    let cyl = crate::primitives::make_cylinder(&mut topo, 3.0, 30.0).unwrap();
+    crate::transform::transform_solid(&mut topo, cyl, &Mat4::translation(0.0, 0.0, -15.0)).unwrap();
+    let result =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Cut, sphere, cyl).unwrap();
+
+    // Analytic surface area: two spherical zones from the equator (z=0) to the
+    // rim (z=±sqrt(R²−r²)) plus the inner cylinder wall.
+    let r_sphere = 6.0_f64;
+    let z_rim = (r_sphere * r_sphere - 9.0).sqrt();
+    let zone = 2.0 * std::f64::consts::PI * r_sphere * z_rim; // one band
+    let cyl_wall = 2.0 * std::f64::consts::PI * 3.0 * (2.0 * z_rim);
+    let analytic = 2.0 * zone + cyl_wall;
+
+    // Area converges to the analytic value from below as deflection tightens.
+    let mut prev_area = 0.0_f64;
+    for &defl in &[0.1_f64, 0.02, 0.01] {
+        let mesh = tessellate_solid(&topo, result, defl).unwrap();
+
+        let mut area = 0.0;
+        for t in 0..mesh.indices.len() / 3 {
+            let a = mesh.positions[mesh.indices[t * 3 + 1] as usize]
+                - mesh.positions[mesh.indices[t * 3] as usize];
+            let b = mesh.positions[mesh.indices[t * 3 + 2] as usize]
+                - mesh.positions[mesh.indices[t * 3] as usize];
+            area += 0.5 * a.cross(b).length();
+        }
+
+        assert!(
+            is_watertight(&mesh),
+            "bored sphere must tessellate watertight at deflection {defl}: bd={} nm={}",
+            boundary_edge_count(&mesh),
+            non_manifold_edge_count(&mesh)
+        );
+
+        // The polar cap must be open: no vertex may approach the sphere pole.
+        let max_abs_z = mesh
+            .positions
+            .iter()
+            .map(|p| p.z().abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            max_abs_z < z_rim + 1e-6,
+            "tunnel mouth is filled: a vertex reached |z|={max_abs_z} (rim is {z_rim}, pole would be {r_sphere})"
+        );
+
+        // Inscribed band: area is below analytic and within deflection-scaled
+        // tolerance, and never below the previous (coarser) deflection.
+        assert!(
+            area <= analytic + 1.0,
+            "mesh area {area} exceeds analytic band area {analytic} (cap fill?) at deflection {defl}"
+        );
+        assert!(
+            area >= prev_area,
+            "area should not regress as deflection tightens: {area} < {prev_area}"
+        );
+        prev_area = area;
+    }
+
+    // At the default display deflection the area is close to analytic (and far
+    // from the ~648 cap-filled value the CDT path produced).
+    let mesh = tessellate_solid(&topo, result, 0.1).unwrap();
+    let mut area = 0.0;
+    for t in 0..mesh.indices.len() / 3 {
+        let a = mesh.positions[mesh.indices[t * 3 + 1] as usize]
+            - mesh.positions[mesh.indices[t * 3] as usize];
+        let b = mesh.positions[mesh.indices[t * 3 + 2] as usize]
+            - mesh.positions[mesh.indices[t * 3] as usize];
+        area += 0.5 * a.cross(b).length();
+    }
+    assert!(
+        (area - analytic).abs() < 5.0,
+        "default-deflection bored-sphere area {area} should be ~{analytic} (band), not ~648 (cap-filled)"
+    );
+}
+
 #[test]
 fn tessellate_solid_box_correct_area() {
     let mut topo = Topology::new();


### PR DESCRIPTION
## What

Makes `Cut(sphere, through-cylinder)` — and the bored-quadric family — produce an **exact analytic, watertight, correctly-rendered** result instead of the mesh fallback. Census: `sphere − cyl` **484ms / 1392 planar faces → 0.84ms / 3 analytic faces**.

Second PR in the campaign to close the four remaining boolean→mesh fallbacks (after #1003, the surface-aware face-AABB keystone).

## The boolean fix (the sphere was being dropped)

GFA returned 3 cyl faces with the sphere entirely gone. Root-caused to **five coupled gaps**, each unblocking the next:

1. **math** — no exact `(Sphere, Cylinder)` intersection arm: the generic marcher returned `NurbsCurve`, so the closed-circle FF split never fired. Added `exact_sphere_cylinder` (coaxial `z = ±√(R²−r²)` circles).
2. **phase_ff** — emit the section as `EdgeCurve::Circle`.
3. **face_splitter** — route an all-closed-circle-section hemisphere to `split_face_with_internal_loops` (cap + band-with-hole) instead of unsplitting; aim the sphere-band interior point toward the hole's latitude.
4. **same_domain** — don't fuse two curved same-surface faces that share an outer-wire edge set but cover **distinct regions** (the two hemisphere bands of a bored sphere share the equator polygon) — discriminate by interior sample.
5. **measure/check** — the annular spherical band over-integrates the removed polar cap; route bored-quadric volume to the orientation-aware, hole-clipped analytic integrator.

Result: 2 spherical bands-with-hole + 1 inner cylinder wall, watertight, volume = `V_sphere − V_bore`.

## The tessellation fix (so it renders correctly)

A sphere/torus band between two constant-`v` latitude circles is degenerate in UV (each latitude projects to a zero-area segment), so the CDT path filled the removed polar cap (mesh area 646 vs 587.7, tunnel mouth skinned over, not watertight). Added `tessellate_latitude_band_shared` — the curved analogue of the cylinder/cone band path: reuses the shared rim vertices at the two latitudes for watertight stitching, and inserts intermediate latitude rows for the surface curvature. Gated conservatively to full-revolution latitude bands; every other sphere/torus face takes the unchanged path. **Mesh area 646 → 586 (→587.9 at fine deflection), watertight, tunnel mouth open.**

## Verification

- Raw GFA: 3 analytic faces (2 sphere bands + cyl wall), free edges 0, manifold.
- Census: `sphere − cyl 0.84ms faces=3 exact analytic` (was 484ms/1392 FALLBACK); the other 8 boolean cases unchanged (no regression).
- Volume = **587.671** = `V_sphere − V_bore`.
- Tessellation: watertight at deflections 0.5→0.01, area converges to the analytic 587.7.
- Full workspace suite: **2454 passed, 9 skipped**; clippy clean; fmt clean; layer boundaries valid.
- Regression fixtures: `cut_sphere_by_through_cylinder_is_analytic_watertight` (boolean) + `bored_sphere_band_area_and_watertight` (tessellation).

## Known tech debt (not introduced here, flagged for follow-up)

`solid_volume` for a holed sphere routes to `analytic_sphere_signed_volume`, a **pre-existing** analytic function whose cap-vs-band logic is wrong for bored spheres (it caps only one of the two bands). This PR routes bored-quadric volume around it via the hole-clipped Gauss integrator (the `analytic_faces_solid_volume` fast path). Fixing `analytic_sphere_signed_volume` directly is a separate, deeper cleanup (three volume paths converge there) and is left for a dedicated PR.

## Does not touch

`box ∩ sphere` (different root — disjoint great-circle arcs), `cyl ∪ cyl`, `torus − box` remain fallback; their analytic splits are later PRs. The curved-band tessellation here will be reused by `torus − box`.
