### PR TITLE
fix(algo): close torus−box boolean analytically (plane×torus seam + toroidal band)

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -498,7 +498,16 @@ fn perform_areas(topo: &Topology, shells: &[Vec<FaceId>]) -> (Vec<Vec<FaceId>>, 
 
         let signed_vol = signed_volume_of_shell(topo, shell);
 
-        if signed_vol >= 0.0 {
+        // A SINGLE shell is the result's outer boundary — there is no enclosing
+        // shell for it to be a cavity OF, so it is always growth. Its
+        // `signed_volume_of_shell` can read negative when a curved band face
+        // (e.g. the torus−box kept toroidal band, which wraps the tube) is
+        // sampled by the fan-tet integral over only its outer-wire CORNER
+        // vertices — a degenerate under-sampling that flips the sign. Treating a
+        // lone shell as growth avoids discarding the whole result as a hole;
+        // multi-shell results keep the volume-sign split (a Cut can leave the
+        // tool's interior as a separate negative-volume shell).
+        if shells.len() == 1 || signed_vol >= 0.0 {
             growth.push(shell.clone());
         } else {
             holes.push(shell.clone());

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -483,6 +483,138 @@ fn face_normal_at(topo: &Topology, face_id: FaceId, point: Point3) -> Option<Vec
 
 // ── Phase 3 ──────────────────────────────────────────────────────────
 
+/// Robust outward-orientation test for a closed shell, independent of face
+/// curvature and wire winding.
+///
+/// `signed_volume_of_shell` signs each face by its surface normal but integrates
+/// the magnitude over the outer-wire CORNER vertices only — a fan that
+/// under-samples (and can sign-flip) a doubly-curved band whose corners barely
+/// bound the wrapped surface (the torus−box notch band reads negative despite
+/// being outward). This computes the divergence-theorem flux `∮ P · n dA` per
+/// face with a curvature-aware quadrature — a planar face from its corner fan
+/// (exact), a curved face from a `(u, v)` GRID over its boundary's parameter box
+/// with the local area element `|∂P/∂u × ∂P/∂v|` — so a wrapped band integrates
+/// correctly. A closed outward shell yields a positive total (≈ 3·Volume); a
+/// genuinely inward-oriented lone shell (a Cut leaving only a cavity component)
+/// yields negative and is still rejected. Returns `None` when no face yields a
+/// usable contribution so the caller falls back to the volume sign.
+fn shell_is_outward_oriented(topo: &Topology, faces: &[FaceId]) -> Option<bool> {
+    let mut flux = 0.0_f64;
+    let mut any = false;
+    for &fid in faces {
+        let Ok(face) = topo.face(fid) else { continue };
+        let surface = face.surface();
+        if let FaceSurface::Plane { .. } = surface {
+            // Planar: corner fan from sampled boundary points is exact.
+            let Ok(wire) = topo.wire(face.outer_wire()) else {
+                continue;
+            };
+            let mut pts: Vec<Point3> = Vec::new();
+            for oe in wire.edges() {
+                let Ok(edge) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+                    continue;
+                };
+                let (sp, ep) = (sv.point(), ev.point());
+                for k in 0..4 {
+                    let f = f64::from(k) / 4.0;
+                    let f = if oe.is_forward() { f } else { 1.0 - f };
+                    pts.push(edge.curve().evaluate_with_endpoints(f, sp, ep));
+                }
+            }
+            if pts.len() < 3 {
+                continue;
+            }
+            let centroid = {
+                let n = pts.len() as f64;
+                let mut c = Vec3::new(0.0, 0.0, 0.0);
+                for p in &pts {
+                    c += Vec3::new(p.x(), p.y(), p.z());
+                }
+                Point3::new(c.x() / n, c.y() / n, c.z() / n)
+            };
+            let Some(normal) = face_normal_at(topo, fid, centroid) else {
+                continue;
+            };
+            let area = newell_normal(&pts).length() * 0.5;
+            flux += area * Vec3::new(centroid.x(), centroid.y(), centroid.z()).dot(normal);
+            any = true;
+        } else {
+            // Curved: integrate over the boundary's (u, v) parameter box.
+            let Ok(wire) = topo.wire(face.outer_wire()) else {
+                continue;
+            };
+            let mut uvs: Vec<(f64, f64)> = Vec::new();
+            for oe in wire.edges() {
+                let Ok(edge) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+                    continue;
+                };
+                let (sp, ep) = (sv.point(), ev.point());
+                for k in 0..=8 {
+                    let f = f64::from(k) / 8.0;
+                    let p = edge.curve().evaluate_with_endpoints(f, sp, ep);
+                    if let Some((u, v)) = surface.project_point(p) {
+                        uvs.push((u, v));
+                    }
+                }
+            }
+            if uvs.len() < 3 {
+                continue;
+            }
+            let (u_lo, u_hi, v_lo, v_hi) = uvs.iter().fold(
+                (f64::MAX, f64::MIN, f64::MAX, f64::MIN),
+                |(ul, uh, vl, vh), &(u, v)| (ul.min(u), uh.max(u), vl.min(v), vh.max(v)),
+            );
+            let reversed = face.is_reversed();
+            let (n_u, n_v) = (24usize, 24usize);
+            let du = (u_hi - u_lo) / n_u as f64;
+            let dv = (v_hi - v_lo) / n_v as f64;
+            if du.abs() < 1e-12 || dv.abs() < 1e-12 {
+                continue;
+            }
+            let eps_u = du * 1e-3;
+            let eps_v = dv * 1e-3;
+            for iu in 0..n_u {
+                for iv in 0..n_v {
+                    let u = u_lo + (iu as f64 + 0.5) * du;
+                    let v = v_lo + (iv as f64 + 0.5) * dv;
+                    let (Some(p), Some(pu1), Some(pu0), Some(pv1), Some(pv0)) = (
+                        surface.evaluate(u, v),
+                        surface.evaluate(u + eps_u, v),
+                        surface.evaluate(u - eps_u, v),
+                        surface.evaluate(u, v + eps_v),
+                        surface.evaluate(u, v - eps_v),
+                    ) else {
+                        continue;
+                    };
+                    let dp_du = (pu1 - pu0) * (1.0 / (2.0 * eps_u));
+                    let dp_dv = (pv1 - pv0) * (1.0 / (2.0 * eps_v));
+                    let cross = dp_du.cross(dp_dv);
+                    let da = cross.length() * du.abs() * dv.abs();
+                    if da < 1e-20 {
+                        continue;
+                    }
+                    let mut n = surface.normal(u, v);
+                    if reversed {
+                        n = -n;
+                    }
+                    flux += da * Vec3::new(p.x(), p.y(), p.z()).dot(n);
+                    any = true;
+                }
+            }
+        }
+    }
+    if !any || flux.abs() < 1e-9 {
+        return None;
+    }
+    Some(flux > 0.0)
+}
+
 /// Classify shells as Growth (outer) or Hole (inner).
 ///
 /// Uses signed volume: positive → outward normals (growth),
@@ -498,16 +630,36 @@ fn perform_areas(topo: &Topology, shells: &[Vec<FaceId>]) -> (Vec<Vec<FaceId>>, 
 
         let signed_vol = signed_volume_of_shell(topo, shell);
 
-        // A SINGLE shell is the result's outer boundary — there is no enclosing
-        // shell for it to be a cavity OF, so it is always growth. Its
-        // `signed_volume_of_shell` can read negative when a curved band face
-        // (e.g. the torus−box kept toroidal band, which wraps the tube) is
-        // sampled by the fan-tet integral over only its outer-wire CORNER
-        // vertices — a degenerate under-sampling that flips the sign. Treating a
-        // lone shell as growth avoids discarding the whole result as a hole;
-        // multi-shell results keep the volume-sign split (a Cut can leave the
-        // tool's interior as a separate negative-volume shell).
-        if shells.len() == 1 || signed_vol >= 0.0 {
+        // `signed_volume_of_shell` integrates over the outer-wire CORNER vertices
+        // only, so it can sign-flip a doubly-curved band whose corners barely
+        // bound the wrapped surface (the torus−box notch band reads negative
+        // despite being outward). For a LONE shell — the result's outer boundary,
+        // with no enclosing shell to be a cavity of — disambiguate with the
+        // curvature-robust `shell_is_outward_oriented` (surface-normal divergence
+        // flux): keep it as growth only when genuinely outward, so a Cut that
+        // leaves only an INWARD cavity component is still rejected. Multi-shell
+        // results keep the volume-sign split (a Cut can leave the tool's interior
+        // as a separate negative-volume cavity shell).
+        let is_growth = if signed_vol >= 0.0 {
+            // Positive corner-fan volume already reads outward — keep the
+            // historical behaviour for every solid that integrates cleanly
+            // (planar, and curved shells whose constant-v boundaries the fan
+            // captures, e.g. the sphere − through-cylinder band). The robust
+            // test is consulted ONLY below, never overriding a positive volume.
+            true
+        } else if shells.len() == 1 {
+            // A LONE shell read NEGATIVE: either it is genuinely inward (a Cut
+            // leaving only a cavity component — must be rejected) or its
+            // corner-fan volume sign-flipped on a doubly-curved band whose
+            // corners barely bound the wrapped surface (the torus−box notch
+            // band). Disambiguate with the curvature-robust surface-normal flux;
+            // fall back to the (negative) volume sign if it is inconclusive.
+            shell_is_outward_oriented(topo, shell).unwrap_or(false)
+        } else {
+            // Multi-shell: a negative shell is the tool's interior cavity (hole).
+            false
+        };
+        if is_growth {
             growth.push(shell.clone());
         } else {
             holes.push(shell.clone());
@@ -2414,6 +2566,39 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
 
     use super::*;
+
+    #[test]
+    fn shell_outward_orientation_outward_cube_is_growth() {
+        let mut topo = Topology::new();
+        let solid = brepkit_topology::test_utils::make_unit_cube_manifold(&mut topo);
+        let faces = brepkit_topology::explorer::solid_faces(&topo, solid).unwrap();
+        assert_eq!(
+            shell_is_outward_oriented(&topo, &faces),
+            Some(true),
+            "a standard outward cube shell must read outward (growth)"
+        );
+    }
+
+    #[test]
+    fn shell_outward_orientation_inward_cube_is_rejected() {
+        // A single INWARD shell (every face reversed, normals point in — the
+        // "Cut leaving only a cavity" case Greptile flagged) must NOT read as
+        // growth, or `perform_areas` would invert it into a solid.
+        let mut topo = Topology::new();
+        let solid = brepkit_topology::test_utils::make_unit_cube_manifold(&mut topo);
+        let faces = brepkit_topology::explorer::solid_faces(&topo, solid).unwrap();
+        for &fid in &faces {
+            let reversed = topo.face(fid).unwrap().is_reversed();
+            if let Ok(f) = topo.face_mut(fid) {
+                f.set_reversed(!reversed);
+            }
+        }
+        assert_eq!(
+            shell_is_outward_oriented(&topo, &faces),
+            Some(false),
+            "an all-faces-reversed (inward) cube shell must read inward (rejected)"
+        );
+    }
 
     #[test]
     fn angle_with_ref_perpendicular() {

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -38,7 +38,7 @@ use edge_splitting::{
 use sampling::{sample_wire_loop_uv, sample_wire_loop_uv_periodic};
 use special_cases::{
     split_face_with_internal_loops, split_noseam_face_direct, split_periodic_face_into_bands,
-    try_split_crossing_plane_face,
+    split_torus_band_by_arrangement, try_split_crossing_plane_face,
 };
 
 /// Number of probe points (plus one for the closing sample) walked along a
@@ -1889,6 +1889,19 @@ pub fn split_face_2d(
             &wire_pts,
             tol.linear,
         );
+    }
+
+    // Torus notch band: a box (or analogous) cut removes a sector of the ring
+    // whose surface boundary is two φ-wrapping loops; the kept torus is the
+    // u-band between them. Contained tracer — defers (None) when the in-box arcs
+    // don't stitch into exactly two φ-wrapping loops.
+    if matches!(surface, FaceSurface::Torus(_))
+        && original_inner_wires.is_empty()
+        && has_open_section
+        && let Some(band) =
+            split_torus_band_by_arrangement(&surface, sections, rank, reversed, face_id, tol.linear)
+    {
+        return band;
     }
 
     // Band shortcut: closed section circles on a u-periodic face split it

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -1894,10 +1894,18 @@ pub fn split_face_2d(
     // Torus notch band: a box (or analogous) cut removes a sector of the ring
     // whose surface boundary is two φ-wrapping loops; the kept torus is the
     // u-band between them. Contained tracer — defers (None) when the in-box arcs
-    // don't stitch into exactly two φ-wrapping loops.
+    // don't stitch into exactly two φ-wrapping loops. Restricted to ALL-OPEN
+    // sections: a CLOSED-loop section (a section circle/loop entirely interior to
+    // the torus, e.g. a small tool poking a closed hole) bounds its own region
+    // that the band tracer would silently drop, so defer those to the
+    // internal-loops path.
+    let all_sections_open = !sections.is_empty()
+        && sections
+            .iter()
+            .all(|s| (s.start - s.end).length() > tol.linear);
     if matches!(surface, FaceSurface::Torus(_))
         && original_inner_wires.is_empty()
-        && has_open_section
+        && all_sections_open
         && let Some(band) =
             split_torus_band_by_arrangement(&surface, sections, rank, reversed, face_id, tol.linear)
     {

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1092,9 +1092,10 @@ pub(super) fn split_torus_band_by_arrangement(
     }
 
     // Stitch arcs into closed loops by chaining shared 3D endpoints. The FF
-    // exact-crossing trim makes adjacent arcs share the box-edge crossing
-    // EXACTLY, so a tight join tolerance suffices.
-    let join_tol = (tol * 1000.0).max(1e-3);
+    // exact-crossing trim snaps adjacent arcs to the SAME box-edge crossing
+    // (and the arc-split shares the exact midpoint), so a tight tolerance
+    // suffices — a loose one could stitch unrelated endpoints into false loops.
+    let join_tol = (tol * 100.0).max(tol);
     let mut used = vec![false; open.len()];
     let mut loops: Vec<Vec<OrientedPCurveEdge>> = Vec::new();
     for s0 in 0..open.len() {
@@ -1185,9 +1186,33 @@ pub(super) fn split_torus_band_by_arrangement(
     }
 
     let outer = loops[0].clone();
+    // Interior sample on the KEPT band: the band spans the ring angle u the LONG
+    // way between the two boundary loops, which sit at roughly constant u (the
+    // box-wall cuts). Take each loop's mean u (wrap-safe via summed unit vectors)
+    // and the MIDPOINT of the long arc between them — NOT a hardcoded u = π,
+    // which is only correct when the notch is on the +x side (a mirrored or
+    // rotated cut puts the kept band's centre elsewhere). The band wraps the tube
+    // v fully at this interior u, so v = 0 is on it.
+    let loop_mean_u = |l: &[OrientedPCurveEdge]| -> f64 {
+        let (mut sx, mut sy) = (0.0, 0.0);
+        for e in l {
+            let (u, _) = torus.project_point(e.start_3d);
+            sx += u.cos();
+            sy += u.sin();
+        }
+        sy.atan2(sx).rem_euclid(TAU)
+    };
+    let u0 = loop_mean_u(&loops[0]);
+    let u1 = loop_mean_u(&loops[1]);
+    // Long-arc midpoint between u0 and u1 (the short gap is the removed notch).
+    let fwd = (u1 - u0).rem_euclid(TAU);
+    let u_mid = if fwd >= PI {
+        (u0 + fwd / 2.0).rem_euclid(TAU) // a->b the long way is increasing
+    } else {
+        (u0 - (TAU - fwd) / 2.0).rem_euclid(TAU) // long way is decreasing
+    };
+    let interior = torus.evaluate(u_mid, 0.0);
     let inner_rev = reverse_loop(&loops[1]);
-    // Interior sample on the KEPT band (θ = π is the far side of the ring).
-    let interior = torus.evaluate(PI, 0.0);
 
     Some(vec![SplitSubFace {
         surface: surface.clone(),

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1027,6 +1027,179 @@ pub(super) fn split_periodic_face_into_bands(
     Some(bands)
 }
 
+/// Build an `OrientedPCurveEdge` (forward) from a section on this (torus) face.
+fn torus_section_to_edge(
+    section: &SectionEdge,
+    surface: &FaceSurface,
+    rank: Rank,
+) -> OrientedPCurveEdge {
+    let pcurve = match rank {
+        Rank::A => &section.pcurve_a,
+        Rank::B => &section.pcurve_b,
+    };
+    let (start_uv, end_uv) = match rank {
+        Rank::A => section.start_uv_a.zip(section.end_uv_a),
+        Rank::B => section.start_uv_b.zip(section.end_uv_b),
+    }
+    .unwrap_or_else(|| uv_endpoints_from_pcurve(pcurve, section.start, section.end, surface, &[]));
+    OrientedPCurveEdge {
+        curve_3d: section.curve_3d.clone(),
+        pcurve: pcurve.clone(),
+        start_uv,
+        end_uv,
+        start_3d: section.start,
+        end_3d: section.end,
+        forward: true,
+        source_edge_idx: None,
+        pave_block_id: section.pave_block_id,
+    }
+}
+
+/// Contained tracer for the `torus − box`-style cut: a box notch removes a
+/// connected sector of the ring whose surface boundary, in the torus `(θ, φ)`
+/// parameter space, is TWO closed loops each WRAPPING the tube angle `φ` fully
+/// (one at each θ-band where the box walls cut the tube partially; the box
+/// swallows the whole tube cross-section in between). The kept toroidal surface
+/// is the annular `u`-band between those two loops — emitted as ONE band face
+/// (outer wire = one φ-loop, the other as an inner wire, like a cylinder band
+/// between two rims).
+///
+/// Returns `None` (defer to the generic path) unless the in-box arcs stitch into
+/// exactly two φ-wrapping closed loops. Relies on the FF exact-crossing trim
+/// (`trim_torus_oval_to_box_face`) having given the arcs faithful endpoints that
+/// share the box-edge crossing vertices.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn split_torus_band_by_arrangement(
+    surface: &FaceSurface,
+    sections: &[SectionEdge],
+    rank: Rank,
+    reversed: bool,
+    face_id: FaceId,
+    tol: f64,
+) -> Option<Vec<SplitSubFace>> {
+    use std::f64::consts::{PI, TAU};
+    let FaceSurface::Torus(torus) = surface else {
+        return None;
+    };
+    // Open arcs only (closed sections would be the lobe-hole case, not a band).
+    let open: Vec<OrientedPCurveEdge> = sections
+        .iter()
+        .filter(|s| (s.start - s.end).length() > tol)
+        .map(|s| torus_section_to_edge(s, surface, rank))
+        .collect();
+    if open.len() < 2 {
+        return None;
+    }
+
+    // Stitch arcs into closed loops by chaining shared 3D endpoints. The FF
+    // exact-crossing trim makes adjacent arcs share the box-edge crossing
+    // EXACTLY, so a tight join tolerance suffices.
+    let join_tol = (tol * 1000.0).max(1e-3);
+    let mut used = vec![false; open.len()];
+    let mut loops: Vec<Vec<OrientedPCurveEdge>> = Vec::new();
+    for s0 in 0..open.len() {
+        if used[s0] {
+            continue;
+        }
+        used[s0] = true;
+        let mut chain = vec![open[s0].clone()];
+        loop {
+            let tail = chain.last().map_or(chain[0].start_3d, |e| e.end_3d);
+            if (tail - chain[0].start_3d).length() < join_tol && chain.len() >= 2 {
+                break; // closed
+            }
+            let nxt = open.iter().enumerate().find_map(|(i, e)| {
+                if used[i] {
+                    None
+                } else if (e.start_3d - tail).length() < join_tol {
+                    Some((i, false))
+                } else if (e.end_3d - tail).length() < join_tol {
+                    Some((i, true))
+                } else {
+                    None
+                }
+            });
+            match nxt {
+                Some((i, rev)) => {
+                    used[i] = true;
+                    let mut e = open[i].clone();
+                    if rev {
+                        std::mem::swap(&mut e.start_uv, &mut e.end_uv);
+                        std::mem::swap(&mut e.start_3d, &mut e.end_3d);
+                        e.forward = !e.forward;
+                    }
+                    chain.push(e);
+                }
+                None => break,
+            }
+        }
+        let closed = chain.len() >= 2
+            && chain
+                .last()
+                .is_some_and(|e| (e.end_3d - chain[0].start_3d).length() < join_tol);
+        if closed {
+            loops.push(chain);
+        }
+    }
+
+    // The kept band needs exactly two φ-wrapping boundary loops.
+    if loops.len() != 2 {
+        return None;
+    }
+    // Each loop must wrap φ fully: net φ-traversal ≈ ±2π.
+    let net_phi = |l: &[OrientedPCurveEdge]| -> f64 {
+        let mut phis: Vec<f64> = Vec::new();
+        for e in l {
+            let (_, v) = torus.project_point(e.start_3d);
+            phis.push(v);
+            let (_, vm) = torus.project_point(
+                e.curve_3d
+                    .evaluate_with_endpoints(0.5, e.start_3d, e.end_3d),
+            );
+            phis.push(vm);
+        }
+        let mut acc = 0.0;
+        for i in 0..phis.len() {
+            let d = phis[(i + 1) % phis.len()] - phis[i];
+            acc += d - TAU * ((d + PI) / TAU).floor();
+        }
+        acc
+    };
+    if loops.iter().any(|l| net_phi(l).abs() < PI) {
+        return None;
+    }
+
+    // Snap each loop's internal junctions to the midpoint of the two meeting
+    // endpoints so the loop is internally watertight at the box-edge vertices.
+    let snap_loop = |l: &mut Vec<OrientedPCurveEdge>| {
+        let n = l.len();
+        for i in 0..n {
+            let j = (i + 1) % n;
+            let mid = l[i].end_3d + (l[j].start_3d - l[i].end_3d) * 0.5;
+            l[i].end_3d = mid;
+            l[j].start_3d = mid;
+        }
+    };
+    for l in &mut loops {
+        snap_loop(l);
+    }
+
+    let outer = loops[0].clone();
+    let inner_rev = reverse_loop(&loops[1]);
+    // Interior sample on the KEPT band (θ = π is the far side of the ring).
+    let interior = torus.evaluate(PI, 0.0);
+
+    Some(vec![SplitSubFace {
+        surface: surface.clone(),
+        outer_wire: outer,
+        inner_wires: vec![inner_rev],
+        reversed,
+        parent: face_id,
+        rank,
+        precomputed_interior: Some(interior),
+    }])
+}
+
 /// Split a face when ALL section edges are interior (don't touch the boundary).
 ///
 /// Groups section edges into closed loops by chaining shared 3D endpoints.

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -200,6 +200,15 @@ pub fn detect_same_domain<S: BuildHasher>(
                 };
 
                 if let Some(same_dir) = surfaces_same_domain(surf_i, surf_j, tol) {
+                    // Two sub-faces split from the SAME input face are
+                    // complementary regions of one face's partition (e.g. the
+                    // in-tube and out-tube parts of a box wall cut by a torus) —
+                    // never same-domain duplicates of each other. Genuine SD
+                    // pairs come from DIFFERENT input faces (coincident walls
+                    // across operands, or sequential-boolean residue). Skip.
+                    if sub_faces[i].source_face == sub_faces[j].source_face {
+                        continue;
+                    }
                     // Two curved faces of the same underlying surface can share an
                     // outer-wire edge set yet cover DIFFERENT regions — e.g. the
                     // two hemisphere bands of a bored sphere share the equator
@@ -251,6 +260,11 @@ pub fn detect_same_domain<S: BuildHasher>(
                 _ => None,
             };
             let Some(same_dir) = same_dir else { continue };
+            // Sub-faces split from the SAME input face are complementary
+            // partition regions, not overlapping duplicates (see Step 1).
+            if sub_faces[i].source_face == sub_faces[j].source_face {
+                continue;
+            }
             if uf.find(i) == uf.find(j) {
                 continue; // already grouped
             }
@@ -298,6 +312,11 @@ pub fn detect_same_domain<S: BuildHasher>(
                 _ => None,
             };
             let Some(same_dir) = same_dir else { continue };
+            // Sub-faces split from the SAME input face are complementary
+            // partition regions, not overlapping duplicates (see Step 1).
+            if sub_faces[i].source_face == sub_faces[j].source_face {
+                continue;
+            }
             if uf.find(i) == uf.find(j) {
                 continue; // already grouped (e.g. identical edge sets)
             }

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -200,13 +200,12 @@ pub fn detect_same_domain<S: BuildHasher>(
                 };
 
                 if let Some(same_dir) = surfaces_same_domain(surf_i, surf_j, tol) {
-                    // Two sub-faces split from the SAME input face are
-                    // complementary regions of one face's partition (e.g. the
-                    // in-tube and out-tube parts of a box wall cut by a torus) —
-                    // never same-domain duplicates of each other. Genuine SD
-                    // pairs come from DIFFERENT input faces (coincident walls
-                    // across operands, or sequential-boolean residue). Skip.
-                    if sub_faces[i].source_face == sub_faces[j].source_face {
+                    // Complementary partition regions of ONE input face's split
+                    // (same source, distinct interiors — e.g. the in-tube and
+                    // out-tube parts of a box wall cut by a torus) are never
+                    // same-domain duplicates of each other. A genuine coincident
+                    // same-source duplicate (same interior) is NOT excluded here.
+                    if same_source_complementary_split(sub_faces, i, j, tol) {
                         continue;
                     }
                     // Two curved faces of the same underlying surface can share an
@@ -260,9 +259,10 @@ pub fn detect_same_domain<S: BuildHasher>(
                 _ => None,
             };
             let Some(same_dir) = same_dir else { continue };
-            // Sub-faces split from the SAME input face are complementary
-            // partition regions, not overlapping duplicates (see Step 1).
-            if sub_faces[i].source_face == sub_faces[j].source_face {
+            // Complementary partition regions of one split (same source, distinct
+            // interiors) are not overlapping duplicates; a coincident same-source
+            // duplicate (same interior) still reaches `planar_faces_overlap`.
+            if same_source_complementary_split(sub_faces, i, j, tol) {
                 continue;
             }
             if uf.find(i) == uf.find(j) {
@@ -312,9 +312,10 @@ pub fn detect_same_domain<S: BuildHasher>(
                 _ => None,
             };
             let Some(same_dir) = same_dir else { continue };
-            // Sub-faces split from the SAME input face are complementary
-            // partition regions, not overlapping duplicates (see Step 1).
-            if sub_faces[i].source_face == sub_faces[j].source_face {
+            // Complementary partition regions of one split (same source, distinct
+            // interiors) are not overlapping duplicates; a coincident same-source
+            // duplicate (same interior) still reaches `analytic_faces_overlap`.
+            if same_source_complementary_split(sub_faces, i, j, tol) {
                 continue;
             }
             if uf.find(i) == uf.find(j) {
@@ -1324,6 +1325,32 @@ fn planar(surf: &FaceSurface) -> bool {
 /// (defer to the edge-set union) when either interior is unavailable, keeping
 /// the conservative pre-existing behaviour.
 fn distinct_curved_regions(sub_faces: &[SubFace], i: usize, j: usize, tol: Tolerance) -> bool {
+    match (sub_faces[i].interior_point, sub_faces[j].interior_point) {
+        (Some(pi), Some(pj)) => (pi - pj).length() > tol.linear * 100.0,
+        _ => false,
+    }
+}
+
+/// Whether two sub-faces are COMPLEMENTARY partition regions of a single split
+/// of one input face — same `source_face` AND distinct interior points (they
+/// tile the parent, e.g. the in-tube and out-tube parts of a box wall cut by a
+/// torus). Such a pair is never a same-domain DUPLICATE of itself, so it is
+/// excluded from SD grouping. Crucially this does NOT exclude two same-source
+/// sub-faces that are genuine COINCIDENT duplicates (sequential-boolean /
+/// split-cascade residue at the SAME region): those share an interior point
+/// (distance ≤ 100·tol) and stay subject to the normal SD overlap checks, so
+/// real duplicates are still caught (Greptile #1010-2). Requires both interior
+/// points to be set — if either is absent the pair is NOT excluded (the SD
+/// checks run as usual).
+fn same_source_complementary_split(
+    sub_faces: &[SubFace],
+    i: usize,
+    j: usize,
+    tol: Tolerance,
+) -> bool {
+    if sub_faces[i].source_face != sub_faces[j].source_face {
+        return false;
+    }
     match (sub_faces[i].interior_point, sub_faces[j].interior_point) {
         (Some(pi), Some(pj)) => (pi - pj).length() > tol.linear * 100.0,
         _ => false,

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -943,8 +943,12 @@ fn trim_torus_oval_to_box_face(
             })
             .collect()
     };
-    // Pick the in-box arc points (longest such — the φ-wrapping outer arc).
-    let mut best_pts: Option<(f64, Vec<Point3>)> = None;
+    // Collect ALL in-box arcs (the oval may cross the box face's boundary into
+    // MORE than one in-box interval — e.g. a plane cut that enters the box face
+    // twice — and each is a valid section; keeping only the longest would drop
+    // the others and leave incomplete walls). Each arc spans between two
+    // consecutive boundary crossings whose mid-arc point is inside the box face.
+    let mut arc_point_sets: Vec<Vec<Point3>> = Vec::new();
     for i in 0..marks.len() {
         let (f0, p0) = marks[i];
         let (f1, p1) = marks[(i + 1) % marks.len()];
@@ -958,14 +962,13 @@ fn trim_torus_oval_to_box_face(
         let last = pts.len() - 1;
         pts[0] = p0;
         pts[last] = p1;
-        let span = if f1 >= f0 { f1 - f0 } else { f1 + 1.0 - f0 };
-        if best_pts.as_ref().is_none_or(|(s, _)| *s < span) {
-            best_pts = Some((span, pts));
-        }
+        arc_point_sets.push(pts);
     }
-    let (span, pts) = best_pts?;
+    if arc_point_sets.is_empty() {
+        return None;
+    }
 
-    // Emit the kept in-box arc ALWAYS SPLIT at its midpoint into two sub-arcs
+    // Emit each kept in-box arc ALWAYS SPLIT at its midpoint into two sub-arcs
     // with a distinct middle vertex. Each kept arc shares BOTH its endpoints (the
     // box-edge∩torus crossings) with the partner box-wall edge that closes the
     // same notch-wall lens — a straight box Line for the inner (x=6) wall, the
@@ -976,7 +979,6 @@ fn trim_torus_oval_to_box_face(
     // arc is emitted as ONE shared FF section, so BOTH consumers — the kept
     // toroidal band and the box-wall sub-face — see the same midpoint vertex and
     // stay watertight. Geometry is unchanged (the two halves retrace the arc).
-    let _ = span;
     let fit = |seg: &[Point3]| -> Option<RawCurve> {
         let curve = brepkit_math::nurbs::fitting::interpolate(seg, 3.min(seg.len() - 1)).ok()?;
         let dom = curve.domain();
@@ -990,16 +992,18 @@ fn trim_torus_oval_to_box_face(
         })
     };
     let mut out_arcs = Vec::new();
-    if pts.len() >= 7 {
-        let mid = pts.len() / 2;
-        if let (Some(a0), Some(a1)) = (fit(&pts[..=mid]), fit(&pts[mid..])) {
-            out_arcs.push(a0);
-            out_arcs.push(a1);
-        } else if let Some(a) = fit(&pts) {
+    for pts in &arc_point_sets {
+        if pts.len() >= 7 {
+            let mid = pts.len() / 2;
+            if let (Some(a0), Some(a1)) = (fit(&pts[..=mid]), fit(&pts[mid..])) {
+                out_arcs.push(a0);
+                out_arcs.push(a1);
+            } else if let Some(a) = fit(pts) {
+                out_arcs.push(a);
+            }
+        } else if let Some(a) = fit(pts) {
             out_arcs.push(a);
         }
-    } else if let Some(a) = fit(&pts) {
-        out_arcs.push(a);
     }
     if out_arcs.is_empty() {
         return None;

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -544,7 +544,25 @@ impl FaceExtent {
                 margin: (smaller * 0.01).max(tol.linear),
             })
         } else {
-            let (v0, v1) = v_range?;
+            // A whole, untrimmed torus has no `v_range` (its boundary is the
+            // degenerate fundamental-polygon seam), yet it IS a real extent: the
+            // full tube v ∈ [0, 2π], full revolution u (no gap). Treating it as
+            // full extent lets `restrict_curves_to_faces` run the in-both clip,
+            // so a plane×torus oval is trimmed to the partner box face's region
+            // instead of bailing unclipped. Mirrors the whole-torus AABB gate
+            // (`face_boundary_all_degenerate` → `t.aabb()`).
+            let (v0, v1) = match v_range {
+                Some(r) => r,
+                None => {
+                    if matches!(surface, FaceSurface::Torus(_))
+                        && face_boundary_all_degenerate(topo, face_id, tol).unwrap_or(false)
+                    {
+                        (0.0, std::f64::consts::TAU)
+                    } else {
+                        return None;
+                    }
+                }
+            };
             let margin = (v1 - v0).abs() * 0.01 + tol.linear;
             // For a partial-arc lateral face (rounded-rect corner = a 90°
             // quarter-cylinder), record the angular gap the face does NOT
@@ -704,6 +722,18 @@ fn restrict_curves_to_faces(
             out.push(raw);
             continue;
         }
+        // Torus × box-plane: a plane×torus oval is clipped to its EXACT in-box
+        // arc at the box-edge∩torus crossings (shared with the adjacent box
+        // wall, so the notch is watertight). Gated to a closed NURBS oval whose
+        // partner is a planar face with straight (Line) boundary edges; defers
+        // (None) otherwise, so all other sections keep the sample-clip below.
+        if let Some(arcs) =
+            trim_torus_oval_to_box_face(topo, fa, fb, surf_a, surf_b, &raw, &ext_a, &ext_b, tol)
+        {
+            out.extend(arcs);
+            continue;
+        }
+
         let pt = |i: usize| -> Point3 {
             #[allow(clippy::cast_precision_loss)]
             let f = i as f64 / N as f64;
@@ -749,6 +779,232 @@ fn restrict_curves_to_faces(
         out.push(raw);
     }
     out
+}
+
+/// Trim a plane×torus oval to its EXACT in-box arc at the box-edge∩torus
+/// crossings (the analogue of box∩sphere's `emit_split_circle_arcs`, for a
+/// marched torus oval instead of a `Circle`).
+///
+/// Gated: fires only when one face is a `Torus`, the partner is a `Plane` whose
+/// outer wire is all straight `Line` edges (a box wall), and `raw` is a CLOSED
+/// non-`Line` oval. Returns:
+/// - `Some(arc)` — the single in-box arc, with its endpoints SNAPPED to the
+///   exact box-edge∩torus crossings so the adjacent box wall (trimmed against
+///   the same edge) shares those vertices and the notch is watertight.
+/// - `Some(vec![raw])` — the oval lies wholly inside the box face (no boundary
+///   crossing): keep it whole.
+/// - `None` — not this case; the caller's sample-clip handles it.
+///
+/// The kept arc is the one whose midpoint is inside the box-face polygon (the
+/// outer arc that wraps most of the tube), not the inner fragment a contiguous
+/// sample run would wrongly keep on a mirror-asymmetric marcher parameterisation.
+#[allow(clippy::too_many_arguments)]
+fn trim_torus_oval_to_box_face(
+    topo: &Topology,
+    fa: FaceId,
+    fb: FaceId,
+    surf_a: &FaceSurface,
+    surf_b: &FaceSurface,
+    raw: &RawCurve,
+    ext_a: &FaceExtent,
+    ext_b: &FaceExtent,
+    tol: Tolerance,
+) -> Option<Vec<RawCurve>> {
+    // Identify the torus face/surface and the box (plane) face; the oval must be
+    // a closed non-Line curve.
+    if matches!(raw.curve, EdgeCurve::Line) {
+        return None;
+    }
+    if (raw.p_start - raw.p_end).length() > 1e-6 {
+        return None; // open curve — not a closed oval
+    }
+    let (torus, plane_face, plane_ext) = match (surf_a, surf_b) {
+        (FaceSurface::Torus(t), FaceSurface::Plane { .. }) => (t, fb, ext_b),
+        (FaceSurface::Plane { .. }, FaceSurface::Torus(t)) => (t, fa, ext_a),
+        _ => return None,
+    };
+    let _ = ext_a;
+    let _ = ext_b;
+
+    // The box face's straight boundary edges (its rectangle sides).
+    let face = topo.face(plane_face).ok()?;
+    let wire = topo.wire(face.outer_wire()).ok()?;
+    let mut box_edges: Vec<(Point3, Point3)> = Vec::new();
+    for oe in wire.edges() {
+        let e = topo.edge(oe.edge()).ok()?;
+        if !matches!(e.curve(), EdgeCurve::Line) {
+            return None; // not a straight-edged wall — defer
+        }
+        let s = topo.vertex(e.start()).ok()?.point();
+        let en = topo.vertex(e.end()).ok()?.point();
+        box_edges.push((s, en));
+    }
+    if box_edges.len() < 3 {
+        return None;
+    }
+
+    // Exact box-edge ∩ torus crossings that lie ON the edge segment AND ON the
+    // oval. The crossing point is EXACT; `on_oval_tol` only has to confirm the
+    // crossing belongs to THIS oval (vs a different oval branch on the same
+    // plane, which is ≳1 mm away) — so it must exceed the MARCHED oval's
+    // approximation error (~0.1 mm), well below the inter-branch separation.
+    let on_oval_tol = 0.3_f64;
+    let dedup_tol = tol.linear * 100.0;
+    let mut crossings: Vec<Point3> = Vec::new();
+    for &(s, en) in &box_edges {
+        let dir = en - s;
+        let len = dir.length();
+        if len < tol.linear {
+            continue;
+        }
+        for t in analytic_intersection::intersect_line_torus(torus, s, dir) {
+            if !(-1e-6..=1.0 + 1e-6).contains(&t) {
+                continue; // off the edge segment
+            }
+            let p = s + dir * t;
+            // Must lie on the oval (the marched NURBS), else it's a crossing of
+            // a DIFFERENT oval branch on this plane.
+            let mut min_d = f64::MAX;
+            for i in 0..=128 {
+                let tt = raw.t_range.0 + (raw.t_range.1 - raw.t_range.0) * f64::from(i) / 128.0;
+                min_d = min_d.min(
+                    (raw.curve
+                        .evaluate_with_endpoints(tt, raw.p_start, raw.p_end)
+                        - p)
+                        .length(),
+                );
+            }
+            let on_oval = min_d < on_oval_tol;
+            if on_oval && !crossings.iter().any(|c| (*c - p).length() < dedup_tol) {
+                crossings.push(p);
+            }
+        }
+    }
+
+    // No boundary crossing: the oval is wholly inside (or outside) the box face.
+    if crossings.is_empty() {
+        // Inside → keep whole; outside → the caller's sample-clip drops it.
+        let mid = raw
+            .curve
+            .evaluate_with_endpoints(0.5, raw.p_start, raw.p_end);
+        return if plane_ext.contains(mid) {
+            Some(vec![raw.clone()])
+        } else {
+            None
+        };
+    }
+    // A single tangential crossing never splits the oval into a kept arc.
+    if crossings.len() < 2 {
+        return None;
+    }
+
+    // Find each crossing's parameter on the closed oval (densest sample).
+    let n_dense = 1024usize;
+    let oval_at = |frac: f64| -> Point3 {
+        let tt = raw.t_range.0 + (raw.t_range.1 - raw.t_range.0) * frac;
+        raw.curve
+            .evaluate_with_endpoints(tt, raw.p_start, raw.p_end)
+    };
+    let frac_of = |p: Point3| -> f64 {
+        let mut best_f = 0.0;
+        let mut best_d = f64::MAX;
+        for i in 0..=n_dense {
+            #[allow(clippy::cast_precision_loss)]
+            let f = i as f64 / n_dense as f64;
+            let d = (oval_at(f) - p).length();
+            if d < best_d {
+                best_d = d;
+                best_f = f;
+            }
+        }
+        best_f
+    };
+    let mut marks: Vec<(f64, Point3)> = crossings.iter().map(|&p| (frac_of(p), p)).collect();
+    marks.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    if marks.len() < 2 {
+        return None;
+    }
+
+    // For each arc between consecutive crossings (wrapping the closed oval), the
+    // kept arc has its interior midpoint inside the box face. Re-sample that arc
+    // (walking the closed oval the correct way) and fit a FRESH NURBS whose
+    // endpoints are the EXACT box-edge crossings — so the adjacent box wall
+    // shares those vertices. Re-sampling avoids out-of-domain clamped-NURBS
+    // evaluation on a wrapping arc.
+    let sample_arc = |f0: f64, f1: f64| -> Vec<Point3> {
+        // Walk f0 -> f1 forward on the closed oval (wrapping past 1.0).
+        let span = if f1 >= f0 { f1 - f0 } else { f1 + 1.0 - f0 };
+        let steps = 48usize;
+        (0..=steps)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let f = (f0 + span * (i as f64 / steps as f64)).rem_euclid(1.0);
+                oval_at(f)
+            })
+            .collect()
+    };
+    // Pick the in-box arc points (longest such — the φ-wrapping outer arc).
+    let mut best_pts: Option<(f64, Vec<Point3>)> = None;
+    for i in 0..marks.len() {
+        let (f0, p0) = marks[i];
+        let (f1, p1) = marks[(i + 1) % marks.len()];
+        let mut pts = sample_arc(f0, f1);
+        if pts.len() < 4 {
+            continue;
+        }
+        if !plane_ext.contains(pts[pts.len() / 2]) {
+            continue;
+        }
+        let last = pts.len() - 1;
+        pts[0] = p0;
+        pts[last] = p1;
+        let span = if f1 >= f0 { f1 - f0 } else { f1 + 1.0 - f0 };
+        if best_pts.as_ref().is_none_or(|(s, _)| *s < span) {
+            best_pts = Some((span, pts));
+        }
+    }
+    let (span, pts) = best_pts?;
+
+    // Emit the kept in-box arc ALWAYS SPLIT at its midpoint into two sub-arcs
+    // with a distinct middle vertex. Each kept arc shares BOTH its endpoints (the
+    // box-edge∩torus crossings) with the partner box-wall edge that closes the
+    // same notch-wall lens — a straight box Line for the inner (x=6) wall, the
+    // partner arc for the y-walls. The endpoint-pair-keyed `merge_duplicate_edges`
+    // (unchanged, gridfinity-load-bearing) would collapse any two co-endpoint
+    // edges, degenerating the wall into a one-edge face. The midpoint vertex
+    // breaks that: no two edges of the lens then share BOTH endpoints. The split
+    // arc is emitted as ONE shared FF section, so BOTH consumers — the kept
+    // toroidal band and the box-wall sub-face — see the same midpoint vertex and
+    // stay watertight. Geometry is unchanged (the two halves retrace the arc).
+    let _ = span;
+    let fit = |seg: &[Point3]| -> Option<RawCurve> {
+        let curve = brepkit_math::nurbs::fitting::interpolate(seg, 3.min(seg.len() - 1)).ok()?;
+        let dom = curve.domain();
+        let bbox = Aabb3::try_from_points(seg.iter().copied())?;
+        Some(RawCurve {
+            curve: EdgeCurve::NurbsCurve(curve),
+            bbox,
+            t_range: dom,
+            p_start: seg[0],
+            p_end: seg[seg.len() - 1],
+        })
+    };
+    let mut out_arcs = Vec::new();
+    if pts.len() >= 7 {
+        let mid = pts.len() / 2;
+        if let (Some(a0), Some(a1)) = (fit(&pts[..=mid]), fit(&pts[mid..])) {
+            out_arcs.push(a0);
+            out_arcs.push(a1);
+        } else if let Some(a) = fit(&pts) {
+            out_arcs.push(a);
+        }
+    } else if let Some(a) = fit(&pts) {
+        out_arcs.push(a);
+    }
+    if out_arcs.is_empty() {
+        return None;
+    }
+    Some(out_arcs)
 }
 
 /// Trim a CLOSED section curve (Ellipse or NURBS) to its in-both arc
@@ -1327,6 +1583,7 @@ fn face_v_range(topo: &Topology, face_id: FaceId, surface: &FaceSurface) -> Opti
 }
 
 /// Intermediate intersection result before face IDs are assigned.
+#[derive(Clone)]
 struct RawCurve {
     /// The 3D curve geometry.
     curve: EdgeCurve,

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -1005,12 +1005,29 @@ fn real_roots_quartic(c4: f64, c3: f64, c2: f64, c1: f64, c0: f64) -> Vec<f64> {
             break;
         }
     }
-    // Keep roots with negligible imaginary part.
-    let mut out = Vec::new();
+    // Keep roots with negligible imaginary part AND a small REAL-polynomial
+    // residual — Durand–Kerner stops after a fixed iteration cap whether or not
+    // it converged, so a non-converged iterate could otherwise be returned as a
+    // spurious root. Evaluate the monic quartic at each candidate (real part) and
+    // keep only |p(x)| below a magnitude-scaled tolerance; de-dup near-equal
+    // roots (a double root converges to two near-identical iterates).
+    let p_real = |x: f64| -> f64 { (((x + a) * x + b) * x + c) * x + d };
+    let mut out: Vec<f64> = Vec::new();
     for z in r {
-        if z.im.abs() < 1e-7 {
-            out.push(z.re);
+        if z.im.abs() >= 1e-7 {
+            continue;
         }
+        let x = z.re;
+        // Residual tolerance scales with the polynomial's coefficient magnitude
+        // and |x|^4 so large-coefficient quartics are not over-rejected.
+        let scale = 1.0 + a.abs() + b.abs() + c.abs() + d.abs() + x.abs().powi(4);
+        if p_real(x).abs() > 1e-6 * scale {
+            continue;
+        }
+        if out.iter().any(|&y| (y - x).abs() < 1e-9 * (1.0 + x.abs())) {
+            continue;
+        }
+        out.push(x);
     }
     out
 }

--- a/crates/math/src/analytic_intersection.rs
+++ b/crates/math/src/analytic_intersection.rs
@@ -813,8 +813,8 @@ pub fn intersect_plane_torus(
         }
 
         if chain.len() >= 4 {
-            let pts: Vec<Point3> = chain.iter().map(|&i| crossing_pts[i].2).collect();
-            let ipts: Vec<IntersectionPoint> = chain
+            let mut pts: Vec<Point3> = chain.iter().map(|&i| crossing_pts[i].2).collect();
+            let mut ipts: Vec<IntersectionPoint> = chain
                 .iter()
                 .map(|&i| IntersectionPoint {
                     point: crossing_pts[i].2,
@@ -822,6 +822,32 @@ pub fn intersect_plane_torus(
                     param2: (0.0, 0.0),
                 })
                 .collect();
+
+            // Plane × full torus is always a set of CLOSED loops, but the greedy
+            // nearest-neighbour chaining stops one step short of closing: the
+            // first point is already `used`, so the walk never re-adds it and the
+            // last point sits ~one grid step from the start. Detect that wrap (the
+            // end-to-start gap is comparable to the chain's own point spacing) and
+            // append the exact start point, so the fitted NURBS closes
+            // (`evaluate(0) == evaluate(1)`) and downstream consumers see a closed
+            // section curve instead of a near-closed open one. A fragmented chain
+            // (greedy walk broke a loop at a near-tangency) ends FAR from its
+            // start (gap ≫ spacing) and is left open — it must not be force-closed
+            // into a wrong loop.
+            let closing_gap = (pts[pts.len() - 1] - pts[0]).length();
+            let median_spacing = {
+                let mut spac: Vec<f64> = pts.windows(2).map(|w| (w[1] - w[0]).length()).collect();
+                spac.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                spac.get(spac.len() / 2).copied().unwrap_or(0.0)
+            };
+            // Wrap when the closing gap is within ~2 point-spacings (measured
+            // ratio ≈ 1.0 for the census ovals) and not already coincident.
+            let wrapped =
+                closing_gap > 1e-9 && median_spacing > 1e-12 && closing_gap <= 2.0 * median_spacing;
+            if wrapped {
+                pts.push(pts[0]);
+                ipts.push(ipts[0]);
+            }
 
             if let Ok(curve) = interpolate(&pts, 3.min(pts.len() - 1)) {
                 curves.push(IntersectionCurve {
@@ -866,6 +892,230 @@ fn newton_refine_torus(
         v -= step * fv;
     }
     (u, v)
+}
+
+/// Real intersection parameters `t` of the line `origin + t·dir` with a torus.
+///
+/// A line meets a torus in up to four points (degree-4). Substituting the line
+/// into the torus implicit `(a² + b² + c² + R² − r²)² = 4R²(a² + b²)` — where
+/// `(a, b, c)` are the line point's coordinates in the torus frame — gives a
+/// quartic in `t`, solved here for its real roots (each refined by one Newton
+/// step against the implicit). `dir` need not be unit length; `t` is in units of
+/// `dir`. Returns the roots sorted ascending (0–4 of them).
+///
+/// Used by the boolean section trimmer to find where a plane×torus oval exits a
+/// box face's straight boundary edge — the exact crossing shared by the two
+/// adjacent faces, which is what makes the notch watertight.
+#[must_use]
+pub fn intersect_line_torus(torus: &ToroidalSurface, origin: Point3, dir: Vec3) -> Vec<f64> {
+    let c = torus.center();
+    let (xa, ya, za) = (torus.x_axis(), torus.y_axis(), torus.z_axis());
+    let big_r = torus.major_radius();
+    let small_r = torus.minor_radius();
+
+    // Line point in torus frame: a(t)=a0+a1 t, b(t)=b0+b1 t, c(t)=c0+c1 t.
+    let o = Vec3::new(origin.x() - c.x(), origin.y() - c.y(), origin.z() - c.z());
+    let (a0, a1) = (xa.dot(o), xa.dot(dir));
+    let (b0, b1) = (ya.dot(o), ya.dot(dir));
+    let (c0, c1) = (za.dot(o), za.dot(dir));
+
+    // G(t) = a² + b² + c² + R² − r²  (quadratic: g2 t² + g1 t + g0)
+    let g2 = a1.mul_add(a1, b1.mul_add(b1, c1 * c1));
+    let g1 = 2.0 * a1.mul_add(a0, b1.mul_add(b0, c1 * c0));
+    let g0 = a0.mul_add(
+        a0,
+        b0.mul_add(b0, c0.mul_add(c0, big_r.mul_add(big_r, -small_r * small_r))),
+    );
+
+    // H(t) = 4R² (a² + b²)  (quadratic: h2 t² + h1 t + h0)
+    let four_rr = 4.0 * big_r * big_r;
+    let h2 = four_rr * a1.mul_add(a1, b1 * b1);
+    let h1 = four_rr * (2.0 * a1.mul_add(a0, b1 * b0));
+    let h0 = four_rr * a0.mul_add(a0, b0 * b0);
+
+    // Quartic G² − H = 0:  e4 t⁴ + e3 t³ + e2 t² + e1 t + e0.
+    let e4 = g2 * g2;
+    let e3 = 2.0 * g2 * g1;
+    let e2 = g1.mul_add(g1, 2.0 * g2 * g0) - h2;
+    let e1 = 2.0f64.mul_add(g1 * g0, -h1);
+    let e0 = g0.mul_add(g0, -h0);
+
+    let mut roots = real_roots_quartic(e4, e3, e2, e1, e0);
+    // One Newton polish against the torus implicit for full precision.
+    let impl_f = |t: f64| -> f64 {
+        let p = origin + dir * t;
+        let q = Vec3::new(p.x() - c.x(), p.y() - c.y(), p.z() - c.z());
+        let (a, b, cc) = (xa.dot(q), ya.dot(q), za.dot(q));
+        (a.hypot(b) - big_r).hypot(cc) - small_r
+    };
+    for t in &mut roots {
+        let eps = 1e-7;
+        let f = impl_f(*t);
+        let df = (impl_f(*t + eps) - impl_f(*t - eps)) / (2.0 * eps);
+        if df.abs() > 1e-12 {
+            *t -= f / df;
+        }
+    }
+    roots.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    roots
+}
+
+/// Real roots of `c4 x⁴ + c3 x³ + c2 x² + c1 x + c0` via Durand–Kerner, falling
+/// back to the lower-degree solvers when the leading coefficients vanish.
+fn real_roots_quartic(c4: f64, c3: f64, c2: f64, c1: f64, c0: f64) -> Vec<f64> {
+    // Degenerate leading coefficient → lower degree.
+    if c4.abs() < 1e-14 {
+        return real_roots_cubic(c3, c2, c1, c0);
+    }
+    // Monic: x⁴ + a x³ + b x² + c x + d.
+    let (a, b, c, d) = (c3 / c4, c2 / c4, c1 / c4, c0 / c4);
+    let eval = |z: Complex| -> Complex {
+        // Horner.
+        let mut acc = Complex::new(1.0, 0.0);
+        acc = acc * z + Complex::new(a, 0.0);
+        acc = acc * z + Complex::new(b, 0.0);
+        acc = acc * z + Complex::new(c, 0.0);
+        acc * z + Complex::new(d, 0.0)
+    };
+    // Durand–Kerner: four roots seeded on a circle, iterated to convergence.
+    let seed = Complex::new(0.4, 0.9);
+    let mut r = [
+        Complex::new(1.0, 0.0),
+        seed,
+        seed * seed,
+        seed * seed * seed,
+    ];
+    for _ in 0..100 {
+        let mut max_step = 0.0_f64;
+        for i in 0..4 {
+            let mut denom = Complex::new(1.0, 0.0);
+            for j in 0..4 {
+                if i != j {
+                    denom = denom * (r[i] - r[j]);
+                }
+            }
+            if denom.norm() < 1e-300 {
+                continue;
+            }
+            let step = eval(r[i]) / denom;
+            r[i] = r[i] - step;
+            max_step = max_step.max(step.norm());
+        }
+        if max_step < 1e-14 {
+            break;
+        }
+    }
+    // Keep roots with negligible imaginary part.
+    let mut out = Vec::new();
+    for z in r {
+        if z.im.abs() < 1e-7 {
+            out.push(z.re);
+        }
+    }
+    out
+}
+
+/// Real roots of `a x³ + b x² + c x + d` (Cardano), with quadratic fallback.
+fn real_roots_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
+    if a.abs() < 1e-14 {
+        return real_roots_quadratic(b, c, d);
+    }
+    // Depressed cubic t³ + p t + q via x = t − b/(3a).
+    let (b, c, d) = (b / a, c / a, d / a);
+    let p = c - b * b / 3.0;
+    let q = 2.0 * b * b * b / 27.0 - b * c / 3.0 + d;
+    let shift = -b / 3.0;
+    let disc = q * q / 4.0 + p * p * p / 27.0;
+    if disc > 1e-14 {
+        let sq = disc.sqrt();
+        let u = (-q / 2.0 + sq).cbrt();
+        let v = (-q / 2.0 - sq).cbrt();
+        vec![u + v + shift]
+    } else if disc < -1e-14 {
+        // Three real roots (trigonometric).
+        let m = 2.0 * (-p / 3.0).sqrt();
+        let theta = (3.0 * q / (p * m)).clamp(-1.0, 1.0).acos() / 3.0;
+        (0..3)
+            .map(|k| {
+                m.mul_add(
+                    (theta - 2.0 * std::f64::consts::PI * f64::from(k) / 3.0).cos(),
+                    shift,
+                )
+            })
+            .collect()
+    } else {
+        // Repeated roots.
+        let u = (-q / 2.0).cbrt();
+        vec![2.0 * u + shift, -u + shift]
+    }
+}
+
+/// Real roots of `a x² + b x + c`, with linear fallback.
+fn real_roots_quadratic(a: f64, b: f64, c: f64) -> Vec<f64> {
+    if a.abs() < 1e-14 {
+        if b.abs() < 1e-14 {
+            return Vec::new();
+        }
+        return vec![-c / b];
+    }
+    let disc = b * b - 4.0 * a * c;
+    if disc < 0.0 {
+        Vec::new()
+    } else {
+        let sq = disc.sqrt();
+        vec![(-b - sq) / (2.0 * a), (-b + sq) / (2.0 * a)]
+    }
+}
+
+/// Minimal complex number for the quartic root finder.
+#[derive(Clone, Copy)]
+struct Complex {
+    re: f64,
+    im: f64,
+}
+
+impl Complex {
+    const fn new(re: f64, im: f64) -> Self {
+        Self { re, im }
+    }
+    fn norm(self) -> f64 {
+        self.re.hypot(self.im)
+    }
+}
+
+impl std::ops::Add for Complex {
+    type Output = Self;
+    fn add(self, o: Self) -> Self {
+        Self::new(self.re + o.re, self.im + o.im)
+    }
+}
+
+impl std::ops::Sub for Complex {
+    type Output = Self;
+    fn sub(self, o: Self) -> Self {
+        Self::new(self.re - o.re, self.im - o.im)
+    }
+}
+
+impl std::ops::Mul for Complex {
+    type Output = Self;
+    fn mul(self, o: Self) -> Self {
+        Self::new(
+            self.re.mul_add(o.re, -(self.im * o.im)),
+            self.re.mul_add(o.im, self.im * o.re),
+        )
+    }
+}
+
+impl std::ops::Div for Complex {
+    type Output = Self;
+    fn div(self, o: Self) -> Self {
+        let den = o.re.mul_add(o.re, o.im * o.im);
+        Self::new(
+            self.re.mul_add(o.re, self.im * o.im) / den,
+            self.im.mul_add(o.re, -(self.re * o.im)) / den,
+        )
+    }
 }
 
 /// Build intersection curves from a collection of ordered 3D points.
@@ -2089,6 +2339,126 @@ mod tests {
             !curves.is_empty(),
             "should find intersection curves with torus"
         );
+    }
+
+    /// Signed distance of a point to a z-axis torus centred at the origin:
+    /// `sqrt((sqrt(x^2+y^2) - R)^2 + z^2) - r`.
+    fn torus_implicit(p: Point3, major: f64, minor: f64) -> f64 {
+        let rho = p.x().hypot(p.y());
+        ((rho - major).hypot(p.z())) - minor
+    }
+
+    #[test]
+    fn plane_torus_lobe_closes_and_stays_on_surface() {
+        use crate::traits::ParametricCurve;
+        let (major, minor) = (10.0, 3.0);
+        let torus = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), major, minor).unwrap();
+
+        // The census cutting planes (y=-4, x=6) each cut the +x and -x tube lobes
+        // in a CLOSED oval. The greedy marcher stops one grid step short of
+        // closing; the wrap-close must make every fitted lobe close exactly.
+        for (n, d) in [
+            (Vec3::new(0.0, -1.0, 0.0), 4.0),  // y = -4
+            (Vec3::new(-1.0, 0.0, 0.0), -6.0), // x = 6
+            (Vec3::new(0.0, 0.0, 1.0), 0.0),   // z = 0 -> two concentric circles
+        ] {
+            let curves = intersect_plane_torus(&torus, n, d).unwrap();
+            assert!(!curves.is_empty(), "plane n={n:?} d={d} found no curves");
+            for c in &curves {
+                let p0 = ParametricCurve::evaluate(&c.curve, 0.0);
+                let p1 = ParametricCurve::evaluate(&c.curve, 1.0);
+                assert!(
+                    (p0 - p1).length() < 1e-7,
+                    "lobe not closed: gap={} (n={n:?} d={d})",
+                    (p0 - p1).length()
+                );
+                // Every fitted sample stays on the torus (shape-preserving).
+                for k in 0..=64 {
+                    let t = f64::from(k) / 64.0;
+                    let p = ParametricCurve::evaluate(&c.curve, t);
+                    assert!(
+                        torus_implicit(p, major, minor).abs() < 1e-2,
+                        "off-surface point {p:?} implicit={}",
+                        torus_implicit(p, major, minor)
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn plane_torus_inner_tangent_figure_eight_stays_open() {
+        use crate::traits::ParametricCurve;
+        let (major, minor) = (10.0, 3.0);
+        let torus = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), major, minor).unwrap();
+
+        // A plane tangent to the inner equator (x = major - minor = 7) cuts a
+        // self-touching figure-eight. The marcher traces it as a single chain
+        // whose end lands on the opposite lobe — FAR from its start (gap is many
+        // point-spacings). The wrap-close must NOT force-close this into a wrong
+        // loop; it must stay OPEN so a self-touching curve is never sealed.
+        let curves =
+            intersect_plane_torus(&torus, Vec3::new(-1.0, 0.0, 0.0), -(major - minor)).unwrap();
+        assert!(!curves.is_empty(), "inner-tangent plane found no curves");
+        let max_gap = curves
+            .iter()
+            .map(|c| {
+                let p0 = ParametricCurve::evaluate(&c.curve, 0.0);
+                let p1 = ParametricCurve::evaluate(&c.curve, 1.0);
+                (p0 - p1).length()
+            })
+            .fold(0.0_f64, f64::max);
+        assert!(
+            max_gap > 1e-2,
+            "figure-eight chain was wrongly force-closed (max end-gap={max_gap})"
+        );
+    }
+
+    #[test]
+    fn line_torus_box_edge_crossing_is_exact() {
+        // The census box edge x=6, y=-4 (z varying) crosses the torus (R=10,r=3)
+        // at z = ±sqrt(r² − (rho−R)²), rho = hypot(6,4) ≈ 7.2111 → z ≈ ±1.1055.
+        let torus = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), 10.0, 3.0).unwrap();
+        let ts = intersect_line_torus(
+            &torus,
+            Point3::new(6.0, -4.0, -5.0),
+            Vec3::new(0.0, 0.0, 1.0),
+        );
+        // Vertical line through (6,-4) meets the tube twice.
+        assert_eq!(ts.len(), 2, "expected 2 crossings, got {ts:?}");
+        let zs: Vec<f64> = ts.iter().map(|t| -5.0 + t).collect();
+        let rho = 6.0_f64.hypot(4.0);
+        let z_exp = (9.0 - (rho - 10.0).powi(2)).sqrt();
+        assert!(
+            (zs[0] - (-z_exp)).abs() < 1e-9,
+            "z0={} exp={}",
+            zs[0],
+            -z_exp
+        );
+        assert!((zs[1] - z_exp).abs() < 1e-9, "z1={} exp={}", zs[1], z_exp);
+        // Each crossing lies on the torus.
+        for &t in &ts {
+            let p = Point3::new(6.0, -4.0, -5.0 + t);
+            let rho = p.x().hypot(p.y());
+            let impl_v = (rho - 10.0).hypot(p.z()) - 3.0;
+            assert!(impl_v.abs() < 1e-9, "off-torus impl={impl_v}");
+        }
+    }
+
+    #[test]
+    fn line_torus_miss_and_tangent() {
+        let torus = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), 10.0, 3.0).unwrap();
+        // A vertical line at rho beyond the outer rim (x=20) misses entirely.
+        let miss = intersect_line_torus(
+            &torus,
+            Point3::new(20.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+        );
+        assert!(miss.is_empty(), "expected no crossings, got {miss:?}");
+        // The z-axis (rho=0) passes through the hole — no intersection.
+        let axis =
+            intersect_line_torus(&torus, Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0));
+        assert!(axis.is_empty(), "z-axis should miss the tube, got {axis:?}");
     }
 
     #[test]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1157,6 +1157,58 @@ fn intersect_box_centered_sphere_is_analytic_collar() {
 }
 
 #[test]
+/// Cut a box notch out of a torus (major 10, minor 3): the box [6,14]×[−4,4]×[−4,4]
+/// scoops a sector of the +x ring lobe, severing the ring into a capped C-tube.
+/// The result is an analytic B-rep — one kept toroidal band (wrapping the tube,
+/// spanning the long 294° ring arc) + the box notch walls — watertight, NOT a
+/// mesh fallback. Volume ≈ torus minus the box∩torus chunk (Monte-carlo 1543).
+fn cut_torus_by_box_notch_is_analytic_watertight() {
+    let mut topo = Topology::new();
+    let tor = crate::primitives::make_torus(&mut topo, 10.0, 3.0, 32).unwrap();
+    let bx = crate::primitives::make_box(&mut topo, 8.0, 8.0, 8.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        bx,
+        &brepkit_math::mat::Mat4::translation(6.0, -4.0, -4.0),
+    )
+    .unwrap();
+    let result = boolean(&mut topo, BooleanOp::Cut, tor, bx).unwrap();
+
+    let face_ids = brepkit_topology::explorer::solid_faces(&topo, result).unwrap();
+    let (mut planes, mut tori, mut others) = (0usize, 0usize, 0usize);
+    for fid in &face_ids {
+        match topo.face(*fid).unwrap().surface() {
+            brepkit_topology::face::FaceSurface::Plane { .. } => planes += 1,
+            brepkit_topology::face::FaceSurface::Torus(_) => tori += 1,
+            _ => others += 1,
+        }
+    }
+    // 1 kept toroidal band + 4 plane notch walls (x=6, y=±4 split; the inner x=6
+    // wall splits into two thin lobes), no NURBS fallback faces.
+    assert_eq!(others, 0, "no non-analytic faces expected, got {others}");
+    assert_eq!(tori, 1, "expected 1 kept toroidal band, got {tori}");
+    assert!(planes >= 3, "expected the box notch walls, got {planes}");
+
+    // Watertight analytic B-rep (not a mesh fallback): every edge shared by
+    // exactly two faces.
+    let adj = brepkit_topology::adjacency::AdjacencyIndex::build(&topo, result).unwrap();
+    assert_eq!(
+        adj.boundary_edges().len(),
+        0,
+        "result must be watertight (0 free edges)"
+    );
+    assert!(adj.is_manifold(), "result must be manifold");
+
+    // Volume ≈ torus (2π²·10·9 = 1776.5) minus the box∩torus chunk (≈233).
+    let expected = 1543.0;
+    let vol = crate::measure::solid_volume(&topo, result, 0.01).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 0.02,
+        "volume {vol:.2} should be within 2% of {expected:.0}"
+    );
+}
+
+#[test]
 /// Fuse a 10³ box with a sphere of r=7.
 ///
 /// By inclusion-exclusion: V(A∪B) = V(A) + V(B) - V(A∩B).

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -1183,11 +1183,21 @@ fn cut_torus_by_box_notch_is_analytic_watertight() {
             _ => others += 1,
         }
     }
-    // 1 kept toroidal band + 4 plane notch walls (x=6, y=±4 split; the inner x=6
-    // wall splits into two thin lobes), no NURBS fallback faces.
+    // Exact analytic decomposition: 1 kept toroidal band + 4 plane notch walls
+    // (the y=±4 walls + the inner x=6 wall split into two thin lobes), with NO
+    // NURBS fallback faces — i.e. NOT a mesh fallback.
     assert_eq!(others, 0, "no non-analytic faces expected, got {others}");
-    assert_eq!(tori, 1, "expected 1 kept toroidal band, got {tori}");
-    assert!(planes >= 3, "expected the box notch walls, got {planes}");
+    assert_eq!(tori, 1, "expected exactly 1 kept toroidal band, got {tori}");
+    assert_eq!(
+        planes, 4,
+        "expected exactly 4 plane notch walls, got {planes}"
+    );
+    assert_eq!(
+        face_ids.len(),
+        5,
+        "expected exactly 5 faces, got {}",
+        face_ids.len()
+    );
 
     // Watertight analytic B-rep (not a mesh fallback): every edge shared by
     // exactly two faces.

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -118,10 +118,17 @@ fn torus_wire_wraps_tube(
         let Ok(e) = topo.edge(oe.edge()) else {
             return false;
         };
-        for vid in [e.start(), e.end()] {
-            if let Ok(v) = topo.vertex(vid) {
-                vs.push(torus.project_point(v.point()).1);
-            }
+        let (Ok(sv), Ok(ev)) = (topo.vertex(e.start()), topo.vertex(e.end())) else {
+            return false;
+        };
+        let (sp, ep) = (sv.point(), ev.point());
+        // Sample ALONG each edge (not just endpoints): a wrapping seam arc bows
+        // far in v between its endpoints, so endpoint-only sampling can miss the
+        // wrap and misclassify a notch band as a constant-v circle.
+        for k in 0..=8 {
+            let f = f64::from(k) / 8.0;
+            let p = e.curve().evaluate_with_endpoints(f, sp, ep);
+            vs.push(torus.project_point(p).1);
         }
     }
     if vs.len() < 3 {

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -82,6 +82,64 @@ fn solid_has_scalloped_sphere_collar(topo: &Topology, solid: SolidId) -> bool {
     })
 }
 
+/// Whether the solid has a torus notch band (torus − box: a kept toroidal patch
+/// bounded by two tube-angle(`v`)-WRAPPING seam-arc loops, NOT constant-`v`
+/// latitude circles). Its per-face analytic tessellation can't be sampled
+/// watertight in isolation (the band wraps `v` and shares vertices with the
+/// notch walls), and there is no closed-form volume — so the volume is taken off
+/// the (watertight) whole-solid mesh instead, like the box ∩ sphere collar.
+fn solid_has_torus_notch_band(topo: &Topology, solid: SolidId) -> bool {
+    let Ok(faces) = brepkit_topology::explorer::solid_faces(topo, solid) else {
+        return false;
+    };
+    faces.iter().any(|&fid| {
+        topo.face(fid).is_ok_and(|f| match f.surface() {
+            FaceSurface::Torus(t) => {
+                f.inner_wires().len() == 1 && torus_wire_wraps_tube(topo, f.outer_wire(), t)
+            }
+            _ => false,
+        })
+    })
+}
+
+/// True when a torus face wire's vertices span the full tube angle `v` (a
+/// `v`-wrapping seam loop), as opposed to a constant-`v` latitude circle. Sampled
+/// from the wire's edge endpoints projected to the torus `v` parameter.
+fn torus_wire_wraps_tube(
+    topo: &Topology,
+    wire_id: brepkit_topology::wire::WireId,
+    torus: &brepkit_math::surfaces::ToroidalSurface,
+) -> bool {
+    let Ok(wire) = topo.wire(wire_id) else {
+        return false;
+    };
+    let mut vs: Vec<f64> = Vec::new();
+    for oe in wire.edges() {
+        let Ok(e) = topo.edge(oe.edge()) else {
+            return false;
+        };
+        for vid in [e.start(), e.end()] {
+            if let Ok(v) = topo.vertex(vid) {
+                vs.push(torus.project_point(v.point()).1);
+            }
+        }
+    }
+    if vs.len() < 3 {
+        return false;
+    }
+    vs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    // Largest v-gap (incl. wrap); a wrapping loop's gap is well under a full turn,
+    // a constant-v circle collapses to ~one v value (gap ≈ 2π).
+    let max_gap = vs
+        .windows(2)
+        .map(|w| w[1] - w[0])
+        .chain(std::iter::once(
+            vs[0] + std::f64::consts::TAU - vs[vs.len() - 1],
+        ))
+        .fold(0.0_f64, f64::max);
+    max_gap < std::f64::consts::PI
+}
+
 /// Count mesh edges incident to a number of triangles other than 2 (boundary or
 /// non-manifold edges). Zero means a closed 2-manifold.
 fn mesh_boundary_edge_count(mesh: &tessellate::TriangleMesh) -> usize {
@@ -730,6 +788,20 @@ pub fn solid_volume(
         }
         // Non-watertight mesh: fall through to the generic paths below rather
         // than return a leaky volume.
+    }
+
+    // A torus notch band (torus − box) likewise has no closed-form volume and
+    // can't be per-face tessellated watertight (the band wraps the tube and
+    // shares vertices with the notch walls). The whole-solid mesh IS watertight
+    // (the structured notch-band tessellator), so take the divergence-theorem
+    // volume off it. Per-face summation would under-count (the band's own per-
+    // face mesh isn't closed).
+    if solid_has_torus_notch_band(topo, solid) {
+        let mesh = tessellate::tessellate_solid(topo, solid, deflection)?;
+        if !mesh.indices.is_empty() && mesh_boundary_edge_count(&mesh) == 0 {
+            return Ok(signed_volume_from_mesh(&mesh));
+        }
+        // Non-watertight mesh: fall through rather than return a leaky volume.
     }
 
     // Fast path: for solids made entirely of planar triangular faces

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -161,8 +161,10 @@ type LatRing = Vec<(f64, u32)>;
 /// sorted by `v`, taking the SHARED global vertices (so the ring shares the
 /// notch walls' vertices) and projecting to the torus `(u, v)`. Accepts edges of
 /// any curve type (the notch seam arcs are NURBS). Returns `None` if any edge is
-/// missing from the shared pool or the ring does not WRAP the tube once (the
-/// largest `v` gap is under a full turn).
+/// missing from the shared pool, or the ring does NOT wrap the tube — detected
+/// as the largest gap between consecutive sorted `v` samples (including the
+/// wrap-around gap) EXCEEDING half a turn (`π`): a ring that encircles the tube
+/// has all its `v`-gaps below `π`, whereas a partial arc leaves one gap above it.
 fn collect_torus_phi_ring(
     topo: &Topology,
     wire_id: brepkit_topology::wire::WireId,

--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -157,6 +157,210 @@ pub(super) fn tessellate_revolution_band_shared(
 /// longitude during stitching.
 type LatRing = Vec<(f64, u32)>;
 
+/// Collect a torus face wire's boundary as a ring of `(tube-angle v, shared gid)`
+/// sorted by `v`, taking the SHARED global vertices (so the ring shares the
+/// notch walls' vertices) and projecting to the torus `(u, v)`. Accepts edges of
+/// any curve type (the notch seam arcs are NURBS). Returns `None` if any edge is
+/// missing from the shared pool or the ring does not WRAP the tube once (the
+/// largest `v` gap is under a full turn).
+fn collect_torus_phi_ring(
+    topo: &Topology,
+    wire_id: brepkit_topology::wire::WireId,
+    torus: &brepkit_math::surfaces::ToroidalSurface,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
+    merged: &TriangleMesh,
+) -> Result<Option<Vec<(f64, u32)>>, crate::OperationsError> {
+    let wire = topo.wire(wire_id)?;
+    let mut gids: Vec<u32> = Vec::new();
+    for oe in wire.edges() {
+        let Some(edge_gids) = edge_global_indices.get(&oe.edge().index()) else {
+            return Ok(None);
+        };
+        gids.extend_from_slice(edge_gids);
+    }
+    let mut seen: DetHashSet<u32> = DetHashSet::default();
+    let mut ring: Vec<(f64, u32)> = Vec::with_capacity(gids.len());
+    for g in gids {
+        if !seen.insert(g) {
+            continue;
+        }
+        let (_, v) = torus.project_point(merged.positions[g as usize]);
+        ring.push((v, g));
+    }
+    if ring.len() < 3 {
+        return Ok(None);
+    }
+    ring.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    // Must wrap the tube once: largest v-gap (incl. wrap) under a full turn.
+    let max_gap = ring
+        .windows(2)
+        .map(|w| w[1].0 - w[0].0)
+        .chain(std::iter::once(
+            ring[0].0 + std::f64::consts::TAU - ring[ring.len() - 1].0,
+        ))
+        .fold(0.0_f64, f64::max);
+    if max_gap > std::f64::consts::PI {
+        return Ok(None);
+    }
+    Ok(Some(ring))
+}
+
+/// Tessellate the `torus − box`-style notch band: a kept toroidal patch that
+/// WRAPS the tube angle `v` fully and is bounded by TWO `v`-wrapping seam-arc
+/// loops at the two ends of a ring-angle (`u`) span (the box notch's `±y` walls).
+/// The band is swept structurally along `u` from one boundary loop to the other
+/// the LONG way (through `u = π`, the 294° kept side), with full-`v` interior
+/// rings; both boundary loops use their SHARED wall vertices, so the band and the
+/// plane notch walls meet crack-free (watertight). Returns `false` (defer to the
+/// CDT path) for any torus face that is not this two-`v`-loop notch band.
+///
+/// Distinct from [`tessellate_latitude_band_shared`]: there the two boundaries
+/// are constant-`v` latitude circles swept along `v`; here they wrap `v` and the
+/// sweep is along `u`.
+pub(super) fn tessellate_torus_notch_band(
+    topo: &Topology,
+    face_data: &brepkit_topology::face::Face,
+    deflection: f64,
+    angular_tol: f64,
+    edge_global_indices: &DetHashMap<usize, Vec<u32>>,
+    merged: &mut TriangleMesh,
+    point_to_global: &mut DetHashMap<(i64, i64, i64), u32>,
+) -> Result<bool, crate::OperationsError> {
+    use std::f64::consts::{PI, TAU};
+    let FaceSurface::Torus(torus) = face_data.surface() else {
+        return Ok(false);
+    };
+    if face_data.inner_wires().len() != 1 {
+        return Ok(false);
+    }
+    let t1 = torus.clone();
+    let t2 = torus.clone();
+    let project = move |p: Point3| t1.project_point(p);
+    let surf_normal = move |u: f64, v: f64| t2.normal(u, v);
+
+    // Both boundary loops wrap the tube (v) once, with their shared wall gids.
+    let Some(ring_a) = collect_torus_phi_ring(
+        topo,
+        face_data.outer_wire(),
+        torus,
+        edge_global_indices,
+        merged,
+    )?
+    else {
+        return Ok(false);
+    };
+    let Some(ring_b) = collect_torus_phi_ring(
+        topo,
+        face_data.inner_wires()[0],
+        torus,
+        edge_global_indices,
+        merged,
+    )?
+    else {
+        return Ok(false);
+    };
+
+    // Ring-angle (u) of each loop: each loop sits at a u-BAND (the box wall's cut
+    // varies in u with the tube angle), one near u_a, the other near u_b, the
+    // kept band the LONG way between them. Take each loop's mean u (wrap-safe)
+    // plus its half-u-spread, so the interior rows start at each loop's KEPT-SIDE
+    // edge (mean ± spread toward the band midpoint), NOT its mean — otherwise the
+    // first/last interior row sits INSIDE the loop's u-band and the stitch folds
+    // back over the boundary strip, under-covering the band.
+    let mean_u = |ring: &[(f64, u32)]| -> f64 {
+        let (mut sx, mut sy) = (0.0, 0.0);
+        for &(_, g) in ring {
+            let (u, _) = project(merged.positions[g as usize]);
+            sx += u.cos();
+            sy += u.sin();
+        }
+        sy.atan2(sx).rem_euclid(TAU)
+    };
+    // Max signed u-offset of a ring's vertices from its mean (wrap into (-π,π]).
+    let half_spread = |ring: &[(f64, u32)], mean: f64| -> f64 {
+        ring.iter()
+            .map(|&(_, g)| {
+                let (u, _) = project(merged.positions[g as usize]);
+                let d = (u - mean + PI).rem_euclid(TAU) - PI;
+                d.abs()
+            })
+            .fold(0.0_f64, f64::max)
+    };
+    let u_a = mean_u(&ring_a);
+    let u_b = mean_u(&ring_b);
+    let spread_a = half_spread(&ring_a, u_a);
+    let spread_b = half_spread(&ring_b, u_b);
+
+    // Sweep the LONG way from ring_a toward ring_b (through the kept far side).
+    let fwd_span = (u_b - u_a).rem_euclid(TAU); // a -> b increasing u
+    // The interior must lie on the long arc; start just past each loop's
+    // kept-side edge so no interior row overlaps a boundary loop's u-band.
+    let (u_start, u_end) = if fwd_span >= PI {
+        // a -> b the long way is INCREASING u: kept edge of a is u_a+spread_a,
+        // of b is u_b-spread_b (i.e. u_a+fwd_span-spread_b).
+        (u_a + spread_a, u_a + fwd_span - spread_b)
+    } else {
+        // a -> b the long way is DECREASING u.
+        (u_a - spread_a, u_a - (TAU - fwd_span) + spread_b)
+    };
+    let span = (u_end - u_start).abs();
+    if span < 1e-6 {
+        return Ok(false);
+    }
+
+    // Interior rows: full-v circles at constant u, stepped along the sweep. Count
+    // from chord deviation over the band's u-arc-length (radius ≈ R, the ring).
+    let n_u =
+        segments_for_chord_deviation_a(torus.major_radius(), span, deflection, angular_tol, true)
+            .max(2);
+    // v-resolution: a full tube circle.
+    let n_v =
+        segments_for_chord_deviation_a(torus.minor_radius(), TAU, deflection, angular_tol, true)
+            .max(8);
+
+    // Build interior rings as `LatRing` (sorted by v) of fresh vertices.
+    let build_u_ring = |u: f64,
+                        merged: &mut TriangleMesh,
+                        point_to_global: &mut DetHashMap<(i64, i64, i64), u32>|
+     -> LatRing {
+        let mut row: LatRing = Vec::with_capacity(n_v);
+        for j in 0..n_v {
+            #[allow(clippy::cast_precision_loss)]
+            let v = TAU * (j as f64) / (n_v as f64);
+            let p = torus.evaluate(u, v);
+            let key = point_merge_key(p, MERGE_GRID);
+            let gid = *point_to_global.entry(key).or_insert_with(|| {
+                let idx = merged.positions.len() as u32;
+                merged.positions.push(p);
+                merged.normals.push(surf_normal(u, v));
+                idx
+            });
+            row.push((v, gid));
+        }
+        row.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        row
+    };
+
+    let emit = make_band_emit(&project, &surf_normal);
+    let idx_start = merged.indices.len();
+
+    // Stitch ring_a -> interior rows -> ring_b. All rings sorted by v; `v` is the
+    // ring parameter passed to `stitch_rings` (it walks the shared tube angle).
+    let mut prev: LatRing = ring_a;
+    for iu in 1..n_u {
+        #[allow(clippy::cast_precision_loss)]
+        let u = u_start + (u_end - u_start) * (iu as f64) / (n_u as f64);
+        let row = build_u_ring(u.rem_euclid(TAU), merged, point_to_global);
+        stitch_rings(merged, &prev, &row, &emit);
+        prev = row;
+    }
+    stitch_rings(merged, &prev, &ring_b, &emit);
+
+    // Orient the whole band once against the torus outward normal.
+    orient_triangle_run(merged, idx_start, &project, &surf_normal);
+    Ok(true)
+}
+
 /// Tessellate a sphere/torus latitude band (the annular region between two
 /// constant-`v` full-revolution boundaries) as a structured UV grid.
 ///

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -12,7 +12,7 @@ use super::edge_sampling::{circle_param_range, sample_edge, segments_for_chord_d
 use super::mesh_ops::{dedupe_coincident_triangles, weld_boundary_vertices};
 use super::nonplanar::{
     tessellate_latitude_band_shared, tessellate_nonplanar_cdt, tessellate_nonplanar_snap,
-    tessellate_revolution_band_shared,
+    tessellate_revolution_band_shared, tessellate_torus_notch_band,
 };
 use super::nurbs::{compute_angular_range, compute_v_param_range};
 use super::planar::{
@@ -891,18 +891,34 @@ pub(super) fn tessellate_face_with_shared_edges(
         // fills the removed polar cap. Tessellate such bands structurally from
         // the shared boundary vertices instead. Returns false for any other
         // sphere/torus face, which then takes the CDT/snap path unchanged.
-        let handled_band = matches!(
-            face_data.surface(),
-            FaceSurface::Sphere(_) | FaceSurface::Torus(_)
-        ) && tessellate_latitude_band_shared(
-            topo,
-            face_data,
-            deflection,
-            angular_tol,
-            edge_global_indices,
-            merged,
-            point_to_global,
-        )?;
+        // A torus notch band (torus − box: a kept patch wrapping the tube fully,
+        // bounded by two v-wrapping seam-arc loops at the ends of a ring-angle
+        // span) is swept along u, not v, so it is not a latitude band. Try it
+        // first; it returns false for any other torus face.
+        let handled_notch = matches!(face_data.surface(), FaceSurface::Torus(_))
+            && tessellate_torus_notch_band(
+                topo,
+                face_data,
+                deflection,
+                angular_tol,
+                edge_global_indices,
+                merged,
+                point_to_global,
+            )?;
+
+        let handled_band = handled_notch
+            || (matches!(
+                face_data.surface(),
+                FaceSurface::Sphere(_) | FaceSurface::Torus(_)
+            ) && tessellate_latitude_band_shared(
+                topo,
+                face_data,
+                deflection,
+                angular_tol,
+                edge_global_indices,
+                merged,
+                point_to_global,
+            )?);
 
         if !handled_band {
             let pos_save = merged.positions.len();

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -769,6 +769,30 @@ fn box_centered_sphere_collar_tessellates_watertight() {
 }
 
 #[test]
+fn torus_box_notch_band_tessellates_watertight() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let tor = crate::primitives::make_torus(&mut topo, 10.0, 3.0, 32).unwrap();
+    let bx = crate::primitives::make_box(&mut topo, 8.0, 8.0, 8.0).unwrap();
+    crate::transform::transform_solid(&mut topo, bx, &Mat4::translation(6.0, -4.0, -4.0)).unwrap();
+    let result =
+        crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Cut, tor, bx).unwrap();
+
+    // The kept toroidal notch band must tessellate watertight (shared seam
+    // vertices with the notch walls — no cracks), STABLE across deflections.
+    for &defl in &[0.1_f64, 0.05, 0.02] {
+        let mesh = tessellate_solid(&topo, result, defl).unwrap();
+        assert!(
+            is_watertight(&mesh),
+            "torus−box notch band must tessellate watertight at deflection {defl}: bd={} nm={}",
+            boundary_edge_count(&mesh),
+            non_manifold_edge_count(&mesh)
+        );
+    }
+}
+
+#[test]
 fn tessellate_solid_box_correct_area() {
     let mut topo = Topology::new();
     let solid = crate::primitives::make_box(&mut topo, 2.0, 3.0, 4.0).unwrap();


### PR DESCRIPTION
## What

Makes `Cut(torus, box)` fully analytic — B-Rep + watertight render + correct volume — instead of a 1733-face mesh fallback. Census: **233ms / 1733 faces → 14ms / 5 faces**.

**The campaign's fourth and final case** (after #1003 keystone, #1005 sphere−cyl, #1006 box∩sphere, #1008 cyl∪cyl). With this, **all primitive-boolean cases in the census are analytic — zero mesh fallbacks.**

The case: torus (major 10, minor 3) minus a side-8 box that severs one side of the ring, leaving a capped C-tube (genus-0).

## The fix (staged)

**B-Rep**
- **plane×torus marcher closure** — the marcher emitted near-closed-but-*open* ovals (~0.15mm gap, one grid step) that fell into a no-man's-land: too open to be recognized as a loop, never clipped. Close the fit when the chain wraps (a grazing inner-tangent figure-eight stays open). Adds exact `intersect_line_torus` (quartic, Durand-Kerner) for box-edge crossings.
- **`FaceExtent` for a whole torus** — a whole untrimmed torus is now full extent, so `restrict_curves_to_faces` clips the ovals against the box (it was bailing on the `None` v-range).
- **exact-crossing trim + arc-split + band tracer** — trim each oval at its **exact** box-edge∩torus crossings (z=±1.105, shared vertices → watertight), always split the kept arc at its midpoint, and trace the kept toroidal band (a φ-wrapping u-band, the long 294° kept side).

**Render + volume**
- `tessellate_torus_notch_band` — sweeps the band along u, sharing seam vertices with the notch walls (crack-free). The u-sweep starts at each boundary loop's **kept-side edge** (a mean start folds the stitch back over the boundary strip → undercount).
- volume via `signed_volume_from_mesh` off the now-watertight mesh (the band isn't closed in isolation), gated to the notch-band signature.

**General engine improvements** (motivated here, gated narrow)
- SD `source_face` guard: complementary sub-faces split from the same input face are never same-domain duplicates of each other.
- `perform_areas`: a single result shell is always growth (no enclosing shell to be a cavity of); multi-shell results keep the volume-sign split.

## Why not the "arc-identity merge-key primitive"

The long-discussed shared *arc-identity-edge-merge primitive* is **not buildable**: `merge_duplicate_edges`'s endpoint-pair key is load-bearing for the gridfinity lip ring (Line-chord + Circle-arc co-endpoint pairs, deviating up to 2.4mm, that **must** collapse for manifoldness), while torus−box's notch-wall lens needs the **opposite** (Line + co-endpoint arc must stay distinct). Same local configuration, opposite required outcome → no merge *key* can separate them. The **splitter-side arc-split** (give the lens arc a midpoint vertex so the face is 3 edges) controls the geometry *we* emit and sidesteps it — so **`merge_duplicate_edges` is byte-identical to main**.

## Verification

- census `torus − box`: 14ms / 5 faces (1 toroidal band + 4 plane notch walls) / exact analytic; free=0, manifold.
- render watertight: whole-solid mesh bd-edges == 0, stable across deflection 0.1/0.05/0.02 (no seam cracks).
- volume: `solid_volume` = 1537.5 vs 1543.07 (Monte-Carlo, 20M) = **0.36%**, convergent upward (inscribed-mesh).
- **No regression:** gridfinity d1/d3/d4/d5 + coplanar caps (#909/#859) + #696 seams green; box∩sphere (8) / sphere−cyl (3) / cyl∪cyl (6) / cyl∩cyl (3) unchanged; **plain torus unchanged** (the new branches gate on the notch-band signature); `merge_duplicate_edges` byte-identical to main; full suite **2476 passed**.
- 2 fixtures: `cut_torus_by_box_notch_is_analytic_watertight`, `torus_box_notch_band_tessellates_watertight`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the torus − box cut fully analytic, watertight, and fast. Replaces a 1733‑face mesh fallback with a 5‑face B‑Rep (233ms → 14ms).

- **New Features**
  - Analytic trim of plane×torus ovals at exact box‑edge×torus crossings using `intersect_line_torus` (quartic), then split the kept arc at its midpoint; keeps all in‑box arcs.
  - Torus notch band tracing with `split_torus_band_by_arrangement` (φ‑wrapping u‑band), and structured `tessellate_torus_notch_band` that sweeps along u from each loop’s kept‑side edge and shares seam vertices; interior point from the boundary loops’ long‑arc midpoint.
  - Volume for this case is taken from the watertight whole‑solid mesh via `signed_volume_from_mesh` when a torus notch band is detected.

- **Bug Fixes**
  - Plane×torus marcher: wrapped ovals now close; grazing inner‑tangent figure‑eight stays open.
  - A whole, untrimmed torus is treated as full `FaceExtent` so ovals are clipped against the box face.
  - Same‑domain detection skips only complementary splits from the same `source_face` (distinct interiors); coincident same‑source duplicates still de‑duplicated.
  - Single‑shell classification: a lone negative‑volume shell is growth only if outward per a curvature‑robust divergence‑flux check; rejects genuine inward cavity results. Added cube orientation tests.
  - Hardened torus pieces: tighter arc‑join tolerance; notch‑band v‑wrap detection samples along edges; quartic root finder filters by residual and de‑dups. Added stronger torus−box fixtures (exact 5‑face decomposition; watertight across deflections).

<sup>Written for commit bcd2832a3932c27827637514ef834a7bd45e9c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

