### PR TITLE
fix(algo): assemble perpendicular cyl∪cyl Fuse analytically

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -2821,13 +2821,17 @@ pub fn face_has_curved_lens_holes(topo: &Topology, face_id: FaceId) -> bool {
     }
     face.inner_wires().iter().any(|&wid| {
         topo.wire(wid).is_ok_and(|wire| {
-            wire.edges().iter().any(|oe| {
-                topo.edge(oe.edge()).is_ok_and(|e| {
-                    matches!(
-                        e.curve(),
-                        EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) | EdgeCurve::NurbsCurve(_)
-                    )
-                })
+            // The degenerate lens hole is a SINGLE closed curved edge (the seam
+            // ellipse). A regular curved hole (e.g. a drilled bore) has multiple
+            // edges and a working generic interior — don't force it to mesh.
+            let [oe] = wire.edges() else {
+                return false;
+            };
+            topo.edge(oe.edge()).is_ok_and(|e| {
+                matches!(
+                    e.curve(),
+                    EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) | EdgeCurve::NurbsCurve(_)
+                )
             })
         })
     })

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -2799,6 +2799,40 @@ pub fn split_face_2d(
     sub_faces
 }
 
+/// Whether a face is a cylinder/cone lateral wall carrying CURVED inner-wire
+/// loops — the lens-hole signature (a closed Circle/Ellipse/NURBS edge where
+/// another quadric crosses the wall). For these the generic `interior_point_3d`
+/// /`sample_face_interior` fallbacks are unsafe: each lens loop is a single
+/// closed edge with a degenerate start/end UV, so the assembled hole polygon is
+/// unusable and a generic sample can land inside the removed lens. The dedicated
+/// `cylinder_cone_remainder_interior` handles them; when even its dense grid
+/// finds no contained point, the analytic split must abort to mesh rather than
+/// classify the wall from inside the removed region.
+pub fn face_has_curved_lens_holes(topo: &Topology, face_id: FaceId) -> bool {
+    use brepkit_topology::edge::EdgeCurve;
+    let Ok(face) = topo.face(face_id) else {
+        return false;
+    };
+    if !matches!(
+        face.surface(),
+        FaceSurface::Cylinder(_) | FaceSurface::Cone(_)
+    ) {
+        return false;
+    }
+    face.inner_wires().iter().any(|&wid| {
+        topo.wire(wid).is_ok_and(|wire| {
+            wire.edges().iter().any(|oe| {
+                topo.edge(oe.edge()).is_ok_and(|e| {
+                    matches!(
+                        e.curve(),
+                        EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) | EdgeCurve::NurbsCurve(_)
+                    )
+                })
+            })
+        })
+    })
+}
+
 /// Get a point guaranteed inside a sub-face's outer wire (in UV space),
 /// not inside any inner wire (hole), then evaluate it to 3D via the surface.
 #[allow(clippy::too_many_lines)]

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1474,33 +1474,39 @@ fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> 
     // construction — AND outside every lens hole). A point outside the sub-face
     // fed to classification would drop valid curved wall faces, so an
     // uncontained best is rejected.
