### PR TITLE
fix(operations): close box∩sphere boolean analytically (seam split + collar render/volume)

### DIFF
--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -50,19 +50,16 @@ pub(super) fn split_noseam_face_direct(
         }]
     };
 
-    // Collect open section arcs on this face.
+    // Collect open section arcs on this face, plus any closed-circle sections
+    // (interior cap circles, e.g. a latitude cut that stays inside one
+    // hemisphere) which become holes in the assembled region.
     let mut open_sections: Vec<OrientedPCurveEdge> = Vec::new();
+    let mut closed_sections: Vec<OrientedPCurveEdge> = Vec::new();
     for section in sections {
         let pcurve_on_this_face = match rank {
             Rank::A => &section.pcurve_a,
             Rank::B => &section.pcurve_b,
         };
-
-        // Skip full-circle section edges (start approx end in 3D) -- only use
-        // the open arcs produced by the FF closed-circle split.
-        if (section.start - section.end).length() < tol {
-            continue;
-        }
 
         let precomputed_uv = match rank {
             Rank::A => section.start_uv_a.zip(section.end_uv_a),
@@ -78,7 +75,7 @@ pub(super) fn split_noseam_face_direct(
             )
         });
 
-        open_sections.push(OrientedPCurveEdge {
+        let edge = OrientedPCurveEdge {
             curve_3d: section.curve_3d.clone(),
             pcurve: pcurve_on_this_face.clone(),
             start_uv,
@@ -88,7 +85,15 @@ pub(super) fn split_noseam_face_direct(
             forward: true,
             source_edge_idx: None,
             pave_block_id: None,
-        });
+        };
+
+        // Full-circle section edges (start approx end in 3D) are interior caps;
+        // open arcs were produced by the FF boundary-crossing split.
+        if (section.start - section.end).length() < tol {
+            closed_sections.push(edge);
+        } else {
+            open_sections.push(edge);
+        }
     }
 
     if open_sections.is_empty() {
@@ -96,9 +101,22 @@ pub(super) fn split_noseam_face_direct(
     }
 
     // Chain the arcs into a single closed loop, greedily matching endpoints
-    // (with reversal). Disconnected or open chains fall back to unsplit.
-    let Some(cap_edges) = chain_closed_loop(open_sections, close_tol) else {
-        return unsplit();
+    // (with reversal). When the open arcs are disjoint (each crossing the
+    // boundary at distinct points, sharing no endpoints — e.g. a sphere
+    // hemisphere cut by several box faces along great-circle arcs), they
+    // cannot chain alone; assemble the regions by interleaving the boundary
+    // sub-segments between the arcs (a UV-space planar arrangement).
+    let Some(cap_edges) = chain_closed_loop(open_sections.clone(), close_tol) else {
+        return split_noseam_by_arrangement(
+            surface,
+            boundary_edges,
+            &open_sections,
+            &closed_sections,
+            rank,
+            reversed,
+            face_id,
+            tol,
+        );
     };
 
     // Boundary edges covered by a cap arc: both segment endpoints lie on
@@ -194,6 +212,491 @@ pub(super) fn split_noseam_face_direct(
             precomputed_interior: None,
         },
     ]
+}
+
+/// Split a sphere face whose disjoint open arcs cannot chain alone into a
+/// region sub-face, by interleaving the seam (boundary) sub-segments between
+/// the arcs.
+///
+/// Each open arc crosses the seam boundary at its two endpoints. The seam is a
+/// polygon inscribed in the seam circle, so the arcs land OFF its chords (by
+/// the polygon sagitta) and the chords cannot be split at them. Instead
+/// reconstruct the seam as its exact circle, split that at the crossings, and
+/// trace the arrangement of (seam arcs + open arcs) in UV. The wanted region —
+/// the slice of this hemisphere inside the cutting solid — is an annular collar
+/// (it wraps fully around longitude) bounded by a scalloped "bottom chain"
+/// (seam arcs alternating with great-circle arcs) with any interior latitude
+/// cap as an inner hole.
+#[allow(clippy::too_many_arguments)]
+fn split_noseam_by_arrangement(
+    surface: &FaceSurface,
+    boundary_edges: &[OrientedPCurveEdge],
+    open_sections: &[OrientedPCurveEdge],
+    closed_sections: &[OrientedPCurveEdge],
+    rank: crate::ds::Rank,
+    reversed: bool,
+    face_id: FaceId,
+    tol: f64,
+) -> Vec<SplitSubFace> {
+    let unsplit = || {
+        vec![SplitSubFace {
+            surface: surface.clone(),
+            outer_wire: boundary_edges.to_vec(),
+            inner_wires: Vec::new(),
+            reversed,
+            parent: face_id,
+            rank,
+            precomputed_interior: None,
+        }]
+    };
+
+    // Need at least two arcs to interleave; one arc is handled by the cap path.
+    if open_sections.len() < 2 {
+        return unsplit();
+    }
+
+    // Reconstruct the seam as its exact circle and split it at the crossings,
+    // so the seam arcs share endpoints EXACTLY with the open arcs.
+    let Some(seam_arcs) = build_seam_arcs(surface, boundary_edges, open_sections, tol) else {
+        return unsplit();
+    };
+
+    // Half-edge soup: every seam arc and every open arc in both orientations,
+    // so the angular traversal can bound a region from either side.
+    let both = |e: &OrientedPCurveEdge| -> [OrientedPCurveEdge; 2] {
+        let rev = OrientedPCurveEdge {
+            curve_3d: e.curve_3d.clone(),
+            pcurve: e.pcurve.clone(),
+            start_uv: e.end_uv,
+            end_uv: e.start_uv,
+            start_3d: e.end_3d,
+            end_3d: e.start_3d,
+            forward: !e.forward,
+            source_edge_idx: e.source_edge_idx,
+            pave_block_id: e.pave_block_id,
+        };
+        [e.clone(), rev]
+    };
+    let mut soup: Vec<OrientedPCurveEdge> = Vec::new();
+    for e in &seam_arcs {
+        soup.extend(both(e));
+    }
+    for a in open_sections {
+        soup.extend(both(a));
+    }
+
+    // Trace the arrangement faces in UV. The shared seam plane (all crossings
+    // at one latitude) makes the generic wire builder's endpoint-tangent sort
+    // ambiguous, so use a dedicated tracer that reads each half-edge's
+    // direction from its pcurve.
+    let loops = trace_region_loops(&soup, tol * 10.0);
+
+    let hole_loops: Vec<Vec<OrientedPCurveEdge>> =
+        closed_sections.iter().map(|c| vec![c.clone()]).collect();
+
+    // Net longitude wound by a loop (≈ ±2π for a chain that encircles the
+    // sphere once, ~0 for a lune or a back-and-forth chain). Robust where signed
+    // UV area is degenerate (all arrangement vertices sit on the seam, v=0).
+    let net_u = |l: &[OrientedPCurveEdge]| -> f64 {
+        use std::f64::consts::{PI, TAU};
+        let poly = loop_polyline(l);
+        if poly.len() < 2 {
+            return 0.0;
+        }
+        // Sum of shortest signed u-steps (each wrapped into (-pi, pi]) — a
+        // discretization-independent winding measure.
+        (0..poly.len())
+            .map(|i| {
+                let d = poly[(i + 1) % poly.len()].x() - poly[i].x();
+                d - TAU * ((d + PI) / TAU).floor()
+            })
+            .sum()
+    };
+    let loop_is_sliver = |l: &[OrientedPCurveEdge]| -> bool {
+        for i in 0..l.len() {
+            for j in (i + 1)..l.len() {
+                if (l[i].start_3d - l[j].end_3d).length() < tol * 100.0
+                    && (l[i].end_3d - l[j].start_3d).length() < tol * 100.0
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    };
+
+    // The collar's outer wire is the unique non-sliver loop encircling the
+    // sphere once in longitude. Orient it to oppose the parent boundary's
+    // winding (so the collar, not the discarded lunes, is its interior).
+    let parent_net_u = net_u(boundary_edges);
+    let mut best: Option<usize> = None;
+    for (i, l) in loops.iter().enumerate() {
+        if l.len() < 3 || loop_is_sliver(l) {
+            continue;
+        }
+        if net_u(l).abs() < std::f64::consts::PI {
+            continue;
+        }
+        if best.is_none_or(|b| l.len() > loops[b].len()) {
+            best = Some(i);
+        }
+    }
+
+    let Some(region_idx) = best else {
+        return unsplit();
+    };
+    let mut region = loops[region_idx].clone();
+    if net_u(&region) * parent_net_u > 0.0 {
+        region = reverse_loop(&region);
+    }
+
+    // 3D interior sample for classification (a point on the collar surface).
+    let interior_3d = patch_interior_point(surface, &hole_loops, open_sections);
+
+    // Each latitude cap on this hemisphere is an inner hole of the collar.
+    let region_holes: Vec<Vec<OrientedPCurveEdge>> =
+        hole_loops.iter().map(|hl| reverse_loop(hl)).collect();
+
+    vec![SplitSubFace {
+        surface: surface.clone(),
+        outer_wire: region,
+        inner_wires: region_holes,
+        reversed,
+        parent: face_id,
+        rank,
+        precomputed_interior: Some(interior_3d),
+    }]
+}
+
+/// Reconstruct a sphere face's seam (boundary) as its exact circle and split it
+/// at the open arcs' crossing points into seam-arc edges.
+///
+/// The seam circle is the intersection of the boundary polygon's plane with the
+/// sphere. Splitting the *circle* (rather than the inscribed chords) means the
+/// seam arcs share their endpoints exactly with the open arcs, which is what
+/// makes the assembled region watertight.
+fn build_seam_arcs(
+    surface: &FaceSurface,
+    boundary_edges: &[OrientedPCurveEdge],
+    open_sections: &[OrientedPCurveEdge],
+    tol: f64,
+) -> Option<Vec<OrientedPCurveEdge>> {
+    use brepkit_math::curves::Circle3D;
+    use brepkit_math::vec::Vec3;
+
+    let FaceSurface::Sphere(sphere) = surface else {
+        return None;
+    };
+
+    // Seam-plane normal + a point on it, from the boundary polygon (Newell).
+    let verts: Vec<Point3> = boundary_edges.iter().map(|e| e.start_3d).collect();
+    if verts.len() < 3 {
+        return None;
+    }
+    let mut nrm = Vec3::new(0.0, 0.0, 0.0);
+    let mut cen = Vec3::new(0.0, 0.0, 0.0);
+    let n = verts.len();
+    for i in 0..n {
+        let a = verts[i];
+        let b = verts[(i + 1) % n];
+        nrm += Vec3::new(
+            (a.y() - b.y()) * (a.z() + b.z()),
+            (a.z() - b.z()) * (a.x() + b.x()),
+            (a.x() - b.x()) * (a.y() + b.y()),
+        );
+        cen += Vec3::new(a.x(), a.y(), a.z());
+    }
+    let plane_n = nrm.normalize().ok()?;
+    #[allow(clippy::cast_precision_loss)]
+    let inv_n = 1.0 / n as f64;
+    let plane_pt = Point3::new(cen.x() * inv_n, cen.y() * inv_n, cen.z() * inv_n);
+
+    // Seam circle on the sphere: centre offset from the sphere centre along the
+    // plane normal by the plane's signed distance; radius from Pythagoras.
+    let h = (plane_pt - sphere.center()).dot(plane_n);
+    let rr = sphere.radius() * sphere.radius() - h * h;
+    if rr <= tol * tol {
+        return None;
+    }
+    let seam_radius = rr.sqrt();
+    let seam_center = sphere.center() + plane_n * h;
+    let seam_circle = Circle3D::new(seam_center, plane_n, seam_radius).ok()?;
+
+    // Crossing points = the open arcs' endpoints (they lie on the seam circle).
+    let mut unique: Vec<Point3> = Vec::new();
+    for p in open_sections.iter().flat_map(|a| [a.start_3d, a.end_3d]) {
+        if !unique.iter().any(|q| (*q - p).length() < tol * 100.0) {
+            unique.push(p);
+        }
+    }
+    if unique.len() < 2 {
+        return None;
+    }
+
+    // Sort crossings by angle on the seam circle, then build the arc between
+    // each consecutive pair (closing the loop).
+    let mut by_angle: Vec<(f64, Point3)> = unique
+        .into_iter()
+        .map(|p| (seam_circle.project(p), p))
+        .collect();
+    by_angle.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    let mut arcs: Vec<OrientedPCurveEdge> = Vec::new();
+    let m = by_angle.len();
+    for i in 0..m {
+        let (_, start_3d) = by_angle[i];
+        let (_, end_3d) = by_angle[(i + 1) % m];
+        if (start_3d - end_3d).length() < tol * 100.0 {
+            continue;
+        }
+        let curve = EdgeCurve::Circle(seam_circle.clone());
+        let pcurve = super::super::pcurve_compute::compute_pcurve_on_surface(
+            &curve,
+            start_3d,
+            end_3d,
+            surface,
+            &[],
+            None,
+        );
+        let start_uv =
+            super::super::pcurve_compute::project_point_on_surface(start_3d, surface, &[], None);
+        let end_uv =
+            super::super::pcurve_compute::project_point_on_surface(end_3d, surface, &[], None);
+        arcs.push(OrientedPCurveEdge {
+            curve_3d: curve,
+            pcurve,
+            start_uv,
+            end_uv,
+            start_3d,
+            end_3d,
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: None,
+        });
+    }
+    if arcs.len() < 2 {
+        return None;
+    }
+    Some(arcs)
+}
+
+/// Trace the faces of a planar half-edge arrangement in UV.
+///
+/// `soup` holds every undirected edge in both orientations. Each directed
+/// half-edge belongs to exactly one face loop; the next half-edge in a face is
+/// the first one counter-clockwise from the incoming edge's reverse at the
+/// shared vertex (the standard DCEL face walk). Directions are read from each
+/// pcurve so curved arcs that share a vertex with straight seam segments at the
+/// same latitude are distinguished. Returns every traced loop (callers drop the
+/// outer face / lunes by winding).
+fn trace_region_loops(soup: &[OrientedPCurveEdge], tol: f64) -> Vec<Vec<OrientedPCurveEdge>> {
+    use std::collections::HashMap;
+    use std::f64::consts::TAU;
+
+    let q = |v: f64| -> i64 {
+        #[allow(clippy::cast_possible_truncation)]
+        let r = (v / tol).round() as i64;
+        r
+    };
+    // u wraps; quantize u modulo 2π so seam-opposite endpoints share a key.
+    let key = |p: brepkit_math::vec::Point2| -> (i64, i64) { (q(p.x().rem_euclid(TAU)), q(p.y())) };
+
+    // Direction of a half-edge at one endpoint, from the pcurve's analytic
+    // tangent (it already encodes the correct arc and bulge — avoiding the
+    // shorter-arc ambiguity of half-circle 3D arcs and the straight-vs-curved
+    // confusion at a shared latitude). A reversed half-edge reuses the forward
+    // pcurve, so its logical start is the pcurve's domain end. `from_start=true`
+    // returns the OUTGOING direction at the logical start; `false` the INCOMING
+    // direction at the logical end (pointing back toward the start).
+    let edge_dir = |e: &OrientedPCurveEdge, from_start: bool| -> f64 {
+        use brepkit_math::curves2d::Curve2D;
+        let (mut dx, dy) = if let Curve2D::Nurbs(nurbs) = &e.pcurve {
+            let (t0, t1) = nurbs.domain();
+            let (t_at, sign) = match (from_start, e.forward) {
+                (true, true) => (t0, 1.0),
+                (true, false) => (t1, -1.0),
+                (false, true) => (t1, -1.0),
+                (false, false) => (t0, 1.0),
+            };
+            let tan = nurbs.tangent(t_at);
+            (tan.x() * sign, tan.y() * sign)
+        } else if from_start {
+            (e.end_uv.x() - e.start_uv.x(), e.end_uv.y() - e.start_uv.y())
+        } else {
+            (e.start_uv.x() - e.end_uv.x(), e.start_uv.y() - e.end_uv.y())
+        };
+        if dx.abs() > TAU * 0.5 {
+            dx -= dx.signum() * TAU;
+        }
+        dy.atan2(dx).rem_euclid(TAU)
+    };
+    let out_dir = |e: &OrientedPCurveEdge| -> f64 { edge_dir(e, true) };
+    let in_dir = |e: &OrientedPCurveEdge| -> f64 { edge_dir(e, false) };
+
+    let mut outgoing: HashMap<(i64, i64), Vec<usize>> = HashMap::new();
+    for (i, e) in soup.iter().enumerate() {
+        outgoing.entry(key(e.start_uv)).or_default().push(i);
+    }
+
+    let mut used = vec![false; soup.len()];
+    let mut loops: Vec<Vec<OrientedPCurveEdge>> = Vec::new();
+
+    for start in 0..soup.len() {
+        if used[start] {
+            continue;
+        }
+        let mut loop_edges: Vec<OrientedPCurveEdge> = Vec::new();
+        let mut cur = start;
+        let mut closed = false;
+        for _ in 0..=soup.len() {
+            used[cur] = true;
+            loop_edges.push(soup[cur].clone());
+            let end_key = key(soup[cur].end_uv);
+            if end_key == key(soup[start].start_uv) && loop_edges.len() >= 2 {
+                closed = true;
+                break;
+            }
+            let arrive_back = in_dir(&soup[cur]);
+            let Some(cands) = outgoing.get(&end_key) else {
+                break;
+            };
+            let mut best: Option<usize> = None;
+            let mut best_score = f64::MAX;
+            let mut fallback: Option<usize> = None;
+            let mut fb_score = f64::MAX;
+            for &c in cands {
+                if used[c] {
+                    continue;
+                }
+                let cd = out_dir(&soup[c]);
+                // First edge counter-clockwise from the reverse of the arriving
+                // edge (CCW-interior face walk).
+                let ccw = (cd - arrive_back).rem_euclid(TAU);
+                if ccw < fb_score {
+                    fb_score = ccw;
+                    fallback = Some(c);
+                }
+                if ccw < 1e-4 || (TAU - ccw) < 1e-4 {
+                    continue; // near-exact reverse (U-turn)
+                }
+                if ccw < best_score {
+                    best_score = ccw;
+                    best = Some(c);
+                }
+            }
+            let Some(next) = best.or(fallback) else {
+                break;
+            };
+            cur = next;
+        }
+        if closed && loop_edges.len() >= 2 {
+            loops.push(loop_edges);
+        }
+    }
+    loops
+}
+
+/// UV point on an oriented half-edge at fraction `f` in [0,1] of its logical
+/// start→end. A reversed half-edge reuses the forward pcurve, so its start is
+/// the pcurve's domain end; curved (NURBS) pcurves are sampled over their own
+/// domain (which is not generally [0,1]).
+fn sample_half_edge_uv(e: &OrientedPCurveEdge, f: f64) -> brepkit_math::vec::Point2 {
+    use brepkit_math::curves2d::Curve2D;
+    use brepkit_math::vec::Point2;
+    match &e.pcurve {
+        Curve2D::Nurbs(nurbs) => {
+            let (t0, t1) = nurbs.domain();
+            let p = if e.forward {
+                t0 + (t1 - t0) * f
+            } else {
+                t1 - (t1 - t0) * f
+            };
+            nurbs.evaluate(p)
+        }
+        _ => Point2::new(
+            e.start_uv.x() + (e.end_uv.x() - e.start_uv.x()) * f,
+            e.start_uv.y() + (e.end_uv.y() - e.start_uv.y()) * f,
+        ),
+    }
+}
+
+/// Polyline (UV) approximation of a loop, sampling curved edges.
+fn loop_polyline(loop_edges: &[OrientedPCurveEdge]) -> Vec<brepkit_math::vec::Point2> {
+    let mut poly = Vec::new();
+    for e in loop_edges {
+        let n = if matches!(e.curve_3d, EdgeCurve::Line) {
+            1
+        } else {
+            16
+        };
+        for k in 0..n {
+            #[allow(clippy::cast_precision_loss)]
+            let f = k as f64 / f64::from(n);
+            poly.push(sample_half_edge_uv(e, f));
+        }
+    }
+    poly
+}
+
+/// Reverse a loop's orientation (a hole is traversed opposite to the containing
+/// region's outer wire).
+fn reverse_loop(loop_edges: &[OrientedPCurveEdge]) -> Vec<OrientedPCurveEdge> {
+    loop_edges
+        .iter()
+        .rev()
+        .map(|e| OrientedPCurveEdge {
+            curve_3d: e.curve_3d.clone(),
+            pcurve: e.pcurve.clone(),
+            start_uv: e.end_uv,
+            end_uv: e.start_uv,
+            start_3d: e.end_3d,
+            end_3d: e.start_3d,
+            forward: !e.forward,
+            source_edge_idx: e.source_edge_idx,
+            pave_block_id: e.pave_block_id,
+        })
+        .collect()
+}
+
+/// A 3D interior sample on the in-solid collar patch, for classification.
+///
+/// When the face has a latitude cap, the sample is a point on the cap's
+/// latitude nudged toward the equator so it lands on the collar surface (not in
+/// the removed cap). Otherwise the patch reaches the pole, so use a near-pole
+/// point on the hemisphere the open arcs bulge toward.
+fn patch_interior_point(
+    surface: &FaceSurface,
+    hole_loops: &[Vec<OrientedPCurveEdge>],
+    open_sections: &[OrientedPCurveEdge],
+) -> Point3 {
+    use brepkit_math::vec::Vec3;
+    let FaceSurface::Sphere(sphere) = surface else {
+        return Point3::new(0.0, 0.0, 0.0);
+    };
+
+    if let Some(cap) = hole_loops.first().and_then(|h| h.first()) {
+        let (u_cap, v_cap) = sphere.project_point(cap.start_3d);
+        let v_sample = v_cap - v_cap.signum() * (v_cap.abs() * 0.25 + 0.05);
+        return sphere.evaluate(u_cap, v_sample);
+    }
+
+    // No cap: aim toward the pole the open arcs bulge to.
+    let mut dir = Vec3::new(0.0, 0.0, 0.0);
+    for e in open_sections {
+        let mid = super::super::pcurve_compute::evaluate_edge_at_t(
+            &e.curve_3d,
+            e.start_3d,
+            e.end_3d,
+            0.5,
+        );
+        if let Ok(d) = (mid - sphere.center()).normalize() {
+            dir += d;
+        }
+    }
+    match dir.normalize() {
+        Ok(d) => sphere.center() + d * sphere.radius(),
+        Err(_) => sphere.center() + Vec3::new(0.0, 0.0, sphere.radius()),
+    }
 }
 
 /// Greedily chain edges into one closed loop by matching 3D endpoints,

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -2366,11 +2366,17 @@ fn emit_split_circle_arcs(
             continue;
         }
 
-        // Split spans > π into 2+ sub-arcs by inserting midpoint vertices
-        // at evenly spaced t-values. Each sub-arc then has span ≤ π so
-        // downstream "shorter arc" interpretation matches the intended arc.
+        // Split into sub-arcs each spanning STRICTLY less than π by inserting
+        // midpoint vertices at evenly spaced t-values. A span of exactly π is a
+        // diametric semicircle: its two endpoints cannot distinguish it from its
+        // complement, so the downstream "shorter arc" interpretation is
+        // ambiguous AND the assembler's endpoint-keyed edge merge would collapse
+        // two distinct semicircles (e.g. the north/south halves of a sphere's
+        // section circle) into one edge. Dividing by a hair under π forces a
+        // midpoint vertex for any span ≥ π, giving each piece distinct
+        // endpoints.
         let arc_span = t1 - t0;
-        let n_sub = (arc_span / std::f64::consts::PI).ceil().max(1.0) as usize;
+        let n_sub = (arc_span / (std::f64::consts::PI * 0.999)).ceil().max(1.0) as usize;
         let step = arc_span / n_sub as f64;
         let mut points: Vec<(f64, Point3, Option<usize>)> = Vec::with_capacity(n_sub + 1);
         points.push((t0, crossings[i].1, Some(i)));

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -2143,6 +2143,24 @@ fn closed_circle_boundary_crossings(
 
     let mut hits: Vec<(f64, Point3)> = Vec::new();
     for &fid in &faces_to_check {
+        // A sphere hemisphere's boundary is a polygon inscribed in the seam
+        // (equator) circle. A section circle that genuinely crosses the seam
+        // does so at points that lie ON the seam circle but OUTSIDE the
+        // inscribed chords (by the polygon sagitta, which is ~5e-2 for 24
+        // facets ≫ tol), so the chord-based `face_hits` misses them entirely.
+        // Compute those crossings analytically against the seam *plane*
+        // instead — exact and independent of the boundary's facet count.
+        if matches!(surface_of(fid), Some(FaceSurface::Sphere(_))) {
+            for (t, p) in sphere_seam_plane_crossings(topo, fid, circle, tol) {
+                let dup = hits
+                    .iter()
+                    .any(|(_, q)| (*q - p).length() < tol.linear * 10.0);
+                if !dup {
+                    hits.push((t, p));
+                }
+            }
+            continue;
+        }
         let fh = face_hits(fid);
         // The boundary is coincident with the section circle when its
         // segments are chords of an *inscribed* polygon: every vertex lands
@@ -2176,6 +2194,116 @@ fn closed_circle_boundary_crossings(
     );
 
     hits
+}
+
+/// Crossings of a section `circle` with a sphere face's seam (boundary) plane.
+///
+/// A sphere hemisphere produced by the primitive builder is bounded by a
+/// polygon inscribed in its seam circle. Testing a section circle against
+/// those chords misses the true seam crossings by the polygon sagitta, so this
+/// computes the crossings analytically: fit the seam plane to the boundary
+/// vertices (independent of facet count and sphere orientation), then solve for
+/// the circle parameters `t` where the circle pierces that plane.
+///
+/// Returns the `(t, point)` crossings (0, 1 for a tangent, or 2) where the
+/// circle meets the seam plane and the crossing point lies on the sphere.
+fn sphere_seam_plane_crossings(
+    topo: &Topology,
+    fid: FaceId,
+    circle: &brepkit_math::curves::Circle3D,
+    tol: Tolerance,
+) -> Vec<(f64, Point3)> {
+    let Ok(face) = topo.face(fid) else {
+        return Vec::new();
+    };
+    let FaceSurface::Sphere(sphere) = face.surface() else {
+        return Vec::new();
+    };
+    let Ok(wire) = topo.wire(face.outer_wire()) else {
+        return Vec::new();
+    };
+
+    // Seam-plane normal + a point on it, from the boundary polygon (Newell's
+    // method), so the result is independent of facet count and orientation.
+    let verts: Vec<Point3> = wire
+        .edges()
+        .iter()
+        .filter_map(|oe| {
+            let edge = topo.edge(oe.edge()).ok()?;
+            let start = if oe.is_forward() {
+                edge.start()
+            } else {
+                edge.end()
+            };
+            topo.vertex(start)
+                .ok()
+                .map(brepkit_topology::vertex::Vertex::point)
+        })
+        .collect();
+    if verts.len() < 3 {
+        return Vec::new();
+    }
+    let mut normal = Vec3::new(0.0, 0.0, 0.0);
+    let mut centroid = Vec3::new(0.0, 0.0, 0.0);
+    let n = verts.len();
+    for i in 0..n {
+        let a = verts[i];
+        let b = verts[(i + 1) % n];
+        normal += Vec3::new(
+            (a.y() - b.y()) * (a.z() + b.z()),
+            (a.z() - b.z()) * (a.x() + b.x()),
+            (a.x() - b.x()) * (a.y() + b.y()),
+        );
+        centroid += Vec3::new(a.x(), a.y(), a.z());
+    }
+    let Ok(plane_n) = normal.normalize() else {
+        return Vec::new();
+    };
+    #[allow(clippy::cast_precision_loss)]
+    let inv_n = 1.0 / n as f64;
+    let plane_pt = Point3::new(
+        centroid.x() * inv_n,
+        centroid.y() * inv_n,
+        centroid.z() * inv_n,
+    );
+
+    // Solve A·cos t + B·sin t = -D for the circle parameter t, where the circle
+    // is C(t) = center + r(u·cos t + v·sin t) and the plane is
+    // (P - plane_pt)·plane_n = 0.
+    let cc = circle.center();
+    let r = circle.radius();
+    let a = r * circle.u_axis().dot(plane_n);
+    let b = r * circle.v_axis().dot(plane_n);
+    let d = (cc - plane_pt).dot(plane_n);
+    let amp = (a * a + b * b).sqrt();
+    if amp < tol.linear {
+        // Circle lies in (or parallel to) the seam plane — not a transversal
+        // crossing; defer to the chord-based path / interior treatment.
+        return Vec::new();
+    }
+    let rhs = -d / amp;
+    if rhs.abs() > 1.0 + 1e-9 {
+        return Vec::new();
+    }
+    let rhs = rhs.clamp(-1.0, 1.0);
+    let phase = b.atan2(a);
+    let alpha = rhs.acos();
+    let mut out: Vec<(f64, Point3)> = Vec::new();
+    for &t in &[phase + alpha, phase - alpha] {
+        let p = circle.evaluate(t);
+        let on_sphere =
+            ((p - sphere.center()).length() - sphere.radius()).abs() < tol.linear * 100.0;
+        if !on_sphere {
+            continue;
+        }
+        if !out
+            .iter()
+            .any(|(_, q)| (*q - p).length() < tol.linear * 10.0)
+        {
+            out.push((t.rem_euclid(std::f64::consts::TAU), p));
+        }
+    }
+    out
 }
 
 /// Whether boundary/circle hits describe an inscribed polygon (the boundary

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -2151,15 +2151,24 @@ fn closed_circle_boundary_crossings(
         // Compute those crossings analytically against the seam *plane*
         // instead — exact and independent of the boundary's facet count.
         if matches!(surface_of(fid), Some(FaceSurface::Sphere(_))) {
-            for (t, p) in sphere_seam_plane_crossings(topo, fid, circle, tol) {
-                let dup = hits
-                    .iter()
-                    .any(|(_, q)| (*q - p).length() < tol.linear * 10.0);
-                if !dup {
-                    hits.push((t, p));
+            let seam = sphere_seam_plane_crossings(topo, fid, circle, tol);
+            // Only take the analytic-seam path (and skip the chord-based
+            // `face_hits`) when the section actually crosses this face's seam —
+            // i.e. a hemisphere whose faceted equator's chords miss the true
+            // crossings by the sagitta. A section that doesn't cross the seam (a
+            // latitude-circle, or a non-hemisphere sphere face) falls through to
+            // the normal `face_hits` path below.
+            if !seam.is_empty() {
+                for (t, p) in seam {
+                    let dup = hits
+                        .iter()
+                        .any(|(_, q)| (*q - p).length() < tol.linear * 10.0);
+                    if !dup {
+                        hits.push((t, p));
+                    }
                 }
+                continue;
             }
-            continue;
         }
         let fh = face_hits(fid);
         // The boundary is coincident with the section circle when its

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1093,6 +1093,70 @@ fn intersect_box_sphere_succeeds() {
 }
 
 #[test]
+/// Intersect a 10³ box with a sphere of r=6 centered inside it (sphere fully
+/// enclosed in x/y/z extent but poking out each face). Each box face cuts a
+/// disc; the sphere becomes two annular "collar" patches (a scalloped
+/// great-circle/equator floor + a latitude-cap hole) — the analytic result is
+/// 6 plane discs + 2 sphere collars, watertight, with the lens volume.
+fn intersect_box_centered_sphere_is_analytic_collar() {
+    let mut topo = Topology::new();
+    let bx = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let sp = crate::primitives::make_sphere(&mut topo, 6.0, 24).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        sp,
+        &brepkit_math::mat::Mat4::translation(5.0, 5.0, 5.0),
+    )
+    .unwrap();
+    let result = boolean(&mut topo, BooleanOp::Intersect, bx, sp).unwrap();
+
+    let face_ids = brepkit_topology::explorer::solid_faces(&topo, result).unwrap();
+    let (mut planes, mut spheres, mut others) = (0usize, 0usize, 0usize);
+    for fid in &face_ids {
+        match topo.face(*fid).unwrap().surface() {
+            brepkit_topology::face::FaceSurface::Plane { .. } => planes += 1,
+            brepkit_topology::face::FaceSurface::Sphere(_) => spheres += 1,
+            _ => others += 1,
+        }
+    }
+    assert_eq!(
+        face_ids.len(),
+        8,
+        "expected 6 plane discs + 2 sphere collars, got {}",
+        face_ids.len()
+    );
+    assert_eq!(planes, 6, "expected 6 plane discs, got {planes}");
+    assert_eq!(
+        spheres, 2,
+        "expected 2 sphere collar patches, got {spheres}"
+    );
+    assert_eq!(others, 0, "no non-analytic faces expected, got {others}");
+
+    // Watertight: every edge shared by exactly two faces (analytic B-rep, not a
+    // mesh fallback).
+    let adj = brepkit_topology::adjacency::AdjacencyIndex::build(&topo, result).unwrap();
+    assert_eq!(
+        adj.boundary_edges().len(),
+        0,
+        "result must be watertight (0 free edges)"
+    );
+    assert!(adj.is_manifold(), "result must be manifold");
+
+    // Volume = V_sphere − 6 spherical caps (each cut at distance 5 from the
+    // r=6 sphere centre: cap height h=1, V_cap = π·h²·(3r−h)/3).
+    let r: f64 = 6.0;
+    let h: f64 = 1.0;
+    let v_sphere = 4.0 / 3.0 * std::f64::consts::PI * r.powi(3);
+    let v_cap = std::f64::consts::PI * h * h * (3.0 * r - h) / 3.0;
+    let expected = v_sphere - 6.0 * v_cap;
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 0.01,
+        "volume {vol:.3} should be within 1% of analytic {expected:.3}"
+    );
+}
+
+#[test]
 /// Fuse a 10³ box with a sphere of r=7.
 ///
 /// By inclusion-exclusion: V(A∪B) = V(A) + V(B) - V(A∩B).

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1092,12 +1092,12 @@ fn intersect_box_sphere_succeeds() {
     );
 }
 
-#[test]
 /// Intersect a 10³ box with a sphere of r=6 centered inside it (sphere fully
 /// enclosed in x/y/z extent but poking out each face). Each box face cuts a
 /// disc; the sphere becomes two annular "collar" patches (a scalloped
 /// great-circle/equator floor + a latitude-cap hole) — the analytic result is
 /// 6 plane discs + 2 sphere collars, watertight, with the lens volume.
+#[test]
 fn intersect_box_centered_sphere_is_analytic_collar() {
     let mut topo = Topology::new();
     let bx = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -44,14 +44,26 @@ fn sphere_outer_wire_constant_v(
         let Ok(edge) = topo.edge(oe.edge()) else {
             return false;
         };
-        let Ok(vtx) = topo.vertex(edge.start()) else {
+        let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
             return false;
         };
-        let (_, v) = sphere.project_point(vtx.point());
-        v_min = v_min.min(v);
-        v_max = v_max.max(v);
+        let (sp, ep) = (sv.point(), ev.point());
+        let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
+        // Sample ALONG each edge, not just its start vertex: a great-circle arc
+        // has both endpoints on the seam latitude yet bulges away from it, so
+        // endpoint-only sampling would mis-read a scalloped collar floor as a
+        // constant-v band and wrongly take the analytic fast path.
+        for i in 0..=8 {
+            let t = t0 + (t1 - t0) * (f64::from(i) / 8.0);
+            let (_, v) = sphere.project_point(edge.curve().evaluate_with_endpoints(t, sp, ep));
+            v_min = v_min.min(v);
+            v_max = v_max.max(v);
+        }
     }
-    (v_max - v_min) <= 1e-6
+    // Latitude-flatness threshold sized to the linear-tolerance magnitude: a
+    // real band's v-spread is ~fp-noise; a collar's is a large fraction of a
+    // radian.
+    (v_max - v_min) <= 1e-7
 }
 
 /// Whether the solid has at least one sphere face that is a scalloped collar

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -23,6 +23,67 @@ use super::helpers::{collect_solid_vertex_points, compute_angular_range};
 /// tessellation-based volume. Returns `None` (defer to tessellation) when no
 /// bored quadric is present, when any face is NURBS, or when a face fails to
 /// integrate.
+/// Whether a sphere face's outer wire lies on a single constant-`v` latitude
+/// (the simple bored-quadric band) rather than a scalloped, varying-`v` collar
+/// floor. Projects the outer wire's vertices to `(u, v)` and tests the `v`
+/// spread.
+fn sphere_outer_wire_constant_v(
+    topo: &Topology,
+    face_id: FaceId,
+    sphere: &brepkit_math::surfaces::SphericalSurface,
+) -> bool {
+    let Ok(face) = topo.face(face_id) else {
+        return false;
+    };
+    let Ok(wire) = topo.wire(face.outer_wire()) else {
+        return false;
+    };
+    let mut v_min = f64::INFINITY;
+    let mut v_max = f64::NEG_INFINITY;
+    for oe in wire.edges() {
+        let Ok(edge) = topo.edge(oe.edge()) else {
+            return false;
+        };
+        let Ok(vtx) = topo.vertex(edge.start()) else {
+            return false;
+        };
+        let (_, v) = sphere.project_point(vtx.point());
+        v_min = v_min.min(v);
+        v_max = v_max.max(v);
+    }
+    (v_max - v_min) <= 1e-6
+}
+
+/// Whether the solid has at least one sphere face that is a scalloped collar
+/// (a bored quadric whose outer wire varies in `v`, e.g. a box ∩ sphere patch).
+fn solid_has_scalloped_sphere_collar(topo: &Topology, solid: SolidId) -> bool {
+    let Ok(faces) = brepkit_topology::explorer::solid_faces(topo, solid) else {
+        return false;
+    };
+    faces.iter().any(|&fid| {
+        topo.face(fid).is_ok_and(|f| match f.surface() {
+            FaceSurface::Sphere(s) => {
+                !f.inner_wires().is_empty() && !sphere_outer_wire_constant_v(topo, fid, s)
+            }
+            _ => false,
+        })
+    })
+}
+
+/// Count mesh edges incident to a number of triangles other than 2 (boundary or
+/// non-manifold edges). Zero means a closed 2-manifold.
+fn mesh_boundary_edge_count(mesh: &tessellate::TriangleMesh) -> usize {
+    use brepkit_math::det_hash::DetHashMap;
+    let mut counts: DetHashMap<(u32, u32), usize> = DetHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        for &(i, j) in &[(tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0])] {
+            let key = if i < j { (i, j) } else { (j, i) };
+            *counts.entry(key).or_insert(0) += 1;
+        }
+    }
+    counts.values().filter(|&&c| c != 2).count()
+}
+
 fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     use brepkit_topology::explorer::solid_faces;
 
@@ -40,7 +101,15 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
             // for spheres. A bored torus would pass `hole_vs = []` and
             // over-integrate, so defer it to tessellation until torus
             // hole-clipping lands (with the torus−box analytic split).
-            FaceSurface::Sphere(_) if !face.inner_wires().is_empty() => {
+            FaceSurface::Sphere(s) if !face.inner_wires().is_empty() => {
+                // The integrator's hole-clipping models a band between two
+                // constant-v latitudes. A collar whose OUTER wire varies in v
+                // (great-circle/seam arcs, e.g. a box ∩ sphere patch) is not
+                // that shape — its scalloped floor and lune bites would be
+                // mis-integrated, so defer the whole solid to tessellation.
+                if !sphere_outer_wire_constant_v(topo, fid, s) {
+                    return None;
+                }
                 has_bored_quadric = true;
             }
             FaceSurface::Torus(_) if !face.inner_wires().is_empty() => return None,
@@ -358,6 +427,20 @@ pub fn solid_volume(
     // extent — never coarsening a finer request — so the volume is accurate
     // regardless of the (preview-tuned) deflection the caller passes.
     let deflection = volume_tessellation_deflection(topo, solid, deflection);
+
+    // A scalloped sphere collar (box ∩ sphere) cannot be per-face tessellated
+    // watertight (its band path needs the solid's shared boundary vertices), and
+    // its analytic integral is the hard u-dependent lune trim we defer. The
+    // whole-solid mesh IS watertight, so take the divergence-theorem volume off
+    // that closed mesh.
+    if solid_has_scalloped_sphere_collar(topo, solid) {
+        let mesh = tessellate::tessellate_solid(topo, solid, deflection)?;
+        if !mesh.indices.is_empty() && mesh_boundary_edge_count(&mesh) == 0 {
+            return Ok(signed_volume_from_mesh(&mesh));
+        }
+        // Non-watertight mesh: fall through to the generic paths below rather
+        // than return a leaky volume.
+    }
 
     // Fast path: for solids made entirely of planar triangular faces
     // (e.g. mesh imports), compute volume directly from face geometry.

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -215,76 +215,254 @@ pub(super) fn tessellate_latitude_band_shared(
         _ => return Ok(false),
     };
 
-    // Build one boundary ring per wire (outer first, then the single inner).
-    // Each must be a closed full-revolution loop at a single constant v.
-    let mut wire_ids = vec![face_data.outer_wire()];
-    wire_ids.extend_from_slice(face_data.inner_wires());
-    let mut rings: Vec<(f64, LatRing)> = Vec::with_capacity(2);
-    for &wid in &wire_ids {
-        let Some((v_level, ring)) =
-            collect_constant_v_ring(topo, wid, project.as_ref(), edge_global_indices, merged)?
-        else {
-            return Ok(false);
-        };
-        rings.push((v_level, ring));
-    }
-
-    // Order by v so we sweep from the lower latitude to the upper.
-    rings.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-    let (v_lo, ring_lo) = &rings[0];
-    let (v_hi, ring_hi) = &rings[1];
-    let (v_lo, v_hi) = (*v_lo, *v_hi);
-    if (v_hi - v_lo).abs() < 1e-9 {
-        return Ok(false);
-    }
-
-    // Number of intermediate latitude rows from the chord error across the band
-    // in v. The bulge radius is the sphere radius (torus: minor radius).
     let band_radius = match face_data.surface() {
         FaceSurface::Sphere(s) => s.radius(),
         FaceSurface::Torus(t) => t.minor_radius(),
         _ => return Ok(false),
     };
-    let n_v =
-        segments_for_chord_deviation_a(band_radius, v_hi - v_lo, deflection, angular_tol, true)
-            .max(1);
-
-    // Column count for the interior rows. Use the full-circle chord-deviation
-    // count at the band radius, but never fewer columns than the denser of the
-    // two boundary rings, so interior rows never undercut the boundary sampling.
-    let n_u_interior = ring_lo
-        .len()
-        .max(ring_hi.len())
-        .max(segments_for_chord_deviation_a(
-            band_radius,
-            std::f64::consts::TAU,
-            deflection,
-            angular_tol,
-            true,
-        ));
-
     let emit = make_band_emit(project.as_ref(), surf_normal.as_ref());
+    let full_circle_cols = segments_for_chord_deviation_a(
+        band_radius,
+        std::f64::consts::TAU,
+        deflection,
+        angular_tol,
+        true,
+    );
 
-    // Build interior rows (new face-local vertices on the full u ring), then
-    // stitch boundary_lo -> interior rows... -> boundary_hi.
-    let mut prev_ring: LatRing = ring_lo.clone();
+    let outer_wid = face_data.outer_wire();
+    let inner_wid = face_data.inner_wires()[0];
+
+    // Case 1 — both boundaries are single constant-v latitude circles (the
+    // bored-quadric band, e.g. sphere − through-cylinder). Sweep constant-v
+    // interior rows between them.
+    let outer_const = collect_constant_v_ring(
+        topo,
+        outer_wid,
+        project.as_ref(),
+        edge_global_indices,
+        merged,
+    )?;
+    let inner_const = collect_constant_v_ring(
+        topo,
+        inner_wid,
+        project.as_ref(),
+        edge_global_indices,
+        merged,
+    )?;
+
+    if let (Some((v_outer, ring_outer)), Some((v_inner, ring_inner))) = (&outer_const, &inner_const)
+    {
+        let mut rings = [
+            (*v_outer, ring_outer.clone()),
+            (*v_inner, ring_inner.clone()),
+        ];
+        rings.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        let (v_lo, ring_lo) = (&rings[0].0, &rings[0].1);
+        let (v_hi, ring_hi) = (&rings[1].0, &rings[1].1);
+        let (v_lo, v_hi) = (*v_lo, *v_hi);
+        if (v_hi - v_lo).abs() < 1e-9 {
+            return Ok(false);
+        }
+        let n_v =
+            segments_for_chord_deviation_a(band_radius, v_hi - v_lo, deflection, angular_tol, true)
+                .max(1);
+        let n_u_interior = ring_lo.len().max(ring_hi.len()).max(full_circle_cols);
+        let mut prev_ring: LatRing = ring_lo.clone();
+        for iv in 1..n_v {
+            #[allow(clippy::cast_precision_loss)]
+            let t = iv as f64 / n_v as f64;
+            let v = v_lo + (v_hi - v_lo) * t;
+            let row = build_interior_row(
+                v,
+                n_u_interior,
+                surf_eval.as_ref(),
+                surf_normal.as_ref(),
+                merged,
+                point_to_global,
+            );
+            stitch_rings(merged, &prev_ring, &row, &emit);
+            prev_ring = row;
+        }
+        stitch_rings(merged, &prev_ring, ring_hi, &emit);
+        return Ok(true);
+    }
+
+    // Case 2 — a COLLAR: the inner wire is a constant-v cap circle, the outer
+    // wire is a full-longitude-wrap "floor" at varying v (great-circle/seam
+    // arcs, e.g. a box ∩ sphere patch). Sweep interior rows whose per-column v
+    // interpolates from the scalloped floor up to the cap.
+    let Some((v_cap, cap_ring)) = inner_const else {
+        return Ok(false);
+    };
+    let Some(floor) = collect_var_v_ring(
+        topo,
+        outer_wid,
+        project.as_ref(),
+        edge_global_indices,
+        merged,
+    )?
+    else {
+        return Ok(false);
+    };
+    // The collar must straddle the cap (the floor sits on the far side of the
+    // cap latitude). Reject a near-flat outer wire (would be Case 1).
+    let floor_v_min = floor.iter().map(|r| r.1).fold(f64::INFINITY, f64::min);
+    let floor_v_max = floor.iter().map(|r| r.1).fold(f64::NEG_INFINITY, f64::max);
+    if (floor_v_max - floor_v_min) <= 1e-6 {
+        return Ok(false); // constant-v outer — Case 1 already tried it
+    }
+    let floor_v_near = if (v_cap - floor_v_max).abs() >= (v_cap - floor_v_min).abs() {
+        floor_v_max
+    } else {
+        floor_v_min
+    };
+    if (v_cap - floor_v_near).abs() < 1e-9 {
+        return Ok(false);
+    }
+
+    // The outer (scalloped) ring is the lower boundary; sweep up to the cap.
+    let _ = full_circle_cols;
+    let n_v = segments_for_chord_deviation_a(
+        band_radius,
+        v_cap - floor_v_near,
+        deflection,
+        angular_tol,
+        true,
+    )
+    .max(1);
+
+    // Lower boundary ring as a LatRing (drop the v component; the gid carries
+    // the shared scalloped-floor vertex).
+    let floor_ring: LatRing = floor.iter().map(|&(u, _, g)| (u, g)).collect();
+
+    // Emit the collar's triangles in the rings' consistent walk order WITHOUT a
+    // per-triangle normal flip, then orient the whole collar once below. (The
+    // per-triangle normal fix that the bored-band path uses is unstable for the
+    // thin stitch triangles bridging the clustered floor to the even cap — it
+    // flips neighbours inconsistently. A single decision keeps the collar a
+    // coherent 2-manifold.)
+    let collar_idx_start = merged.indices.len();
+    let emit_raw = |merged: &mut TriangleMesh, a: u32, b: u32, c: u32| {
+        if a == b || b == c || a == c {
+            return;
+        }
+        let (pa, pb, pc) = (
+            merged.positions[a as usize],
+            merged.positions[b as usize],
+            merged.positions[c as usize],
+        );
+        if (pb - pa).cross(pc - pa).length() < 1e-20 {
+            return;
+        }
+        merged.indices.extend_from_slice(&[a, b, c]);
+    };
+
+    // Connect the floor to each interior row as COLUMN-ALIGNED quad strips
+    // (same longitudes, same count), then zipper only the topmost interior row
+    // to the cap (different longitude sampling) with `stitch_rings`.
+    let mut prev_ring: LatRing = floor_ring;
     for iv in 1..n_v {
+        #[allow(clippy::cast_precision_loss)]
         let t = iv as f64 / n_v as f64;
-        let v = v_lo + (v_hi - v_lo) * t;
-        let row = build_interior_row(
-            v,
-            n_u_interior,
+        let row = build_collar_row(
+            &floor,
+            v_cap,
+            t,
             surf_eval.as_ref(),
             surf_normal.as_ref(),
             merged,
             point_to_global,
         );
-        stitch_rings(merged, &prev_ring, &row, &emit);
+        emit_aligned_quad_strip(merged, &prev_ring, &row, &emit_raw);
         prev_ring = row;
     }
-    stitch_rings(merged, &prev_ring, ring_hi, &emit);
+    stitch_rings(merged, &prev_ring, &cap_ring, &emit_raw);
+
+    // Orient the collar as a whole: pick the best-conditioned triangle (largest
+    // area), compare its geometric normal to the surface outward normal at its
+    // centroid, and flip every collar triangle's winding if they disagree.
+    orient_triangle_run(
+        merged,
+        collar_idx_start,
+        project.as_ref(),
+        surf_normal.as_ref(),
+    );
 
     Ok(true)
+}
+
+/// Make a contiguous run of triangles (added from `idx_start` onward) wind
+/// consistently outward. The run is already wound coherently (one orientation)
+/// by construction; this only decides whether that single orientation needs a
+/// global flip, using the largest-area triangle (most reliable normal) against
+/// the surface outward normal at its centroid.
+fn orient_triangle_run(
+    merged: &mut TriangleMesh,
+    idx_start: usize,
+    project: &dyn Fn(Point3) -> (f64, f64),
+    surf_normal: &dyn Fn(f64, f64) -> Vec3,
+) {
+    let mut best_area = 0.0_f64;
+    let mut flip = false;
+    let mut t = idx_start;
+    while t + 3 <= merged.indices.len() {
+        let (a, b, c) = (
+            merged.indices[t],
+            merged.indices[t + 1],
+            merged.indices[t + 2],
+        );
+        let (pa, pb, pc) = (
+            merged.positions[a as usize],
+            merged.positions[b as usize],
+            merged.positions[c as usize],
+        );
+        let geo = (pb - pa).cross(pc - pa);
+        let area = geo.length();
+        if area > best_area {
+            best_area = area;
+            let centroid = Point3::new(
+                (pa.x() + pb.x() + pc.x()) / 3.0,
+                (pa.y() + pb.y() + pc.y()) / 3.0,
+                (pa.z() + pb.z() + pc.z()) / 3.0,
+            );
+            let (u, v) = project(centroid);
+            flip = geo.dot(surf_normal(u, v)) < 0.0;
+        }
+        t += 3;
+    }
+    if flip {
+        let mut t = idx_start;
+        while t + 3 <= merged.indices.len() {
+            merged.indices.swap(t + 1, t + 2);
+            t += 3;
+        }
+    }
+}
+
+/// Connect two column-aligned rings (identical longitude order and count) as a
+/// quad strip: column `i` of `lo` joins column `i` of `hi`. Each quad is split
+/// into two triangles via [`emit`] (which fixes per-triangle winding from the
+/// surface normal). Watertight by construction when the rings share columns.
+fn emit_aligned_quad_strip(
+    merged: &mut TriangleMesh,
+    lo: &LatRing,
+    hi: &LatRing,
+    emit: &impl Fn(&mut TriangleMesh, u32, u32, u32),
+) {
+    let n = lo.len();
+    if n < 2 || hi.len() != n {
+        // Counts diverged (a merged-away duplicate column) — fall back to the
+        // longitude zipper, which tolerates unequal counts.
+        stitch_rings(merged, lo, hi, emit);
+        return;
+    }
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let (l0, l1) = (lo[i].1, lo[j].1);
+        let (h0, h1) = (hi[i].1, hi[j].1);
+        emit(merged, l0, l1, h1);
+        emit(merged, l0, h1, h0);
+    }
 }
 
 /// Collect a wire's shared boundary vertices as a `(v_level, ring)` pair, or
@@ -360,6 +538,68 @@ fn collect_constant_v_ring(
     Ok(Some((v_level, ring)))
 }
 
+/// A boundary ring whose latitude varies with longitude: `(u_angle, v, gid)`
+/// sorted ascending by `u_angle`. Used for a collar's scalloped outer wire (the
+/// great-circle/seam-arc "floor" of a box∩sphere patch), which encircles
+/// longitude fully but at a non-constant `v`.
+type VarRing = Vec<(f64, f64, u32)>;
+
+/// Collect a wire's shared boundary vertices as a longitude-sorted [`VarRing`],
+/// or `None` if the wire is not a closed full-revolution loop (built only from
+/// `Line`/`Circle` edges). Unlike [`collect_constant_v_ring`], the latitude may
+/// vary with longitude.
+fn collect_var_v_ring(
+    topo: &Topology,
+    wire_id: brepkit_topology::wire::WireId,
+    project: &dyn Fn(Point3) -> (f64, f64),
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
+    merged: &TriangleMesh,
+) -> Result<Option<VarRing>, crate::OperationsError> {
+    let wire = topo.wire(wire_id)?;
+    let mut gids: Vec<u32> = Vec::new();
+    for oe in wire.edges() {
+        let e = topo.edge(oe.edge())?;
+        match e.curve() {
+            EdgeCurve::Line | EdgeCurve::Circle(_) => {}
+            _ => return Ok(None),
+        }
+        let Some(edge_gids) = edge_global_indices.get(&oe.edge().index()) else {
+            return Ok(None);
+        };
+        gids.extend_from_slice(edge_gids);
+    }
+    if gids.len() < 3 {
+        return Ok(None);
+    }
+    let mut seen: DetHashSet<u32> = DetHashSet::default();
+    let mut ring: VarRing = Vec::with_capacity(gids.len());
+    for g in gids {
+        if !seen.insert(g) {
+            continue;
+        }
+        let (u, v) = project(merged.positions[g as usize]);
+        ring.push((u, v, g));
+    }
+    if ring.len() < 3 {
+        return Ok(None);
+    }
+    ring.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Full-revolution check: the largest longitude gap (including wrap-around)
+    // must be under a full turn — else it is a partial arc, not a closed loop.
+    let max_gap = ring
+        .windows(2)
+        .map(|w| w[1].0 - w[0].0)
+        .chain(std::iter::once(
+            ring[0].0 + std::f64::consts::TAU - ring[ring.len() - 1].0,
+        ))
+        .fold(0.0_f64, f64::max);
+    if max_gap > std::f64::consts::PI {
+        return Ok(None);
+    }
+    Ok(Some(ring))
+}
+
 /// Build an interior latitude row of `n` evenly-spaced new vertices at constant
 /// `v`, returning them as a ring sorted by longitude.
 fn build_interior_row(
@@ -373,6 +613,37 @@ fn build_interior_row(
     let mut row: LatRing = Vec::with_capacity(n);
     for i in 0..n {
         let u = std::f64::consts::TAU * (i as f64) / (n as f64);
+        let p = surf_eval(u, v);
+        let key = point_merge_key(p, MERGE_GRID);
+        let gid = *point_to_global.entry(key).or_insert_with(|| {
+            let idx = merged.positions.len() as u32;
+            merged.positions.push(p);
+            merged.normals.push(surf_normal(u, v));
+            idx
+        });
+        row.push((u, gid));
+    }
+    row
+}
+
+/// Build a collar interior row at the floor ring's exact longitudes — one
+/// column per floor vertex — each column's `v` interpolated a fraction `t` from
+/// that floor vertex's `v` up to the constant cap latitude `v_cap`. Keeping the
+/// interior rows column-aligned with the scalloped floor lets them connect as
+/// clean quad strips (no longitude zippering, so the scallop corners — where
+/// the floor dips to the seam — produce no flipped slivers).
+fn build_collar_row(
+    floor: &VarRing,
+    v_cap: f64,
+    t: f64,
+    surf_eval: &dyn Fn(f64, f64) -> Point3,
+    surf_normal: &dyn Fn(f64, f64) -> Vec3,
+    merged: &mut TriangleMesh,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
+) -> LatRing {
+    let mut row: LatRing = Vec::with_capacity(floor.len());
+    for &(u, v_floor, _) in floor {
+        let v = v_floor + (v_cap - v_floor) * t;
         let p = surf_eval(u, v);
         let key = point_merge_key(p, MERGE_GRID);
         let gid = *point_to_global.entry(key).or_insert_with(|| {
@@ -407,8 +678,16 @@ fn make_band_emit<'a>(
         if geo.length() < 1e-20 {
             return;
         }
-        let (u, v) = project(pa);
-        let outward = surf_normal(u, v);
+        // Reference the outward normal at all three vertices (averaged), not just
+        // `pa`: a thin stitch triangle bridging a clustered ring to an even one
+        // can sit nearly tangent to the surface, where the single-vertex normal
+        // makes `geo.dot(outward)` sign-unstable and flips the triangle relative
+        // to its neighbours. The averaged normal is stable across the triangle.
+        let n_at = |p: Point3| -> Vec3 {
+            let (u, v) = project(p);
+            surf_normal(u, v)
+        };
+        let outward = n_at(pa) + n_at(pb) + n_at(pc);
         let mut tri = [a, b, c];
         if geo.dot(outward) < 0.0 {
             tri.swap(1, 2);

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -321,10 +321,12 @@ pub(super) fn tessellate_latitude_band_shared(
     }
 
     // The outer (scalloped) ring is the lower boundary; sweep up to the cap.
-    let _ = full_circle_cols;
+    // Use the absolute band height: the floor can sit above the cap latitude
+    // (a southern collar), and a negative range trips the chord-deviation
+    // helper's `<= 0` fallback (a fixed count) instead of scaling with height.
     let n_v = segments_for_chord_deviation_a(
         band_radius,
-        v_cap - floor_v_near,
+        (v_cap - floor_v_near).abs(),
         deflection,
         angular_tol,
         true,
@@ -441,8 +443,10 @@ fn orient_triangle_run(
 
 /// Connect two column-aligned rings (identical longitude order and count) as a
 /// quad strip: column `i` of `lo` joins column `i` of `hi`. Each quad is split
-/// into two triangles via [`emit`] (which fixes per-triangle winding from the
-/// surface normal). Watertight by construction when the rings share columns.
+/// into two triangles via the supplied `emit` closure. The collar path passes
+/// `emit_raw` (no per-triangle winding correction — the whole run is oriented
+/// once afterward by [`orient_triangle_run`], which is stable for the thin
+/// stitch triangles). Watertight by construction when the rings share columns.
 fn emit_aligned_quad_strip(
     merged: &mut TriangleMesh,
     lo: &LatRing,

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -720,12 +720,12 @@ fn bored_sphere_band_area_and_watertight() {
     );
 }
 
-#[test]
 /// A box ∩ centered-sphere produces two annular sphere "collar" patches whose
 /// outer wire varies in v (a scalloped great-circle/equator floor) plus a
 /// latitude-cap hole. This is the varying-v generalization of the bored-sphere
 /// band: the collar must tessellate watertight (the CDT path leaves 98+ free
 /// edges) and its area must match the analytic box∩sphere boundary.
+#[test]
 fn box_centered_sphere_collar_tessellates_watertight() {
     use brepkit_math::mat::Mat4;
 

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -721,6 +721,54 @@ fn bored_sphere_band_area_and_watertight() {
 }
 
 #[test]
+/// A box ∩ centered-sphere produces two annular sphere "collar" patches whose
+/// outer wire varies in v (a scalloped great-circle/equator floor) plus a
+/// latitude-cap hole. This is the varying-v generalization of the bored-sphere
+/// band: the collar must tessellate watertight (the CDT path leaves 98+ free
+/// edges) and its area must match the analytic box∩sphere boundary.
+fn box_centered_sphere_collar_tessellates_watertight() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let bx = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let sp = crate::primitives::make_sphere(&mut topo, 6.0, 24).unwrap();
+    crate::transform::transform_solid(&mut topo, sp, &Mat4::translation(5.0, 5.0, 5.0)).unwrap();
+    let result =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Intersect, bx, sp).unwrap();
+
+    // Analytic boundary area: 6 plane discs (radius² = R²−5² = 11) + the sphere
+    // minus 6 spherical caps (each cap zone area = 2πRh, h=1).
+    let r: f64 = 6.0;
+    let disc_area = 6.0 * std::f64::consts::PI * 11.0;
+    let cap_zone = 2.0 * std::f64::consts::PI * r * 1.0;
+    let sphere_patch = 4.0 * std::f64::consts::PI * r * r - 6.0 * cap_zone;
+    let analytic_area = disc_area + sphere_patch;
+
+    for &defl in &[0.05_f64, 0.005] {
+        let mesh = tessellate_solid(&topo, result, defl).unwrap();
+        assert!(
+            is_watertight(&mesh),
+            "box∩sphere collar must tessellate watertight at deflection {defl}: bd={} nm={}",
+            boundary_edge_count(&mesh),
+            non_manifold_edge_count(&mesh)
+        );
+        let mut area = 0.0;
+        for t in 0..mesh.indices.len() / 3 {
+            let a = mesh.positions[mesh.indices[t * 3 + 1] as usize]
+                - mesh.positions[mesh.indices[t * 3] as usize];
+            let b = mesh.positions[mesh.indices[t * 3 + 2] as usize]
+                - mesh.positions[mesh.indices[t * 3] as usize];
+            area += 0.5 * a.cross(b).length();
+        }
+        // Inscribed mesh area is below analytic; within ~3% at these deflections.
+        assert!(
+            area <= analytic_area + 1.0 && area > analytic_area * 0.97,
+            "collar mesh area {area} should be ~{analytic_area} (no cap-fill) at deflection {defl}"
+        );
+    }
+}
+
+#[test]
 fn tessellate_solid_box_correct_area() {
     let mut topo = Topology::new();
     let solid = crate::primitives::make_box(&mut topo, 2.0, 3.0, 4.0).unwrap();


### PR DESCRIPTION
## What

Makes `Intersect(box, sphere)` produce an **exact analytic, watertight, correctly-rendered, correctly-measured** result instead of a 956-face mesh fallback. Census: **190ms / 956 mesh → 1.94ms / 8 analytic faces** (6 plane disks + 2 spherical collar patches).

Third PR in the campaign to close the four remaining boolean→mesh fallbacks (after #1003 keystone AABB, #1005 sphere−cyl). This is the hardest case — the centered sphere's collars are full-longitude-wrap bands with a *scalloped* floor.

## The fix — four coupled layers

**1. Section-circle split (`algo/phase_ff::emit_split_circle_arcs`)** — split arcs strictly *below* π. A span of exactly π is a diametric semicircle whose two halves share both endpoints, so the assembler's endpoint-keyed `merge_duplicate_edges` collapsed the distinct north/south arcs into one edge (failing the Euler gate). Forcing a midpoint vertex for any span ≥ π gives the two arcs distinct endpoints — **no merge-key change**, so the reversed-vertex merge of genuinely-shared arcs is untouched (this is what makes it regression-safe where a merge-key discriminator was not).

**2. Seam crossings (`algo/phase_ff::sphere_seam_plane_crossings`)** — a box face's great-circle section must cross the sphere's *faceted* equator to split, but testing against the inscribed chords missed the crossings by the polygon sagitta. Fit the seam plane (Newell) and solve circle∩plane analytically — facet-independent.

**3. Arrangement walk (`algo/face_splitter::split_noseam_by_arrangement`)** — the disjoint great-circle arcs share no endpoints, so the generic wire builder (which U-turns on the degenerate v=0 seam confluence) can't chain them. A dedicated DCEL arrangement walk assembles the box-face disks + the two collar patches, selecting the collar by longitude winding.

**4. Collar render + volume:**
- **Render** (`operations/tessellate`): generalize the revolution-band mesher to a *varying-v* collar — outer ring = scalloped great-circle/seam floor, inner ring = latitude-cap hole — with column-aligned curvature rows and a single whole-run orientation (the per-triangle normal flip is unstable on the thin stitch triangles). Watertight: 304 → 0 boundary edges.
- **Volume** (`operations/measure`): a scalloped collar's analytic integral is a deferred u-dependent lune trim, so its volume comes from the (now watertight) whole-solid mesh via the divergence theorem. The constant-v bored-quadric fast path (#1005 sphere−cyl) is gated to stay analytic and is unchanged.

## Verification

- Raw GFA: F=8 (6 disks + 2 collars), free edges 0, manifold.
- Census: `box ∩ sphere 1.94ms faces=8 exact analytic`; the other 8 boolean cases unchanged.
- Render: tessellated mesh watertight (0 boundary edges) at deflections 0.05 and 0.005; area matches analytic (no cap-fill).
- Volume: `solid_volume` = 797.4 (analytic 797.97, <0.1%), convergent across deflections.
- No regression: `sphere − cyl` still 587.671 analytic/watertight; plain sphere/cyl/cone/torus tessellate unchanged.
- Full suite: **2456 passed, 9 skipped**; clippy clean; fmt clean; layer boundaries valid.
- Fixtures: `intersect_box_centered_sphere_is_analytic_collar` (boolean) + `box_centered_sphere_collar_tessellates_watertight` (tessellation).

## Reused by `torus − box` (PR5)

Layer 1 (split) and the Layer-4 collar render/volume machinery are surface-agnostic / already dispatch for `Torus`, so the toroidal collar of `torus − box` will reuse them; only its analytic *split* (the plane×torus quartic) remains case-specific work.