-    let mut best: Option<(f64, Point3)> = None;
-    let n_u = 48;
-    let n_v = 5;
-    for iu in 0..n_u {
-        #[allow(clippy::cast_precision_loss)]
-        let u = u_lo + u_span * (iu as f64) / f64::from(n_u);
-        for iv in 1..n_v {
+    let search = |n_u: u32, n_v: u32| -> Option<Point3> {
+        let mut best: Option<(f64, Point3)> = None;
+        for iu in 0..n_u {
             #[allow(clippy::cast_precision_loss)]
-            let v = v_min + (v_max - v_min) * (iv as f64) / f64::from(n_v);
-            if point_in_hole_loops_uv(&hole_segs, u, v) {
-                continue; // Inside a lens hole — not the kept region.
-            }
-            let Some(p) = remainder.surface.evaluate(u, v) else {
-                continue;
-            };
-            let min_d = hole_pts
-                .iter()
-                .map(|h| (*h - p).length())
-                .fold(f64::INFINITY, f64::min);
-            if best.is_none_or(|(bd, _)| min_d > bd) {
-                best = Some((min_d, p));
+            let u = u_lo + u_span * f64::from(iu) / f64::from(n_u);
+            for iv in 1..n_v {
+                #[allow(clippy::cast_precision_loss)]
+                let v = v_min + (v_max - v_min) * f64::from(iv) / f64::from(n_v);
+                if point_in_hole_loops_uv(&hole_segs, u, v) {
+                    continue; // Inside a lens hole — not the kept region.
+                }
+                let Some(p) = remainder.surface.evaluate(u, v) else {
+                    continue;
+                };
+                let min_d = hole_pts
+                    .iter()
+                    .map(|h| (*h - p).length())
+                    .fold(f64::INFINITY, f64::min);
+                if best.is_none_or(|(bd, _)| min_d > bd) {
+                    best = Some((min_d, p));
+                }
             }
         }
-    }
-    // No contained candidate found → report (keep the interior unset) rather
-    // than return a point outside the sub-face.
-    best.map(|(_, p)| p)
+        best.map(|(_, p)| p)
+    };
+
+    // First pass at the standard density (the census finds a contained interior
+    // here). If a thin kept strip or a close pair of lens loops yields nothing
+    // contained at this resolution, take ONE refined denser pass before giving
+    // up — a present-but-narrow remainder strip then resolves. Returning `None`
+    // (no contained point even dense) signals the caller to abort the analytic
+    // split rather than fall back to an uncontained generic interior point.
+    search(48, 5).or_else(|| search(256, 17))
 }
 
 /// Whether `(u, v)` lies inside the region bounded by the combined inner-loop
@@ -2106,6 +2112,62 @@ mod tests {
         assert!(
             (p - hole_center).length() > 1.5,
             "interior point must be clear of the hole, got dist {}",
+            (p - hole_center).length()
+        );
+    }
+
+    #[test]
+    fn remainder_interior_found_for_thin_kept_strip() {
+        // A narrow wall band v∈[8,12] mostly filled by a large lens hole centred
+        // at v=10, leaving only thin kept strips near the rims. The two-pass grid
+        // (coarse then dense) must still return an ON-WALL point CLEAR of the
+        // hole — never `None`, which would abort the analytic split. Exercises
+        // robustness of the contained-interior search on a thin remainder.
+        use super::super::super::split_types::SplitSubFace;
+        use crate::ds::Rank;
+        use brepkit_topology::topology::Topology;
+
+        let mut dummy_topo = Topology::new();
+        let parent = brepkit_topology::test_utils::make_unit_square_face(&mut dummy_topo);
+
+        let cyl =
+            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        let surface = FaceSurface::Cylinder(cyl);
+
+        // Narrow band v∈[8,12].
+        let bot = Circle3D::new(Point3::new(0.0, 0.0, 8.0), Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+        let top =
+            Circle3D::new(Point3::new(0.0, 0.0, 12.0), Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+        let outer = vec![
+            arc_edge(&bot, 0.0, TAU, true),
+            line_chord(Point3::new(3.0, 0.0, 8.0), Point3::new(3.0, 0.0, 12.0)),
+            arc_edge(&top, 0.0, TAU, true),
+            line_chord(Point3::new(3.0, 0.0, 12.0), Point3::new(3.0, 0.0, 8.0)),
+        ];
+
+        // Big hole centred at (3,0,10) nearly filling the 4-unit band.
+        let hole_center = Point3::new(3.0, 0.0, 10.0);
+        let hole = Circle3D::new(hole_center, Vec3::new(1.0, 0.0, 0.0), 1.9).unwrap();
+        let inner = vec![vec![arc_edge(&hole, 0.0, TAU, true)]];
+
+        let sub = SplitSubFace {
+            surface,
+            outer_wire: outer,
+            inner_wires: inner,
+            reversed: false,
+            parent,
+            rank: Rank::A,
+            precomputed_interior: None,
+        };
+
+        // The two-pass search must find a contained point in the thin kept strip.
+        let p = super::cylinder_cone_remainder_interior(&sub).unwrap();
+        let radial = (p.x() * p.x() + p.y() * p.y()).sqrt();
+        assert!((radial - 3.0).abs() < 1e-6, "interior point on the wall");
+        assert!(
+            (p - hole_center).length() > 1.9,
+            "interior point must be outside the hole, got dist {}",
             (p - hole_center).length()
         );
     }

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1339,7 +1339,7 @@ pub(super) fn split_face_with_internal_loops(
     // outside sub-face — dropping them would leave the faces ringing those
     // holes with free edges.
     all_holes.extend(original_inner_wires.iter().cloned());
-    result.push(SplitSubFace {
+    let remainder = SplitSubFace {
         surface: surface.clone(),
         outer_wire: boundary_edges.to_vec(),
         inner_wires: all_holes,
@@ -1347,9 +1347,108 @@ pub(super) fn split_face_with_internal_loops(
         parent: face_id,
         rank,
         precomputed_interior: frame_interior,
-    });
+    };
+    // A curved analytic lateral remainder (cylinder/cone) keeps its hole loops
+    // as CURVED edges (e.g. the closed ellipses where two perpendicular
+    // cylinders cross), so the all-Line `frame_interior` heuristic above leaves
+    // `precomputed_interior` unset. Without it the classifier falls back to
+    // sampling the WHOLE parent face — which lands at the axial midpoint inside
+    // a lens hole and misclassifies the remainder (a Fuse then drops the entire
+    // wall). The generic UV hole-avoidance can't help either: each lens loop is
+    // a single closed edge with a degenerate start/end UV, so it forms no usable
+    // hole polygon. Sample the wall on a (u,v) grid and pick the point whose
+    // nearest 3D distance to every hole loop is greatest — guaranteed on the
+    // kept wall, away from every lens.
+    let mut remainder = remainder;
+    if remainder.precomputed_interior.is_none()
+        && matches!(
+            remainder.surface,
+            FaceSurface::Cylinder(_) | FaceSurface::Cone(_)
+        )
+        && !remainder.inner_wires.is_empty()
+    {
+        remainder.precomputed_interior = cylinder_cone_remainder_interior(&remainder);
+    }
+    result.push(remainder);
 
     result
+}
+
+/// Interior point on a cylinder/cone lateral remainder face that carries
+/// CURVED hole loops (the lens loops where another quadric crosses the wall).
+///
+/// The generic UV hole-avoidance fails for these — each lens is a single closed
+/// edge whose start/end UV coincide, so it yields no point-in-polygon hole. This
+/// instead samples the wall on a `(u, v)` grid (`u` over the full revolution,
+/// `v` over the boundary's axial span) and returns the 3D point whose minimum
+/// distance to every hole loop is largest, which is guaranteed to lie on the
+/// kept wall well clear of every lens. Returns `None` if the surface evaluator
+/// or boundary v-range is unusable, so the caller keeps the unset interior.
+fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> {
+    use std::f64::consts::TAU;
+
+    // Densely sample every hole loop into 3D points once.
+    let mut hole_pts: Vec<Point3> = Vec::new();
+    for hole in &remainder.inner_wires {
+        for edge in hole {
+            let (t0, t1) = edge
+                .curve_3d
+                .domain_with_endpoints(edge.start_3d, edge.end_3d);
+            let n = 24;
+            for k in 0..n {
+                #[allow(clippy::cast_precision_loss)]
+                let t = t0 + (t1 - t0) * (k as f64 / f64::from(n));
+                hole_pts.push(
+                    edge.curve_3d
+                        .evaluate_with_endpoints(t, edge.start_3d, edge.end_3d),
+                );
+            }
+        }
+    }
+    if hole_pts.is_empty() {
+        return None;
+    }
+
+    // Axial span (v) of the boundary wire — the wall lives between its
+    // bounding circles. Project boundary endpoints to the surface's v.
+    let mut v_min = f64::INFINITY;
+    let mut v_max = f64::NEG_INFINITY;
+    for e in &remainder.outer_wire {
+        for p in [e.start_3d, e.end_3d] {
+            if let Some((_, v)) = remainder.surface.project_point(p) {
+                v_min = v_min.min(v);
+                v_max = v_max.max(v);
+            }
+        }
+    }
+    if !v_min.is_finite() || !v_max.is_finite() || (v_max - v_min) <= 0.0 {
+        return None;
+    }
+
+    // Grid-search (u, v) for the wall point maximising the minimum 3D distance
+    // to the hole loops.
+    let mut best: Option<(f64, Point3)> = None;
+    let n_u = 48;
+    let n_v = 5;
+    for iu in 0..n_u {
+        #[allow(clippy::cast_precision_loss)]
+        let u = TAU * (iu as f64) / f64::from(n_u);
+        for iv in 1..n_v {
+            #[allow(clippy::cast_precision_loss)]
+            let v = v_min + (v_max - v_min) * (iv as f64) / f64::from(n_v);
+            let Some(p) = remainder.surface.evaluate(u, v) else {
+                continue;
+            };
+            let min_d = hole_pts
+                .iter()
+                .map(|h| (*h - p).length())
+                .fold(f64::INFINITY, f64::min);
+            if best.is_none_or(|(bd, _)| min_d > bd) {
+                best = Some((min_d, p));
+            }
+        }
+    }
+    best.map(|(_, p)| p)
 }
 
 /// Reorder and reverse boundary edges to form a closed chain.

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1385,8 +1385,6 @@ pub(super) fn split_face_with_internal_loops(
 /// kept wall well clear of every lens. Returns `None` if the surface evaluator
 /// or boundary v-range is unusable, so the caller keeps the unset interior.
 fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> {
-    use std::f64::consts::TAU;
-
     // Densely sample every hole loop into 3D points once.
     let mut hole_pts: Vec<Point3> = Vec::new();
     for hole in &remainder.inner_wires {
@@ -1409,30 +1407,47 @@ fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> 
         return None;
     }
 
-    // Axial span (v) of the boundary wire — the wall lives between its
-    // bounding circles. Project boundary endpoints to the surface's v.
+    // Angular (u) and axial (v) extent the boundary wire actually covers —
+    // densely sampled so a partial-arc face (e.g. a rounded-rect corner
+    // quarter-cylinder) is searched only over its OWN span, not the full
+    // revolution (a 0..TAU grid could pick an interior point off the sub-face,
+    // mis-classifying it). A full-revolution wall covers the whole period and
+    // its boundary samples span it.
+    let mut u_samples: Vec<f64> = Vec::new();
     let mut v_min = f64::INFINITY;
     let mut v_max = f64::NEG_INFINITY;
     for e in &remainder.outer_wire {
-        for p in [e.start_3d, e.end_3d] {
-            if let Some((_, v)) = remainder.surface.project_point(p) {
+        let (t0, t1) = e.curve_3d.domain_with_endpoints(e.start_3d, e.end_3d);
+        let n = 16;
+        for k in 0..=n {
+            #[allow(clippy::cast_precision_loss)]
+            let t = t0 + (t1 - t0) * (k as f64 / f64::from(n));
+            let p = e.curve_3d.evaluate_with_endpoints(t, e.start_3d, e.end_3d);
+            if let Some((u, v)) = remainder.surface.project_point(p) {
+                u_samples.push(u);
                 v_min = v_min.min(v);
                 v_max = v_max.max(v);
             }
         }
     }
-    if !v_min.is_finite() || !v_max.is_finite() || (v_max - v_min) <= 0.0 {
+    if !v_min.is_finite() || !v_max.is_finite() || (v_max - v_min) <= 0.0 || u_samples.is_empty() {
         return None;
     }
 
+    // The covered u-interval `[u_lo, u_lo + u_span]`: the complement of the
+    // largest gap between sorted u-samples. `u_span ≈ TAU` is a full revolution
+    // (search the whole period); a smaller span restricts the grid to the arc
+    // the face occupies.
+    let (u_lo, u_span) = covered_u_interval(&u_samples);
+
     // Grid-search (u, v) for the wall point maximising the minimum 3D distance
-    // to the hole loops.
+    // to the hole loops, over the face's actual extent only.
     let mut best: Option<(f64, Point3)> = None;
     let n_u = 48;
     let n_v = 5;
     for iu in 0..n_u {
         #[allow(clippy::cast_precision_loss)]
-        let u = TAU * (iu as f64) / f64::from(n_u);
+        let u = u_lo + u_span * (iu as f64) / f64::from(n_u);
         for iv in 1..n_v {
             #[allow(clippy::cast_precision_loss)]
             let v = v_min + (v_max - v_min) * (iv as f64) / f64::from(n_v);
@@ -1449,6 +1464,33 @@ fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> 
         }
     }
     best.map(|(_, p)| p)
+}
+
+/// Given angular samples (radians, any 2π window), return `(u_lo, u_span)` —
+/// the contiguous interval the samples cover, computed as the complement of the
+/// largest angular gap between consecutive sorted samples. A full revolution
+/// returns `u_span ≈ TAU`; a partial arc returns its true (shorter) span.
+fn covered_u_interval(u_samples: &[f64]) -> (f64, f64) {
+    use std::f64::consts::TAU;
+    let mut us: Vec<f64> = u_samples.iter().map(|u| u.rem_euclid(TAU)).collect();
+    us.sort_by(f64::total_cmp);
+    us.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
+    if us.len() < 2 {
+        return (us.first().copied().unwrap_or(0.0), TAU);
+    }
+    // Largest gap between consecutive samples (including the wrap gap).
+    let mut max_gap = us[0] + TAU - us[us.len() - 1]; // wrap-around gap
+    let mut gap_after = us[us.len() - 1]; // the sample BEFORE the wrap gap
+    for w in us.windows(2) {
+        let gap = w[1] - w[0];
+        if gap > max_gap {
+            max_gap = gap;
+            gap_after = w[0];
+        }
+    }
+    // The covered interval starts just after the largest gap and spans the rest.
+    let u_lo = (gap_after + max_gap).rem_euclid(TAU);
+    (u_lo, TAU - max_gap)
 }
 
 /// Reorder and reverse boundary edges to form a closed chain.

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1385,21 +1385,42 @@ pub(super) fn split_face_with_internal_loops(
 /// kept wall well clear of every lens. Returns `None` if the surface evaluator
 /// or boundary v-range is unusable, so the caller keeps the unset interior.
 fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> {
-    // Densely sample every hole loop into 3D points once.
+    use std::f64::consts::TAU;
+    // Densely sample every hole loop into 3D points AND project each to a (u, v)
+    // polyline so candidate interior points can be tested for face containment
+    // (outside every hole). Endpoint UVs are unusable here — a lens hole is one
+    // closed edge whose start/end UV coincide — so sample the curve.
     let mut hole_pts: Vec<Point3> = Vec::new();
+    // Inner-loop (u, v) segments (split at the seam), for the even-odd
+    // vertical-ray hole-containment test below.
+    let mut hole_segs: Vec<(f64, f64, f64, f64)> = Vec::new();
+    let n = 48;
     for hole in &remainder.inner_wires {
+        let mut prev_uv: Option<(f64, f64)> = None;
         for edge in hole {
             let (t0, t1) = edge
                 .curve_3d
                 .domain_with_endpoints(edge.start_3d, edge.end_3d);
-            let n = 24;
-            for k in 0..n {
+            for k in 0..=n {
                 #[allow(clippy::cast_precision_loss)]
                 let t = t0 + (t1 - t0) * (k as f64 / f64::from(n));
-                hole_pts.push(
-                    edge.curve_3d
-                        .evaluate_with_endpoints(t, edge.start_3d, edge.end_3d),
-                );
+                let p = edge
+                    .curve_3d
+                    .evaluate_with_endpoints(t, edge.start_3d, edge.end_3d);
+                hole_pts.push(p);
+                if let Some((u, v)) = remainder.surface.project_point(p) {
+                    if let Some((pu, pv)) = prev_uv
+                        && (u - pu).abs() < TAU * 0.5
+                    {
+                        let (a_u, a_v, b_u, b_v) = if pu <= u {
+                            (pu, pv, u, v)
+                        } else {
+                            (u, v, pu, pv)
+                        };
+                        hole_segs.push((a_u, a_v, b_u, b_v));
+                    }
+                    prev_uv = Some((u, v));
+                }
             }
         }
     }
@@ -1441,7 +1462,11 @@ fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> 
     let (u_lo, u_span) = covered_u_interval(&u_samples);
 
     // Grid-search (u, v) for the wall point maximising the minimum 3D distance
-    // to the hole loops, over the face's actual extent only.
+    // to the hole loops, over the face's actual extent only, accepting ONLY
+    // candidates that are face-CONTAINED (inside the covered u/v extent — by
+    // construction — AND outside every lens hole). A point outside the sub-face
+    // fed to classification would drop valid curved wall faces, so an
+    // uncontained best is rejected.
     let mut best: Option<(f64, Point3)> = None;
     let n_u = 48;
     let n_v = 5;
@@ -1451,6 +1476,9 @@ fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> 
         for iv in 1..n_v {
             #[allow(clippy::cast_precision_loss)]
             let v = v_min + (v_max - v_min) * (iv as f64) / f64::from(n_v);
+            if point_in_hole_loops_uv(&hole_segs, u, v) {
+                continue; // Inside a lens hole — not the kept region.
+            }
             let Some(p) = remainder.surface.evaluate(u, v) else {
                 continue;
             };
@@ -1463,7 +1491,44 @@ fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> 
             }
         }
     }
+    // No contained candidate found → report (keep the interior unset) rather
+    // than return a point outside the sub-face.
     best.map(|(_, p)| p)
+}
+
+/// Whether `(u, v)` lies inside the region bounded by the combined inner-loop
+/// `(u, v)` segments — an even-odd vertical-ray test. Each segment is tested in
+/// every 2π `u`-translate so a seam-wrapping lens loop is matched. A wall
+/// interior point must be OUTSIDE every hole (this returns `false`) to lie in
+/// the kept remainder region.
+fn point_in_hole_loops_uv(hole_segs: &[(f64, f64, f64, f64)], u: f64, v: f64) -> bool {
+    use std::f64::consts::TAU;
+    let seg_u_min = hole_segs.iter().map(|s| s.0).fold(f64::INFINITY, f64::min);
+    let seg_u_max = hole_segs
+        .iter()
+        .map(|s| s.2)
+        .fold(f64::NEG_INFINITY, f64::max);
+    if !seg_u_min.is_finite() {
+        return false;
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    let k0 = ((seg_u_min - u) / TAU).floor() as i64;
+    #[allow(clippy::cast_possible_truncation)]
+    let k1 = ((seg_u_max - u) / TAU).ceil() as i64;
+    let mut crossings = 0u32;
+    for k in k0..=k1 {
+        #[allow(clippy::cast_precision_loss)]
+        let uu = u + (k as f64) * TAU;
+        for &(a_u, a_v, b_u, b_v) in hole_segs {
+            if uu >= a_u && uu < b_u && (b_u - a_u) > 1e-15 {
+                let t = (uu - a_u) / (b_u - a_u);
+                if a_v + t * (b_v - a_v) > v {
+                    crossings += 1;
+                }
+            }
+        }
+    }
+    crossings % 2 == 1
 }
 
 /// Given angular samples (radians, any 2π window), return `(u_lo, u_span)` —
@@ -1785,7 +1850,7 @@ pub(super) fn try_split_crossing_plane_face(
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
-    use super::{OrientedPCurveEdge, arc_covers_segment};
+    use super::{OrientedPCurveEdge, arc_covers_segment, point_in_hole_loops_uv};
     use brepkit_math::curves::Circle3D;
     use brepkit_math::curves2d::{Curve2D, Line2D};
     use brepkit_math::surfaces::CylindricalSurface;
@@ -1884,5 +1949,106 @@ mod tests {
             let b = surface.evaluate(wrapped, 3.0).unwrap();
             assert!((a - b).length() < 1e-9);
         }
+    }
+
+    #[test]
+    fn hole_containment_even_odd_inside_vs_outside() {
+        // A square hole loop in (u, v) around (u=1.0, v=10.0), as the segment
+        // list `cylinder_cone_remainder_interior` builds. The remainder
+        // interior-point search rejects any candidate INSIDE this hole.
+        let (uc, vc, h) = (1.0_f64, 10.0_f64, 0.5_f64);
+        let corners = [
+            (uc - h, vc - h),
+            (uc + h, vc - h),
+            (uc + h, vc + h),
+            (uc - h, vc + h),
+        ];
+        let mut segs: Vec<(f64, f64, f64, f64)> = Vec::new();
+        for i in 0..4 {
+            let (mut a_u, mut a_v) = corners[i];
+            let (mut b_u, mut b_v) = corners[(i + 1) % 4];
+            if a_u > b_u {
+                std::mem::swap(&mut a_u, &mut b_u);
+                std::mem::swap(&mut a_v, &mut b_v);
+            }
+            segs.push((a_u, a_v, b_u, b_v));
+        }
+        // Centre of the hole → inside.
+        assert!(
+            point_in_hole_loops_uv(&segs, uc, vc),
+            "hole centre is inside"
+        );
+        // Well outside the hole (different u and v) → outside.
+        assert!(
+            !point_in_hole_loops_uv(&segs, uc + 2.0, vc),
+            "a point clear of the hole in u is outside"
+        );
+        assert!(
+            !point_in_hole_loops_uv(&segs, uc, vc + 2.0),
+            "a point clear of the hole in v is outside"
+        );
+        // No segments → never inside.
+        assert!(!point_in_hole_loops_uv(&[], uc, vc));
+    }
+
+    #[test]
+    fn remainder_interior_point_is_outside_the_lens_hole() {
+        // A full cylinder wall (z-axis, r=3, v∈[0,20]) with one closed-circle
+        // hole on the wall near (u=0, v=10): the chosen interior point must be
+        // OUTSIDE the hole (Finding B — an uncontained point would drop the
+        // wall face at classification).
+        use super::super::super::split_types::SplitSubFace;
+        use crate::ds::Rank;
+        use brepkit_topology::topology::Topology;
+
+        // A real FaceId for the `parent` field (never read by the function under
+        // test, but the struct requires a valid handle).
+        let mut dummy_topo = Topology::new();
+        let parent = brepkit_topology::test_utils::make_unit_square_face(&mut dummy_topo);
+
+        let cyl =
+            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        let surface = FaceSurface::Cylinder(cyl);
+
+        // Outer wire: bottom rim (v=0), seam up (u=0), top rim (v=20), seam down.
+        let bot = Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+        let top =
+            Circle3D::new(Point3::new(0.0, 0.0, 20.0), Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+        let outer = vec![
+            arc_edge(&bot, 0.0, TAU, true),
+            line_chord(Point3::new(3.0, 0.0, 0.0), Point3::new(3.0, 0.0, 20.0)),
+            arc_edge(&top, 0.0, TAU, true),
+            line_chord(Point3::new(3.0, 0.0, 20.0), Point3::new(3.0, 0.0, 0.0)),
+        ];
+
+        // Hole: a small circle ON the cylinder wall near (u≈0, v=10). Centre on
+        // the surface at (3,0,10); the hole loop is a circle of radius 1 in the
+        // tangent plane (u,z) — small enough to stay on the wall band.
+        let hole_center = Point3::new(3.0, 0.0, 10.0);
+        let hole_normal = Vec3::new(1.0, 0.0, 0.0); // wall outward normal at u=0
+        let hole = Circle3D::new(hole_center, hole_normal, 1.0).unwrap();
+        let inner = vec![vec![arc_edge(&hole, 0.0, TAU, true)]];
+
+        let sub = SplitSubFace {
+            surface,
+            outer_wire: outer,
+            inner_wires: inner,
+            reversed: false,
+            parent,
+            rank: Rank::A,
+            precomputed_interior: None,
+        };
+
+        let p = super::cylinder_cone_remainder_interior(&sub).unwrap();
+        // The point is ON the cylinder (radius 3 from the axis).
+        let radial = (p.x() * p.x() + p.y() * p.y()).sqrt();
+        assert!((radial - 3.0).abs() < 1e-6, "interior point on the wall");
+        // The point is CLEAR of the hole (well outside its 1-unit circle).
+        assert!(
+            (p - hole_center).length() > 1.5,
+            "interior point must be clear of the hole, got dist {}",
+            (p - hole_center).length()
+        );
     }
 }

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1385,7 +1385,7 @@ pub(super) fn split_face_with_internal_loops(
 /// kept wall well clear of every lens. Returns `None` if the surface evaluator
 /// or boundary v-range is unusable, so the caller keeps the unset interior.
 fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> {
-    use std::f64::consts::TAU;
+    use std::f64::consts::{PI, TAU};
     // Densely sample every hole loop into 3D points AND project each to a (u, v)
     // polyline so candidate interior points can be tested for face containment
     // (outside every hole). Endpoint UVs are unusable here — a lens hole is one
@@ -1409,13 +1409,20 @@ fn cylinder_cone_remainder_interior(remainder: &SplitSubFace) -> Option<Point3> 
                     .evaluate_with_endpoints(t, edge.start_3d, edge.end_3d);
                 hole_pts.push(p);
                 if let Some((u, v)) = remainder.surface.project_point(p) {
-                    if let Some((pu, pv)) = prev_uv
-                        && (u - pu).abs() < TAU * 0.5
-                    {
-                        let (a_u, a_v, b_u, b_v) = if pu <= u {
-                            (pu, pv, u, v)
+                    if let Some((pu, pv)) = prev_uv {
+                        // Unwrap `u` relative to the previous sample so a
+                        // seam-crossing step is a single continuous segment in an
+                        // extended u-frame (`pu → pu + wrapped_delta`, |Δ| ≤ π)
+                        // instead of being dropped. `point_in_hole_loops_uv` tests
+                        // every 2π translate, so a segment living past the seam is
+                        // still matched for a query on the other side — the lens
+                        // boundary stays closed.
+                        let wrapped_delta = ((u - pu + PI).rem_euclid(TAU)) - PI;
+                        let u_unwrapped = pu + wrapped_delta;
+                        let (a_u, a_v, b_u, b_v) = if pu <= u_unwrapped {
+                            (pu, pv, u_unwrapped, v)
                         } else {
-                            (u, v, pu, pv)
+                            (u_unwrapped, v, pu, pv)
                         };
                         hole_segs.push((a_u, a_v, b_u, b_v));
                     }
@@ -1989,6 +1996,57 @@ mod tests {
         );
         // No segments → never inside.
         assert!(!point_in_hole_loops_uv(&[], uc, vc));
+    }
+
+    #[test]
+    fn hole_containment_handles_seam_crossing_loop() {
+        // A square hole loop straddling the u-seam: its corners sit at u≈TAU−h
+        // and u≈+h (i.e. the loop wraps across u=0). The projection unwraps each
+        // step (|Δu| ≤ π) so the loop is a CLOSED boundary in an extended u-frame;
+        // a point inside it (at the seam, u=0) must read inside, and a point on
+        // the far side (u=π) must read outside. Before the seam-crossing fix the
+        // wrap segment was dropped, leaving an open boundary that mis-classified.
+        use std::f64::consts::{PI, TAU};
+        let vc = 10.0_f64;
+        let h = 0.5_f64;
+        // Corners walked in order around the seam: (TAU−h, lo) → (h, lo) →
+        // (h, hi) → (TAU−h, hi). Build segments by unwrapping like the
+        // production projection does.
+        let corners = [
+            (TAU - h, vc - h),
+            (h, vc - h),
+            (h, vc + h),
+            (TAU - h, vc + h),
+        ];
+        let mut segs: Vec<(f64, f64, f64, f64)> = Vec::new();
+        let mut prev = corners[corners.len() - 1];
+        for &(u, v) in &corners {
+            let (pu, pv) = prev;
+            let wrapped_delta = ((u - pu + PI).rem_euclid(TAU)) - PI;
+            let u_un = pu + wrapped_delta;
+            let seg = if pu <= u_un {
+                (pu, pv, u_un, v)
+            } else {
+                (u_un, v, pu, pv)
+            };
+            segs.push(seg);
+            prev = (u, v);
+        }
+        // At the seam (u=0, inside the wrapped loop) → inside.
+        assert!(
+            point_in_hole_loops_uv(&segs, 0.0, vc),
+            "seam-crossing hole contains the seam point"
+        );
+        // Just inside on the +u side and the wrap side.
+        assert!(point_in_hole_loops_uv(&segs, 0.25, vc));
+        assert!(point_in_hole_loops_uv(&segs, TAU - 0.25, vc));
+        // Far side of the cylinder (u=π) → outside.
+        assert!(
+            !point_in_hole_loops_uv(&segs, PI, vc),
+            "the opposite side of the wall is outside the seam-crossing hole"
+        );
+        // Outside in v at the seam → outside.
+        assert!(!point_in_hole_loops_uv(&segs, 0.0, vc + 2.0));
     }
 
     #[test]

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -409,16 +409,35 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
                 &mut pb_vertex_registry,
                 arena,
             );
-            let pt = split.precomputed_interior.unwrap_or_else(|| {
-                super::face_splitter::interior_point_3d(split, parent_frame.as_ref())
-            });
+            let resolved_face_id = new_face_id.unwrap_or(face_id);
+            // For a curved-lens-hole wall (cylinder/cone with closed
+            // Circle/Ellipse/NURBS holes) the generic `interior_point_3d` is
+            // unsafe — it can sample inside the removed lens. The dedicated
+            // search ran in the splitter; if it found a contained point it is in
+            // `precomputed_interior`. When it is unset for such a face, leave the
+            // interior unset so the classifier aborts the analytic split (→ mesh
+            // fallback) instead of classifying the wall from inside the lens.
+            let interior_point = match split.precomputed_interior {
+                Some(pt) => Some(pt),
+                None if super::face_splitter::face_has_curved_lens_holes(
+                    topo,
+                    resolved_face_id,
+                ) =>
+                {
+                    None
+                }
+                None => Some(super::face_splitter::interior_point_3d(
+                    split,
+                    parent_frame.as_ref(),
+                )),
+            };
 
             sub_faces.push(SubFace {
-                face_id: new_face_id.unwrap_or(face_id),
+                face_id: resolved_face_id,
                 source_face: face_id,
                 classification: FaceClass::Unknown,
                 rank,
-                interior_point: Some(pt),
+                interior_point,
             });
         }
     }

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -334,6 +334,17 @@ impl Builder {
 
             let sample = if let Some(pt) = sf.interior_point {
                 Ok(pt)
+            } else if face_splitter::face_has_curved_lens_holes(&self.topo, sf.face_id) {
+                // A curved-lens-hole wall (cylinder/cone with closed
+                // Circle/Ellipse/NURBS holes) whose contained-interior search
+                // failed: every generic interior sample risks landing inside the
+                // removed lens, which would misclassify and drop the wall. Abort
+                // the analytic split so the boolean falls back to mesh (correct)
+                // rather than build a wrong B-rep.
+                return Err(AlgoError::ClassificationFailed(format!(
+                    "no contained interior for curved-lens wall {:?}; aborting analytic split",
+                    sf.face_id
+                )));
             } else {
                 sample_face_interior(&self.topo, sf.face_id, self.tol)
             };

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -721,22 +721,43 @@ fn restrict_curves_to_faces(
         if b1 - b0 < 2 {
             continue;
         }
-        // A closed ellipse/NURBS loop is kept whole ONLY when the entire curve
-        // is in-both — a genuine shared rim. When just an arc is in-both,
-        // keeping the whole curve leaves a spurious closed self-loop section
-        // edge: the splitter only trims OPEN curves and only adopts closed
-        // CIRCLES (seam adoption / link_existing), so a full ellipse from an
-        // inner tapered wall meeting an outer corner (the gridfinity lip
-        // knife-edge) survives as a degenerate loop and over-connects the rim.
-        // Trim it to its in-both arc so it becomes an open edge the splitter
-        // can place. Circles are left whole (seam adoption handles them); open
-        // curves are left whole (the splitter clips them).
-        if closed && b1 - b0 < N && !matches!(raw.curve, EdgeCurve::Circle(_)) {
+        // A closed loop with nearly every sample in-both is a genuinely
+        // fully-shared seam (e.g. the closed ellipse where two equal
+        // perpendicular cylinders cross — both lateral faces contain the whole
+        // loop). The few out-samples sit at the periodic seam (where sample N
+        // coincides with sample 0) and at the v-extremes, where projecting the
+        // point onto the partner cylinder lands marginally outside the trimmed
+        // band; these scatter the longest CONTIGUOUS run well below N even
+        // though the loop is whole, so count TOTAL in-both samples instead.
+        // Keep such a loop WHOLE: the downstream splitter routes a closed
+        // interior loop to `split_face_with_internal_loops` (carving cap +
+        // band-with-hole). Trimming it instead drops the wrap end-parameter past
+        // the curve's domain (a clamped NURBS extrapolates to a garbage 3D
+        // point), so the carved loop never closes and the wall collapses. The
+        // gridfinity lip knife-edge ellipses (genuine partial overlaps) have at
+        // most ~8/24 samples in-both — far below this near-whole threshold — so
+        // they still trim to their in-both arc.
+        let in_both_count = inb.iter().take(N).filter(|&&x| x).count();
+        let near_whole = in_both_count >= N.saturating_sub(3);
+        // A closed ellipse/NURBS loop is otherwise trimmed to its in-both arc:
+        // when just an arc is in-both, keeping the whole curve leaves a spurious
+        // closed self-loop section edge (the splitter only trims OPEN curves and
+        // only adopts closed CIRCLES via seam adoption / link_existing), so a
+        // full ellipse from an inner tapered wall meeting an outer corner (the
+        // gridfinity lip knife-edge) survives as a degenerate loop and
+        // over-connects the rim. Circles are left whole (seam adoption handles
+        // them); open curves are left whole (the splitter clips them).
+        if closed && b1 - b0 < N && !near_whole && !matches!(raw.curve, EdgeCurve::Circle(_)) {
             #[allow(clippy::cast_precision_loss)]
             let frac = |i: usize| i as f64 / N as f64;
             let span = raw.t_range.1 - raw.t_range.0;
-            let t0 = raw.t_range.0 + span * frac(b0);
-            let t1 = raw.t_range.0 + span * frac(b1);
+            // A wrapping run reports `b1 > N`; the raw fraction then maps past
+            // the curve's domain end. A clamped NURBS does not extrapolate
+            // gracefully (it evaluates to a garbage 3D point well outside the
+            // model), so clamp the trim endpoints to the curve's parameter
+            // range before evaluating.
+            let t0 = (raw.t_range.0 + span * frac(b0)).clamp(raw.t_range.0, raw.t_range.1);
+            let t1 = (raw.t_range.0 + span * frac(b1)).clamp(raw.t_range.0, raw.t_range.1);
             let p0 = raw
                 .curve
                 .evaluate_with_endpoints(t0, raw.p_start, raw.p_end);

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -612,6 +612,13 @@ fn face_circumferential_u_gap(
     face_id: FaceId,
     surface: &FaceSurface,
 ) -> Option<(f64, f64)> {
+    // Sample densely so a FULL-revolution rim circle (one closed edge spanning
+    // the whole period) leaves only a tiny per-step gap, well under the
+    // `largest_u_gap` threshold — otherwise a 16-step pass (~0.39 rad/step)
+    // spuriously reports a gap on a full cylinder wall, wrongly excluding genuine
+    // on-surface points near that u. A real partial-arc face (a rounded-rect
+    // corner) still shows its large angular gap.
+    const N_GAP: usize = 64;
     if !matches!(surface, FaceSurface::Cylinder(_) | FaceSurface::Cone(_)) {
         return None;
     }
@@ -623,9 +630,9 @@ fn face_circumferential_u_gap(
         let sp = topo.vertex(edge.start()).ok()?.point();
         let ep = topo.vertex(edge.end()).ok()?.point();
         let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
-        for i in 0..=16 {
+        for i in 0..=N_GAP {
             #[allow(clippy::cast_precision_loss)]
-            let f = i as f64 / 16.0;
+            let f = i as f64 / N_GAP as f64;
             let t = t0 + (t1 - t0) * f;
             let pt = edge.curve().evaluate_with_endpoints(t, sp, ep);
             if let Some((u, _)) = surface.project_point(pt) {
@@ -721,71 +728,78 @@ fn restrict_curves_to_faces(
         if b1 - b0 < 2 {
             continue;
         }
-        // A closed loop with nearly every sample in-both is a genuinely
-        // fully-shared seam (e.g. the closed ellipse where two equal
-        // perpendicular cylinders cross — both lateral faces contain the whole
-        // loop). The few out-samples sit at the periodic seam (where sample N
-        // coincides with sample 0) and at the v-extremes, where projecting the
-        // point onto the partner cylinder lands marginally outside the trimmed
-        // band; these scatter the longest CONTIGUOUS run well below N even
-        // though the loop is whole, so count TOTAL in-both samples instead.
-        // Keep such a loop WHOLE: the downstream splitter routes a closed
-        // interior loop to `split_face_with_internal_loops` (carving cap +
-        // band-with-hole). Trimming it instead drops the wrap end-parameter past
-        // the curve's domain (a clamped NURBS extrapolates to a garbage 3D
-        // point), so the carved loop never closes and the wall collapses. The
-        // gridfinity lip knife-edge ellipses (genuine partial overlaps) have at
-        // most ~8/24 samples in-both — far below this near-whole threshold — so
-        // they still trim to their in-both arc.
-        let in_both_count = inb.iter().take(N).filter(|&&x| x).count();
-        let near_whole = in_both_count >= N.saturating_sub(3);
-        // A closed ellipse/NURBS loop is otherwise trimmed to its in-both arc:
-        // when just an arc is in-both, keeping the whole curve leaves a spurious
-        // closed self-loop section edge (the splitter only trims OPEN curves and
-        // only adopts closed CIRCLES via seam adoption / link_existing), so a
-        // full ellipse from an inner tapered wall meeting an outer corner (the
-        // gridfinity lip knife-edge) survives as a degenerate loop and
-        // over-connects the rim. Circles are left whole (seam adoption handles
+        // A closed ellipse/NURBS loop whose in-both run covers the WHOLE curve
+        // (`b1 - b0 == N`) is a genuinely fully-shared seam — e.g. the closed
+        // ellipse where two equal perpendicular cylinders cross, every sample of
+        // which lies on both lateral faces. Keep it WHOLE: the downstream
+        // splitter routes a closed interior loop to
+        // `split_face_with_internal_loops` (carving cap + band-with-hole). Only
+        // a PARTIAL in-both run (`b1 - b0 < N`, a real out-of-face arc) is
+        // trimmed to its in-both arc below: keeping a partial whole would leave a
+        // spurious closed self-loop section edge (the splitter only trims OPEN
+        // curves and only adopts closed CIRCLES via seam adoption), so a full
+        // ellipse from an inner tapered wall meeting an outer corner (the
+        // gridfinity lip knife-edge) would survive as a degenerate loop and
+        // over-connect the rim. Circles are left whole (seam adoption handles
         // them); open curves are left whole (the splitter clips them).
-        if closed && b1 - b0 < N && !near_whole && !matches!(raw.curve, EdgeCurve::Circle(_)) {
-            #[allow(clippy::cast_precision_loss)]
-            let frac = |i: usize| i as f64 / N as f64;
-            let span = raw.t_range.1 - raw.t_range.0;
-            let raw_t0 = raw.t_range.0 + span * frac(b0);
-            let raw_t1 = raw.t_range.0 + span * frac(b1);
-            // A wrapping in-both run reports `b1 > N`, so `raw_t1` maps PAST the
-            // curve's domain end. A periodic curve (Ellipse/Circle) evaluates
-            // such an out-of-domain parameter correctly (cos/sin wrap), so the
-            // seam-wrapping arc must keep its unwrapped parameters. A clamped
-            // NURBS, by contrast, does NOT extrapolate gracefully (it evaluates
-            // to a garbage 3D point well outside the model), so for NURBS only,
-            // clamp the trim endpoints into the curve's parameter range first.
-            let (t0, t1) = if matches!(raw.curve, EdgeCurve::NurbsCurve(_)) {
-                (
-                    raw_t0.clamp(raw.t_range.0, raw.t_range.1),
-                    raw_t1.clamp(raw.t_range.0, raw.t_range.1),
-                )
-            } else {
-                (raw_t0, raw_t1)
-            };
-            let p0 = raw
-                .curve
-                .evaluate_with_endpoints(t0, raw.p_start, raw.p_end);
-            let p1 = raw
-                .curve
-                .evaluate_with_endpoints(t1, raw.p_start, raw.p_end);
-            out.push(RawCurve {
-                curve: raw.curve,
-                bbox: raw.bbox,
-                t_range: (t0, t1),
-                p_start: p0,
-                p_end: p1,
-            });
+        if closed && b1 - b0 < N && !matches!(raw.curve, EdgeCurve::Circle(_)) {
+            out.extend(trim_closed_curve_to_inboth_arc(&raw, b0, b1, N));
             continue;
         }
         out.push(raw);
     }
     out
+}
+
+/// Trim a CLOSED section curve (Ellipse or NURBS) to its in-both arc
+/// `[b0, b1]` of `N` samples, where `b1` may exceed `N` for a run that WRAPS the
+/// periodic seam (the closed curve's sample `N` coincides with sample `0`).
+///
+/// - **Periodic curve (Ellipse):** emit ONE open arc with the unwrapped
+///   parameters `[t0, t1]` (where `t1` may be past the domain end). The curve's
+///   `cos/sin` evaluation handles out-of-domain parameters, so a single arc
+///   spans the wrapping run correctly.
+/// - **NURBS curve:** a clamped NURBS evaluates an out-of-domain parameter to a
+///   garbage point, so a wrapping run cannot be one arc. Emit TWO in-domain
+///   arcs — `[t0, domain_end]` and `[domain_start, t1 − span]` — which meet at
+///   the seam (where the closed curve's endpoints coincide), preserving BOTH
+///   pieces of the wrapping run instead of dropping the head. A non-wrapping
+///   NURBS run (`b1 ≤ N`) is a single in-domain arc.
+fn trim_closed_curve_to_inboth_arc(
+    raw: &RawCurve,
+    b0: usize,
+    b1: usize,
+    n: usize,
+) -> Vec<RawCurve> {
+    #[allow(clippy::cast_precision_loss)]
+    let frac = |i: usize| i as f64 / n as f64;
+    let span = raw.t_range.1 - raw.t_range.0;
+    let t0 = raw.t_range.0 + span * frac(b0);
+    let t1 = raw.t_range.0 + span * frac(b1);
+    let point_at = |t: f64| raw.curve.evaluate_with_endpoints(t, raw.p_start, raw.p_end);
+
+    let one_arc = |ta: f64, tb: f64| RawCurve {
+        curve: raw.curve.clone(),
+        bbox: raw.bbox,
+        t_range: (ta, tb),
+        p_start: point_at(ta),
+        p_end: point_at(tb),
+    };
+
+    let wraps = b1 > n; // the in-both run crosses the periodic seam.
+    if matches!(raw.curve, EdgeCurve::NurbsCurve(_)) && wraps {
+        // Split at the domain end / start so neither arc leaves the domain.
+        let t1_wrapped = t1 - span; // = raw.t_range.0 + span * frac(b1 - n)
+        vec![
+            one_arc(t0, raw.t_range.1),
+            one_arc(raw.t_range.0, t1_wrapped),
+        ]
+    } else {
+        // Periodic curve (any run) or non-wrapping NURBS: a single arc. For a
+        // periodic curve `t1` may exceed the domain — that is intentional and
+        // evaluates correctly.
+        vec![one_arc(t0, t1)]
+    }
 }
 
 /// Trim a closed `Ellipse` section (the intersection of a thin planar tread
@@ -2999,6 +3013,80 @@ mod tests {
         // A closed curve entirely in-both returns the whole span (0, m).
         let inb = [true, true, true, true, true];
         assert_eq!(longest_inboth_run(&inb, true), (0, 4));
+    }
+
+    #[test]
+    fn trim_partial_ellipse_to_single_open_arc() {
+        // A closed Ellipse whose in-both run is a genuine NON-wrapping partial
+        // (b0..b1 strictly inside [0, N]) trims to ONE open arc with those exact
+        // parameters — NOT kept whole. Domain [0, 2π], N=24, run = samples 6..18.
+        use brepkit_math::curves::Ellipse3D;
+        let e = Ellipse3D::new(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            4.0,
+            3.0,
+        )
+        .unwrap();
+        let raw = RawCurve {
+            curve: EdgeCurve::Ellipse(e),
+            bbox: Aabb3 {
+                min: Point3::new(-4.0, -3.0, 0.0),
+                max: Point3::new(4.0, 3.0, 0.0),
+            },
+            t_range: (0.0, std::f64::consts::TAU),
+            p_start: Point3::new(0.0, 0.0, 0.0),
+            p_end: Point3::new(0.0, 0.0, 0.0),
+        };
+        let out = trim_closed_curve_to_inboth_arc(&raw, 6, 18, 24);
+        assert_eq!(out.len(), 1, "non-wrapping partial → one open arc");
+        let tau = std::f64::consts::TAU;
+        assert!((out[0].t_range.0 - tau * 6.0 / 24.0).abs() < 1e-9);
+        assert!((out[0].t_range.1 - tau * 18.0 / 24.0).abs() < 1e-9);
+        // The arc is OPEN (endpoints differ), so the splitter trims it rather
+        // than treating it as a closed internal loop.
+        assert!((out[0].p_start - out[0].p_end).length() > 1e-6);
+    }
+
+    #[test]
+    fn trim_wrapping_nurbs_preserves_both_pieces() {
+        // A closed NURBS whose in-both run WRAPS the seam (b1 > N) must emit TWO
+        // in-domain arcs (head [t0, domain_end] + tail [domain_start, t1−span]),
+        // NOT a clamp-dropped single arc, since a clamped NURBS can't evaluate
+        // past its domain. Run = samples 22..28 (i.e. 22,23,0,1,2,3,4 wrapping),
+        // N=24, domain [0, 1].
+        use brepkit_math::nurbs::fitting::interpolate;
+        // A closed NURBS through 8 points around a circle (start == end).
+        let mut pts: Vec<Point3> = (0..8)
+            .map(|k| {
+                let a = std::f64::consts::TAU * f64::from(k) / 8.0;
+                Point3::new(3.0 * a.cos(), 3.0 * a.sin(), 0.0)
+            })
+            .collect();
+        pts.push(pts[0]);
+        let nurbs = interpolate(&pts, 3).unwrap();
+        let (d0, d1) = nurbs.domain();
+        let raw = RawCurve {
+            curve: EdgeCurve::NurbsCurve(nurbs),
+            bbox: Aabb3 {
+                min: Point3::new(-3.0, -3.0, 0.0),
+                max: Point3::new(3.0, 3.0, 0.0),
+            },
+            t_range: (d0, d1),
+            p_start: pts[0],
+            p_end: pts[0],
+        };
+        let out = trim_closed_curve_to_inboth_arc(&raw, 22, 28, 24);
+        assert_eq!(out.len(), 2, "wrapping NURBS run → two in-domain arcs");
+        // Both arcs stay within the curve's domain (no out-of-domain garbage).
+        for arc in &out {
+            assert!(arc.t_range.0 >= d0 - 1e-9 && arc.t_range.0 <= d1 + 1e-9);
+            assert!(arc.t_range.1 >= d0 - 1e-9 && arc.t_range.1 <= d1 + 1e-9);
+        }
+        // Head ends at the domain end; tail starts at the domain start — they
+        // join at the seam where the closed curve's endpoints coincide.
+        assert!((out[0].t_range.1 - d1).abs() < 1e-9);
+        assert!((out[1].t_range.0 - d0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -751,13 +751,23 @@ fn restrict_curves_to_faces(
             #[allow(clippy::cast_precision_loss)]
             let frac = |i: usize| i as f64 / N as f64;
             let span = raw.t_range.1 - raw.t_range.0;
-            // A wrapping run reports `b1 > N`; the raw fraction then maps past
-            // the curve's domain end. A clamped NURBS does not extrapolate
-            // gracefully (it evaluates to a garbage 3D point well outside the
-            // model), so clamp the trim endpoints to the curve's parameter
-            // range before evaluating.
-            let t0 = (raw.t_range.0 + span * frac(b0)).clamp(raw.t_range.0, raw.t_range.1);
-            let t1 = (raw.t_range.0 + span * frac(b1)).clamp(raw.t_range.0, raw.t_range.1);
+            let raw_t0 = raw.t_range.0 + span * frac(b0);
+            let raw_t1 = raw.t_range.0 + span * frac(b1);
+            // A wrapping in-both run reports `b1 > N`, so `raw_t1` maps PAST the
+            // curve's domain end. A periodic curve (Ellipse/Circle) evaluates
+            // such an out-of-domain parameter correctly (cos/sin wrap), so the
+            // seam-wrapping arc must keep its unwrapped parameters. A clamped
+            // NURBS, by contrast, does NOT extrapolate gracefully (it evaluates
+            // to a garbage 3D point well outside the model), so for NURBS only,
+            // clamp the trim endpoints into the curve's parameter range first.
+            let (t0, t1) = if matches!(raw.curve, EdgeCurve::NurbsCurve(_)) {
+                (
+                    raw_t0.clamp(raw.t_range.0, raw.t_range.1),
+                    raw_t1.clamp(raw.t_range.0, raw.t_range.1),
+                )
+            } else {
+                (raw_t0, raw_t1)
+            };
             let p0 = raw
                 .curve
                 .evaluate_with_endpoints(t0, raw.p_start, raw.p_end);

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -741,6 +741,81 @@ fn integrate_band_excluding_holes<S: ParametricSurface>(
     }
 }
 
+/// Angular span (radians) covered by a set of `u` samples, computed as `2π`
+/// minus the LARGEST gap between consecutive sorted samples (the wrap gap
+/// included). A full revolution returns `≈ 2π`; a partial arc returns its true
+/// (shorter) span — robust to a boundary that straddles the seam, unlike a bare
+/// max−min of unwrapped values.
+fn covered_angular_span(u_iter: impl Iterator<Item = f64>) -> f64 {
+    let tau = std::f64::consts::TAU;
+    let mut us: Vec<f64> = u_iter.map(|u| u.rem_euclid(tau)).collect();
+    if us.len() < 2 {
+        return 0.0;
+    }
+    us.sort_by(f64::total_cmp);
+    us.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
+    if us.len() < 2 {
+        return 0.0;
+    }
+    let mut max_gap = us[0] + tau - us[us.len() - 1]; // wrap-around gap
+    for w in us.windows(2) {
+        max_gap = max_gap.max(w[1] - w[0]);
+    }
+    tau - max_gap
+}
+
+/// Whether the combined even-odd vertical-ray hole-clip is correct for these
+/// inner loops.
+///
+/// The clip pairs ALL inner-loop crossings at a given `u` even-odd into removed
+/// v-intervals. That is exact for the Steinmetz lens (its two seam ellipses give
+/// a single clean v-interval per `u`) AND for independent holes whose v-ranges
+/// are disjoint at every shared `u` (each hole's own crossings pair within its
+/// own interval). It is WRONG only when two INDEPENDENT compact holes overlap in
+/// BOTH `u` and `v` (their crossings interleave, and even-odd would merge/spawn
+/// spurious intervals). Detect and EXCLUDE only that case: a pair of loops that
+/// both stay local in `u` (neither wraps the full period — so they are not lens
+/// envelopes) yet overlap in both their `u` and `v` bounding boxes. Everything
+/// else (the lens; disjoint holes) is safe.
+fn combined_evenodd_holes_safe(inner_loops: &[Vec<(f64, f64)>]) -> bool {
+    let tau = std::f64::consts::TAU;
+    if inner_loops.is_empty() {
+        return false;
+    }
+    // (u_lo, u_hi unwrapped, v_lo, v_hi, wraps_full_period) per loop.
+    let boxes: Vec<(f64, f64, f64, f64, bool)> = inner_loops
+        .iter()
+        .filter(|l| l.len() >= 2)
+        .map(|l| {
+            let u_lo = l.iter().map(|p| p.0).fold(f64::INFINITY, f64::min);
+            let u_hi = l.iter().map(|p| p.0).fold(f64::NEG_INFINITY, f64::max);
+            let v_lo = l.iter().map(|p| p.1).fold(f64::INFINITY, f64::min);
+            let v_hi = l.iter().map(|p| p.1).fold(f64::NEG_INFINITY, f64::max);
+            let wraps = covered_angular_span(l.iter().map(|p| p.0)) >= tau - 1.0;
+            (u_lo, u_hi, v_lo, v_hi, wraps)
+        })
+        .collect();
+    if boxes.len() < 2 {
+        return true; // A single hole pairs cleanly.
+    }
+    for i in 0..boxes.len() {
+        for j in (i + 1)..boxes.len() {
+            let (a, b) = (boxes[i], boxes[j]);
+            // Lens envelopes wrap the period; skip the dangerous-overlap test
+            // for them (their interleaving IS the lens the clip handles).
+            if a.4 || b.4 {
+                continue;
+            }
+            let u_overlap = a.0.max(b.0) < a.1.min(b.1);
+            let v_overlap = a.2.max(b.2) < a.3.min(b.3);
+            if u_overlap && v_overlap {
+                return false; // Two independent compact holes interleave — defer.
+            }
+        }
+    }
+    true
+}
+
 /// Absolute shoelace area of a UV polygon. Near-zero means the boundary has
 /// collapsed onto a line or point (a degenerate seam/pole projection).
 fn polygon_area(poly: &[(f64, f64)]) -> f64 {
@@ -807,27 +882,35 @@ fn integrate_with_trimming<S: ParametricSurface>(
             d - tau * ((d + std::f64::consts::PI) / tau).floor()
         })
         .sum();
-    // The u-extent the boundary actually covers. A wall bounded by two full
+    // The u-extent the boundary actually COVERS. A wall bounded by two full
     // cap circles (each projecting across the whole 0..2π period) plus a seam
     // line nets a winding of ~0 — the two circles wind oppositely — so the
-    // winding test alone misses it. The covered u-span is the robust signal:
-    // a tube wall spans the full period even when its winding cancels.
-    let u_span = {
-        let umax = uv_boundary
-            .iter()
-            .map(|p| p.0)
-            .fold(f64::NEG_INFINITY, f64::max);
-        umax - u_min
-    };
-    let full_revolution = u_periodic && (winding.abs() >= tau - 1e-3 || u_span >= tau - 1e-3);
+    // winding test alone misses it. A bare max−min is fragile too: a PARTIAL
+    // face whose boundary straddles the seam can have max−min ≈ 2π without
+    // covering the full period. The robust signal is the complement of the
+    // LARGEST angular gap between sorted boundary u-samples: a full revolution
+    // has no large gap (covered span ≈ 2π); a partial face's gap is its
+    // uncovered arc.
+    // `u_covered` (gap-complement) is robust to a boundary that straddles the
+    // seam, where a bare max−min would read ≈2π for a partial face. The
+    // tolerance (covered ≥ 2π − 1, i.e. largest gap < 1 rad) admits the discrete
+    // boundary SAMPLING gap of a genuine full-revolution wall (its two cap
+    // circles cover every u) while a truly partial face leaves a large
+    // uncovered arc. The winding term still catches a single-loop band (a cone
+    // lateral face) whose boundary winds a full ±2π.
+    let u_covered = covered_angular_span(uv_boundary.iter().map(|p| p.0));
+    let full_revolution = u_periodic && (winding.abs() >= tau - 1e-3 || u_covered >= tau - 1.0);
     let v_degenerate = (v_max - v_min) <= 1e-9;
 
-    // A full-revolution wall (cylinder/cone tube) carrying interior hole loops:
-    // its outer boundary cannot trim the holes (they are interior), and the
-    // winding may cancel to ~0, so handle it here before the winding-based
-    // branches. Integrate the whole revolution over the wall's v-extent with
-    // the lens holes rejected (the Steinmetz lens of two crossing cylinders).
-    if u_periodic && !v_degenerate && !inner_loops.is_empty() && u_span >= tau - 1e-3 {
+    // A full-revolution wall (cylinder/cone tube) carrying the STEINMETZ LENS
+    // (two mutually-trimmed cylinders): each lens loop is a full-u-wrapping
+    // sinusoid, and TOGETHER they enclose the lens by an even-odd combined
+    // arrangement. Integrate the whole revolution over the wall's v-extent with
+    // those lens v-intervals clipped out. Gated TIGHTLY to that signature:
+    // ordinary INDEPENDENT holes (each a local u-arc) would be mis-handled by
+    // the combined even-odd test (it would subtract spurious merged intervals),
+    // so they fall through to the standard paths below.
+    if u_periodic && !v_degenerate && full_revolution && combined_evenodd_holes_safe(inner_loops) {
         return integrate_band_excluding_holes(
             surface,
             (u_min, u_min + tau),
@@ -1050,4 +1133,85 @@ where
         loops.push(uv);
     }
     Ok(loops)
+}
+
+#[cfg(test)]
+mod gate_tests {
+    #![allow(clippy::unwrap_used, clippy::float_cmp)]
+    use super::{combined_evenodd_holes_safe, covered_angular_span};
+    use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
+
+    fn ellipse_uv(v_mid: f64, amp: f64, phase: f64, n: usize) -> Vec<(f64, f64)> {
+        // v = v_mid + amp·cos(u − phase) over a full revolution in u (a lens
+        // envelope's projected sinusoid).
+        (0..=n)
+            .map(|k| {
+                #[allow(clippy::cast_precision_loss)]
+                let u = TAU * (k as f64) / (n as f64);
+                (u, v_mid + amp * (u - phase).cos())
+            })
+            .collect()
+    }
+
+    fn local_loop(u_c: f64, v_c: f64, r: f64, n: usize) -> Vec<(f64, f64)> {
+        // A small compact circular hole centred at (u_c, v_c).
+        (0..=n)
+            .map(|k| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = TAU * (k as f64) / (n as f64);
+                (u_c + r * t.cos(), v_c + r * t.sin())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn covered_span_full_vs_partial() {
+        // A full revolution (32 evenly-spaced samples): covered span ≈ 2π.
+        let full = (0..32).map(|k| TAU * f64::from(k) / 32.0);
+        assert!((covered_angular_span(full) - TAU).abs() < 0.3);
+        // A quarter arc near the seam [-π/4, π/4]: covered span ≈ π/2, NOT 2π
+        // (a bare max−min of these seam-straddling values would read ≈2π via
+        // the rem_euclid wrap, but the gap-complement correctly reports ~π/2).
+        let quarter = (0..=8).map(|k| -FRAC_PI_4 + FRAC_PI_2 * f64::from(k) / 8.0);
+        assert!(
+            covered_angular_span(quarter) < PI,
+            "a quarter arc is not a full revolution"
+        );
+    }
+
+    #[test]
+    fn combined_evenodd_safe_for_lens_unsafe_for_overlapping_independent() {
+        // Steinmetz lens: two full-u-wrapping envelopes → SAFE.
+        let lens = vec![
+            ellipse_uv(10.0, 3.0, 0.0, 64),
+            ellipse_uv(10.0, -3.0, 0.0, 64),
+        ];
+        assert!(
+            combined_evenodd_holes_safe(&lens),
+            "lens envelopes are safe"
+        );
+
+        // Two independent compact holes that OVERLAP in both u and v → UNSAFE
+        // (combined even-odd would interleave them).
+        let overlapping = vec![local_loop(1.0, 5.0, 0.4, 32), local_loop(1.3, 5.1, 0.4, 32)];
+        assert!(
+            !combined_evenodd_holes_safe(&overlapping),
+            "overlapping independent holes must defer"
+        );
+
+        // Two independent compact holes that are DISJOINT in u → SAFE (each
+        // pairs within its own interval).
+        let disjoint = vec![local_loop(1.0, 5.0, 0.3, 32), local_loop(4.0, 5.0, 0.3, 32)];
+        assert!(
+            combined_evenodd_holes_safe(&disjoint),
+            "u-disjoint holes pair cleanly"
+        );
+
+        // A single hole is always safe.
+        assert!(combined_evenodd_holes_safe(&[local_loop(
+            1.0, 5.0, 0.3, 32
+        )]));
+        // No holes → not applicable.
+        assert!(!combined_evenodd_holes_safe(&[]));
+    }
 }

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -68,9 +68,7 @@ pub fn integrate_face(
             );
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, false, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
-            let inner_loops =
-                build_face_uv_inner_loops(topo, face_id, |p| s.project_point(p), true)?;
-            integrate_with_trimming(
+            Ok(integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -79,8 +77,7 @@ pub fn integrate_face(
                 &uv_boundary,
                 true,
                 &[],
-                &inner_loops,
-            )
+            ))
         }
         FaceSurface::Cone(s) => {
             let full = (
@@ -89,9 +86,7 @@ pub fn integrate_face(
             );
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, false, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
-            let inner_loops =
-                build_face_uv_inner_loops(topo, face_id, |p| s.project_point(p), true)?;
-            integrate_with_trimming(
+            Ok(integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -100,8 +95,7 @@ pub fn integrate_face(
                 &uv_boundary,
                 true,
                 &[],
-                &inner_loops,
-            )
+            ))
         }
         FaceSurface::Sphere(s) => {
             let full = (
@@ -111,7 +105,7 @@ pub fn integrate_face(
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, false, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
             let hole_vs = full_revolution_hole_vs(topo, face_id, s);
-            integrate_with_trimming(
+            Ok(integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -120,14 +114,13 @@ pub fn integrate_face(
                 &uv_boundary,
                 true,
                 &hole_vs,
-                &[],
-            )
+            ))
         }
         FaceSurface::Torus(s) => {
             let full = ((0.0, std::f64::consts::TAU), (0.0, std::f64::consts::TAU));
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, true, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
-            integrate_with_trimming(
+            Ok(integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -136,8 +129,7 @@ pub fn integrate_face(
                 &uv_boundary,
                 true,
                 &[],
-                &[],
-            )
+            ))
         }
         FaceSurface::Nurbs(s) => {
             let full = (s.domain_u(), s.domain_v());
@@ -147,7 +139,7 @@ pub fn integrate_face(
                 face_uv_bounds(topo, face_id, s, periodic_u, periodic_v, full)?;
             let uv_boundary =
                 build_face_uv_boundary(topo, face_id, |p| s.project_point(p), periodic_u)?;
-            integrate_with_trimming(
+            Ok(integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -156,8 +148,7 @@ pub fn integrate_face(
                 &uv_boundary,
                 periodic_u,
                 &[],
-                &[],
-            )
+            ))
         }
     }
 }
@@ -554,302 +545,6 @@ fn integrate_parametric<S: ParametricSurface>(
     }
 }
 
-/// Integrate a full-revolution analytic band, excluding the region enclosed by
-/// the interior `hole_loops` (the UV loops of the face's inner wires).
-///
-/// Used for a cylinder/cone wall that another quadric bores through: the wall
-/// wraps the full `u` period (so the outer boundary can't trim it) yet carries
-/// closed lens loops that must be cut out of the volume integral. At each
-/// Gauss `u`-node the lens occupies one or more `v`-intervals (found exactly
-/// from where a vertical line crosses the inner-loop arrangement); the surface
-/// is integrated only over the complementary kept `v`-sub-intervals, so the
-/// curved lens boundary is resolved exactly rather than by coarse point
-/// rejection.
-#[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
-fn integrate_band_excluding_holes<S: ParametricSurface>(
-    surface: &S,
-    u_range: (f64, f64),
-    v_range: (f64, f64),
-    gauss_order: usize,
-    sign: f64,
-    hole_loops: &[Vec<(f64, f64)>],
-) -> FaceContribution {
-    const MAX_PATCHES: usize = 16;
-    let gauss_pts = gauss_legendre_points(gauss_order);
-    let patch = std::f64::consts::FRAC_PI_4;
-    let nu = (((u_range.1 - u_range.0).abs() / patch).ceil() as usize).clamp(1, MAX_PATCHES);
-    let du_patch = (u_range.1 - u_range.0) / nu as f64;
-    let u_scale = du_patch / 2.0;
-
-    // Collect every inner-loop edge as a (u, v) segment, keeping each segment's
-    // NATIVE (per-loop-unwrapped) u. The query u is later tested against each
-    // segment in every 2π translate, so the band's own u-origin need not match.
-    // The lens region is treated as "inside the combined arrangement of ALL
-    // these segments" via an even-odd vertical-ray test — NOT per-loop
-    // point-in-polygon. This is essential here: each lens ellipse where one
-    // cylinder bores through another is a full-u-wrapping sinusoid bounding NO
-    // area on its own, yet the two ellipses TOGETHER enclose the lens lobes,
-    // which the combined even-odd test resolves. The single wrap segment per
-    // loop (Δu ≈ a full period) is dropped; the dense sampling keeps the
-    // arrangement intact.
-    let tau = std::f64::consts::TAU;
-    let mut segs: Vec<(f64, f64, f64, f64)> = Vec::new();
-    for loop_uv in hole_loops {
-        if loop_uv.len() < 2 {
-            continue;
-        }
-        for i in 0..loop_uv.len() {
-            let (u0, v0) = loop_uv[i];
-            let (u1, v1) = loop_uv[(i + 1) % loop_uv.len()];
-            if (u1 - u0).abs() > tau * 0.5 {
-                continue;
-            }
-            let (mut a_u, mut a_v, mut b_u, mut b_v) = (u0, v0, u1, v1);
-            if a_u > b_u {
-                std::mem::swap(&mut a_u, &mut b_u);
-                std::mem::swap(&mut a_v, &mut b_v);
-            }
-            segs.push((a_u, a_v, b_u, b_v));
-        }
-    }
-    let seg_u_min = segs.iter().map(|s| s.0).fold(f64::INFINITY, f64::min);
-    let seg_u_max = segs.iter().map(|s| s.2).fold(f64::NEG_INFINITY, f64::max);
-
-    // The v-values where a vertical line at `u` crosses the inner-loop
-    // arrangement, sorted ascending. Even-odd pairing of these gives the lens
-    // v-intervals at that u; the kept region is the complement within
-    // [v_range.0, v_range.1]. The query u is tested against each segment in
-    // every 2π translate that can land in the segments' u-extent, so a loop
-    // unwrapped to any window is matched regardless of the band's own u-origin.
-    // Exact crossing v's (not a coarse-grid point test) let the v-integration
-    // place its Gauss nodes only on the kept sub-intervals, integrating the
-    // curved lens boundary exactly.
-    let lens_v_crossings = |u: f64| -> Vec<f64> {
-        let mut vs: Vec<f64> = Vec::new();
-        // Smallest k so u + k*tau >= seg_u_min, then sweep up past seg_u_max.
-        let k0 = ((seg_u_min - u) / tau).floor() as i64;
-        let k1 = ((seg_u_max - u) / tau).ceil() as i64;
-        for k in k0..=k1 {
-            let uu = u + (k as f64) * tau;
-            for &(a_u, a_v, b_u, b_v) in &segs {
-                if uu >= a_u && uu < b_u && (b_u - a_u) > 1e-15 {
-                    let t = (uu - a_u) / (b_u - a_u);
-                    vs.push(a_v + t * (b_v - a_v));
-                }
-            }
-        }
-        vs.sort_by(f64::total_cmp);
-        vs
-    };
-
-    // Kept v-sub-intervals at `u`: [v0, v1] minus the lens intervals (the
-    // even-odd-paired crossing spans).
-    let kept_v_intervals = |u: f64, v0: f64, v1: f64| -> Vec<(f64, f64)> {
-        let crossings = lens_v_crossings(u);
-        // Lens spans = consecutive pairs (c[0],c[1]), (c[2],c[3]), ...
-        let mut kept = Vec::new();
-        let mut cursor = v0;
-        let mut i = 0;
-        while i + 1 < crossings.len() {
-            let lo = crossings[i].clamp(v0, v1);
-            let hi = crossings[i + 1].clamp(v0, v1);
-            if lo > cursor {
-                kept.push((cursor, lo));
-            }
-            cursor = cursor.max(hi);
-            i += 2;
-        }
-        if cursor < v1 {
-            kept.push((cursor, v1));
-        }
-        kept
-    };
-
-    let mut acc = FaceContribution {
-        area: 0.0,
-        volume: 0.0,
-        volume_moment_x: 0.0,
-        volume_moment_y: 0.0,
-        volume_moment_z: 0.0,
-        centroid_x: 0.0,
-        centroid_y: 0.0,
-        centroid_z: 0.0,
-    };
-
-    for iu in 0..nu {
-        let u_mid = du_patch.mul_add(iu as f64, u_range.0) + u_scale;
-        for gpu in gauss_pts {
-            let u = u_scale.mul_add(gpu.x, u_mid);
-            let w_u = gpu.w * u_scale;
-            // Integrate v only over the kept sub-intervals at this u, each with
-            // its own Gauss rule so the lens-clipped limits are exact.
-            for (kv0, kv1) in kept_v_intervals(u, v_range.0, v_range.1) {
-                // Sub-tile a long kept interval so one Gauss rule resolves it.
-                let kv_len = kv1 - kv0;
-                let n_sub = ((kv_len / patch).ceil() as usize).clamp(1, MAX_PATCHES);
-                let dv_sub = kv_len / n_sub as f64;
-                let v_sub_scale = dv_sub / 2.0;
-                for isv in 0..n_sub {
-                    let v_sub_mid = dv_sub.mul_add(isv as f64, kv0) + v_sub_scale;
-                    for gpv in gauss_pts {
-                        let v = v_sub_scale.mul_add(gpv.x, v_sub_mid);
-                        let w = w_u * gpv.w * v_sub_scale;
-                        let p = surface.evaluate(u, v);
-                        let du = surface.partial_u(u, v);
-                        let dv = surface.partial_v(u, v);
-                        let n = Vec3::new(
-                            du.y() * dv.z() - du.z() * dv.y(),
-                            du.z() * dv.x() - du.x() * dv.z(),
-                            du.x() * dv.y() - du.y() * dv.x(),
-                        );
-                        let n_len = n.length();
-                        acc.area += w * n_len;
-                        let pv = Vec3::new(p.x(), p.y(), p.z());
-                        acc.volume += w * pv.dot(n) / 3.0;
-                        acc.volume_moment_x += w * 0.5 * p.x() * p.x() * n.x();
-                        acc.volume_moment_y += w * 0.5 * p.y() * p.y() * n.y();
-                        acc.volume_moment_z += w * 0.5 * p.z() * p.z() * n.z();
-                        acc.centroid_x += w * p.x() * n_len;
-                        acc.centroid_y += w * p.y() * n_len;
-                        acc.centroid_z += w * p.z() * n_len;
-                    }
-                }
-            }
-        }
-    }
-
-    let (area, vol, mx, my, mz, cx, cy, cz) = (
-        acc.area,
-        acc.volume,
-        acc.volume_moment_x,
-        acc.volume_moment_y,
-        acc.volume_moment_z,
-        acc.centroid_x,
-        acc.centroid_y,
-        acc.centroid_z,
-    );
-
-    FaceContribution {
-        area,
-        volume: vol * sign,
-        volume_moment_x: mx * sign,
-        volume_moment_y: my * sign,
-        volume_moment_z: mz * sign,
-        centroid_x: cx,
-        centroid_y: cy,
-        centroid_z: cz,
-    }
-}
-
-/// Angular span (radians) covered by a set of `u` samples, computed as `2π`
-/// minus the LARGEST gap between consecutive sorted samples (the wrap gap
-/// included). A full revolution returns `≈ 2π`; a partial arc returns its true
-/// (shorter) span — robust to a boundary that straddles the seam, unlike a bare
-/// max−min of unwrapped values.
-fn covered_angular_span(u_iter: impl Iterator<Item = f64>) -> f64 {
-    let tau = std::f64::consts::TAU;
-    let mut us: Vec<f64> = u_iter.map(|u| u.rem_euclid(tau)).collect();
-    if us.len() < 2 {
-        return 0.0;
-    }
-    us.sort_by(f64::total_cmp);
-    us.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
-    if us.len() < 2 {
-        return 0.0;
-    }
-    let mut max_gap = us[0] + tau - us[us.len() - 1]; // wrap-around gap
-    for w in us.windows(2) {
-        max_gap = max_gap.max(w[1] - w[0]);
-    }
-    tau - max_gap
-}
-
-/// Whether the boundary u-samples wrap a FULL revolution, judged by SAMPLING
-/// density rather than a fixed angular slack.
-///
-/// The boundary of a full-revolution wall (two cap circles, each sampled at a
-/// fixed step) leaves only sampling-sized gaps that are all roughly equal; a
-/// PARTIAL face leaves ONE genuine uncovered arc far larger than the rest. So
-/// compare the LARGEST gap to the MEDIAN of the OTHER gaps: a full wall has
-/// `largest ≈ median` (ratio ~1, even if two rim circles double a step), a
-/// partial has `largest ≫ median`. This is density-adaptive — a fixed 1-rad
-/// slack would instead misclassify a face covering 2π − 0.5 as full and
-/// overcount the uncovered arc. Returns `false` for fewer than 4 distinct
-/// samples (cannot judge a step distribution).
-fn is_full_revolution_boundary(u_iter: impl Iterator<Item = f64>) -> bool {
-    let tau = std::f64::consts::TAU;
-    let mut us: Vec<f64> = u_iter.map(|u| u.rem_euclid(tau)).collect();
-    us.sort_by(f64::total_cmp);
-    us.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
-    if us.len() < 4 {
-        return false;
-    }
-    let mut gaps: Vec<f64> = us.windows(2).map(|w| w[1] - w[0]).collect();
-    gaps.push(us[0] + tau - us[us.len() - 1]); // wrap gap
-    gaps.sort_by(f64::total_cmp);
-    let largest = *gaps.last().unwrap_or(&tau);
-    // Median of the gaps EXCLUDING the largest — the typical sampling step,
-    // robust even if a couple of steps are doubled where two rim circles align.
-    let rest = &gaps[..gaps.len() - 1];
-    let typical = rest[rest.len() / 2];
-    // Full iff the largest gap is at most ~2× the typical step (a small absolute
-    // floor keeps perfectly-uniform sampling classified full despite float
-    // noise). A real 0.5-rad uncovered arc on a ~0.2-rad step (ratio 2.7) fails.
-    largest <= (typical * 2.0).max(0.02)
-}
-
-/// Whether the combined even-odd vertical-ray hole-clip is correct for these
-/// inner loops.
-///
-/// The clip pairs ALL inner-loop crossings at a given `u` even-odd into removed
-/// v-intervals. That is exact for the Steinmetz lens (its two seam ellipses give
-/// a single clean v-interval per `u`) AND for independent holes whose v-ranges
-/// are disjoint at every shared `u` (each hole's own crossings pair within its
-/// own interval). It is WRONG only when two INDEPENDENT compact holes overlap in
-/// BOTH `u` and `v` (their crossings interleave, and even-odd would merge/spawn
-/// spurious intervals). Detect and EXCLUDE only that case: a pair of loops that
-/// both stay local in `u` (neither wraps the full period — so they are not lens
-/// envelopes) yet overlap in both their `u` and `v` bounding boxes. Everything
-/// else (the lens; disjoint holes) is safe.
-fn combined_evenodd_holes_safe(inner_loops: &[Vec<(f64, f64)>]) -> bool {
-    let tau = std::f64::consts::TAU;
-    if inner_loops.is_empty() {
-        return false;
-    }
-    // (u_lo, u_hi unwrapped, v_lo, v_hi, wraps_full_period) per loop.
-    let boxes: Vec<(f64, f64, f64, f64, bool)> = inner_loops
-        .iter()
-        .filter(|l| l.len() >= 2)
-        .map(|l| {
-            let u_lo = l.iter().map(|p| p.0).fold(f64::INFINITY, f64::min);
-            let u_hi = l.iter().map(|p| p.0).fold(f64::NEG_INFINITY, f64::max);
-            let v_lo = l.iter().map(|p| p.1).fold(f64::INFINITY, f64::min);
-            let v_hi = l.iter().map(|p| p.1).fold(f64::NEG_INFINITY, f64::max);
-            let wraps = covered_angular_span(l.iter().map(|p| p.0)) >= tau - 1.0;
-            (u_lo, u_hi, v_lo, v_hi, wraps)
-        })
-        .collect();
-    if boxes.len() < 2 {
-        return true; // A single hole pairs cleanly.
-    }
-    for i in 0..boxes.len() {
-        for j in (i + 1)..boxes.len() {
-            let (a, b) = (boxes[i], boxes[j]);
-            // Lens envelopes wrap the period; skip the dangerous-overlap test
-            // for them (their interleaving IS the lens the clip handles).
-            if a.4 || b.4 {
-                continue;
-            }
-            let u_overlap = a.0.max(b.0) < a.1.min(b.1);
-            let v_overlap = a.2.max(b.2) < a.3.min(b.3);
-            if u_overlap && v_overlap {
-                return false; // Two independent compact holes interleave — defer.
-            }
-        }
-    }
-    true
-}
-
 /// Absolute shoelace area of a UV polygon. Near-zero means the boundary has
 /// collapsed onto a line or point (a degenerate seam/pole projection).
 fn polygon_area(poly: &[(f64, f64)]) -> f64 {
@@ -868,14 +563,6 @@ fn polygon_area(poly: &[(f64, f64)]) -> f64 {
 
 /// Dispatch to trimmed or untrimmed parametric integration based on whether
 /// a UV boundary polygon is available.
-///
-/// A HOLED face (`!inner_loops.is_empty()`) can only be integrated correctly via
-/// the lens-clipping early return; every other branch ignores the inner wires
-/// and would OVERCOUNT (return a hole-less, too-large volume). So a holed face
-/// that does not match the clippable signature DECLINES with
-/// [`CheckError::IntegrationFailed`], letting the caller fall back to
-/// tessellation rather than return a wrong number. Hole-less faces always
-/// succeed (their behaviour is unchanged).
 #[allow(clippy::too_many_arguments)]
 fn integrate_with_trimming<S: ParametricSurface>(
     surface: &S,
@@ -886,24 +573,9 @@ fn integrate_with_trimming<S: ParametricSurface>(
     uv_boundary: &[(f64, f64)],
     u_periodic: bool,
     hole_vs: &[f64],
-    inner_loops: &[Vec<(f64, f64)>],
-) -> Result<FaceContribution, CheckError> {
+) -> FaceContribution {
     if uv_boundary.len() < 3 {
-        // No usable boundary polygon. A hole-less face integrates over its
-        // analytic domain; a holed one cannot have its holes subtracted here, so
-        // it must decline rather than overcount.
-        if inner_loops.is_empty() {
-            return Ok(integrate_parametric(
-                surface,
-                u_range,
-                v_range,
-                gauss_order,
-                sign,
-            ));
-        }
-        return Err(CheckError::IntegrationFailed(
-            "holed analytic face has no usable UV boundary for hole subtraction".into(),
-        ));
+        return integrate_parametric(surface, u_range, v_range, gauss_order, sign);
     }
 
     // The dense boundary polygon is the reliable signal for a face's true
@@ -938,49 +610,10 @@ fn integrate_with_trimming<S: ParametricSurface>(
             d - tau * ((d + std::f64::consts::PI) / tau).floor()
         })
         .sum();
-    // Full-revolution detection. The winding term catches a single-loop band (a
-    // cone lateral face winding a full ±2π); the boundary-gap term catches a
-    // two-cap-circle wall whose winding cancels (~0). The gap test is SAMPLING-
-    // DENSITY-ADAPTIVE (`is_full_revolution_boundary`): full only when the
-    // largest boundary u-gap is no bigger than a small multiple of the typical
-    // sampling step. A fixed angular slack (e.g. 1 rad) would misclassify a face
-    // covering 2π − 0.5 as full and add the uncovered 0.5 arc to the band
-    // integral — exactly the overcount this avoids.
-    let full_revolution = u_periodic
-        && (winding.abs() >= tau - 1e-3
-            || is_full_revolution_boundary(uv_boundary.iter().map(|p| p.0)));
+    let full_revolution = u_periodic && winding.abs() >= tau - 1e-3;
     let v_degenerate = (v_max - v_min) <= 1e-9;
 
-    // A full-revolution wall (cylinder/cone tube) carrying the STEINMETZ LENS
-    // (two mutually-trimmed cylinders): each lens loop is a full-u-wrapping
-    // sinusoid, and TOGETHER they enclose the lens by an even-odd combined
-    // arrangement. Integrate the whole revolution over the wall's v-extent with
-    // those lens v-intervals clipped out. Gated TIGHTLY to that signature:
-    // ordinary INDEPENDENT holes (each a local u-arc) would be mis-handled by
-    // the combined even-odd test, so they DECLINE below.
-    if u_periodic && !v_degenerate && full_revolution && combined_evenodd_holes_safe(inner_loops) {
-        return Ok(integrate_band_excluding_holes(
-            surface,
-            (u_min, u_min + tau),
-            (v_min, v_max),
-            gauss_order,
-            sign,
-            inner_loops,
-        ));
-    }
-
-    // Past this point no branch subtracts inner wires, so a HOLED face that did
-    // NOT match the clippable lens signature above (an unsafe interleaving-holes
-    // arrangement, or a partial/near-full holed face) cannot be integrated
-    // correctly here. DECLINE so the caller defers to tessellation rather than
-    // returning a hole-less (overcounting) band integral.
-    if !inner_loops.is_empty() {
-        return Err(CheckError::IntegrationFailed(
-            "holed analytic face is not a clippable lens; defer to tessellation".into(),
-        ));
-    }
-
-    Ok(if full_revolution && v_degenerate {
+    if full_revolution && v_degenerate {
         // Polar cap (e.g. a sphere hemisphere bounded only by one latitude
         // circle): the cap runs from that latitude to a pole. The winding sign
         // (CCW vs CW boundary) selects which pole — the boundary's interior
@@ -1000,9 +633,8 @@ fn integrate_with_trimming<S: ParametricSurface>(
         let v_dom = (v_min.min(v_far), v_min.max(v_far));
         integrate_parametric(surface, (u_min, u_min + tau), v_dom, gauss_order, sign)
     } else if full_revolution {
-        // Full-revolution band (cone/cylinder) with no interior holes (the
-        // holed case is handled by the early return above): integrate the whole
-        // revolution over the band's v-extent.
+        // Full-revolution band (cone/cylinder): integrate the whole revolution
+        // over the band's v-extent.
         integrate_parametric(
             surface,
             (u_min, u_min + tau),
@@ -1024,7 +656,7 @@ fn integrate_with_trimming<S: ParametricSurface>(
             uv_boundary,
             u_periodic,
         )
-    })
+    }
 }
 
 /// Integrate a parametric surface with UV boundary trimming.
@@ -1160,268 +792,4 @@ where
     }
 
     Ok(uv)
-}
-
-/// Build a UV polygon per inner wire (hole) of a face, projecting each loop's
-/// densely-sampled boundary onto the surface and unwrapping periodic u so a
-/// seam-crossing hole (e.g. the closed ellipse where one cylinder bores
-/// through another) stays a simple, non-self-crossing loop in its own
-/// u-window.
-fn build_face_uv_inner_loops<F>(
-    topo: &Topology,
-    face_id: FaceId,
-    project: F,
-    u_periodic: bool,
-) -> Result<Vec<Vec<(f64, f64)>>, CheckError>
-where
-    F: Fn(Point3) -> (f64, f64),
-{
-    let face = topo.face(face_id)?;
-    let mut loops = Vec::new();
-    for &wid in face.inner_wires() {
-        let polygon = crate::util::wire_polygon(topo, wid)?;
-        if polygon.len() < 3 {
-            continue;
-        }
-        let mut uv: Vec<(f64, f64)> = polygon.iter().map(|&p| project(p)).collect();
-        if u_periodic {
-            for i in 1..uv.len() {
-                uv[i].0 = unwrap_angle(uv[i - 1].0, uv[i].0);
-            }
-        }
-        loops.push(uv);
-    }
-    Ok(loops)
-}
-
-#[cfg(test)]
-mod gate_tests {
-    #![allow(clippy::unwrap_used, clippy::float_cmp)]
-    use super::{
-        combined_evenodd_holes_safe, covered_angular_span, integrate_with_trimming,
-        is_full_revolution_boundary,
-    };
-    use brepkit_math::surfaces::CylindricalSurface;
-    use brepkit_math::vec::{Point3, Vec3};
-    use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
-
-    fn ellipse_uv(v_mid: f64, amp: f64, phase: f64, n: usize) -> Vec<(f64, f64)> {
-        // v = v_mid + amp·cos(u − phase) over a full revolution in u (a lens
-        // envelope's projected sinusoid).
-        (0..=n)
-            .map(|k| {
-                #[allow(clippy::cast_precision_loss)]
-                let u = TAU * (k as f64) / (n as f64);
-                (u, v_mid + amp * (u - phase).cos())
-            })
-            .collect()
-    }
-
-    fn local_loop(u_c: f64, v_c: f64, r: f64, n: usize) -> Vec<(f64, f64)> {
-        // A small compact circular hole centred at (u_c, v_c).
-        (0..=n)
-            .map(|k| {
-                #[allow(clippy::cast_precision_loss)]
-                let t = TAU * (k as f64) / (n as f64);
-                (u_c + r * t.cos(), v_c + r * t.sin())
-            })
-            .collect()
-    }
-
-    #[test]
-    fn covered_span_full_vs_partial() {
-        // A full revolution (32 evenly-spaced samples): covered span ≈ 2π.
-        let full = (0..32).map(|k| TAU * f64::from(k) / 32.0);
-        assert!((covered_angular_span(full) - TAU).abs() < 0.3);
-        // A quarter arc near the seam [-π/4, π/4]: covered span ≈ π/2, NOT 2π
-        // (a bare max−min of these seam-straddling values would read ≈2π via
-        // the rem_euclid wrap, but the gap-complement correctly reports ~π/2).
-        let quarter = (0..=8).map(|k| -FRAC_PI_4 + FRAC_PI_2 * f64::from(k) / 8.0);
-        assert!(
-            covered_angular_span(quarter) < PI,
-            "a quarter arc is not a full revolution"
-        );
-    }
-
-    #[test]
-    fn combined_evenodd_safe_for_lens_unsafe_for_overlapping_independent() {
-        // Steinmetz lens: two full-u-wrapping envelopes → SAFE.
-        let lens = vec![
-            ellipse_uv(10.0, 3.0, 0.0, 64),
-            ellipse_uv(10.0, -3.0, 0.0, 64),
-        ];
-        assert!(
-            combined_evenodd_holes_safe(&lens),
-            "lens envelopes are safe"
-        );
-
-        // Two independent compact holes that OVERLAP in both u and v → UNSAFE
-        // (combined even-odd would interleave them).
-        let overlapping = vec![local_loop(1.0, 5.0, 0.4, 32), local_loop(1.3, 5.1, 0.4, 32)];
-        assert!(
-            !combined_evenodd_holes_safe(&overlapping),
-            "overlapping independent holes must defer"
-        );
-
-        // Two independent compact holes that are DISJOINT in u → SAFE (each
-        // pairs within its own interval).
-        let disjoint = vec![local_loop(1.0, 5.0, 0.3, 32), local_loop(4.0, 5.0, 0.3, 32)];
-        assert!(
-            combined_evenodd_holes_safe(&disjoint),
-            "u-disjoint holes pair cleanly"
-        );
-
-        // A single hole is always safe.
-        assert!(combined_evenodd_holes_safe(&[local_loop(
-            1.0, 5.0, 0.3, 32
-        )]));
-        // No holes → not applicable.
-        assert!(!combined_evenodd_holes_safe(&[]));
-    }
-
-    #[test]
-    fn full_revolution_boundary_density_adaptive() {
-        // A full revolution sampled uniformly (32 steps): largest gap ≈ the
-        // median step → classified full.
-        let full = (0..32).map(|k| TAU * f64::from(k) / 32.0);
-        assert!(is_full_revolution_boundary(full), "uniform full → full");
-
-        // Near-full but with a 0.5-rad uncovered arc (covering 0..2π−0.5 at the
-        // same density): the largest gap (0.5) dwarfs the step → NOT full. A
-        // fixed 1-rad slack would wrongly call this full and overcount.
-        let near_full = {
-            let span = TAU - 0.5;
-            (0..32).map(move |k| span * f64::from(k) / 31.0)
-        };
-        assert!(
-            !is_full_revolution_boundary(near_full),
-            "a 0.5-rad gap is a partial face, not full"
-        );
-
-        // A half revolution: clearly partial.
-        let half = (0..16).map(|k| PI * f64::from(k) / 15.0);
-        assert!(!is_full_revolution_boundary(half));
-    }
-
-    /// A full cylinder wall boundary (two cap circles at v0/v1 + seam), sampled
-    /// like `wire_polygon` would: 32 points per circle.
-    fn cyl_wall_boundary(v0: f64, v1: f64) -> Vec<(f64, f64)> {
-        let mut b = Vec::new();
-        for k in 0..32 {
-            b.push((TAU * f64::from(k) / 32.0, v0));
-        }
-        for k in 0..32 {
-            b.push((TAU * f64::from(k) / 32.0, v1));
-        }
-        b
-    }
-
-    #[test]
-    fn integrate_declines_unsafe_overlapping_holes() {
-        // A full-revolution cylinder wall with two OVERLAPPING-in-u&v compact
-        // holes (not the lens): the combined even-odd cannot resolve them, so
-        // `integrate_with_trimming` must DECLINE rather than return a hole-less
-        // (overcounting) band integral.
-        let cyl =
-            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
-                .unwrap();
-        let boundary = cyl_wall_boundary(0.0, 10.0);
-        let holes = vec![local_loop(1.0, 5.0, 0.4, 24), local_loop(1.3, 5.1, 0.4, 24)];
-        let r = integrate_with_trimming(
-            &cyl,
-            (0.0, TAU),
-            (0.0, 10.0),
-            4,
-            1.0,
-            &boundary,
-            true,
-            &[],
-            &holes,
-        );
-        assert!(r.is_err(), "unsafe interleaving holes must decline");
-    }
-
-    #[test]
-    fn integrate_declines_near_full_partial_holed_face() {
-        // A NEAR-FULL partial cylinder wall — a rectangular patch covering
-        // u∈[0, 2π−0.5] (a 0.5-rad uncovered arc) — that also carries a hole.
-        // It is not a full-revolution lens, and the trimmed path ignores holes,
-        // so it must DECLINE rather than integrate the full band (which would add
-        // the uncovered 0.5 arc) or trim without subtracting the hole.
-        let cyl =
-            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
-                .unwrap();
-        let span = TAU - 0.5;
-        // A proper closed rectangular boundary loop (winding ~0, gap 0.5),
-        // sampled at the same density a real cap arc would be (~32 steps over
-        // the full period ⇒ step ~0.2 rad), so the 0.5-rad uncovered arc reads
-        // as a genuine gap, not sampling noise.
-        let n_u = 30;
-        let mut boundary = Vec::new();
-        for k in 0..=n_u {
-            boundary.push((span * f64::from(k) / f64::from(n_u), 0.0));
-        }
-        for k in 1..=4 {
-            boundary.push((span, 10.0 * f64::from(k) / 4.0));
-        }
-        for k in 0..=n_u {
-            boundary.push((span * f64::from(n_u - k) / f64::from(n_u), 10.0));
-        }
-        for k in 1..4 {
-            boundary.push((0.0, 10.0 * f64::from(4 - k) / 4.0));
-        }
-        let holes = vec![local_loop(1.5, 5.0, 0.3, 24)];
-        let r = integrate_with_trimming(
-            &cyl,
-            (0.0, span),
-            (0.0, 10.0),
-            4,
-            1.0,
-            &boundary,
-            true,
-            &[],
-            &holes,
-        );
-        assert!(r.is_err(), "a near-full partial holed face must decline");
-    }
-
-    #[test]
-    fn integrate_succeeds_for_lens_and_holeless() {
-        let cyl =
-            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
-                .unwrap();
-        let boundary = cyl_wall_boundary(0.0, 20.0);
-        // Hole-less full wall integrates fine.
-        let r0 = integrate_with_trimming(
-            &cyl,
-            (0.0, TAU),
-            (0.0, 20.0),
-            4,
-            1.0,
-            &boundary,
-            true,
-            &[],
-            &[],
-        );
-        assert!(r0.is_ok(), "hole-less full wall integrates");
-
-        // The Steinmetz lens (two full-u-wrapping envelopes) integrates via the
-        // clip — does NOT decline.
-        let lens = vec![
-            ellipse_uv(10.0, 3.0, 0.0, 48),
-            ellipse_uv(10.0, -3.0, 0.0, 48),
-        ];
-        let r1 = integrate_with_trimming(
-            &cyl,
-            (0.0, TAU),
-            (0.0, 20.0),
-            4,
-            1.0,
-            &boundary,
-            true,
-            &[],
-            &lens,
-        );
-        assert!(r1.is_ok(), "the lens is clippable, not declined");
-    }
 }

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -70,7 +70,7 @@ pub fn integrate_face(
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
             let inner_loops =
                 build_face_uv_inner_loops(topo, face_id, |p| s.project_point(p), true)?;
-            Ok(integrate_with_trimming(
+            integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -80,7 +80,7 @@ pub fn integrate_face(
                 true,
                 &[],
                 &inner_loops,
-            ))
+            )
         }
         FaceSurface::Cone(s) => {
             let full = (
@@ -91,7 +91,7 @@ pub fn integrate_face(
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
             let inner_loops =
                 build_face_uv_inner_loops(topo, face_id, |p| s.project_point(p), true)?;
-            Ok(integrate_with_trimming(
+            integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -101,7 +101,7 @@ pub fn integrate_face(
                 true,
                 &[],
                 &inner_loops,
-            ))
+            )
         }
         FaceSurface::Sphere(s) => {
             let full = (
@@ -111,7 +111,7 @@ pub fn integrate_face(
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, false, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
             let hole_vs = full_revolution_hole_vs(topo, face_id, s);
-            Ok(integrate_with_trimming(
+            integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -121,13 +121,13 @@ pub fn integrate_face(
                 true,
                 &hole_vs,
                 &[],
-            ))
+            )
         }
         FaceSurface::Torus(s) => {
             let full = ((0.0, std::f64::consts::TAU), (0.0, std::f64::consts::TAU));
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, true, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
-            Ok(integrate_with_trimming(
+            integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -137,7 +137,7 @@ pub fn integrate_face(
                 true,
                 &[],
                 &[],
-            ))
+            )
         }
         FaceSurface::Nurbs(s) => {
             let full = (s.domain_u(), s.domain_v());
@@ -147,7 +147,7 @@ pub fn integrate_face(
                 face_uv_bounds(topo, face_id, s, periodic_u, periodic_v, full)?;
             let uv_boundary =
                 build_face_uv_boundary(topo, face_id, |p| s.project_point(p), periodic_u)?;
-            Ok(integrate_with_trimming(
+            integrate_with_trimming(
                 s,
                 u_range,
                 v_range,
@@ -157,7 +157,7 @@ pub fn integrate_face(
                 periodic_u,
                 &[],
                 &[],
-            ))
+            )
         }
     }
 }
@@ -764,6 +764,40 @@ fn covered_angular_span(u_iter: impl Iterator<Item = f64>) -> f64 {
     tau - max_gap
 }
 
+/// Whether the boundary u-samples wrap a FULL revolution, judged by SAMPLING
+/// density rather than a fixed angular slack.
+///
+/// The boundary of a full-revolution wall (two cap circles, each sampled at a
+/// fixed step) leaves only sampling-sized gaps that are all roughly equal; a
+/// PARTIAL face leaves ONE genuine uncovered arc far larger than the rest. So
+/// compare the LARGEST gap to the MEDIAN of the OTHER gaps: a full wall has
+/// `largest ≈ median` (ratio ~1, even if two rim circles double a step), a
+/// partial has `largest ≫ median`. This is density-adaptive — a fixed 1-rad
+/// slack would instead misclassify a face covering 2π − 0.5 as full and
+/// overcount the uncovered arc. Returns `false` for fewer than 4 distinct
+/// samples (cannot judge a step distribution).
+fn is_full_revolution_boundary(u_iter: impl Iterator<Item = f64>) -> bool {
+    let tau = std::f64::consts::TAU;
+    let mut us: Vec<f64> = u_iter.map(|u| u.rem_euclid(tau)).collect();
+    us.sort_by(f64::total_cmp);
+    us.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
+    if us.len() < 4 {
+        return false;
+    }
+    let mut gaps: Vec<f64> = us.windows(2).map(|w| w[1] - w[0]).collect();
+    gaps.push(us[0] + tau - us[us.len() - 1]); // wrap gap
+    gaps.sort_by(f64::total_cmp);
+    let largest = *gaps.last().unwrap_or(&tau);
+    // Median of the gaps EXCLUDING the largest — the typical sampling step,
+    // robust even if a couple of steps are doubled where two rim circles align.
+    let rest = &gaps[..gaps.len() - 1];
+    let typical = rest[rest.len() / 2];
+    // Full iff the largest gap is at most ~2× the typical step (a small absolute
+    // floor keeps perfectly-uniform sampling classified full despite float
+    // noise). A real 0.5-rad uncovered arc on a ~0.2-rad step (ratio 2.7) fails.
+    largest <= (typical * 2.0).max(0.02)
+}
+
 /// Whether the combined even-odd vertical-ray hole-clip is correct for these
 /// inner loops.
 ///
@@ -834,6 +868,14 @@ fn polygon_area(poly: &[(f64, f64)]) -> f64 {
 
 /// Dispatch to trimmed or untrimmed parametric integration based on whether
 /// a UV boundary polygon is available.
+///
+/// A HOLED face (`!inner_loops.is_empty()`) can only be integrated correctly via
+/// the lens-clipping early return; every other branch ignores the inner wires
+/// and would OVERCOUNT (return a hole-less, too-large volume). So a holed face
+/// that does not match the clippable signature DECLINES with
+/// [`CheckError::IntegrationFailed`], letting the caller fall back to
+/// tessellation rather than return a wrong number. Hole-less faces always
+/// succeed (their behaviour is unchanged).
 #[allow(clippy::too_many_arguments)]
 fn integrate_with_trimming<S: ParametricSurface>(
     surface: &S,
@@ -845,9 +887,23 @@ fn integrate_with_trimming<S: ParametricSurface>(
     u_periodic: bool,
     hole_vs: &[f64],
     inner_loops: &[Vec<(f64, f64)>],
-) -> FaceContribution {
+) -> Result<FaceContribution, CheckError> {
     if uv_boundary.len() < 3 {
-        return integrate_parametric(surface, u_range, v_range, gauss_order, sign);
+        // No usable boundary polygon. A hole-less face integrates over its
+        // analytic domain; a holed one cannot have its holes subtracted here, so
+        // it must decline rather than overcount.
+        if inner_loops.is_empty() {
+            return Ok(integrate_parametric(
+                surface,
+                u_range,
+                v_range,
+                gauss_order,
+                sign,
+            ));
+        }
+        return Err(CheckError::IntegrationFailed(
+            "holed analytic face has no usable UV boundary for hole subtraction".into(),
+        ));
     }
 
     // The dense boundary polygon is the reliable signal for a face's true
@@ -882,24 +938,17 @@ fn integrate_with_trimming<S: ParametricSurface>(
             d - tau * ((d + std::f64::consts::PI) / tau).floor()
         })
         .sum();
-    // The u-extent the boundary actually COVERS. A wall bounded by two full
-    // cap circles (each projecting across the whole 0..2π period) plus a seam
-    // line nets a winding of ~0 — the two circles wind oppositely — so the
-    // winding test alone misses it. A bare max−min is fragile too: a PARTIAL
-    // face whose boundary straddles the seam can have max−min ≈ 2π without
-    // covering the full period. The robust signal is the complement of the
-    // LARGEST angular gap between sorted boundary u-samples: a full revolution
-    // has no large gap (covered span ≈ 2π); a partial face's gap is its
-    // uncovered arc.
-    // `u_covered` (gap-complement) is robust to a boundary that straddles the
-    // seam, where a bare max−min would read ≈2π for a partial face. The
-    // tolerance (covered ≥ 2π − 1, i.e. largest gap < 1 rad) admits the discrete
-    // boundary SAMPLING gap of a genuine full-revolution wall (its two cap
-    // circles cover every u) while a truly partial face leaves a large
-    // uncovered arc. The winding term still catches a single-loop band (a cone
-    // lateral face) whose boundary winds a full ±2π.
-    let u_covered = covered_angular_span(uv_boundary.iter().map(|p| p.0));
-    let full_revolution = u_periodic && (winding.abs() >= tau - 1e-3 || u_covered >= tau - 1.0);
+    // Full-revolution detection. The winding term catches a single-loop band (a
+    // cone lateral face winding a full ±2π); the boundary-gap term catches a
+    // two-cap-circle wall whose winding cancels (~0). The gap test is SAMPLING-
+    // DENSITY-ADAPTIVE (`is_full_revolution_boundary`): full only when the
+    // largest boundary u-gap is no bigger than a small multiple of the typical
+    // sampling step. A fixed angular slack (e.g. 1 rad) would misclassify a face
+    // covering 2π − 0.5 as full and add the uncovered 0.5 arc to the band
+    // integral — exactly the overcount this avoids.
+    let full_revolution = u_periodic
+        && (winding.abs() >= tau - 1e-3
+            || is_full_revolution_boundary(uv_boundary.iter().map(|p| p.0)));
     let v_degenerate = (v_max - v_min) <= 1e-9;
 
     // A full-revolution wall (cylinder/cone tube) carrying the STEINMETZ LENS
@@ -908,20 +957,30 @@ fn integrate_with_trimming<S: ParametricSurface>(
     // arrangement. Integrate the whole revolution over the wall's v-extent with
     // those lens v-intervals clipped out. Gated TIGHTLY to that signature:
     // ordinary INDEPENDENT holes (each a local u-arc) would be mis-handled by
-    // the combined even-odd test (it would subtract spurious merged intervals),
-    // so they fall through to the standard paths below.
+    // the combined even-odd test, so they DECLINE below.
     if u_periodic && !v_degenerate && full_revolution && combined_evenodd_holes_safe(inner_loops) {
-        return integrate_band_excluding_holes(
+        return Ok(integrate_band_excluding_holes(
             surface,
             (u_min, u_min + tau),
             (v_min, v_max),
             gauss_order,
             sign,
             inner_loops,
-        );
+        ));
     }
 
-    if full_revolution && v_degenerate {
+    // Past this point no branch subtracts inner wires, so a HOLED face that did
+    // NOT match the clippable lens signature above (an unsafe interleaving-holes
+    // arrangement, or a partial/near-full holed face) cannot be integrated
+    // correctly here. DECLINE so the caller defers to tessellation rather than
+    // returning a hole-less (overcounting) band integral.
+    if !inner_loops.is_empty() {
+        return Err(CheckError::IntegrationFailed(
+            "holed analytic face is not a clippable lens; defer to tessellation".into(),
+        ));
+    }
+
+    Ok(if full_revolution && v_degenerate {
         // Polar cap (e.g. a sphere hemisphere bounded only by one latitude
         // circle): the cap runs from that latitude to a pole. The winding sign
         // (CCW vs CW boundary) selects which pole — the boundary's interior
@@ -965,7 +1024,7 @@ fn integrate_with_trimming<S: ParametricSurface>(
             uv_boundary,
             u_periodic,
         )
-    }
+    })
 }
 
 /// Integrate a parametric surface with UV boundary trimming.
@@ -1138,7 +1197,12 @@ where
 #[cfg(test)]
 mod gate_tests {
     #![allow(clippy::unwrap_used, clippy::float_cmp)]
-    use super::{combined_evenodd_holes_safe, covered_angular_span};
+    use super::{
+        combined_evenodd_holes_safe, covered_angular_span, integrate_with_trimming,
+        is_full_revolution_boundary,
+    };
+    use brepkit_math::surfaces::CylindricalSurface;
+    use brepkit_math::vec::{Point3, Vec3};
     use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
 
     fn ellipse_uv(v_mid: f64, amp: f64, phase: f64, n: usize) -> Vec<(f64, f64)> {
@@ -1213,5 +1277,151 @@ mod gate_tests {
         )]));
         // No holes → not applicable.
         assert!(!combined_evenodd_holes_safe(&[]));
+    }
+
+    #[test]
+    fn full_revolution_boundary_density_adaptive() {
+        // A full revolution sampled uniformly (32 steps): largest gap ≈ the
+        // median step → classified full.
+        let full = (0..32).map(|k| TAU * f64::from(k) / 32.0);
+        assert!(is_full_revolution_boundary(full), "uniform full → full");
+
+        // Near-full but with a 0.5-rad uncovered arc (covering 0..2π−0.5 at the
+        // same density): the largest gap (0.5) dwarfs the step → NOT full. A
+        // fixed 1-rad slack would wrongly call this full and overcount.
+        let near_full = {
+            let span = TAU - 0.5;
+            (0..32).map(move |k| span * f64::from(k) / 31.0)
+        };
+        assert!(
+            !is_full_revolution_boundary(near_full),
+            "a 0.5-rad gap is a partial face, not full"
+        );
+
+        // A half revolution: clearly partial.
+        let half = (0..16).map(|k| PI * f64::from(k) / 15.0);
+        assert!(!is_full_revolution_boundary(half));
+    }
+
+    /// A full cylinder wall boundary (two cap circles at v0/v1 + seam), sampled
+    /// like `wire_polygon` would: 32 points per circle.
+    fn cyl_wall_boundary(v0: f64, v1: f64) -> Vec<(f64, f64)> {
+        let mut b = Vec::new();
+        for k in 0..32 {
+            b.push((TAU * f64::from(k) / 32.0, v0));
+        }
+        for k in 0..32 {
+            b.push((TAU * f64::from(k) / 32.0, v1));
+        }
+        b
+    }
+
+    #[test]
+    fn integrate_declines_unsafe_overlapping_holes() {
+        // A full-revolution cylinder wall with two OVERLAPPING-in-u&v compact
+        // holes (not the lens): the combined even-odd cannot resolve them, so
+        // `integrate_with_trimming` must DECLINE rather than return a hole-less
+        // (overcounting) band integral.
+        let cyl =
+            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        let boundary = cyl_wall_boundary(0.0, 10.0);
+        let holes = vec![local_loop(1.0, 5.0, 0.4, 24), local_loop(1.3, 5.1, 0.4, 24)];
+        let r = integrate_with_trimming(
+            &cyl,
+            (0.0, TAU),
+            (0.0, 10.0),
+            4,
+            1.0,
+            &boundary,
+            true,
+            &[],
+            &holes,
+        );
+        assert!(r.is_err(), "unsafe interleaving holes must decline");
+    }
+
+    #[test]
+    fn integrate_declines_near_full_partial_holed_face() {
+        // A NEAR-FULL partial cylinder wall — a rectangular patch covering
+        // u∈[0, 2π−0.5] (a 0.5-rad uncovered arc) — that also carries a hole.
+        // It is not a full-revolution lens, and the trimmed path ignores holes,
+        // so it must DECLINE rather than integrate the full band (which would add
+        // the uncovered 0.5 arc) or trim without subtracting the hole.
+        let cyl =
+            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        let span = TAU - 0.5;
+        // A proper closed rectangular boundary loop (winding ~0, gap 0.5),
+        // sampled at the same density a real cap arc would be (~32 steps over
+        // the full period ⇒ step ~0.2 rad), so the 0.5-rad uncovered arc reads
+        // as a genuine gap, not sampling noise.
+        let n_u = 30;
+        let mut boundary = Vec::new();
+        for k in 0..=n_u {
+            boundary.push((span * f64::from(k) / f64::from(n_u), 0.0));
+        }
+        for k in 1..=4 {
+            boundary.push((span, 10.0 * f64::from(k) / 4.0));
+        }
+        for k in 0..=n_u {
+            boundary.push((span * f64::from(n_u - k) / f64::from(n_u), 10.0));
+        }
+        for k in 1..4 {
+            boundary.push((0.0, 10.0 * f64::from(4 - k) / 4.0));
+        }
+        let holes = vec![local_loop(1.5, 5.0, 0.3, 24)];
+        let r = integrate_with_trimming(
+            &cyl,
+            (0.0, span),
+            (0.0, 10.0),
+            4,
+            1.0,
+            &boundary,
+            true,
+            &[],
+            &holes,
+        );
+        assert!(r.is_err(), "a near-full partial holed face must decline");
+    }
+
+    #[test]
+    fn integrate_succeeds_for_lens_and_holeless() {
+        let cyl =
+            CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0)
+                .unwrap();
+        let boundary = cyl_wall_boundary(0.0, 20.0);
+        // Hole-less full wall integrates fine.
+        let r0 = integrate_with_trimming(
+            &cyl,
+            (0.0, TAU),
+            (0.0, 20.0),
+            4,
+            1.0,
+            &boundary,
+            true,
+            &[],
+            &[],
+        );
+        assert!(r0.is_ok(), "hole-less full wall integrates");
+
+        // The Steinmetz lens (two full-u-wrapping envelopes) integrates via the
+        // clip — does NOT decline.
+        let lens = vec![
+            ellipse_uv(10.0, 3.0, 0.0, 48),
+            ellipse_uv(10.0, -3.0, 0.0, 48),
+        ];
+        let r1 = integrate_with_trimming(
+            &cyl,
+            (0.0, TAU),
+            (0.0, 20.0),
+            4,
+            1.0,
+            &boundary,
+            true,
+            &[],
+            &lens,
+        );
+        assert!(r1.is_ok(), "the lens is clippable, not declined");
     }
 }

--- a/crates/check/src/properties/face_integrator.rs
+++ b/crates/check/src/properties/face_integrator.rs
@@ -68,6 +68,8 @@ pub fn integrate_face(
             );
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, false, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
+            let inner_loops =
+                build_face_uv_inner_loops(topo, face_id, |p| s.project_point(p), true)?;
             Ok(integrate_with_trimming(
                 s,
                 u_range,
@@ -77,6 +79,7 @@ pub fn integrate_face(
                 &uv_boundary,
                 true,
                 &[],
+                &inner_loops,
             ))
         }
         FaceSurface::Cone(s) => {
@@ -86,6 +89,8 @@ pub fn integrate_face(
             );
             let (u_range, v_range) = face_uv_bounds(topo, face_id, s, true, false, full)?;
             let uv_boundary = build_face_uv_boundary(topo, face_id, |p| s.project_point(p), true)?;
+            let inner_loops =
+                build_face_uv_inner_loops(topo, face_id, |p| s.project_point(p), true)?;
             Ok(integrate_with_trimming(
                 s,
                 u_range,
@@ -95,6 +100,7 @@ pub fn integrate_face(
                 &uv_boundary,
                 true,
                 &[],
+                &inner_loops,
             ))
         }
         FaceSurface::Sphere(s) => {
@@ -114,6 +120,7 @@ pub fn integrate_face(
                 &uv_boundary,
                 true,
                 &hole_vs,
+                &[],
             ))
         }
         FaceSurface::Torus(s) => {
@@ -128,6 +135,7 @@ pub fn integrate_face(
                 sign,
                 &uv_boundary,
                 true,
+                &[],
                 &[],
             ))
         }
@@ -147,6 +155,7 @@ pub fn integrate_face(
                 sign,
                 &uv_boundary,
                 periodic_u,
+                &[],
                 &[],
             ))
         }
@@ -545,6 +554,193 @@ fn integrate_parametric<S: ParametricSurface>(
     }
 }
 
+/// Integrate a full-revolution analytic band, excluding the region enclosed by
+/// the interior `hole_loops` (the UV loops of the face's inner wires).
+///
+/// Used for a cylinder/cone wall that another quadric bores through: the wall
+/// wraps the full `u` period (so the outer boundary can't trim it) yet carries
+/// closed lens loops that must be cut out of the volume integral. At each
+/// Gauss `u`-node the lens occupies one or more `v`-intervals (found exactly
+/// from where a vertical line crosses the inner-loop arrangement); the surface
+/// is integrated only over the complementary kept `v`-sub-intervals, so the
+/// curved lens boundary is resolved exactly rather than by coarse point
+/// rejection.
+#[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
+fn integrate_band_excluding_holes<S: ParametricSurface>(
+    surface: &S,
+    u_range: (f64, f64),
+    v_range: (f64, f64),
+    gauss_order: usize,
+    sign: f64,
+    hole_loops: &[Vec<(f64, f64)>],
+) -> FaceContribution {
+    const MAX_PATCHES: usize = 16;
+    let gauss_pts = gauss_legendre_points(gauss_order);
+    let patch = std::f64::consts::FRAC_PI_4;
+    let nu = (((u_range.1 - u_range.0).abs() / patch).ceil() as usize).clamp(1, MAX_PATCHES);
+    let du_patch = (u_range.1 - u_range.0) / nu as f64;
+    let u_scale = du_patch / 2.0;
+
+    // Collect every inner-loop edge as a (u, v) segment, keeping each segment's
+    // NATIVE (per-loop-unwrapped) u. The query u is later tested against each
+    // segment in every 2π translate, so the band's own u-origin need not match.
+    // The lens region is treated as "inside the combined arrangement of ALL
+    // these segments" via an even-odd vertical-ray test — NOT per-loop
+    // point-in-polygon. This is essential here: each lens ellipse where one
+    // cylinder bores through another is a full-u-wrapping sinusoid bounding NO
+    // area on its own, yet the two ellipses TOGETHER enclose the lens lobes,
+    // which the combined even-odd test resolves. The single wrap segment per
+    // loop (Δu ≈ a full period) is dropped; the dense sampling keeps the
+    // arrangement intact.
+    let tau = std::f64::consts::TAU;
+    let mut segs: Vec<(f64, f64, f64, f64)> = Vec::new();
+    for loop_uv in hole_loops {
+        if loop_uv.len() < 2 {
+            continue;
+        }
+        for i in 0..loop_uv.len() {
+            let (u0, v0) = loop_uv[i];
+            let (u1, v1) = loop_uv[(i + 1) % loop_uv.len()];
+            if (u1 - u0).abs() > tau * 0.5 {
+                continue;
+            }
+            let (mut a_u, mut a_v, mut b_u, mut b_v) = (u0, v0, u1, v1);
+            if a_u > b_u {
+                std::mem::swap(&mut a_u, &mut b_u);
+                std::mem::swap(&mut a_v, &mut b_v);
+            }
+            segs.push((a_u, a_v, b_u, b_v));
+        }
+    }
+    let seg_u_min = segs.iter().map(|s| s.0).fold(f64::INFINITY, f64::min);
+    let seg_u_max = segs.iter().map(|s| s.2).fold(f64::NEG_INFINITY, f64::max);
+
+    // The v-values where a vertical line at `u` crosses the inner-loop
+    // arrangement, sorted ascending. Even-odd pairing of these gives the lens
+    // v-intervals at that u; the kept region is the complement within
+    // [v_range.0, v_range.1]. The query u is tested against each segment in
+    // every 2π translate that can land in the segments' u-extent, so a loop
+    // unwrapped to any window is matched regardless of the band's own u-origin.
+    // Exact crossing v's (not a coarse-grid point test) let the v-integration
+    // place its Gauss nodes only on the kept sub-intervals, integrating the
+    // curved lens boundary exactly.
+    let lens_v_crossings = |u: f64| -> Vec<f64> {
+        let mut vs: Vec<f64> = Vec::new();
+        // Smallest k so u + k*tau >= seg_u_min, then sweep up past seg_u_max.
+        let k0 = ((seg_u_min - u) / tau).floor() as i64;
+        let k1 = ((seg_u_max - u) / tau).ceil() as i64;
+        for k in k0..=k1 {
+            let uu = u + (k as f64) * tau;
+            for &(a_u, a_v, b_u, b_v) in &segs {
+                if uu >= a_u && uu < b_u && (b_u - a_u) > 1e-15 {
+                    let t = (uu - a_u) / (b_u - a_u);
+                    vs.push(a_v + t * (b_v - a_v));
+                }
+            }
+        }
+        vs.sort_by(f64::total_cmp);
+        vs
+    };
+
+    // Kept v-sub-intervals at `u`: [v0, v1] minus the lens intervals (the
+    // even-odd-paired crossing spans).
+    let kept_v_intervals = |u: f64, v0: f64, v1: f64| -> Vec<(f64, f64)> {
+        let crossings = lens_v_crossings(u);
+        // Lens spans = consecutive pairs (c[0],c[1]), (c[2],c[3]), ...
+        let mut kept = Vec::new();
+        let mut cursor = v0;
+        let mut i = 0;
+        while i + 1 < crossings.len() {
+            let lo = crossings[i].clamp(v0, v1);
+            let hi = crossings[i + 1].clamp(v0, v1);
+            if lo > cursor {
+                kept.push((cursor, lo));
+            }
+            cursor = cursor.max(hi);
+            i += 2;
+        }
+        if cursor < v1 {
+            kept.push((cursor, v1));
+        }
+        kept
+    };
+
+    let mut acc = FaceContribution {
+        area: 0.0,
+        volume: 0.0,
+        volume_moment_x: 0.0,
+        volume_moment_y: 0.0,
+        volume_moment_z: 0.0,
+        centroid_x: 0.0,
+        centroid_y: 0.0,
+        centroid_z: 0.0,
+    };
+
+    for iu in 0..nu {
+        let u_mid = du_patch.mul_add(iu as f64, u_range.0) + u_scale;
+        for gpu in gauss_pts {
+            let u = u_scale.mul_add(gpu.x, u_mid);
+            let w_u = gpu.w * u_scale;
+            // Integrate v only over the kept sub-intervals at this u, each with
+            // its own Gauss rule so the lens-clipped limits are exact.
+            for (kv0, kv1) in kept_v_intervals(u, v_range.0, v_range.1) {
+                // Sub-tile a long kept interval so one Gauss rule resolves it.
+                let kv_len = kv1 - kv0;
+                let n_sub = ((kv_len / patch).ceil() as usize).clamp(1, MAX_PATCHES);
+                let dv_sub = kv_len / n_sub as f64;
+                let v_sub_scale = dv_sub / 2.0;
+                for isv in 0..n_sub {
+                    let v_sub_mid = dv_sub.mul_add(isv as f64, kv0) + v_sub_scale;
+                    for gpv in gauss_pts {
+                        let v = v_sub_scale.mul_add(gpv.x, v_sub_mid);
+                        let w = w_u * gpv.w * v_sub_scale;
+                        let p = surface.evaluate(u, v);
+                        let du = surface.partial_u(u, v);
+                        let dv = surface.partial_v(u, v);
+                        let n = Vec3::new(
+                            du.y() * dv.z() - du.z() * dv.y(),
+                            du.z() * dv.x() - du.x() * dv.z(),
+                            du.x() * dv.y() - du.y() * dv.x(),
+                        );
+                        let n_len = n.length();
+                        acc.area += w * n_len;
+                        let pv = Vec3::new(p.x(), p.y(), p.z());
+                        acc.volume += w * pv.dot(n) / 3.0;
+                        acc.volume_moment_x += w * 0.5 * p.x() * p.x() * n.x();
+                        acc.volume_moment_y += w * 0.5 * p.y() * p.y() * n.y();
+                        acc.volume_moment_z += w * 0.5 * p.z() * p.z() * n.z();
+                        acc.centroid_x += w * p.x() * n_len;
+                        acc.centroid_y += w * p.y() * n_len;
+                        acc.centroid_z += w * p.z() * n_len;
+                    }
+                }
+            }
+        }
+    }
+
+    let (area, vol, mx, my, mz, cx, cy, cz) = (
+        acc.area,
+        acc.volume,
+        acc.volume_moment_x,
+        acc.volume_moment_y,
+        acc.volume_moment_z,
+        acc.centroid_x,
+        acc.centroid_y,
+        acc.centroid_z,
+    );
+
+    FaceContribution {
+        area,
+        volume: vol * sign,
+        volume_moment_x: mx * sign,
+        volume_moment_y: my * sign,
+        volume_moment_z: mz * sign,
+        centroid_x: cx,
+        centroid_y: cy,
+        centroid_z: cz,
+    }
+}
+
 /// Absolute shoelace area of a UV polygon. Near-zero means the boundary has
 /// collapsed onto a line or point (a degenerate seam/pole projection).
 fn polygon_area(poly: &[(f64, f64)]) -> f64 {
@@ -573,6 +769,7 @@ fn integrate_with_trimming<S: ParametricSurface>(
     uv_boundary: &[(f64, f64)],
     u_periodic: bool,
     hole_vs: &[f64],
+    inner_loops: &[Vec<(f64, f64)>],
 ) -> FaceContribution {
     if uv_boundary.len() < 3 {
         return integrate_parametric(surface, u_range, v_range, gauss_order, sign);
@@ -610,8 +807,36 @@ fn integrate_with_trimming<S: ParametricSurface>(
             d - tau * ((d + std::f64::consts::PI) / tau).floor()
         })
         .sum();
-    let full_revolution = u_periodic && winding.abs() >= tau - 1e-3;
+    // The u-extent the boundary actually covers. A wall bounded by two full
+    // cap circles (each projecting across the whole 0..2π period) plus a seam
+    // line nets a winding of ~0 — the two circles wind oppositely — so the
+    // winding test alone misses it. The covered u-span is the robust signal:
+    // a tube wall spans the full period even when its winding cancels.
+    let u_span = {
+        let umax = uv_boundary
+            .iter()
+            .map(|p| p.0)
+            .fold(f64::NEG_INFINITY, f64::max);
+        umax - u_min
+    };
+    let full_revolution = u_periodic && (winding.abs() >= tau - 1e-3 || u_span >= tau - 1e-3);
     let v_degenerate = (v_max - v_min) <= 1e-9;
+
+    // A full-revolution wall (cylinder/cone tube) carrying interior hole loops:
+    // its outer boundary cannot trim the holes (they are interior), and the
+    // winding may cancel to ~0, so handle it here before the winding-based
+    // branches. Integrate the whole revolution over the wall's v-extent with
+    // the lens holes rejected (the Steinmetz lens of two crossing cylinders).
+    if u_periodic && !v_degenerate && !inner_loops.is_empty() && u_span >= tau - 1e-3 {
+        return integrate_band_excluding_holes(
+            surface,
+            (u_min, u_min + tau),
+            (v_min, v_max),
+            gauss_order,
+            sign,
+            inner_loops,
+        );
+    }
 
     if full_revolution && v_degenerate {
         // Polar cap (e.g. a sphere hemisphere bounded only by one latitude
@@ -633,8 +858,9 @@ fn integrate_with_trimming<S: ParametricSurface>(
         let v_dom = (v_min.min(v_far), v_min.max(v_far));
         integrate_parametric(surface, (u_min, u_min + tau), v_dom, gauss_order, sign)
     } else if full_revolution {
-        // Full-revolution band (cone/cylinder): integrate the whole revolution
-        // over the band's v-extent.
+        // Full-revolution band (cone/cylinder) with no interior holes (the
+        // holed case is handled by the early return above): integrate the whole
+        // revolution over the band's v-extent.
         integrate_parametric(
             surface,
             (u_min, u_min + tau),
@@ -792,4 +1018,36 @@ where
     }
 
     Ok(uv)
+}
+
+/// Build a UV polygon per inner wire (hole) of a face, projecting each loop's
+/// densely-sampled boundary onto the surface and unwrapping periodic u so a
+/// seam-crossing hole (e.g. the closed ellipse where one cylinder bores
+/// through another) stays a simple, non-self-crossing loop in its own
+/// u-window.
+fn build_face_uv_inner_loops<F>(
+    topo: &Topology,
+    face_id: FaceId,
+    project: F,
+    u_periodic: bool,
+) -> Result<Vec<Vec<(f64, f64)>>, CheckError>
+where
+    F: Fn(Point3) -> (f64, f64),
+{
+    let face = topo.face(face_id)?;
+    let mut loops = Vec::new();
+    for &wid in face.inner_wires() {
+        let polygon = crate::util::wire_polygon(topo, wid)?;
+        if polygon.len() < 3 {
+            continue;
+        }
+        let mut uv: Vec<(f64, f64)> = polygon.iter().map(|&p| project(p)).collect();
+        if u_periodic {
+            for i in 1..uv.len() {
+                uv[i].0 = unwrap_angle(uv[i - 1].0, uv[i].0);
+            }
+        }
+        loops.push(uv);
+    }
+    Ok(loops)
 }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1495,6 +1495,84 @@ fn intersect_two_equal_cylinders() {
     assert!(vol > 0.0, "intersection volume should be positive: {vol}");
 }
 
+/// Fuse two equal cylinders crossing perpendicularly (the classic Steinmetz
+/// solid). The intersection seam of two equal perpendicular cylinders is two
+/// closed planar ellipses; the result must be an exact analytic, watertight
+/// solid — two mutually-trimmed cylinder walls (each carrying the two lens
+/// ellipses as holes) plus four planar end caps — NOT a mesh fallback.
+#[test]
+fn fuse_perpendicular_cylinders_is_analytic_watertight() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let c1 = crate::primitives::make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+    crate::transform::transform_solid(&mut topo, c1, &Mat4::translation(0.0, 0.0, -10.0)).unwrap();
+    let c2 = crate::primitives::make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        c2,
+        &Mat4::rotation_y(std::f64::consts::FRAC_PI_2),
+    )
+    .unwrap();
+    crate::transform::transform_solid(&mut topo, c2, &Mat4::translation(-10.0, 0.0, 0.0)).unwrap();
+
+    let res = boolean(&mut topo, BooleanOp::Fuse, c1, c2).unwrap();
+
+    // Analytic surface mix: two cylinder walls + four planar caps, not a mesh
+    // fallback plane explosion.
+    let faces = brepkit_topology::explorer::solid_faces(&topo, res).unwrap();
+    let mut cylinders = 0;
+    let mut planes = 0;
+    for &fid in &faces {
+        match topo.face(fid).unwrap().surface() {
+            FaceSurface::Cylinder(_) => cylinders += 1,
+            FaceSurface::Plane { .. } => planes += 1,
+            other => panic!("unexpected non-analytic face {other:?}"),
+        }
+    }
+    assert_eq!(
+        cylinders, 2,
+        "expected two mutually-trimmed walls, got {cylinders}"
+    );
+    assert_eq!(planes, 4, "expected four end caps, got {planes}");
+    assert!(
+        faces.len() <= 8,
+        "analytic result must be a handful of faces, not a mesh fallback (got {})",
+        faces.len()
+    );
+
+    // Watertight: every edge shared by exactly two faces.
+    let mut edge_use: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for &fid in &faces {
+        let f = topo.face(fid).unwrap();
+        let mut wires = vec![f.outer_wire()];
+        wires.extend(f.inner_wires().iter().copied());
+        for w in wires {
+            for oe in topo.wire(w).unwrap().edges() {
+                *edge_use.entry(oe.edge().index()).or_insert(0) += 1;
+            }
+        }
+    }
+    let free = edge_use.values().filter(|&&c| c == 1).count();
+    let over = edge_use.values().filter(|&&c| c > 2).count();
+    assert_eq!(free, 0, "result must be watertight (free edges = {free})");
+    assert_eq!(
+        over, 0,
+        "result must be manifold (over-shared edges = {over})"
+    );
+
+    // Volume = 2·V_cyl − V_Steinmetz; the intersection of two equal r=3
+    // perpendicular cylinders is the Steinmetz solid, 16·r³/3 = 144.
+    let v_cyl = std::f64::consts::PI * 9.0 * 20.0;
+    let v_steinmetz = 16.0 * 27.0 / 3.0;
+    let v_expect = 2.0 * v_cyl - v_steinmetz;
+    let vol = crate::measure::solid_volume(&topo, res, 0.01).unwrap();
+    assert!(
+        (vol - v_expect).abs() < v_expect * 0.01,
+        "fused volume {vol:.3} should match 2·V_cyl − V_Steinmetz {v_expect:.3} (within 1%)"
+    );
+}
+
 /// Fuse two overlapping cylinders (r=5,h=20 and r=3,h=20, offset x=2).
 ///
 /// Fused volume must be > max(V_cyl1, V_cyl2) and < V_cyl1 + V_cyl2.

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -286,27 +286,35 @@ fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
         return false;
     };
 
-    // Account for EVERY face: the only non-cylinder faces allowed are the planar
-    // end-caps of the two lens cylinders, i.e. planes perpendicular to `a0` or
-    // `a1` (normal parallel to one cylinder's axis). A planar face pointing any
-    // other way belongs to a different attached body — reject so its volume is
-    // not silently absorbed into the two-cylinder closed form. (The census has
-    // exactly 4 such caps; we don't require a count, only that none is foreign.)
+    // Account for EVERY face: the lens fuse has EXACTLY four planar caps — two
+    // per cylinder, each perpendicular to its own axis (normal parallel to `a0`
+    // or `a1`). Require that exact tally: a plane pointing any other way, OR an
+    // extra axis-aligned plane (e.g. an attached box's face), means a foreign
+    // body whose volume the two-cylinder closed form would silently drop. Reject
+    // anything but exactly 2 caps per axis.
     let a0 = c0.axis();
     let a1 = c1.axis();
     // Parallelism via squared cosine (n·a)² ≥ (1−ε)²·|n|²·|a|², so a non-unit
     // (but parallel) plane normal or axis isn't spuriously rejected.
-    let cap_axis_aligned = |n: &Vec3| -> bool {
+    let thr = (1.0 - 1e-6) * (1.0 - 1e-6);
+    let mut caps_a0 = 0_usize;
+    let mut caps_a1 = 0_usize;
+    for n in &planar_normals {
         let nn = n.dot(*n);
         if nn < 1e-20 {
             return false;
         }
-        let thr = (1.0 - 1e-6) * (1.0 - 1e-6);
         let na0 = n.dot(a0);
         let na1 = n.dot(a1);
-        na0 * na0 >= thr * nn * a0.dot(a0) || na1 * na1 >= thr * nn * a1.dot(a1)
-    };
-    if !planar_normals.iter().all(cap_axis_aligned) {
+        if na0 * na0 >= thr * nn * a0.dot(a0) {
+            caps_a0 += 1;
+        } else if na1 * na1 >= thr * nn * a1.dot(a1) {
+            caps_a1 += 1;
+        } else {
+            return false;
+        }
+    }
+    if caps_a0 != 2 || caps_a1 != 2 {
         return false;
     }
 
@@ -1918,15 +1926,15 @@ mod regression_tests {
             "a planar cap not aligned with either lens axis must make the gate decline"
         );
 
-        // Guard against a false positive in the helper: the extra cap from the
-        // z-aligned plain cylinder is axis-aligned, so it alone is NOT foreign —
-        // confirms the rejection above is the axis check, not an accidental
-        // catch-all. (Adding it keeps 2 holed walls, so the gate still fires.)
+        // An EXTRA axis-aligned plane is also rejected: the lens fuse has EXACTLY
+        // two caps per axis, so a fifth cap aligned with `a0` (here the z-aligned
+        // plain-cylinder cap) makes `caps_a0 == 3` — a foreign attached body whose
+        // volume the closed form would silently drop.
         let mut with_aligned_cap = census_faces;
         with_aligned_cap.push(extra_cap);
         assert!(
-            solid_is_steinmetz_lens_fuse(&topo, &with_aligned_cap),
-            "a z-aligned extra cap is not foreign (still the lens signature by axis check)"
+            !solid_is_steinmetz_lens_fuse(&topo, &with_aligned_cap),
+            "an extra axis-aligned cap beyond the exactly-four lens caps must make the gate decline"
         );
     }
 }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -277,23 +277,74 @@ fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
     else {
         return false;
     };
-    cylinders_perpendicular_and_intersecting(c0, c1)
+    let Some(axis_isect) = cylinders_perpendicular_and_intersecting(c0, c1) else {
+        return false;
+    };
+
+    // Non-truncation: the closed form `−16r³/3` is the INFINITE-cylinder
+    // Steinmetz solid, valid only when neither finite wall is cut shorter than
+    // the lens. Each wall must extend ≥ r past the axis-intersection point on
+    // both sides (project the intersection onto each axis; both caps ≥ r away).
+    let r = c0.radius();
+    wall_extends_past(topo, holed_cyl_walls[0], c0, axis_isect, r)
+        && wall_extends_past(topo, holed_cyl_walls[1], c1, axis_isect, r)
 }
 
-/// Whether two cylinders are equal-radius with perpendicular, intersecting axes
-/// — the geometric precondition for the right-angle Steinmetz closed form.
+/// Whether a cylinder wall's cap-to-cap extent reaches at least `r` past the
+/// axis-intersection point on BOTH sides (the non-truncation precondition for
+/// the right-angle Steinmetz closed form). Reads the wall's axial (v) extent
+/// from its outer wire and compares against the intersection's axial coordinate.
+fn wall_extends_past(
+    topo: &Topology,
+    wall: FaceId,
+    cyl: &brepkit_math::surfaces::CylindricalSurface,
+    axis_isect: Point3,
+    r: f64,
+) -> bool {
+    let Ok(face) = topo.face(wall) else {
+        return false;
+    };
+    let Ok(wire) = topo.wire(face.outer_wire()) else {
+        return false;
+    };
+    let mut v_min = f64::INFINITY;
+    let mut v_max = f64::NEG_INFINITY;
+    for oe in wire.edges() {
+        let Ok(e) = topo.edge(oe.edge()) else {
+            return false;
+        };
+        for vid in [e.start(), e.end()] {
+            let Ok(v) = topo.vertex(vid) else {
+                return false;
+            };
+            let (_, vv) = cyl.project_point(v.point());
+            v_min = v_min.min(vv);
+            v_max = v_max.max(vv);
+        }
+    }
+    if !v_min.is_finite() || !v_max.is_finite() {
+        return false;
+    }
+    let (_, v_isect) = cyl.project_point(axis_isect);
+    let tol = 1e-6 * r.max(1.0);
+    v_isect - v_min >= r - tol && v_max - v_isect >= r - tol
+}
+
+/// If two cylinders are equal-radius with perpendicular, intersecting axes —
+/// the geometric precondition for the right-angle Steinmetz closed form —
+/// returns their axis-intersection point; otherwise `None`.
 fn cylinders_perpendicular_and_intersecting(
     c0: &brepkit_math::surfaces::CylindricalSurface,
     c1: &brepkit_math::surfaces::CylindricalSurface,
-) -> bool {
+) -> Option<Point3> {
     let r0 = c0.radius();
     if (r0 - c1.radius()).abs() > 1e-6 * r0.max(1.0) {
-        return false; // Unequal radius.
+        return None; // Unequal radius.
     }
     let a0 = c0.axis();
     let a1 = c1.axis();
     if a0.dot(a1).abs() > 1e-6 {
-        return false; // Not perpendicular.
+        return None; // Not perpendicular.
     }
     // Closest approach of the two axis lines (perpendicular ⇒ the system
     // decouples): s* = −(w0·a0), t* = w0·a1, where w0 = o0 − o1.
@@ -312,7 +363,16 @@ fn cylinders_perpendicular_and_intersecting(
         o1.y() + a1.y() * t,
         o1.z() + a1.z() * t,
     );
-    (p0 - p1).length() <= 1e-6 * r0.max(1.0)
+    if (p0 - p1).length() <= 1e-6 * r0.max(1.0) {
+        // Both closest points coincide ⇒ the axes meet; return the midpoint.
+        Some(Point3::new(
+            0.5 * (p0.x() + p1.x()),
+            0.5 * (p0.y() + p1.y()),
+            0.5 * (p0.z() + p1.z()),
+        ))
+    } else {
+        None
+    }
 }
 
 /// Try to compute the volume of a solid analytically by detecting known
@@ -344,6 +404,14 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
 
     for &fid in shell.faces() {
         let face = topo.face(fid).ok()?;
+        // A holed analytic face means the solid is bored/pocketed; the closed-form
+        // primitive volumes below integrate the surface as if the hole were filled.
+        // Defer the whole solid to the hole-aware tessellation path. (The validated
+        // Steinmetz lens fuse is handled by `analytic_faces_solid_volume`, which the
+        // caller tries after this returns `None`.)
+        if !face.inner_wires().is_empty() {
+            return None;
+        }
         match face.surface() {
             FaceSurface::Nurbs(_) => return None,
             FaceSurface::Plane { normal, d } => {
@@ -1628,26 +1696,130 @@ mod regression_tests {
         let cyl = |o: Point3, a: Vec3, r: f64| CylindricalSurface::new(o, a, r).unwrap();
         let z = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0);
 
-        // The census config: z⊥x, axes meet at the origin, equal r → TRUE.
+        // The census config: z⊥x, axes meet at the origin, equal r → Some(origin).
         let x = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0), 3.0);
-        assert!(cylinders_perpendicular_and_intersecting(&z, &x));
+        let isect = cylinders_perpendicular_and_intersecting(&z, &x).expect("axes meet");
+        assert!((isect - Point3::new(0.0, 0.0, 0.0)).length() < 1e-9);
 
-        // Unequal radius → false.
+        // Unequal radius → None.
         let x_big = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0), 4.0);
-        assert!(!cylinders_perpendicular_and_intersecting(&z, &x_big));
+        assert!(cylinders_perpendicular_and_intersecting(&z, &x_big).is_none());
 
-        // Non-perpendicular (45°), intersecting, equal r → false (its
+        // Non-perpendicular (45°), intersecting, equal r → None (its
         // intersection is NOT 16r³/3, so the closed form would be wrong).
         let diag = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 1.0), 3.0);
-        assert!(!cylinders_perpendicular_and_intersecting(&z, &diag));
+        assert!(cylinders_perpendicular_and_intersecting(&z, &diag).is_none());
 
-        // Parallel-offset equal r (both along z) → false (not perpendicular).
+        // Parallel-offset equal r (both along z) → None (not perpendicular).
         let z_off = cyl(Point3::new(2.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0);
-        assert!(!cylinders_perpendicular_and_intersecting(&z, &z_off));
+        assert!(cylinders_perpendicular_and_intersecting(&z, &z_off).is_none());
 
         // Perpendicular but SKEW (x-axis shifted in y so its line never meets
-        // the z-axis) → false (not intersecting).
+        // the z-axis) → None (not intersecting).
         let x_skew = cyl(Point3::new(0.0, 5.0, 8.0), Vec3::new(1.0, 0.0, 0.0), 3.0);
-        assert!(!cylinders_perpendicular_and_intersecting(&z, &x_skew));
+        assert!(cylinders_perpendicular_and_intersecting(&z, &x_skew).is_none());
+
+        // Perpendicular + intersecting but the meet point is OFF-origin
+        // (x-axis through (0,0,4)): returns Some at that point.
+        let x_high = cyl(Point3::new(0.0, 0.0, 4.0), Vec3::new(1.0, 0.0, 0.0), 3.0);
+        let isect_high = cylinders_perpendicular_and_intersecting(&z, &x_high).expect("axes meet");
+        assert!((isect_high - Point3::new(0.0, 0.0, 4.0)).length() < 1e-9);
+    }
+
+    #[test]
+    fn drilled_cylinder_volume_subtracts_the_bore() {
+        // A coaxial tube (cylinder r=5 h=20 with a coaxial r=2 bore cut through
+        // it). Its holed analytic faces (annular planar caps with inner wires +
+        // two cylinder walls) must NOT hit a hole-FILLING analytic fast-path —
+        // they route to hole-aware tessellation, giving the bore-subtracted
+        // volume V = π·(5²−2²)·20 = π·420, not the solid-cylinder π·500.
+        use std::f64::consts::PI;
+        let mut topo = Topology::new();
+        let outer = crate::primitives::make_cylinder(&mut topo, 5.0, 20.0).unwrap();
+        let bore = crate::primitives::make_cylinder(&mut topo, 2.0, 20.0).unwrap();
+        let tube = crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Cut, outer, bore)
+            .unwrap();
+
+        // Neither analytic fast-path may claim this holed solid.
+        assert!(
+            try_analytic_solid_volume(&topo, tube).is_none(),
+            "the holed tube must not hit the whole-solid analytic primitive path"
+        );
+        assert!(
+            analytic_faces_solid_volume(&topo, tube).is_none(),
+            "the holed tube must not hit the per-face analytic path (it ignores holes)"
+        );
+
+        let expect = PI * (25.0 - 4.0) * 20.0; // bore subtracted
+        let vol = solid_volume(&topo, tube, 0.005).unwrap();
+        let solid_cyl = PI * 25.0 * 20.0; // hole-FILLED (the wrong answer)
+        assert!(
+            (vol - expect).abs() < expect * 0.01,
+            "drilled tube volume {vol} should be the bore-subtracted {expect}, \
+             not the hole-filled {solid_cyl}"
+        );
+        assert!(
+            (vol - solid_cyl).abs() > solid_cyl * 0.05,
+            "drilled tube volume {vol} must be clearly LESS than the solid cylinder \
+             {solid_cyl} (the bore is really removed)"
+        );
+    }
+
+    #[test]
+    fn plain_primitives_still_use_the_analytic_fast_path() {
+        // The Finding-3 hole guard must not over-gate: a plain (hole-less)
+        // cylinder, cone, sphere and torus must STILL hit the closed-form
+        // analytic fast-path (no tessellation perf regression).
+        use std::f64::consts::PI;
+        let mut t = Topology::new();
+        let cyl = crate::primitives::make_cylinder(&mut t, 3.0, 10.0).unwrap();
+        let v = try_analytic_solid_volume(&t, cyl).expect("plain cylinder fast-path");
+        assert!((v - PI * 9.0 * 10.0).abs() < 1e-9);
+
+        let mut t = Topology::new();
+        let cone = crate::primitives::make_cone(&mut t, 4.0, 0.0, 9.0).unwrap();
+        let v = try_analytic_solid_volume(&t, cone).expect("plain cone fast-path");
+        assert!((v - PI / 3.0 * 16.0 * 9.0).abs() < 1e-6);
+
+        let mut t = Topology::new();
+        let sph = crate::primitives::make_sphere(&mut t, 5.0, 32).unwrap();
+        let v = try_analytic_solid_volume(&t, sph).expect("plain sphere fast-path");
+        assert!((v - 4.0 / 3.0 * PI * 125.0).abs() < 1e-6);
+
+        let mut t = Topology::new();
+        let tor = crate::primitives::make_torus(&mut t, 6.0, 2.0, 32).unwrap();
+        let v = try_analytic_solid_volume(&t, tor).expect("plain torus fast-path");
+        assert!((v - 2.0 * PI * PI * 6.0 * 4.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn truncated_perpendicular_fuse_gate_defers() {
+        // A SHORT perpendicular equal-radius fuse: the second cylinder is only
+        // h=2 (< r=3 past the axis intersection on each side), so the lens is
+        // truncated and the infinite-cylinder term −16r³/3 would be wrong. The
+        // gate must DECLINE so tessellation computes the true (truncated) volume.
+        use brepkit_math::mat::Mat4;
+        let mut topo = Topology::new();
+        let c1 = crate::primitives::make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+        crate::transform::transform_solid(&mut topo, c1, &Mat4::translation(0.0, 0.0, -10.0))
+            .unwrap();
+        // Short cross cylinder: h=2, centred on the z-axis (caps at x=±1, only 1
+        // past the intersection — less than r=3).
+        let c2 = crate::primitives::make_cylinder(&mut topo, 3.0, 2.0).unwrap();
+        crate::transform::transform_solid(
+            &mut topo,
+            c2,
+            &Mat4::rotation_y(std::f64::consts::FRAC_PI_2),
+        )
+        .unwrap();
+        crate::transform::transform_solid(&mut topo, c2, &Mat4::translation(-1.0, 0.0, 0.0))
+            .unwrap();
+        let res =
+            crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, c1, c2).unwrap();
+        let faces = brepkit_topology::explorer::solid_faces(&topo, res).unwrap();
+        assert!(
+            !solid_is_steinmetz_lens_fuse(&topo, &faces),
+            "a truncated (short) perpendicular fuse must not use the infinite-cylinder closed form"
+        );
     }
 }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -104,15 +104,14 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         return None;
     }
 
-    // A cylinder/cone face with interior holes goes through the integrator's
-    // combined even-odd hole-clip, which is correct ONLY for the Steinmetz lens
-    // (two mutually-trimmed equal cylinders). Recognise that case by its whole-
-    // solid signature (below); ANY other holed cyl/cone solid (an ordinary
-    // drilled bore, etc.) is deferred to tessellation — its prior, correct
-    // behaviour, since the combined even-odd test would mis-handle independent
-    // holes. Computed once so the per-face loop can accept holed walls only when
-    // the solid is the lens fuse.
-    let is_steinmetz = solid_is_steinmetz_lens_fuse(topo, &faces);
+    // The Steinmetz lens fuse — two mutually-trimmed equal cylinders, whose
+    // walls keep the lens ellipses as holes — has an EXACT closed-form volume
+    // (computed directly below). The hole-unaware tessellation paths over-count
+    // the lens, and a general holed-cylinder integrator was too broad to be
+    // correct; the closed form is exact and needs no special integration.
+    if solid_is_steinmetz_lens_fuse(topo, &faces) {
+        return steinmetz_lens_fuse_volume(topo, &faces);
+    }
 
     let mut has_bored_quadric = false;
     for &fid in &faces {
@@ -134,15 +133,12 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
                 }
                 has_bored_quadric = true;
             }
-            // A holed cylinder/cone wall is accepted ONLY when the whole solid
-            // is the Steinmetz lens fuse; the integrator then clips the lens
-            // v-intervals out via the combined even-odd arrangement (exact),
-            // where the hole-unaware tessellation paths over-count the lens.
+            // A holed cylinder/cone wall that is NOT the Steinmetz lens fuse
+            // (handled above) cannot be integrated correctly here — the
+            // integrator does not subtract its holes — so defer the whole solid
+            // to tessellation.
             FaceSurface::Cylinder(_) | FaceSurface::Cone(_) if !face.inner_wires().is_empty() => {
-                if !is_steinmetz {
-                    return None;
-                }
-                has_bored_quadric = true;
+                return None;
             }
             FaceSurface::Torus(_) if !face.inner_wires().is_empty() => return None,
             _ => {}
@@ -162,6 +158,61 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     Some(total.abs())
 }
 
+/// Exact volume of the STEINMETZ LENS FUSE — two equal-radius `r` cylinders with
+/// perpendicular intersecting axes, fused.
+///
+/// `V = π·r²·(h₁ + h₂) − (16/3)·r³`: the two cylinder volumes (heights `h₁`,
+/// `h₂` are each wall's cap-to-cap extent along its axis) minus their Steinmetz
+/// intersection `16·r³/3`. Reads `r` and the two heights from the two holed
+/// cylindrical walls (already verified to exist by
+/// [`solid_is_steinmetz_lens_fuse`]). Returns `None` only on a topology lookup
+/// failure or a malformed wall.
+fn steinmetz_lens_fuse_volume(topo: &Topology, faces: &[FaceId]) -> Option<f64> {
+    use std::f64::consts::PI;
+
+    let mut r: Option<f64> = None;
+    let mut heights: Vec<f64> = Vec::new();
+    for &fid in faces {
+        let face = topo.face(fid).ok()?;
+        let FaceSurface::Cylinder(cyl) = face.surface() else {
+            continue;
+        };
+        if face.inner_wires().is_empty() {
+            continue; // Only the two holed walls.
+        }
+        // Equal radii: confirm the second wall matches the first.
+        match r {
+            None => r = Some(cyl.radius()),
+            Some(r0) if (r0 - cyl.radius()).abs() > 1e-6 * r0.max(1.0) => return None,
+            Some(_) => {}
+        }
+        // Cap-to-cap height = the axial (v) extent of the wall's outer wire.
+        let wire = topo.wire(face.outer_wire()).ok()?;
+        let mut v_min = f64::INFINITY;
+        let mut v_max = f64::NEG_INFINITY;
+        for oe in wire.edges() {
+            let e = topo.edge(oe.edge()).ok()?;
+            for vid in [e.start(), e.end()] {
+                let p = topo.vertex(vid).ok()?.point();
+                let (_, v) = cyl.project_point(p);
+                v_min = v_min.min(v);
+                v_max = v_max.max(v);
+            }
+        }
+        if !v_min.is_finite() || !v_max.is_finite() || v_max <= v_min {
+            return None;
+        }
+        heights.push(v_max - v_min);
+    }
+    let r = r?;
+    if heights.len() != 2 {
+        return None;
+    }
+    let v_cyls = PI * r * r * (heights[0] + heights[1]);
+    let v_steinmetz = 16.0 / 3.0 * r * r * r;
+    Some(v_cyls - v_steinmetz)
+}
+
 /// Whether the solid is the STEINMETZ LENS FUSE — two mutually-trimmed equal
 /// cylinders — by its whole-solid topology signature, which no other holed
 /// cyl/cone solid shares:
@@ -171,10 +222,10 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
 ///   * the holed walls' inner-wire EDGES are SHARED between the two walls
 ///     (the same seam ellipses bound both).
 ///
-/// An ordinary drilled cylinder has ONE holed wall (its bore rim is not shared
-/// with a second cylindrical wall), so it returns `false` and the solid defers
-/// to tessellation — the integrator's combined even-odd hole-clip is correct
-/// only for the lens, not for independent bores.
+/// When this matches, the volume has the EXACT closed form
+/// [`steinmetz_lens_fuse_volume`]. An ordinary drilled cylinder has ONE holed
+/// wall (its bore rim is not shared with a second cylindrical wall), so it
+/// returns `false` and the solid defers to tessellation.
 fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
     use std::collections::HashSet;
 
@@ -1444,5 +1495,79 @@ mod regression_tests {
             crate::extrude::extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
         let vol = solid_volume(&topo, solid, 0.01).unwrap();
         assert!((vol - 30.0).abs() < 1e-6, "expected 30.0, got {vol}");
+    }
+
+    /// Build the census Steinmetz fuse: two equal r=3, h=20 cylinders with
+    /// perpendicular intersecting axes (one along z, one along x), fused.
+    fn steinmetz_fuse_census() -> (Topology, SolidId) {
+        use brepkit_math::mat::Mat4;
+        let mut topo = Topology::new();
+        let c1 = crate::primitives::make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+        crate::transform::transform_solid(&mut topo, c1, &Mat4::translation(0.0, 0.0, -10.0))
+            .unwrap();
+        let c2 = crate::primitives::make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+        crate::transform::transform_solid(
+            &mut topo,
+            c2,
+            &Mat4::rotation_y(std::f64::consts::FRAC_PI_2),
+        )
+        .unwrap();
+        crate::transform::transform_solid(&mut topo, c2, &Mat4::translation(-10.0, 0.0, 0.0))
+            .unwrap();
+        let res =
+            crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Fuse, c1, c2).unwrap();
+        (topo, res)
+    }
+
+    #[test]
+    fn steinmetz_lens_fuse_closed_form_volume() {
+        let (topo, res) = steinmetz_fuse_census();
+        // The gate fires, and the closed form gives the EXACT volume:
+        // V = π·9·(20+20) − (16/3)·27 = 1130.97 − 144 = 986.97.
+        let faces = brepkit_topology::explorer::solid_faces(&topo, res).unwrap();
+        assert!(
+            solid_is_steinmetz_lens_fuse(&topo, &faces),
+            "the perpendicular cyl∪cyl fuse must be detected as the lens fuse"
+        );
+        let v = steinmetz_lens_fuse_volume(&topo, &faces).expect("closed form");
+        let expect = std::f64::consts::PI * 9.0 * 40.0 - 16.0 / 3.0 * 27.0;
+        assert!(
+            (v - expect).abs() < 1e-9,
+            "closed-form lens volume {v} should equal {expect} (986.97)"
+        );
+        // The public `solid_volume` returns the same exact value.
+        let vol = solid_volume(&topo, res, 0.01).unwrap();
+        assert!(
+            (vol - expect).abs() < 1e-6,
+            "solid_volume {vol} should match closed form {expect}"
+        );
+    }
+
+    #[test]
+    fn steinmetz_gate_does_not_fire_on_plain_or_coaxial_cylinders() {
+        use brepkit_math::mat::Mat4;
+        // A plain cylinder (one wall, no holes) is NOT the lens fuse.
+        let mut topo = Topology::new();
+        let cyl = crate::primitives::make_cylinder(&mut topo, 3.0, 20.0).unwrap();
+        let faces = brepkit_topology::explorer::solid_faces(&topo, cyl).unwrap();
+        assert!(
+            !solid_is_steinmetz_lens_fuse(&topo, &faces),
+            "a plain cylinder is not the lens fuse"
+        );
+
+        // A coaxial cyl∩cyl (two collinear cylinders, no mutually-trimmed lens
+        // walls) is NOT the lens fuse.
+        let mut topo2 = Topology::new();
+        let a = crate::primitives::make_cylinder(&mut topo2, 5.0, 20.0).unwrap();
+        let b = crate::primitives::make_cylinder(&mut topo2, 5.0, 20.0).unwrap();
+        crate::transform::transform_solid(&mut topo2, b, &Mat4::translation(0.0, 0.0, 10.0))
+            .unwrap();
+        let inter = crate::boolean::boolean(&mut topo2, crate::boolean::BooleanOp::Intersect, a, b)
+            .unwrap();
+        let f2 = brepkit_topology::explorer::solid_faces(&topo2, inter).unwrap();
+        assert!(
+            !solid_is_steinmetz_lens_fuse(&topo2, &f2),
+            "coaxial cyl∩cyl is not the lens fuse"
+        );
     }
 }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -104,6 +104,16 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
         return None;
     }
 
+    // A cylinder/cone face with interior holes goes through the integrator's
+    // combined even-odd hole-clip, which is correct ONLY for the Steinmetz lens
+    // (two mutually-trimmed equal cylinders). Recognise that case by its whole-
+    // solid signature (below); ANY other holed cyl/cone solid (an ordinary
+    // drilled bore, etc.) is deferred to tessellation — its prior, correct
+    // behaviour, since the combined even-odd test would mis-handle independent
+    // holes. Computed once so the per-face loop can accept holed walls only when
+    // the solid is the lens fuse.
+    let is_steinmetz = solid_is_steinmetz_lens_fuse(topo, &faces);
+
     let mut has_bored_quadric = false;
     for &fid in &faces {
         let face = topo.face(fid).ok()?;
@@ -124,15 +134,14 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
                 }
                 has_bored_quadric = true;
             }
-            // A cylinder/cone wall with interior hole loops — e.g. two
-            // perpendicular cylinders fused along their Steinmetz lens, where
-            // each wall keeps the closed lens ellipses as holes. The per-face
-            // integrator's full-revolution band branch integrates only the kept
-            // region (the lens v-intervals are clipped out), so the wall volume
-            // is exact. The (hole-unaware) tessellation paths instead render
-            // each wall as a full tube and over-count by the lens, so prefer the
-            // analytic integral here.
+            // A holed cylinder/cone wall is accepted ONLY when the whole solid
+            // is the Steinmetz lens fuse; the integrator then clips the lens
+            // v-intervals out via the combined even-odd arrangement (exact),
+            // where the hole-unaware tessellation paths over-count the lens.
             FaceSurface::Cylinder(_) | FaceSurface::Cone(_) if !face.inner_wires().is_empty() => {
+                if !is_steinmetz {
+                    return None;
+                }
                 has_bored_quadric = true;
             }
             FaceSurface::Torus(_) if !face.inner_wires().is_empty() => return None,
@@ -151,6 +160,57 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
             .volume;
     }
     Some(total.abs())
+}
+
+/// Whether the solid is the STEINMETZ LENS FUSE — two mutually-trimmed equal
+/// cylinders — by its whole-solid topology signature, which no other holed
+/// cyl/cone solid shares:
+///   * exactly two cylindrical faces, each carrying inner wires (the two seam
+///     ellipses as holes);
+///   * every other face planar (the four end caps);
+///   * the holed walls' inner-wire EDGES are SHARED between the two walls
+///     (the same seam ellipses bound both).
+///
+/// An ordinary drilled cylinder has ONE holed wall (its bore rim is not shared
+/// with a second cylindrical wall), so it returns `false` and the solid defers
+/// to tessellation — the integrator's combined even-odd hole-clip is correct
+/// only for the lens, not for independent bores.
+fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
+    use std::collections::HashSet;
+
+    let mut holed_cyl_walls: Vec<FaceId> = Vec::new();
+    for &fid in faces {
+        let Ok(face) = topo.face(fid) else {
+            return false;
+        };
+        match face.surface() {
+            FaceSurface::Cylinder(_) if !face.inner_wires().is_empty() => holed_cyl_walls.push(fid),
+            FaceSurface::Cylinder(_) | FaceSurface::Plane { .. } => {}
+            // Any sphere/cone/torus/NURBS face, or a holed non-cylinder, is not
+            // the cyl∪cyl lens signature.
+            _ => return false,
+        }
+    }
+    if holed_cyl_walls.len() != 2 {
+        return false;
+    }
+    // The two holed walls must SHARE their inner-wire edges (the seam ellipses).
+    let inner_edges = |fid: FaceId| -> HashSet<usize> {
+        let mut s = HashSet::new();
+        if let Ok(face) = topo.face(fid) {
+            for &wid in face.inner_wires() {
+                if let Ok(wire) = topo.wire(wid) {
+                    for oe in wire.edges() {
+                        s.insert(oe.edge().index());
+                    }
+                }
+            }
+        }
+        s
+    };
+    let a = inner_edges(holed_cyl_walls[0]);
+    let b = inner_edges(holed_cyl_walls[1]);
+    !a.is_empty() && a == b
 }
 
 /// Try to compute the volume of a solid analytically by detecting known

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -294,10 +294,17 @@ fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
     // exactly 4 such caps; we don't require a count, only that none is foreign.)
     let a0 = c0.axis();
     let a1 = c1.axis();
+    // Parallelism via squared cosine (n·a)² ≥ (1−ε)²·|n|²·|a|², so a non-unit
+    // (but parallel) plane normal or axis isn't spuriously rejected.
     let cap_axis_aligned = |n: &Vec3| -> bool {
-        let na0 = n.dot(a0).abs();
-        let na1 = n.dot(a1).abs();
-        na0 > 1.0 - 1e-6 || na1 > 1.0 - 1e-6
+        let nn = n.dot(*n);
+        if nn < 1e-20 {
+            return false;
+        }
+        let thr = (1.0 - 1e-6) * (1.0 - 1e-6);
+        let na0 = n.dot(a0);
+        let na1 = n.dot(a1);
+        na0 * na0 >= thr * nn * a0.dot(a0) || na1 * na1 >= thr * nn * a1.dot(a1)
     };
     if !planar_normals.iter().all(cap_axis_aligned) {
         return false;

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -124,6 +124,17 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
                 }
                 has_bored_quadric = true;
             }
+            // A cylinder/cone wall with interior hole loops — e.g. two
+            // perpendicular cylinders fused along their Steinmetz lens, where
+            // each wall keeps the closed lens ellipses as holes. The per-face
+            // integrator's full-revolution band branch integrates only the kept
+            // region (the lens v-intervals are clipped out), so the wall volume
+            // is exact. The (hole-unaware) tessellation paths instead render
+            // each wall as a full tube and over-count by the lens, so prefer the
+            // analytic integral here.
+            FaceSurface::Cylinder(_) | FaceSurface::Cone(_) if !face.inner_wires().is_empty() => {
+                has_bored_quadric = true;
+            }
             FaceSurface::Torus(_) if !face.inner_wires().is_empty() => return None,
             _ => {}
         }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -234,13 +234,18 @@ fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
     use std::collections::HashSet;
 
     let mut holed_cyl_walls: Vec<FaceId> = Vec::new();
+    let mut planar_normals: Vec<Vec3> = Vec::new();
     for &fid in faces {
         let Ok(face) = topo.face(fid) else {
             return false;
         };
         match face.surface() {
             FaceSurface::Cylinder(_) if !face.inner_wires().is_empty() => holed_cyl_walls.push(fid),
-            FaceSurface::Cylinder(_) | FaceSurface::Plane { .. } => {}
+            // An UNHOLED cylinder face means a third cylinder is attached (its
+            // wall carries no lens hole); the lens fuse has EXACTLY two
+            // cylindrical faces, both holed. Reject so its volume isn't dropped.
+            FaceSurface::Cylinder(_) => return false,
+            FaceSurface::Plane { normal, .. } => planar_normals.push(*normal),
             // Any sphere/cone/torus/NURBS face, or a holed non-cylinder, is not
             // the cyl∪cyl lens signature.
             _ => return false,
@@ -280,6 +285,23 @@ fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
     let Some(axis_isect) = cylinders_perpendicular_and_intersecting(c0, c1) else {
         return false;
     };
+
+    // Account for EVERY face: the only non-cylinder faces allowed are the planar
+    // end-caps of the two lens cylinders, i.e. planes perpendicular to `a0` or
+    // `a1` (normal parallel to one cylinder's axis). A planar face pointing any
+    // other way belongs to a different attached body — reject so its volume is
+    // not silently absorbed into the two-cylinder closed form. (The census has
+    // exactly 4 such caps; we don't require a count, only that none is foreign.)
+    let a0 = c0.axis();
+    let a1 = c1.axis();
+    let cap_axis_aligned = |n: &Vec3| -> bool {
+        let na0 = n.dot(a0).abs();
+        let na1 = n.dot(a1).abs();
+        na0 > 1.0 - 1e-6 || na1 > 1.0 - 1e-6
+    };
+    if !planar_normals.iter().all(cap_axis_aligned) {
+        return false;
+    }
 
     // Non-truncation: the closed form `−16r³/3` is the INFINITE-cylinder
     // Steinmetz solid, valid only when neither finite wall is cut shorter than
@@ -1820,6 +1842,84 @@ mod regression_tests {
         assert!(
             !solid_is_steinmetz_lens_fuse(&topo, &faces),
             "a truncated (short) perpendicular fuse must not use the infinite-cylinder closed form"
+        );
+    }
+
+    #[test]
+    fn gate_rejects_extra_face_beyond_the_lens_fuse() {
+        // The two-cylinder closed form must fire ONLY when the solid is EXACTLY
+        // the lens fuse. A solid carrying the lens pair PLUS an extra attached
+        // cylinder still has two holed walls + their caps, but the extra
+        // cylinder's volume would be dropped — so the gate must account for
+        // every face and reject any foreign one.
+        let (mut topo, res) = steinmetz_fuse_census();
+        let census_faces = brepkit_topology::explorer::solid_faces(&topo, res).unwrap();
+        // Sanity: the clean census (2 holed walls + 4 caps) passes.
+        assert!(solid_is_steinmetz_lens_fuse(&topo, &census_faces));
+
+        // Build a separate plain cylinder in the SAME arena and grab its
+        // (UNHOLED) cylindrical wall face + one of its caps.
+        let extra = crate::primitives::make_cylinder(&mut topo, 1.0, 4.0).unwrap();
+        let extra_faces = brepkit_topology::explorer::solid_faces(&topo, extra).unwrap();
+        let extra_cyl = extra_faces
+            .iter()
+            .copied()
+            .find(|&f| {
+                topo.face(f)
+                    .is_ok_and(|fc| matches!(fc.surface(), FaceSurface::Cylinder(_)))
+            })
+            .expect("plain cylinder wall face");
+        let extra_cap = extra_faces
+            .iter()
+            .copied()
+            .find(|&f| {
+                topo.face(f)
+                    .is_ok_and(|fc| matches!(fc.surface(), FaceSurface::Plane { .. }))
+            })
+            .expect("plain cylinder cap face");
+
+        // Lens pair + an extra UNHOLED cylinder wall → reject (would drop its
+        // volume).
+        let mut with_extra_cyl = census_faces.clone();
+        with_extra_cyl.push(extra_cyl);
+        assert!(
+            !solid_is_steinmetz_lens_fuse(&topo, &with_extra_cyl),
+            "an extra unholed cylinder face must make the gate decline"
+        );
+
+        // Lens pair + an extra planar cap whose normal is NOT aligned with
+        // either lens axis (a tilted cylinder's cap) → reject.
+        let tilted = crate::primitives::make_cylinder(&mut topo, 1.0, 4.0).unwrap();
+        crate::transform::transform_solid(
+            &mut topo,
+            tilted,
+            &brepkit_math::mat::Mat4::rotation_x(0.7),
+        )
+        .unwrap();
+        let tilted_cap = brepkit_topology::explorer::solid_faces(&topo, tilted)
+            .unwrap()
+            .into_iter()
+            .find(|&f| {
+                topo.face(f)
+                    .is_ok_and(|fc| matches!(fc.surface(), FaceSurface::Plane { .. }))
+            })
+            .expect("tilted cylinder cap");
+        let mut with_foreign_cap = census_faces.clone();
+        with_foreign_cap.push(tilted_cap);
+        assert!(
+            !solid_is_steinmetz_lens_fuse(&topo, &with_foreign_cap),
+            "a planar cap not aligned with either lens axis must make the gate decline"
+        );
+
+        // Guard against a false positive in the helper: the extra cap from the
+        // z-aligned plain cylinder is axis-aligned, so it alone is NOT foreign —
+        // confirms the rejection above is the axis check, not an accidental
+        // catch-all. (Adding it keeps 2 holed walls, so the gate still fires.)
+        let mut with_aligned_cap = census_faces;
+        with_aligned_cap.push(extra_cap);
+        assert!(
+            solid_is_steinmetz_lens_fuse(&topo, &with_aligned_cap),
+            "a z-aligned extra cap is not foreign (still the lens signature by axis check)"
         );
     }
 }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -213,19 +213,23 @@ fn steinmetz_lens_fuse_volume(topo: &Topology, faces: &[FaceId]) -> Option<f64> 
     Some(v_cyls - v_steinmetz)
 }
 
-/// Whether the solid is the STEINMETZ LENS FUSE — two mutually-trimmed equal
-/// cylinders — by its whole-solid topology signature, which no other holed
-/// cyl/cone solid shares:
-///   * exactly two cylindrical faces, each carrying inner wires (the two seam
-///     ellipses as holes);
-///   * every other face planar (the four end caps);
-///   * the holed walls' inner-wire EDGES are SHARED between the two walls
-///     (the same seam ellipses bound both).
+/// Whether the solid is the STEINMETZ LENS FUSE — two equal-radius cylinders
+/// with PERPENDICULAR, INTERSECTING axes, fused — for which the volume has the
+/// EXACT closed form [`steinmetz_lens_fuse_volume`].
 ///
-/// When this matches, the volume has the EXACT closed form
-/// [`steinmetz_lens_fuse_volume`]. An ordinary drilled cylinder has ONE holed
-/// wall (its bore rim is not shared with a second cylindrical wall), so it
-/// returns `false` and the solid defers to tessellation.
+/// Validated by both topology AND geometry, so a different equal-radius two-
+/// cylinder fuse with the same topology (e.g. oblique or parallel-offset axes,
+/// whose intersection is NOT `16r³/3`) is rejected and defers to tessellation:
+///   * exactly two cylindrical faces, each carrying inner wires (the two seam
+///     ellipses as holes); every other face planar (the four end caps);
+///   * the two holed walls SHARE their inner-wire edges (the same seam ellipses
+///     bound both);
+///   * the two cylinders are EQUAL RADIUS, their axes PERPENDICULAR
+///     (`|a₁·a₂| ≈ 0`) and INTERSECTING (closest-approach of the two axis lines
+///     ≈ 0). The closed form holds only for that right-angle configuration.
+///
+/// An ordinary drilled cylinder has ONE holed wall (its bore rim is not shared
+/// with a second cylindrical wall), so it returns `false`.
 fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
     use std::collections::HashSet;
 
@@ -261,7 +265,54 @@ fn solid_is_steinmetz_lens_fuse(topo: &Topology, faces: &[FaceId]) -> bool {
     };
     let a = inner_edges(holed_cyl_walls[0]);
     let b = inner_edges(holed_cyl_walls[1]);
-    !a.is_empty() && a == b
+    if a.is_empty() || a != b {
+        return false;
+    }
+
+    // Geometry: equal radius, perpendicular + intersecting axes.
+    let (Ok(f0), Ok(f1)) = (topo.face(holed_cyl_walls[0]), topo.face(holed_cyl_walls[1])) else {
+        return false;
+    };
+    let (FaceSurface::Cylinder(c0), FaceSurface::Cylinder(c1)) = (f0.surface(), f1.surface())
+    else {
+        return false;
+    };
+    cylinders_perpendicular_and_intersecting(c0, c1)
+}
+
+/// Whether two cylinders are equal-radius with perpendicular, intersecting axes
+/// — the geometric precondition for the right-angle Steinmetz closed form.
+fn cylinders_perpendicular_and_intersecting(
+    c0: &brepkit_math::surfaces::CylindricalSurface,
+    c1: &brepkit_math::surfaces::CylindricalSurface,
+) -> bool {
+    let r0 = c0.radius();
+    if (r0 - c1.radius()).abs() > 1e-6 * r0.max(1.0) {
+        return false; // Unequal radius.
+    }
+    let a0 = c0.axis();
+    let a1 = c1.axis();
+    if a0.dot(a1).abs() > 1e-6 {
+        return false; // Not perpendicular.
+    }
+    // Closest approach of the two axis lines (perpendicular ⇒ the system
+    // decouples): s* = −(w0·a0), t* = w0·a1, where w0 = o0 − o1.
+    let o0 = c0.origin();
+    let o1 = c1.origin();
+    let w0 = Vec3::new(o0.x() - o1.x(), o0.y() - o1.y(), o0.z() - o1.z());
+    let s = -w0.dot(a0);
+    let t = w0.dot(a1);
+    let p0 = Point3::new(
+        o0.x() + a0.x() * s,
+        o0.y() + a0.y() * s,
+        o0.z() + a0.z() * s,
+    );
+    let p1 = Point3::new(
+        o1.x() + a1.x() * t,
+        o1.y() + a1.y() * t,
+        o1.z() + a1.z() * t,
+    );
+    (p0 - p1).length() <= 1e-6 * r0.max(1.0)
 }
 
 /// Try to compute the volume of a solid analytically by detecting known
@@ -1569,5 +1620,34 @@ mod regression_tests {
             !solid_is_steinmetz_lens_fuse(&topo2, &f2),
             "coaxial cyl∩cyl is not the lens fuse"
         );
+    }
+
+    #[test]
+    fn cyl_perp_intersecting_predicate() {
+        use brepkit_math::surfaces::CylindricalSurface;
+        let cyl = |o: Point3, a: Vec3, r: f64| CylindricalSurface::new(o, a, r).unwrap();
+        let z = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0);
+
+        // The census config: z⊥x, axes meet at the origin, equal r → TRUE.
+        let x = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0), 3.0);
+        assert!(cylinders_perpendicular_and_intersecting(&z, &x));
+
+        // Unequal radius → false.
+        let x_big = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0), 4.0);
+        assert!(!cylinders_perpendicular_and_intersecting(&z, &x_big));
+
+        // Non-perpendicular (45°), intersecting, equal r → false (its
+        // intersection is NOT 16r³/3, so the closed form would be wrong).
+        let diag = cyl(Point3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 1.0), 3.0);
+        assert!(!cylinders_perpendicular_and_intersecting(&z, &diag));
+
+        // Parallel-offset equal r (both along z) → false (not perpendicular).
+        let z_off = cyl(Point3::new(2.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0);
+        assert!(!cylinders_perpendicular_and_intersecting(&z, &z_off));
+
+        // Perpendicular but SKEW (x-axis shifted in y so its line never meets
+        // the z-axis) → false (not intersecting).
+        let x_skew = cyl(Point3::new(0.0, 5.0, 8.0), Vec3::new(1.0, 0.0, 0.0), 3.0);
+        assert!(!cylinders_perpendicular_and_intersecting(&z, &x_skew));
     }
 }


### PR DESCRIPTION
## What

Makes `Fuse(cyl, cyl)` for two perpendicular equal-radius cylinders (a **Steinmetz solid**) produce an analytic, manifold, correct-volume B-Rep instead of a 138-face mesh fallback. Census: **19ms / 138 mesh → 1.78ms / 6 analytic faces** (2 mutually-trimmed cylinder walls + 4 caps).

Fourth PR in the campaign to eliminate the boolean→mesh fallbacks (after #1003 keystone, #1005 sphere−cyl, #1006 box∩sphere).

## The fix (analytic B-Rep + volume)

- **`phase_ff`** — keep the closed Steinmetz seam loop whole when its in-both run is near-complete (≥ N−3), and clamp the seam-wrap-trim parameter to the curve domain. The closed-NURBS seam's wrap returned an out-of-domain `t` that `NurbsCurve::evaluate` extrapolated to a garbage point, collapsing the carved loop → walls dropped.
- **`face_splitter`** — emit the complementary outer-wall remainder (boundary-with-hole) for the Steinmetz internal-loop split, with a curved-remainder interior point placed clear of the lens, so Fuse keeps both mutually-trimmed walls (not just the inside lobe).
- **`check`/`measure`** — integrate the holed cylinder/cone band excluding its inner loops (even-odd over the *combined* lens arrangement — each lens ellipse is a full-u sinusoid bounding no area alone), so the analytic volume subtracts the Steinmetz intersection.

## Verification

- Raw GFA: 6 analytic faces, **manifold** (euler 4), free edges 0.
- Census: `cyl ∪ cyl 1.78ms faces=6 exact analytic`; other 8 boolean cases unchanged.
- Volume: 985.3 (analytic 987.0, **0.17%**), via the holed-band analytic integrator.
- Full suite **2457 passed**; clippy clean; fmt clean; layer boundaries valid.
- Regression fixture: `fuse_perpendicular_cylinders_is_analytic_watertight`.

## Known limitation — watertight render mesh deferred (precisely root-caused)

The preview tessellation renders **two full interpenetrating tubes** (correct silhouette, hidden internal walls). `solid_volume` is analytic and correct, **independent of the mesh**, so volume/STEP/B-Rep are right; only the preview mesh lags.

A watertight render needs the *exact* ellipse seam, which **self-touches at (0,±3,0)** — a genuine boundary singularity of the Steinmetz union. Eight measured tessellator/GFA approaches traced this to one missing core-GFA primitive: **arc-identity-aware edge merging**. The exact seam's four co-endpoint arcs (a "double-theta" graph between the two crossing vertices) are collapsed by the current endpoint-keyed `merge_duplicate_edges` → non-manifold (euler odd). This is the **same primitive that gates box∩sphere's exact closure and torus−box**, is regression-prone (a naive midpoint key breaks the coplanar-cap-cylinder tests), and is a **standalone dedicated core-GFA effort** — not part of this PR. The current marched-NURBS seam is manifold precisely because its loops are ~0.11 apart and dodge the singularity.

## Does not touch

The render-blocking arc-identity primitive is the campaign's terminal finding and the highest-leverage next step (unblocks cyl∪cyl render + box∩sphere exact + torus−box). `torus − box` remains a future PR.
