### PR TITLE
feat(operations): recover analytic surfaces of revolution + exact volume

### DIFF
--- a/crates/operations/examples/approx_census.rs
+++ b/crates/operations/examples/approx_census.rs
@@ -349,18 +349,21 @@ fn rz_profile(topo: &mut Topology, pts: &[(f64, f64)]) -> Result<FaceId, Box<dyn
 
 /// Count faces by analytic surface type for the revolve survey.
 fn surf_tags(topo: &Topology, s: SolidId) -> String {
-    let (mut pl, mut cy, mut co, mut to, mut nu) = (0, 0, 0, 0, 0);
+    let (mut pl, mut cy, mut co, mut sp, mut to, mut nu) = (0, 0, 0, 0, 0, 0);
     for f in solid_faces(topo, s).unwrap_or_default() {
+        // Exhaustive over `FaceSurface` so a new variant is compiler-flagged here
+        // (the project forbids a `_ =>` wildcard on `FaceSurface`).
         match topo.face(f).map(|fc| fc.surface().clone()) {
             Ok(FaceSurface::Plane { .. }) => pl += 1,
             Ok(FaceSurface::Cylinder(_)) => cy += 1,
             Ok(FaceSurface::Cone(_)) => co += 1,
+            Ok(FaceSurface::Sphere(_)) => sp += 1,
             Ok(FaceSurface::Torus(_)) => to += 1,
             Ok(FaceSurface::Nurbs(_)) => nu += 1,
-            _ => {}
+            Err(_) => {}
         }
     }
-    format!("plane={pl} cyl={cy} cone={co} torus={to} NURBS={nu}")
+    format!("plane={pl} cyl={cy} cone={co} sphere={sp} torus={to} NURBS={nu}")
 }
 
 /// Revolve survey: each profile-edge type revolves into its exact analytic

--- a/crates/operations/examples/approx_census.rs
+++ b/crates/operations/examples/approx_census.rs
@@ -371,7 +371,6 @@ fn surf_tags(topo: &Topology, s: SolidId) -> String {
 /// pointed-cone apex or an annulus cap keep the segmented (analytic but
 /// over-segmented) bands — still NURBS-free for the walls.
 fn revolve_matrix() {
-    use std::f64::consts::TAU;
     println!("\nREVOLVE (profile edges → analytic surfaces of revolution):");
     let z = Point3::new(0.0, 0.0, 0.0);
     let zdir = Vec3::new(0.0, 0.0, 1.0);
@@ -399,69 +398,84 @@ fn revolve_matrix() {
         let face = match rz_profile(&mut topo, pts) {
             Ok(f) => f,
             Err(e) => {
-                println!("  {name:<38} build ERR: {e}");
+                report(
+                    "revolve",
+                    &format!("{name} [build ERR]"),
+                    0.0,
+                    0,
+                    &[format!("err: {e}")],
+                );
                 continue;
             }
         };
-        let t = Instant::now();
-        let res = revolve(&mut topo, face, z, zdir, TAU);
-        let ms = t.elapsed().as_secs_f64() * 1000.0;
-        match res {
-            Ok(s) => {
-                let nf = face_count(&topo, s);
-                let tags = surf_tags(&topo, s);
-                println!("  {name:<38} {ms:>7.3}ms  faces={nf:<3}  {tags}");
-            }
-            Err(e) => println!("  {name:<38} ERR: {e}"),
-        }
+        report_revolve(&mut topo, name, face, z, zdir);
     }
 
     // Circular-arc profile edge → Torus band. A half-disc (semicircle arc + its
     // diameter on an axis-parallel line) makes the arc bands `Torus`.
-    {
-        use brepkit_math::curves::Circle3D;
-        use brepkit_topology::edge::Edge;
-        use brepkit_topology::vertex::Vertex;
-        let mut topo = Topology::new();
-        let Ok(circ) = Circle3D::new(Point3::new(10.0, 0.0, 0.0), Vec3::new(0.0, 1.0, 0.0), 3.0)
-        else {
-            return;
-        };
-        let pa = circ.evaluate(-std::f64::consts::FRAC_PI_2);
-        let pb = circ.evaluate(std::f64::consts::FRAC_PI_2);
-        let va = topo.add_vertex(Vertex::new(pa, 1e-7));
-        let vb = topo.add_vertex(Vertex::new(pb, 1e-7));
-        let e_arc = topo.add_edge(Edge::new(va, vb, EdgeCurve::Circle(circ)));
-        let e_dia = topo.add_edge(Edge::new(vb, va, EdgeCurve::Line));
-        let Ok(wire) = Wire::new(
-            vec![
-                OrientedEdge::new(e_arc, true),
-                OrientedEdge::new(e_dia, true),
-            ],
-            true,
-        ) else {
-            return;
-        };
-        let wid = topo.add_wire(wire);
-        let face = topo.add_face(Face::new(
-            wid,
-            vec![],
-            FaceSurface::Plane {
-                normal: Vec3::new(0.0, 1.0, 0.0),
-                d: 0.0,
-            },
-        ));
-        let t = Instant::now();
-        let res = revolve(&mut topo, face, z, zdir, TAU);
-        let ms = t.elapsed().as_secs_f64() * 1000.0;
-        match res {
-            Ok(s) => println!(
-                "  {:<38} {ms:>7.3}ms  faces={:<3}  {}",
-                "half-disc (arc→Torus)",
-                face_count(&topo, s),
-                surf_tags(&topo, s)
-            ),
-            Err(e) => println!("  half-disc (arc→Torus) ERR: {e}"),
+    let mut topo = Topology::new();
+    match build_half_disc_profile(&mut topo) {
+        Ok(face) => report_revolve(&mut topo, "half-disc (arc→Torus)", face, z, zdir),
+        Err(e) => report(
+            "revolve",
+            "half-disc (arc→Torus) [build ERR]",
+            0.0,
+            0,
+            &[format!("err: {e}")],
+        ),
+    }
+}
+
+/// Build the half-disc profile (a semicircle arc bulging away from the axis,
+/// closed by its diameter on an axis-parallel line) for the revolve survey's
+/// torus case. Surfaces any construction error to the caller instead of
+/// swallowing it.
+fn build_half_disc_profile(topo: &mut Topology) -> Result<FaceId, Box<dyn Error>> {
+    use brepkit_math::curves::Circle3D;
+    use brepkit_topology::edge::Edge;
+    use brepkit_topology::vertex::Vertex;
+    let circ = Circle3D::new(Point3::new(10.0, 0.0, 0.0), Vec3::new(0.0, 1.0, 0.0), 3.0)?;
+    let pa = circ.evaluate(-std::f64::consts::FRAC_PI_2);
+    let pb = circ.evaluate(std::f64::consts::FRAC_PI_2);
+    let va = topo.add_vertex(Vertex::new(pa, 1e-7));
+    let vb = topo.add_vertex(Vertex::new(pb, 1e-7));
+    let e_arc = topo.add_edge(Edge::new(va, vb, EdgeCurve::Circle(circ)));
+    let e_dia = topo.add_edge(Edge::new(vb, va, EdgeCurve::Line));
+    let wire = Wire::new(
+        vec![
+            OrientedEdge::new(e_arc, true),
+            OrientedEdge::new(e_dia, true),
+        ],
+        true,
+    )?;
+    let wid = topo.add_wire(wire);
+    Ok(topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 1.0, 0.0),
+            d: 0.0,
+        },
+    )))
+}
+
+/// Revolve a profile a full turn and report via the shared capture/report path
+/// (so any `brepkit_approx` probe that fires is surfaced), with the analytic
+/// surface-type breakdown appended.
+fn report_revolve(topo: &mut Topology, name: &str, face: FaceId, z: Point3, zdir: Vec3) {
+    let _ = drain();
+    let t = Instant::now();
+    let res = revolve(topo, face, z, zdir, std::f64::consts::TAU);
+    let ms = t.elapsed().as_secs_f64() * 1000.0;
+    let mut ev = drain();
+    match res {
+        Ok(s) => {
+            report("revolve", name, ms, face_count(topo, s), &ev);
+            println!("            {}", surf_tags(topo, s));
+        }
+        Err(e) => {
+            ev.push(format!("err: {e}"));
+            report("revolve", &format!("{name} [ERR]"), ms, 0, &ev);
         }
     }
 }

--- a/crates/operations/examples/approx_census.rs
+++ b/crates/operations/examples/approx_census.rs
@@ -35,6 +35,7 @@ use brepkit_operations::loft::loft_smooth;
 use brepkit_operations::offset_face::offset_face;
 use brepkit_operations::offset_v2::{offset_solid_v2, shell_v2};
 use brepkit_operations::primitives;
+use brepkit_operations::revolve::revolve;
 use brepkit_operations::transform::transform_solid;
 use brepkit_topology::Topology;
 use brepkit_topology::edge::{Edge, EdgeCurve};
@@ -317,6 +318,152 @@ fn nurbs_section() -> Result<(), Box<dyn Error>> {
         }
     }
     Ok(())
+}
+
+/// Build a closed planar profile in the XZ plane (Y-up normal) from
+/// `(radial, axial)` points, for revolving about the Z axis.
+fn rz_profile(topo: &mut Topology, pts: &[(f64, f64)]) -> Result<FaceId, Box<dyn Error>> {
+    let tol = 1e-7;
+    let v: Vec<_> = pts
+        .iter()
+        .map(|(r, z)| topo.add_vertex(Vertex::new(Point3::new(*r, 0.0, *z), tol)))
+        .collect();
+    let n = v.len();
+    let e: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(v[i], v[(i + 1) % n], EdgeCurve::Line)))
+        .collect();
+    let wire = Wire::new(
+        (0..n).map(|i| OrientedEdge::new(e[i], true)).collect(),
+        true,
+    )?;
+    let wid = topo.add_wire(wire);
+    Ok(topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 1.0, 0.0),
+            d: 0.0,
+        },
+    )))
+}
+
+/// Count faces by analytic surface type for the revolve survey.
+fn surf_tags(topo: &Topology, s: SolidId) -> String {
+    let (mut pl, mut cy, mut co, mut to, mut nu) = (0, 0, 0, 0, 0);
+    for f in solid_faces(topo, s).unwrap_or_default() {
+        match topo.face(f).map(|fc| fc.surface().clone()) {
+            Ok(FaceSurface::Plane { .. }) => pl += 1,
+            Ok(FaceSurface::Cylinder(_)) => cy += 1,
+            Ok(FaceSurface::Cone(_)) => co += 1,
+            Ok(FaceSurface::Torus(_)) => to += 1,
+            Ok(FaceSurface::Nurbs(_)) => nu += 1,
+            _ => {}
+        }
+    }
+    format!("plane={pl} cyl={cy} cone={co} torus={to} NURBS={nu}")
+}
+
+/// Revolve survey: each profile-edge type revolves into its exact analytic
+/// surface of revolution — axis-parallel line → `Cylinder`, oblique line →
+/// `Cone`, perpendicular line → `Plane`, circular arc → `Torus`. A fully-analytic
+/// full revolution with disc caps builds ONE periodic face per profile edge
+/// (frustum/cylinder → 3 faces, matching the primitives); profiles with a
+/// pointed-cone apex or an annulus cap keep the segmented (analytic but
+/// over-segmented) bands — still NURBS-free for the walls.
+fn revolve_matrix() {
+    use std::f64::consts::TAU;
+    println!("\nREVOLVE (profile edges → analytic surfaces of revolution):");
+    let z = Point3::new(0.0, 0.0, 0.0);
+    let zdir = Vec3::new(0.0, 0.0, 1.0);
+
+    let cases: [(&str, &[(f64, f64)]); 3] = [
+        // Oblique outer wall → Cone, perpendicular caps → Plane (solid frustum,
+        // caps reach the axis).
+        (
+            "frustum (oblique→Cone, caps→Plane)",
+            &[(6.0, 0.0), (2.0, 12.0), (0.0, 12.0), (0.0, 0.0)],
+        ),
+        // Axis-parallel outer wall → Cylinder, perpendicular caps → Plane.
+        (
+            "cylinder (parallel→Cyl, caps→Plane)",
+            &[(5.0, 0.0), (5.0, 10.0), (0.0, 10.0), (0.0, 0.0)],
+        ),
+        // Pointed cone apex on the axis (exercises the apex-band volume guard).
+        (
+            "pointed cone (apex on axis)",
+            &[(5.0, 0.0), (0.0, 12.0), (0.0, 0.0)],
+        ),
+    ];
+    for (name, pts) in cases {
+        let mut topo = Topology::new();
+        let face = match rz_profile(&mut topo, pts) {
+            Ok(f) => f,
+            Err(e) => {
+                println!("  {name:<38} build ERR: {e}");
+                continue;
+            }
+        };
+        let t = Instant::now();
+        let res = revolve(&mut topo, face, z, zdir, TAU);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        match res {
+            Ok(s) => {
+                let nf = face_count(&topo, s);
+                let tags = surf_tags(&topo, s);
+                println!("  {name:<38} {ms:>7.3}ms  faces={nf:<3}  {tags}");
+            }
+            Err(e) => println!("  {name:<38} ERR: {e}"),
+        }
+    }
+
+    // Circular-arc profile edge → Torus band. A half-disc (semicircle arc + its
+    // diameter on an axis-parallel line) makes the arc bands `Torus`.
+    {
+        use brepkit_math::curves::Circle3D;
+        use brepkit_topology::edge::Edge;
+        use brepkit_topology::vertex::Vertex;
+        let mut topo = Topology::new();
+        let Ok(circ) = Circle3D::new(Point3::new(10.0, 0.0, 0.0), Vec3::new(0.0, 1.0, 0.0), 3.0)
+        else {
+            return;
+        };
+        let pa = circ.evaluate(-std::f64::consts::FRAC_PI_2);
+        let pb = circ.evaluate(std::f64::consts::FRAC_PI_2);
+        let va = topo.add_vertex(Vertex::new(pa, 1e-7));
+        let vb = topo.add_vertex(Vertex::new(pb, 1e-7));
+        let e_arc = topo.add_edge(Edge::new(va, vb, EdgeCurve::Circle(circ)));
+        let e_dia = topo.add_edge(Edge::new(vb, va, EdgeCurve::Line));
+        let Ok(wire) = Wire::new(
+            vec![
+                OrientedEdge::new(e_arc, true),
+                OrientedEdge::new(e_dia, true),
+            ],
+            true,
+        ) else {
+            return;
+        };
+        let wid = topo.add_wire(wire);
+        let face = topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 1.0, 0.0),
+                d: 0.0,
+            },
+        ));
+        let t = Instant::now();
+        let res = revolve(&mut topo, face, z, zdir, TAU);
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        match res {
+            Ok(s) => println!(
+                "  {:<38} {ms:>7.3}ms  faces={:<3}  {}",
+                "half-disc (arc→Torus)",
+                face_count(&topo, s),
+                surf_tags(&topo, s)
+            ),
+            Err(e) => println!("  half-disc (arc→Torus) ERR: {e}"),
+        }
+    }
 }
 
 fn blend_matrix() -> Result<(), Box<dyn Error>> {
@@ -618,6 +765,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     boolean_matrix();
     offset_matrix()?;
     nurbs_section()?;
+    revolve_matrix();
     blend_matrix()?;
     remaining_paths()?;
 

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -1332,13 +1332,18 @@ fn planar_cap_signed_volume(
 
             if let Some((center, radius)) = arc {
                 arc_edges += 1;
-                // The bulge term is `sign·ρ²·(|α| − sin|α|)`, α the signed sweep.
-                // `planar_cap_signed_volume` takes the absolute area, so only |α|
-                // matters here.
-                let alpha = if is_closed_circle {
-                    // A full circle sweeps 2π → the bulge gives the disc area πρ².
-                    // (The seam endpoint's antipode is NOT the domain midpoint, so
-                    // the open-arc disambiguation below does not apply.)
+                // The bulge correction (circular segment between the arc and its
+                // chord) is `sign·ρ²·(|α| − sin|α|)`. Compute the sweep in the
+                // curve's NATURAL direction (start→mid→end), then flip its sign for
+                // a reversed `OrientedEdge`, so the bulge is consistent with the
+                // chord term above (which uses the oriented endpoints). Without the
+                // flip, a reversed inner rim of an annulus ADDS its segment instead
+                // of subtracting it (inflated area).
+                let nat_alpha = if is_closed_circle {
+                    // A full circle sweeps 2π in its natural (CCW) direction → the
+                    // bulge gives the disc area πρ². (The seam endpoint's antipode is
+                    // NOT the domain midpoint, so the open-arc disambiguation below
+                    // does not apply.)
                     std::f64::consts::TAU
                 } else {
                     // Sample the arc at its DOMAIN midpoint (the domain need not be
@@ -1352,15 +1357,22 @@ fn planar_cap_signed_volume(
                         nat_end,
                     );
                     let (cx, cy) = to_2d(center);
+                    let (sx, sy) = to_2d(nat_start);
+                    let (ex, ey) = to_2d(nat_end);
                     let (mx, my) = to_2d(mid_pt);
-                    let va = (ax - cx, ay - cy);
+                    let va = (sx - cx, sy - cy);
                     let vm = (mx - cx, my - cy);
-                    let vb = (bx - cx, by - cy);
-                    // Signed sweep a→mid→b (each leg in (−π, π]).
+                    let vb = (ex - cx, ey - cy);
+                    // Signed sweep start→mid→end (each leg in (−π, π]).
                     let ang = |u: (f64, f64), w: (f64, f64)| -> f64 {
                         (u.0 * w.1 - u.1 * w.0).atan2(u.0 * w.0 + u.1 * w.1)
                     };
                     ang(va, vm) + ang(vm, vb)
+                };
+                let alpha = if oe.is_forward() {
+                    nat_alpha
+                } else {
+                    -nat_alpha
                 };
                 area2 += alpha.signum() * radius * radius * (alpha.abs() - alpha.abs().sin());
             }
@@ -2510,6 +2522,55 @@ mod regression_tests {
         assert!(
             (cap_v.abs() - 12.0 * PI * 4.0 / 3.0).abs() < 1e-9,
             "closed-circle disc cap contribution should be (1/3)·12·π·4, got {cap_v}"
+        );
+    }
+
+    /// An ANNULAR planar cap (outer rim + a reversed inner-rim hole) must
+    /// SUBTRACT the inner circular segment, giving area `π(R²−r²)`. The arc-bulge
+    /// sweep must respect the oriented (reversed) inner rim — otherwise the inner
+    /// segment is added (inflated area `π(R²+r²)`).
+    #[test]
+    fn annular_cap_volume_is_exact() {
+        use brepkit_math::curves::Circle3D;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::Face;
+        use brepkit_topology::vertex::Vertex;
+        use brepkit_topology::wire::{OrientedEdge, Wire};
+        use std::f64::consts::PI;
+
+        let (r_out, r_in, h) = (7.0_f64, 5.0_f64, 4.0_f64);
+        let axis = Vec3::new(0.0, 0.0, 1.0);
+        let mut topo = Topology::new();
+
+        // Outer rim: a closed CCW circle at z = h, radius r_out.
+        let v_out = topo.add_vertex(Vertex::new(Point3::new(r_out, 0.0, h), 1e-7));
+        let outer_c = Circle3D::new(Point3::new(0.0, 0.0, h), axis, r_out).unwrap();
+        let e_out = topo.add_edge(Edge::new(v_out, v_out, EdgeCurve::Circle(outer_c)));
+        let outer_wire =
+            topo.add_wire(Wire::new(vec![OrientedEdge::new(e_out, true)], true).unwrap());
+
+        // Inner rim (the hole): a closed circle at the same z, radius r_in, wound
+        // OPPOSITE the outer wire — here via a reversed `OrientedEdge`.
+        let v_in = topo.add_vertex(Vertex::new(Point3::new(r_in, 0.0, h), 1e-7));
+        let inner_c = Circle3D::new(Point3::new(0.0, 0.0, h), axis, r_in).unwrap();
+        let e_in = topo.add_edge(Edge::new(v_in, v_in, EdgeCurve::Circle(inner_c)));
+        let inner_wire =
+            topo.add_wire(Wire::new(vec![OrientedEdge::new(e_in, false)], true).unwrap());
+
+        let cap = topo.add_face(Face::new(
+            outer_wire,
+            vec![inner_wire],
+            FaceSurface::Plane { normal: axis, d: h },
+        ));
+
+        let cap_v = planar_cap_signed_volume(&topo, cap).unwrap().unwrap();
+        // Exact annulus contribution: (1/3)·h·π·(R²−r²) (outward normal +axis).
+        let expected = h * PI * (r_out * r_out - r_in * r_in) / 3.0;
+        assert!(
+            (cap_v.abs() - expected).abs() < 1e-9,
+            "annular cap contribution should subtract the inner segment: \
+             expected {expected}, got {cap_v} (inflated would be {})",
+            h * PI * (r_out * r_out + r_in * r_in) / 3.0
         );
     }
 }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -311,7 +311,10 @@ fn analytic_revolution_solid_volume(topo: &Topology, solid: SolidId) -> Option<f
 
     // Second pass (axis known): every planar face must be a circular
     // disc/annulus/sector centred on the shared axis, and every NURBS face must
-    // be the degenerate on-axis band (zero radial extent).
+    // be the degenerate on-axis band (zero radial extent). Cache each planar
+    // cap's analytic volume here so the summation below reuses it rather than
+    // re-traversing the wire and re-running arc recognition a second time.
+    let mut cap_volumes: std::collections::HashMap<FaceId, f64> = std::collections::HashMap::new();
     for &fid in &faces {
         let face = topo.face(fid).ok()?;
         match face.surface() {
@@ -322,8 +325,9 @@ fn analytic_revolution_solid_volume(topo: &Topology, solid: SolidId) -> Option<f
                 if !planar_face_arcs_centered_on_axis(topo, fid, axis_o, axis_d) {
                     return None;
                 }
-                // Confirm the cap is analytically integrable (has a circular arc).
-                planar_cap_signed_volume(topo, fid).ok()??;
+                // Must be analytically integrable (a circular-arc-bounded cap).
+                let v = planar_cap_signed_volume(topo, fid).ok()??;
+                cap_volumes.insert(fid, v);
             }
             FaceSurface::Nurbs(_) if !nurbs_band_is_on_axis(topo, fid, axis_o, axis_d) => {
                 return None;
@@ -342,7 +346,7 @@ fn analytic_revolution_solid_volume(topo: &Topology, solid: SolidId) -> Option<f
             FaceSurface::Cylinder(_) => analytic_cylinder_signed_volume(topo, fid).ok()?,
             FaceSurface::Cone(_) => analytic_cone_signed_volume(topo, fid).ok()?,
             FaceSurface::Torus(_) => analytic_torus_signed_volume(topo, fid).ok()?,
-            FaceSurface::Plane { .. } => planar_cap_signed_volume(topo, fid).ok()??,
+            FaceSurface::Plane { .. } => *cap_volumes.get(&fid)?,
             FaceSurface::Nurbs(_) => 0.0, // degenerate on-axis band
             FaceSurface::Sphere(_) => return None,
         };

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -223,6 +223,210 @@ fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     Some(total.abs())
 }
 
+/// Exact volume of a fully-analytic SURFACE-OF-REVOLUTION solid (cone / cylinder
+/// / torus walls + concentric circular planar disc caps) via the per-face
+/// divergence-theorem integrators — no tessellation, so it is immune to the
+/// inscribed-mesh undercount.
+///
+/// Returns `None` (defer to tessellation) unless EVERY face fits the revolution
+/// signature, so this does NOT fire for boolean results that merely have an
+/// arc-bounded planar face (a rounded-rect cap, an arc-frame lip):
+///   * no NURBS face, and no face carries inner wires (a bored solid is handled
+///     by [`analytic_faces_solid_volume`]; a holed planar cap is deferred);
+///   * at least one quadric wall (cylinder/cone/torus) — it is a revolution;
+///   * every cylinder/cone/torus shares ONE axis line;
+///   * every planar face is a circular disc/annulus/sector whose bounding
+///     arc(s) are centred ON that shared axis.
+fn analytic_revolution_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
+    use brepkit_topology::explorer::solid_faces;
+
+    let faces = solid_faces(topo, solid).ok()?;
+    if faces.is_empty() {
+        return None;
+    }
+
+    // Establish the shared revolution axis from the first quadric wall.
+    let mut axis: Option<(Point3, Vec3)> = None;
+    let mut has_wall = false;
+    let axis_tol = 1e-7;
+
+    let set_or_check_axis = |axis: &mut Option<(Point3, Vec3)>, o: Point3, d: Vec3| -> bool {
+        let d = match d.normalize() {
+            Ok(d) => d,
+            Err(_) => return false,
+        };
+        match axis {
+            None => {
+                *axis = Some((o, d));
+                true
+            }
+            Some((o0, d0)) => {
+                // Same axis LINE: parallel directions and the origins' offset is
+                // along the axis (no perpendicular component).
+                if d0.cross(d).length() > 1e-6 {
+                    return false;
+                }
+                let off = o - *o0;
+                (off - *d0 * off.dot(*d0)).length() <= axis_tol * off.length().max(1.0)
+            }
+        }
+    };
+
+    for &fid in &faces {
+        let face = topo.face(fid).ok()?;
+        if !face.inner_wires().is_empty() {
+            return None;
+        }
+        match face.surface() {
+            FaceSurface::Sphere(_) => return None,
+            // NURBS faces are validated in the second pass (they must be the
+            // degenerate on-axis band the revolve leaves when a profile touches
+            // the axis); they need the axis, established here.
+            FaceSurface::Nurbs(_) => {}
+            FaceSurface::Cylinder(c) => {
+                has_wall = true;
+                if !set_or_check_axis(&mut axis, c.origin(), c.axis()) {
+                    return None;
+                }
+            }
+            FaceSurface::Cone(c) => {
+                has_wall = true;
+                if !set_or_check_axis(&mut axis, c.apex(), c.axis()) {
+                    return None;
+                }
+            }
+            FaceSurface::Torus(t) => {
+                has_wall = true;
+                if !set_or_check_axis(&mut axis, t.center(), t.z_axis()) {
+                    return None;
+                }
+            }
+            FaceSurface::Plane { .. } => {} // checked below, once the axis is known
+        }
+    }
+    let (axis_o, axis_d) = axis?;
+    if !has_wall {
+        return None;
+    }
+
+    // Second pass (axis known): every planar face must be a circular
+    // disc/annulus/sector centred on the shared axis, and every NURBS face must
+    // be the degenerate on-axis band (zero radial extent).
+    for &fid in &faces {
+        let face = topo.face(fid).ok()?;
+        match face.surface() {
+            FaceSurface::Plane { normal, .. } => {
+                if normal.normalize().ok()?.cross(axis_d).length() > 1e-6 {
+                    return None; // cap not perpendicular to the axis
+                }
+                if !planar_face_arcs_centered_on_axis(topo, fid, axis_o, axis_d) {
+                    return None;
+                }
+                // Confirm the cap is analytically integrable (has a circular arc).
+                planar_cap_signed_volume(topo, fid).ok()??;
+            }
+            FaceSurface::Nurbs(_) if !nurbs_band_is_on_axis(topo, fid, axis_o, axis_d) => {
+                return None;
+            }
+            _ => {}
+        }
+    }
+
+    // All faces fit — sum the exact per-face divergence-theorem contributions
+    // (quadric walls + analytic planar disc caps; the on-axis NURBS bands are
+    // zero-area and contribute nothing). No tessellation occurs.
+    let mut total = 0.0;
+    for &fid in &faces {
+        let face = topo.face(fid).ok()?;
+        total += match face.surface() {
+            FaceSurface::Cylinder(_) => analytic_cylinder_signed_volume(topo, fid).ok()?,
+            FaceSurface::Cone(_) => analytic_cone_signed_volume(topo, fid).ok()?,
+            FaceSurface::Torus(_) => analytic_torus_signed_volume(topo, fid).ok()?,
+            FaceSurface::Plane { .. } => planar_cap_signed_volume(topo, fid).ok()??,
+            FaceSurface::Nurbs(_) => 0.0, // degenerate on-axis band
+            FaceSurface::Sphere(_) => return None,
+        };
+    }
+    Some(total.abs())
+}
+
+/// Whether a NURBS face is a degenerate revolution band on the axis — all its
+/// boundary vertices lie on the axis line (zero radial extent), so it bounds no
+/// volume. This is the band a revolve leaves when the profile touches the axis.
+fn nurbs_band_is_on_axis(topo: &Topology, face_id: FaceId, axis_o: Point3, axis_d: Vec3) -> bool {
+    let Ok(face) = topo.face(face_id) else {
+        return false;
+    };
+    let tol = 1e-7;
+    let Ok(wire) = topo.wire(face.outer_wire()) else {
+        return false;
+    };
+    for oe in wire.edges() {
+        let Ok(edge) = topo.edge(oe.edge()) else {
+            return false;
+        };
+        for vid in [edge.start(), edge.end()] {
+            let Ok(v) = topo.vertex(vid) else {
+                return false;
+            };
+            let off = v.point() - axis_o;
+            let radial = off - axis_d * off.dot(axis_d);
+            if radial.length() > tol {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Whether every circular-arc edge of a planar face is centred on the given axis
+/// line — the test that distinguishes a revolution disc/annulus cap (arcs about
+/// the axis) from an arbitrary arc-bounded planar face (e.g. a rounded rectangle,
+/// whose corner arcs are centred at the corners, off the axis).
+fn planar_face_arcs_centered_on_axis(
+    topo: &Topology,
+    face_id: FaceId,
+    axis_o: Point3,
+    axis_d: Vec3,
+) -> bool {
+    let Ok(face) = topo.face(face_id) else {
+        return false;
+    };
+    let tol = 1e-6;
+    for wire_id in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+        let Ok(wire) = topo.wire(wire_id) else {
+            return false;
+        };
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                return false;
+            };
+            let center = match edge.curve() {
+                brepkit_topology::edge::EdgeCurve::Circle(c) => Some(c.center()),
+                brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) => {
+                    let rtol = brepkit_math::tolerance::Tolerance::default().linear * 100.0;
+                    match brepkit_geometry::convert::recognize_curve(nc, rtol) {
+                        brepkit_geometry::convert::RecognizedCurve::Circle { center, .. } => {
+                            Some(center)
+                        }
+                        _ => None,
+                    }
+                }
+                _ => None,
+            };
+            if let Some(center) = center {
+                // Distance from the arc centre to the axis line must be ~0.
+                let off = center - axis_o;
+                let perp = off - axis_d * off.dot(axis_d);
+                if perp.length() > tol * off.length().max(1.0) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
 /// Exact volume of the STEINMETZ LENS FUSE — two equal-radius `r` cylinders with
 /// perpendicular intersecting axes, fused.
 ///
@@ -775,6 +979,16 @@ pub fn solid_volume(
         return Ok(v);
     }
 
+    // A surface-of-revolution solid that is fully analytic (cone / cylinder /
+    // torus walls with concentric circular disc-cap planes, no NURBS) integrates
+    // with NO tessellation — exact, immune to the inscribed-mesh undercount. The
+    // recogniser is deliberately narrow (concentric caps about one axis) so it
+    // does NOT catch boolean results that merely happen to have arc-bounded
+    // planar faces (rounded-rect caps, arc-frame lips).
+    if let Some(v) = analytic_revolution_solid_volume(topo, solid) {
+        return Ok(v);
+    }
+
     // Volume integrates the boundary, so curved faces must be tessellated
     // finely or the inscribed mesh under-counts them (a swept cylinder or a
     // box with a cylindrical hole measures ~1-2% low at a coarse preview
@@ -1025,6 +1239,135 @@ fn analytic_cylinder_signed_volume(
 /// For a cone parameterised as
 ///   `P(u,v) = apex + v*(cos_a*(cos u * ex + sin u * ey) + sin_a * axis)`
 /// the outward normal is `n = sin_a*(cos u * ex + sin u * ey) - cos_a * axis`,
+/// Exact signed volume contribution of a PLANAR face whose boundary is made of
+/// straight and circular-arc edges (a revolve cap: a disc, an annulus, or an
+/// angular sector of either), via the divergence theorem.
+///
+/// For a planar face every point satisfies `P·n = d` (the plane offset), so the
+/// volume integral `(1/3)∮∮ P·n dA` reduces to `(1/3)·d·A`, where `A` is the
+/// signed area in the plane oriented by the face normal. `A` is computed
+/// EXACTLY by Green's theorem — `A = (1/2)∮(x dy − y dx)` — summing each edge's
+/// chord term plus the exact circular-segment bulge for arc edges, so a circular
+/// boundary is not chorded (the reason the tessellation path under-counts it).
+///
+/// Returns `Ok(None)` when an edge is neither a line nor a circular arc (e.g. a
+/// general spline boundary), so the caller falls back to tessellation.
+fn planar_cap_signed_volume(
+    topo: &Topology,
+    face_id: FaceId,
+) -> Result<Option<f64>, crate::OperationsError> {
+    let face = topo.face(face_id)?;
+    let FaceSurface::Plane { normal, d } = face.surface() else {
+        return Ok(None);
+    };
+    let normal = *normal;
+    let d = *d;
+
+    // Right-handed in-plane frame: ex × ey = normal, so a boundary wound CCW as
+    // seen from +normal yields a positive signed area.
+    let frame = match brepkit_math::frame::Frame3::from_normal(Point3::new(0.0, 0.0, 0.0), normal) {
+        Ok(f) => f,
+        Err(_) => return Ok(None),
+    };
+    let (ex, ey) = (frame.x, frame.y);
+    let to_2d = |p: Point3| {
+        let v = Vec3::new(p.x(), p.y(), p.z());
+        (v.dot(ex), v.dot(ey))
+    };
+
+    let tol_lin = brepkit_math::tolerance::Tolerance::default().linear;
+    let mut area2: f64 = 0.0; // accumulates 2·A (Green's ∮(x dy − y dx))
+    let mut arc_edges = 0_usize;
+    // The outer wire bounds positive area; inner wires (holes) are wound opposite
+    // the outer wire, so their Green's sum is already negative and subtracts.
+    for wire_id in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+        let wire = topo.wire(wire_id)?;
+        for oe in wire.edges() {
+            let edge = topo.edge(oe.edge())?;
+            let (sv, ev) = if oe.is_forward() {
+                (edge.start(), edge.end())
+            } else {
+                (edge.end(), edge.start())
+            };
+            let pa = topo.vertex(sv)?.point();
+            let pb = topo.vertex(ev)?.point();
+            let (ax, ay) = to_2d(pa);
+            let (bx, by) = to_2d(pb);
+            // Chord term: triangle (origin, a, b) doubled.
+            area2 += ax * by - bx * ay;
+
+            // A degenerate edge collapsed to a point (e.g. the inner "arc" at the
+            // axis where a disc cap reaches r = 0) contributes no chord and no
+            // bulge — skip it (and do NOT let curve recognition on a zero-length
+            // arc decline the whole cap).
+            if (pa - pb).length() < tol_lin {
+                continue;
+            }
+
+            // Circular-arc bulge correction (segment between the arc and its
+            // chord). A `Line` has no bulge. A `Circle`/arc-`NurbsCurve` adds
+            // sign·ρ²·(|α| − sin|α|), α the signed sweep about the arc centre.
+            let arc = match edge.curve() {
+                brepkit_topology::edge::EdgeCurve::Line => None,
+                brepkit_topology::edge::EdgeCurve::Ellipse(_) => return Ok(None),
+                brepkit_topology::edge::EdgeCurve::Circle(c) => Some((c.center(), c.radius())),
+                brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) => {
+                    let tol = brepkit_math::tolerance::Tolerance::default().linear * 100.0;
+                    match brepkit_geometry::convert::recognize_curve(nc, tol) {
+                        brepkit_geometry::convert::RecognizedCurve::Circle {
+                            center,
+                            radius,
+                            ..
+                        } => Some((center, radius)),
+                        brepkit_geometry::convert::RecognizedCurve::Line { .. } => None,
+                        _ => return Ok(None),
+                    }
+                }
+            };
+
+            if let Some((center, radius)) = arc {
+                arc_edges += 1;
+                // Midpoint on the arc disambiguates the signed sweep > π. Evaluate
+                // at the curve's natural parameter midpoint (its own start→end).
+                let nat_start = topo.vertex(edge.start())?.point();
+                let nat_end = topo.vertex(edge.end())?.point();
+                let mid_pt = edge
+                    .curve()
+                    .evaluate_with_endpoints(0.5, nat_start, nat_end);
+                let (cx, cy) = to_2d(center);
+                let (mx, my) = to_2d(mid_pt);
+                let va = (ax - cx, ay - cy);
+                let vm = (mx - cx, my - cy);
+                let vb = (bx - cx, by - cy);
+                // Signed sweep a→mid→b (each leg in (−π, π], summed for the full arc).
+                let ang = |u: (f64, f64), w: (f64, f64)| -> f64 {
+                    (u.0 * w.1 - u.1 * w.0).atan2(u.0 * w.0 + u.1 * w.1)
+                };
+                let alpha = ang(va, vm) + ang(vm, vb);
+                area2 += alpha.signum() * radius * radius * (alpha.abs() - alpha.abs().sin());
+            }
+        }
+    }
+
+    // Only claim a circular CAP (disc / annulus / sector) — a face with no arc
+    // edge is an ordinary polygon (e.g. a box face), which the tessellation path
+    // already integrates exactly; deferring it keeps this analytic path scoped to
+    // genuine revolve caps and out of arbitrary planar-faced solids.
+    if arc_edges == 0 {
+        return Ok(None);
+    }
+
+    // `area2/2` is the SIGNED area in the `+normal` frame; its magnitude is the
+    // geometric area. The divergence-theorem contribution is
+    // (1/3)·(p·n̂_out)·|A|, where the outward normal is `+normal` for a forward
+    // face and `−normal` for a reversed one, so `p·n̂_out = ±d` (the plane offset
+    // along that outward normal). The sign therefore comes only from the outward
+    // offset, not from the wire winding.
+    let area = (area2 / 2.0).abs();
+    let d_out = if face.is_reversed() { -d } else { d };
+    Ok(Some(d_out * area / 3.0))
+}
+
 /// and `dA = v * cos_a * du dv`.
 ///
 /// The integrand `P.n * dA` simplifies to closed form over `[u1,u2] x [v1,v2]`.
@@ -1050,7 +1393,13 @@ fn analytic_cone_signed_volume(
             for &vid in &[edge.start(), edge.end()] {
                 if let Ok(vtx) = topo.vertex(vid) {
                     let (u, v) = cone.project_point(vtx.point());
-                    u_vals.push(u);
+                    // The apex (v ≈ 0) lies on the axis where u is undefined;
+                    // its arbitrary projected u corrupts the angular-range gap
+                    // detection (a per-segment band touching the apex would read
+                    // a 2× span). Keep its v for the v-range, but omit its u.
+                    if v.abs() > 1e-9 {
+                        u_vals.push(u);
+                    }
                     v_vals.push(v);
                 }
             }
@@ -1071,12 +1420,16 @@ fn analytic_cone_signed_volume(
                 u_vals.push(u);
             }
             // Sample NURBS revolution-band arcs too (see the cylinder case, #968).
+            // Skip an arc that degenerates to the apex (v ≈ 0), where u is
+            // undefined.
             if !edge.is_closed()
                 && let brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) = edge.curve()
             {
                 let (t0, t1) = nc.domain();
-                let (u, _) = cone.project_point(nc.evaluate(f64::midpoint(t0, t1)));
-                u_vals.push(u);
+                let (u, v) = cone.project_point(nc.evaluate(f64::midpoint(t0, t1)));
+                if v.abs() > 1e-9 {
+                    u_vals.push(u);
+                }
             }
         }
     }
@@ -1293,21 +1646,39 @@ fn analytic_torus_signed_volume(
                     v_vals.push(v);
                 }
             }
+            // Sample each arc edge's midpoint to widen the angular ranges past
+            // the two endpoint angles — without this a partial (sub-2π) band has
+            // only its corner angles, `compute_angular_range` falls back to the
+            // full 2π, and the band over-counts (gh #968). Both the major (u) and
+            // minor (v) ranges are captured, since an arc may run in either
+            // direction. A revolution-band boundary is a rational `NurbsCurve`
+            // (the swept circle) or a `Circle` (the profile arc copy).
             if !edge.is_closed()
-                && let brepkit_topology::edge::EdgeCurve::Circle(circle) = edge.curve()
                 && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
             {
-                let ts = circle.project(sv.point());
-                let te = circle.project(ev.point());
-                let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
-                let mid_t = if fwd <= std::f64::consts::PI {
-                    ts + fwd * 0.5
-                } else {
-                    ts - (std::f64::consts::TAU - fwd) * 0.5
+                let mid = match edge.curve() {
+                    brepkit_topology::edge::EdgeCurve::Circle(circle) => {
+                        let ts = circle.project(sv.point());
+                        let te = circle.project(ev.point());
+                        let fwd = (te - ts).rem_euclid(std::f64::consts::TAU);
+                        let mid_t = if fwd <= std::f64::consts::PI {
+                            ts + fwd * 0.5
+                        } else {
+                            ts - (std::f64::consts::TAU - fwd) * 0.5
+                        };
+                        Some(circle.evaluate(mid_t))
+                    }
+                    brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) => {
+                        let (t0, t1) = nc.domain();
+                        Some(nc.evaluate(f64::midpoint(t0, t1)))
+                    }
+                    _ => None,
                 };
-                let mid = circle.evaluate(mid_t);
-                let (u, _) = tor.project_point(mid);
-                u_vals.push(u);
+                if let Some(mid) = mid {
+                    let (u, v) = tor.project_point(mid);
+                    u_vals.push(u);
+                    v_vals.push(v);
+                }
             }
         }
     }

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -338,7 +338,7 @@ fn analytic_revolution_solid_volume(topo: &Topology, solid: SolidId) -> Option<f
     let mut total = 0.0;
     for &fid in &faces {
         let face = topo.face(fid).ok()?;
-        total += match face.surface() {
+        let c = match face.surface() {
             FaceSurface::Cylinder(_) => analytic_cylinder_signed_volume(topo, fid).ok()?,
             FaceSurface::Cone(_) => analytic_cone_signed_volume(topo, fid).ok()?,
             FaceSurface::Torus(_) => analytic_torus_signed_volume(topo, fid).ok()?,
@@ -346,6 +346,7 @@ fn analytic_revolution_solid_volume(topo: &Topology, solid: SolidId) -> Option<f
             FaceSurface::Nurbs(_) => 0.0, // degenerate on-axis band
             FaceSurface::Sphere(_) => return None,
         };
+        total += c;
     }
     Some(total.abs())
 }
@@ -1233,12 +1234,6 @@ fn analytic_cylinder_signed_volume(
     Ok(if face.is_reversed() { -vol } else { vol })
 }
 
-/// Exact signed volume contribution of a conical face via the divergence
-/// theorem: `V = (1/3) integral P.n dA`.
-///
-/// For a cone parameterised as
-///   `P(u,v) = apex + v*(cos_a*(cos u * ex + sin u * ey) + sin_a * axis)`
-/// the outward normal is `n = sin_a*(cos u * ex + sin u * ey) - cos_a * axis`,
 /// Exact signed volume contribution of a PLANAR face whose boundary is made of
 /// straight and circular-arc edges (a revolve cap: a disc, an annulus, or an
 /// angular sector of either), via the divergence theorem.
@@ -1247,7 +1242,8 @@ fn analytic_cylinder_signed_volume(
 /// volume integral `(1/3)∮∮ P·n dA` reduces to `(1/3)·d·A`, where `A` is the
 /// signed area in the plane oriented by the face normal. `A` is computed
 /// EXACTLY by Green's theorem — `A = (1/2)∮(x dy − y dx)` — summing each edge's
-/// chord term plus the exact circular-segment bulge for arc edges, so a circular
+/// chord term plus the exact circular-segment bulge for arc edges (including a
+/// full closed circle, whose 2π sweep gives the disc area πρ²), so a circular
 /// boundary is not chorded (the reason the tessellation path under-counts it).
 ///
 /// Returns `Ok(None)` when an edge is neither a line nor a circular arc (e.g. a
@@ -1296,11 +1292,16 @@ fn planar_cap_signed_volume(
             // Chord term: triangle (origin, a, b) doubled.
             area2 += ax * by - bx * ay;
 
-            // A degenerate edge collapsed to a point (e.g. the inner "arc" at the
-            // axis where a disc cap reaches r = 0) contributes no chord and no
-            // bulge — skip it (and do NOT let curve recognition on a zero-length
-            // arc decline the whole cap).
-            if (pa - pb).length() < tol_lin {
+            // A degenerate edge collapsed to a point that is NOT a closed circle
+            // (e.g. the inner "arc" at the axis where a disc cap reaches r = 0, or
+            // a zero-length line) contributes no chord and no bulge — skip it (and
+            // do NOT let curve recognition on a zero-length arc decline the whole
+            // cap). A CLOSED `Circle` rim also has coincident endpoints but bounds
+            // a full disc, so it falls through to the arc handler below.
+            let is_closed_circle =
+                matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Circle(_))
+                    && edge.start() == edge.end();
+            if (pa - pb).length() < tol_lin && !is_closed_circle {
                 continue;
             }
 
@@ -1327,23 +1328,36 @@ fn planar_cap_signed_volume(
 
             if let Some((center, radius)) = arc {
                 arc_edges += 1;
-                // Midpoint on the arc disambiguates the signed sweep > π. Evaluate
-                // at the curve's natural parameter midpoint (its own start→end).
-                let nat_start = topo.vertex(edge.start())?.point();
-                let nat_end = topo.vertex(edge.end())?.point();
-                let mid_pt = edge
-                    .curve()
-                    .evaluate_with_endpoints(0.5, nat_start, nat_end);
-                let (cx, cy) = to_2d(center);
-                let (mx, my) = to_2d(mid_pt);
-                let va = (ax - cx, ay - cy);
-                let vm = (mx - cx, my - cy);
-                let vb = (bx - cx, by - cy);
-                // Signed sweep a→mid→b (each leg in (−π, π], summed for the full arc).
-                let ang = |u: (f64, f64), w: (f64, f64)| -> f64 {
-                    (u.0 * w.1 - u.1 * w.0).atan2(u.0 * w.0 + u.1 * w.1)
+                // The bulge term is `sign·ρ²·(|α| − sin|α|)`, α the signed sweep.
+                // `planar_cap_signed_volume` takes the absolute area, so only |α|
+                // matters here.
+                let alpha = if is_closed_circle {
+                    // A full circle sweeps 2π → the bulge gives the disc area πρ².
+                    // (The seam endpoint's antipode is NOT the domain midpoint, so
+                    // the open-arc disambiguation below does not apply.)
+                    std::f64::consts::TAU
+                } else {
+                    // Sample the arc at its DOMAIN midpoint (the domain need not be
+                    // [0,1]) to disambiguate the signed sweep > π for a major arc.
+                    let nat_start = topo.vertex(edge.start())?.point();
+                    let nat_end = topo.vertex(edge.end())?.point();
+                    let (t0, t1) = edge.curve().domain_with_endpoints(nat_start, nat_end);
+                    let mid_pt = edge.curve().evaluate_with_endpoints(
+                        f64::midpoint(t0, t1),
+                        nat_start,
+                        nat_end,
+                    );
+                    let (cx, cy) = to_2d(center);
+                    let (mx, my) = to_2d(mid_pt);
+                    let va = (ax - cx, ay - cy);
+                    let vm = (mx - cx, my - cy);
+                    let vb = (bx - cx, by - cy);
+                    // Signed sweep a→mid→b (each leg in (−π, π]).
+                    let ang = |u: (f64, f64), w: (f64, f64)| -> f64 {
+                        (u.0 * w.1 - u.1 * w.0).atan2(u.0 * w.0 + u.1 * w.1)
+                    };
+                    ang(va, vm) + ang(vm, vb)
                 };
-                let alpha = ang(va, vm) + ang(vm, vb);
                 area2 += alpha.signum() * radius * radius * (alpha.abs() - alpha.abs().sin());
             }
         }
@@ -1368,6 +1382,12 @@ fn planar_cap_signed_volume(
     Ok(Some(d_out * area / 3.0))
 }
 
+/// Exact signed volume contribution of a conical face via the divergence
+/// theorem: `V = (1/3) integral P.n dA`.
+///
+/// For a cone parameterised as
+///   `P(u,v) = apex + v*(cos_a*(cos u * ex + sin u * ey) + sin_a * axis)`
+/// the outward normal is `n = sin_a*(cos u * ex + sin u * ey) - cos_a * axis`,
 /// and `dA = v * cos_a * du dv`.
 ///
 /// The integrand `P.n * dA` simplifies to closed form over `[u1,u2] x [v1,v2]`.
@@ -1687,6 +1707,25 @@ fn analytic_torus_signed_volume(
     let v_max = v_vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
     if (v_max - v_min).abs() < 1e-15 {
         return Ok(0.0);
+    }
+
+    // The minor (v) range is taken as the raw [min, max] span, which is only
+    // correct when the band does NOT straddle the v = 0/2π seam. A band given by
+    // just two distinct minor angles spanning MORE than π is ambiguous: the true
+    // arc could be the short complementary side (e.g. a fillet's concave quarter
+    // rim, whose endpoints are 270° apart but whose band is the 90° short side).
+    // Without an interior minor sample to disambiguate, decline so the caller
+    // falls back to tessellation rather than integrate the wrong portion.
+    {
+        let mut sorted = v_vals.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.dedup_by(|a, b| (*a - *b).abs() < 1e-6);
+        if sorted.len() < 3 && (v_max - v_min) > std::f64::consts::PI + 1e-9 {
+            return Err(crate::OperationsError::InvalidInput {
+                reason: "torus band minor range is ambiguous (seam-straddling, no interior sample)"
+                    .into(),
+            });
+        }
     }
 
     let u_range = compute_angular_range(&mut u_vals);
@@ -2385,6 +2424,88 @@ mod regression_tests {
         assert!(
             !solid_is_steinmetz_lens_fuse(&topo, &with_aligned_cap),
             "an extra axis-aligned cap beyond the exactly-four lens caps must make the gate decline"
+        );
+    }
+
+    /// A full-disc cap bounded by a SINGLE closed circle (`v→v`) must integrate to
+    /// the exact disc area `πρ²` — its 2π sweep, not a dropped zero. Exercised via
+    /// a TWO-section revolution (two stacked cone frustums → two cone walls + two
+    /// closed-circle disc caps), which the single-primitive volume path declines
+    /// (two cones), forcing `analytic_revolution_solid_volume`. The volume must be
+    /// exact AND deflection-independent (analytic, not the inscribed mesh).
+    #[test]
+    fn closed_circle_disc_cap_volume_is_exact() {
+        use brepkit_topology::explorer::solid_faces;
+        use std::f64::consts::{PI, TAU};
+        let mut topo = Topology::new();
+        // (6,0)→(4,6) cone, (4,6)→(2,12) cone, (2,12)→(0,12) top disc cap,
+        // (0,12)→(0,0) on-axis (no face); bottom (0,0)→(6,0) disc cap.
+        let wire = make_polygon_wire(
+            &mut topo,
+            &[
+                Point3::new(6.0, 0.0, 0.0),
+                Point3::new(4.0, 0.0, 6.0),
+                Point3::new(2.0, 0.0, 12.0),
+                Point3::new(0.0, 0.0, 12.0),
+                Point3::new(0.0, 0.0, 0.0),
+            ],
+            1e-7,
+        )
+        .unwrap();
+        let face = topo.add_face(brepkit_topology::face::Face::new(
+            wire,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 1.0, 0.0),
+                d: 0.0,
+            },
+        ));
+        let solid = crate::revolve::revolve(
+            &mut topo,
+            face,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            TAU,
+        )
+        .unwrap();
+
+        // The merged solid has 2 cone walls + 2 closed-circle disc caps; the top
+        // cap's closed circle must contribute (1/3)·12·π·2² to the volume.
+        let fr = |rb: f64, rt: f64, h: f64| PI * h / 3.0 * rb.mul_add(rb, rb.mul_add(rt, rt * rt));
+        let expected = fr(6.0, 4.0, 6.0) + fr(4.0, 2.0, 6.0);
+
+        let v_fine = solid_volume(&topo, solid, 0.0001).unwrap();
+        let v_coarse = solid_volume(&topo, solid, 0.1).unwrap();
+        assert!(
+            (v_fine - expected).abs() / expected < 1e-9,
+            "two-section revolve volume {expected}, got {v_fine}"
+        );
+        assert!(
+            (v_fine - v_coarse).abs() < 1e-9,
+            "volume must be analytic (deflection-independent): {v_fine} vs {v_coarse}"
+        );
+
+        // Direct check: the top disc cap (a single closed circle, radius 2 at
+        // z=12) contributes exactly (1/3)·12·π·4 via `planar_cap_signed_volume`.
+        let top_cap = solid_faces(&topo, solid)
+            .unwrap()
+            .into_iter()
+            .find(|&fid| {
+                let f = topo.face(fid).unwrap();
+                matches!(f.surface(), FaceSurface::Plane { .. })
+                    && topo.wire(f.outer_wire()).unwrap().edges().iter().all(|oe| {
+                        topo.vertex(topo.edge(oe.edge()).unwrap().start())
+                            .unwrap()
+                            .point()
+                            .z()
+                            > 11.0
+                    })
+            })
+            .expect("top disc cap");
+        let cap_v = planar_cap_signed_volume(&topo, top_cap).unwrap().unwrap();
+        assert!(
+            (cap_v.abs() - 12.0 * PI * 4.0 / 3.0).abs() < 1e-9,
+            "closed-circle disc cap contribution should be (1/3)·12·π·4, got {cap_v}"
         );
     }
 }

--- a/crates/operations/src/revolve.rs
+++ b/crates/operations/src/revolve.rs
@@ -1520,11 +1520,19 @@ mod tests {
             "top+bottom annulus caps × 4 segments are planar"
         );
 
-        let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+        // Cylinder walls + analytic annular-sector disc caps ⇒ EXACT volume,
+        // independent of deflection (the annular sectors must SUBTRACT their inner
+        // arc segment — a reversed-inner-rim orientation bug would inflate it).
         let expected = PI * (49.0 - 25.0) * 5.0;
+        let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+        let vol_fine = crate::measure::solid_volume(&topo, solid, 0.0001).unwrap();
         assert!(
             (vol - expected).abs() / expected < 1e-6,
             "washer volume {expected}, got {vol}"
+        );
+        assert!(
+            (vol - vol_fine).abs() < 1e-9,
+            "washer volume must be analytic (deflection-independent): {vol} vs {vol_fine}"
         );
         assert!(
             crate::validate::validate_solid(&topo, solid)

--- a/crates/operations/src/revolve.rs
+++ b/crates/operations/src/revolve.rs
@@ -150,17 +150,25 @@ fn radial_axial(p: Point3, axis_origin: Point3, axis: Vec3) -> (f64, f64) {
 
 /// Build the surface for one revolution band.
 ///
-/// For a straight (line) profile edge, returns the **exact** analytic surface
-/// of revolution — a `Cylinder` (edge parallel to the axis) or a `Plane` (edge
-/// perpendicular to it) — so the band integrates exactly instead of inscribing
-/// the swept arc as a NURBS band (~2% / ~0.04% deficit, gh #968). The surface is
-/// oriented to agree with the correctly-wound NURBS band normal.
+/// Returns the **exact** analytic surface of revolution so the band integrates
+/// exactly instead of inscribing the swept arc as a NURBS band (~2% / ~0.04%
+/// deficit, gh #968):
+/// - axis-parallel line edge → `Cylinder`
+/// - oblique line edge → `Cone` (the line, extended, meets the axis at the apex)
+/// - perpendicular line edge → `Plane` (a flat annular disk normal to the axis)
+/// - circular-arc edge clearing the axis → `Torus` band
 ///
-/// Oblique line edges (cones), curved profile edges, and degenerate on-axis
-/// bands keep the NURBS band — they have no simpler exact form here.
+/// The returned `reversed` flag orients the analytic surface to agree with the
+/// correctly-wound NURBS band normal.
+///
+/// A general spline profile edge, a spindle/self-intersecting torus arc (arc
+/// radius ≥ its centre's axis distance), and degenerate on-axis bands keep the
+/// NURBS band. (A circular arc whose centre is ON the axis sweeps a sphere; that
+/// case also falls back to NURBS here — recognising it as a `Sphere` band is a
+/// follow-up.)
 #[allow(clippy::too_many_arguments)]
 fn revolution_band_surface(
-    profile_is_line: bool,
+    profile_curve: &EdgeCurve,
     p0_start: Point3,
     p0_end: Point3,
     p1_start: Point3,
@@ -178,37 +186,181 @@ fn revolution_band_surface(
         axis,
         seg_angle,
     )?;
-    if !profile_is_line {
+
+    // A circular-arc profile edge sweeps an exact torus band. (`p0_start` and
+    // `p1_start` are the arc's endpoints on this segment's ring.)
+    if let Some((center, radius)) = profile_arc_center_radius(profile_curve, p0_start, p1_start) {
+        if let Some(result) =
+            revolution_torus_band(center, radius, axis_origin, axis, &nurbs, seg_angle)?
+        {
+            return Ok(result);
+        }
+        return Ok((FaceSurface::Nurbs(nurbs), false));
+    }
+
+    if !matches!(profile_curve, EdgeCurve::Line) {
         return Ok((FaceSurface::Nurbs(nurbs), false));
     }
 
     let tol = 1e-9;
-    let (r0, _z0) = radial_axial(p0_start, axis_origin, axis);
-    let (r1, _z1) = radial_axial(p1_start, axis_origin, axis);
+    // The profile edge runs `p0_start → p1_start` (vertex i to vertex i+1 on the
+    // SAME segment ring); `p0_start → p0_end` is the swept-arc direction. Decompose
+    // both edge endpoints into (radial, axial) coordinates about the axis.
+    let (r0, z0) = radial_axial(p0_start, axis_origin, axis);
+    let (r1, z1) = radial_axial(p1_start, axis_origin, axis);
+    let dr = r1 - r0;
+    let dz = z1 - z0;
 
-    // Only the axis-parallel case (a cylinder wall) is converted: it has the
-    // dominant inscription error and integrates exactly via the analytic
-    // cylinder formula. A perpendicular edge would become a flat annular Plane,
-    // but the planar tessellator samples its circular boundary more coarsely
-    // than the rational-NURBS band does, so those caps stay NURBS.
-    if r0 < tol || (r0 - r1).abs() >= tol {
+    // A profile edge on the axis (both endpoints at r ≈ 0) sweeps a degenerate
+    // zero-area band; keep the NURBS form (and avoid evaluating its degenerate
+    // normal below).
+    if r0 < tol && r1 < tol {
         return Ok((FaceSurface::Nurbs(nurbs), false));
     }
 
-    let surface = brepkit_math::surfaces::CylindricalSurface::new(axis_origin, axis, r0)?;
-    // Match the NURBS bands' orientation so every face of the result winds the
-    // same way (the volume integrator takes the absolute value of the total, so
-    // consistency — not outward-vs-inward per se — is what matters). The NURBS
-    // band `normal` (its du×dv) points into the swept material; the cylinder's
-    // natural normal is radial-outward, so reverse the wall exactly when that
-    // outward radial opposes the NURBS band normal.
-    let center = rotate_point(p0_start, axis_origin, axis, seg_angle / 2.0);
-    let radial = center - (axis_origin + axis * (center - axis_origin).dot(axis));
-    let natural_outward = radial.normalize().unwrap_or(axis);
-    Ok((
-        FaceSurface::Cylinder(surface),
-        natural_outward.dot(nurbs.normal(0.5, 0.5)?) < 0.0,
-    ))
+    // Orientation reference: match the analytic surface's winding to the NURBS
+    // band normal (its du×dv, pointing into the swept material), so every face
+    // of the result winds consistently. The volume integrator takes the absolute
+    // value of the total, so consistency — not outward-vs-inward per se — matters.
+    let band_normal = nurbs.normal(0.5, 0.5)?;
+
+    // The radial-outward direction at the band's mid-arc. Both the cylinder and
+    // cone faces have a natural radially-outward normal, so they are reversed
+    // exactly when this outward direction opposes the consistent band normal.
+    let mid = rotate_point(p0_start, axis_origin, axis, seg_angle / 2.0);
+    let mid_radial = mid - (axis_origin + axis * (mid - axis_origin).dot(axis));
+    let natural_outward = mid_radial.normalize().unwrap_or(axis);
+    let outward_reversed = natural_outward.dot(band_normal) < 0.0;
+
+    // Axis-parallel edge (Δr ≈ 0, radius > 0) → cylinder wall.
+    if dr.abs() < tol {
+        let surface = brepkit_math::surfaces::CylindricalSurface::new(axis_origin, axis, r0)?;
+        return Ok((FaceSurface::Cylinder(surface), outward_reversed));
+    }
+
+    // Perpendicular edge (Δz ≈ 0) → flat annular disk normal to the axis. The
+    // analytic volume path integrates a circular-arc-bounded planar cap exactly
+    // (`planar_cap_signed_volume`), so the disc no longer suffers the chorded-
+    // boundary under-count that previously kept these caps NURBS.
+    if dz.abs() < tol {
+        let plane_d = dot_normal_point(axis, p0_start);
+        // Stored normal is `+axis`; reverse when the consistent band normal
+        // points along `−axis`.
+        return Ok((
+            FaceSurface::Plane {
+                normal: axis,
+                d: plane_d,
+            },
+            band_normal.dot(axis) < 0.0,
+        ));
+    }
+
+    // Oblique edge (both Δr and Δz non-negligible) → cone. The line, extended to
+    // r = 0, meets the axis at the apex; the half-angle is the angle from the
+    // radial plane to the generator (matching `make_cone`).
+    let half_angle = dz.abs().atan2(dr.abs());
+    if half_angle <= tol || half_angle >= FRAC_PI_2 - tol {
+        // Numerically parallel/perpendicular despite the guards above — keep the
+        // exact NURBS band rather than build an invalid cone.
+        return Ok((FaceSurface::Nurbs(nurbs), false));
+    }
+    let apex = revolution_cone_apex(axis_origin, axis, r0, z0, dr, dz);
+    // The cone axis points apex → widening end (radius grows from the apex). Pick
+    // the axial direction from the apex toward the larger-radius endpoint.
+    let wide_z = if r1 >= r0 { z1 } else { z0 };
+    let apex_z = axis.dot(apex - axis_origin);
+    let cone_axis = if wide_z >= apex_z { axis } else { -axis };
+    let surface = brepkit_math::surfaces::ConicalSurface::new(apex, cone_axis, half_angle)?;
+    Ok((FaceSurface::Cone(surface), outward_reversed))
+}
+
+/// Axial position (along the revolution axis) where the profile line, extended,
+/// crosses the axis (r = 0) — the cone apex. Built from one endpoint and the
+/// (Δr, Δz) slope so it is exact for the infinite line through the edge.
+fn revolution_cone_apex(
+    axis_origin: Point3,
+    axis: Vec3,
+    r_ref: f64,
+    z_ref: f64,
+    dr: f64,
+    dz: f64,
+) -> Point3 {
+    // Parametrize the line in (r, z): at r = 0, the axial coordinate is
+    // z_apex = z_ref - r_ref * (dz / dr). Place the apex on the axis at z_apex.
+    let z_apex = z_ref - r_ref * (dz / dr);
+    axis_origin + axis * z_apex
+}
+
+/// Recognise a profile edge as a circular arc, returning its `(center, radius)`.
+///
+/// A `Circle` edge reports them directly; a rational-quadratic `NurbsCurve`
+/// (how circles are often constructed) is run through curve recognition. Returns
+/// `None` for lines, ellipses, and unrecognised splines. `p_start`/`p_end` are
+/// the arc endpoints, used only as the recognition tolerance scale.
+fn profile_arc_center_radius(
+    curve: &EdgeCurve,
+    p_start: Point3,
+    p_end: Point3,
+) -> Option<(Point3, f64)> {
+    match curve {
+        EdgeCurve::Circle(c) => Some((c.center(), c.radius())),
+        EdgeCurve::NurbsCurve(nc) => {
+            let scale = (p_end - p_start).length().max(1.0);
+            let tol = Tolerance::new().linear * 100.0 * scale;
+            match brepkit_geometry::convert::recognize_curve(nc, tol) {
+                brepkit_geometry::convert::RecognizedCurve::Circle { center, radius, .. } => {
+                    Some((center, radius))
+                }
+                _ => None,
+            }
+        }
+        EdgeCurve::Line | EdgeCurve::Ellipse(_) => None,
+    }
+}
+
+/// Build the `Torus` band swept by a circular-arc profile edge with the given
+/// `(center, radius)` about the revolution axis.
+///
+/// The torus center is the arc centre projected onto the axis; the major radius
+/// is the arc centre's perpendicular distance to the axis; the minor radius is
+/// the arc radius. Returns `Ok(None)` (caller keeps the NURBS band) when the arc
+/// does not clear the axis (`major ≤ minor`, a spindle/degenerate torus that
+/// would self-intersect) or the arc centre lies on the axis (a sphere band).
+fn revolution_torus_band(
+    arc_center: Point3,
+    arc_radius: f64,
+    axis_origin: Point3,
+    axis: Vec3,
+    nurbs: &NurbsSurface,
+    seg_angle: f64,
+) -> Result<Option<(FaceSurface, bool)>, brepkit_math::MathError> {
+    let tol = 1e-9;
+    // Decompose the arc centre into its axial position and radial offset.
+    let to_center = arc_center - axis_origin;
+    let axial = axis * to_center.dot(axis);
+    let radial = to_center - axial;
+    let major = radial.length();
+    // Centre on the axis → sphere band (a different surface type); spindle /
+    // horn torus (major ≤ minor) self-intersects. Both keep the NURBS band.
+    if major <= arc_radius + tol {
+        return Ok(None);
+    }
+    let torus_center = axis_origin + axial;
+    let surface =
+        brepkit_math::surfaces::ToroidalSurface::with_axis(torus_center, major, arc_radius, axis)?;
+    // Match the band's winding to the NURBS band normal (consistent winding
+    // across all faces; the volume integrator uses the absolute total). Compare
+    // the toroidal surface's natural normal to the NURBS one at the SAME 3D
+    // point — the band centre, projected onto the torus for its (u, v).
+    let _ = seg_angle;
+    let band_center = brepkit_math::traits::ParametricSurface::evaluate(nurbs, 0.5, 0.5);
+    let band_normal = nurbs.normal(0.5, 0.5)?;
+    let (tu, tv) = surface.project_point(band_center);
+    let outward = surface.normal(tu, tv);
+    Ok(Some((
+        FaceSurface::Torus(surface),
+        outward.dot(band_normal) < 0.0,
+    )))
 }
 
 /// Index of the next ring for a given segment, wrapping to 0 for the last
@@ -237,6 +389,386 @@ struct WireRevolveData {
 /// into a NURBS band, which inscribes the circle and undershoots the analytic
 /// volume by ~2% (gh #968). A `Torus` face is integrated exactly.
 ///
+/// One profile edge classified for the analytic full-revolution fast path.
+enum RevEdge {
+    /// Axis-parallel line at radius `r`, axial span `[z0, z1]` → cylinder wall.
+    Cylinder { r: f64 },
+    /// Oblique line → cone wall. `apex` on the axis, `half_angle` from `make_cone`.
+    Cone { apex: Point3, half_angle: f64 },
+    /// Perpendicular line → flat disc/annulus cap (normal ±axis).
+    Plane,
+    /// Circular arc clearing the axis → torus band.
+    Torus {
+        center: Point3,
+        major: f64,
+        minor: f64,
+    },
+    /// Degenerate edge on the axis (both endpoints at r≈0) → no face.
+    OnAxis,
+}
+
+/// Fast exact path: a FULL revolution of a fully-analytic planar profile (every
+/// edge a line or circular arc) built as ONE periodic face per profile edge —
+/// matching `make_cylinder`/`make_cone`/`make_torus` — instead of the segmented
+/// NURBS path's 4×90° bands.
+///
+/// Each profile vertex off the axis becomes a shared rim `Circle3D` edge; each
+/// non-degenerate profile edge becomes one periodic wall (cylinder/cone/torus,
+/// closed by a seam line between its two rim circles) or one planar disc/annulus
+/// cap (bounded by its rim circle(s)). Adjacent faces reuse the same rim circle,
+/// so the shell is watertight with no segment seams.
+///
+/// Returns `Ok(None)` (fall back to the segmented revolve) unless the revolution
+/// is full, the profile is planar with the axis in its plane, has no inner
+/// wires, and every edge classifies analytically (no spline, no axis-crossing
+/// arc). The closed-circle→torus and degenerate cases defer too.
+#[allow(clippy::too_many_lines)]
+fn try_analytic_full_revolution(
+    topo: &mut Topology,
+    face: FaceId,
+    axis_origin: Point3,
+    axis: Vec3,
+    is_full: bool,
+) -> Result<Option<SolidId>, crate::OperationsError> {
+    if !is_full {
+        return Ok(None);
+    }
+    let face_data = topo.face(face)?;
+    if !face_data.inner_wires().is_empty() {
+        return Ok(None);
+    }
+    // Planar profile with the axis lying in its plane (else not a clean
+    // surface of revolution about this axis).
+    let normal = match face_data.surface() {
+        FaceSurface::Plane { normal, .. } => *normal,
+        _ => return Ok(None),
+    };
+    if normal.dot(axis).abs() > 1e-9 {
+        return Ok(None);
+    }
+
+    let tol = Tolerance::new();
+    let lin = tol.linear;
+
+    let wire = topo.wire(face_data.outer_wire())?;
+    let oriented: Vec<OrientedEdge> = wire.edges().to_vec();
+    if oriented.len() < 2 {
+        // A single closed circle is the torus fast path's job; a single open
+        // edge cannot bound a face. Defer.
+        return Ok(None);
+    }
+
+    // Ordered profile vertices (the start of each oriented edge) and a per-edge
+    // (start_point, end_point) in traversal order.
+    let mut verts: Vec<Point3> = Vec::with_capacity(oriented.len());
+    let mut edge_pts: Vec<(Point3, Point3, EdgeCurve)> = Vec::with_capacity(oriented.len());
+    for oe in &oriented {
+        let edge = topo.edge(oe.edge())?;
+        let (s, e) = if oe.is_forward() {
+            (edge.start(), edge.end())
+        } else {
+            (edge.end(), edge.start())
+        };
+        let sp = topo.vertex(s)?.point();
+        let ep = topo.vertex(e)?.point();
+        verts.push(sp);
+        edge_pts.push((sp, ep, edge.curve().clone()));
+    }
+
+    // Classify every edge analytically; bail to the segmented path on the first
+    // edge that has no closed-form revolution surface.
+    //
+    // SCOPE (kept deliberately narrow so every periodic face is unambiguous):
+    //   * a wall (cylinder/cone/torus) needs BOTH endpoints off the axis — a
+    //     pointed-cone apex (one endpoint on the axis) needs a degenerate seam
+    //     wire, deferred to the segmented path;
+    //   * a planar cap must be a DISC (exactly one endpoint on the axis) — an
+    //     annulus cap (both endpoints off the axis) co-occurs with an inner wall
+    //     whose outward normal points toward the axis, an orientation the simple
+    //     "radially outward" wall builder does not handle; deferred.
+    let mut classes: Vec<RevEdge> = Vec::with_capacity(edge_pts.len());
+    for (sp, ep, curve) in &edge_pts {
+        let (r0, z0) = radial_axial(*sp, axis_origin, axis);
+        let (r1, z1) = radial_axial(*ep, axis_origin, axis);
+        let s_on_axis = r0 < lin;
+        let e_on_axis = r1 < lin;
+        // Arc edge → torus band (both ends must clear the axis).
+        if let Some((center, radius)) = profile_arc_center_radius(curve, *sp, *ep) {
+            if s_on_axis || e_on_axis {
+                return Ok(None); // arc meeting the axis — defer
+            }
+            let to_c = center - axis_origin;
+            let major = (to_c - axis * to_c.dot(axis)).length();
+            if major <= radius + lin {
+                return Ok(None); // sphere/spindle — defer
+            }
+            classes.push(RevEdge::Torus {
+                center,
+                major,
+                minor: radius,
+            });
+            continue;
+        }
+        if !matches!(curve, EdgeCurve::Line) {
+            return Ok(None); // spline — defer
+        }
+        let dr = r1 - r0;
+        let dz = z1 - z0;
+        if s_on_axis && e_on_axis {
+            classes.push(RevEdge::OnAxis);
+        } else if dr.abs() < lin {
+            // Axis-parallel wall: both ends share radius r0 (> lin here).
+            classes.push(RevEdge::Cylinder { r: r0 });
+        } else if dz.abs() < lin {
+            // Perpendicular cap: a disc only (exactly one end on the axis).
+            if s_on_axis == e_on_axis {
+                return Ok(None); // annulus (neither end on axis) — defer
+            }
+            classes.push(RevEdge::Plane);
+        } else {
+            // Oblique wall → cone; both ends must clear the axis (no apex here).
+            if s_on_axis || e_on_axis {
+                return Ok(None); // pointed-cone apex — defer
+            }
+            let apex = revolution_cone_apex(axis_origin, axis, r0, z0, dr, dz);
+            let half_angle = dz.abs().atan2(dr.abs());
+            if half_angle <= lin || half_angle >= FRAC_PI_2 - lin {
+                return Ok(None);
+            }
+            classes.push(RevEdge::Cone { apex, half_angle });
+        }
+    }
+
+    Some(build_analytic_revolution(
+        topo,
+        axis_origin,
+        axis,
+        &verts,
+        &edge_pts,
+        &classes,
+    ))
+    .transpose()
+}
+
+/// Build the periodic faces for a classified analytic full revolution (see
+/// [`try_analytic_full_revolution`]). Returns the assembled solid.
+#[allow(clippy::too_many_lines)]
+fn build_analytic_revolution(
+    topo: &mut Topology,
+    axis_origin: Point3,
+    axis: Vec3,
+    verts: &[Point3],
+    edge_pts: &[(Point3, Point3, EdgeCurve)],
+    classes: &[RevEdge],
+) -> Result<SolidId, crate::OperationsError> {
+    use brepkit_topology::edge::EdgeId;
+    let lin = Tolerance::new().linear;
+    let n = verts.len();
+
+    // One shared rim per profile vertex that is off the axis: a seam vertex at
+    // the vertex's own position and a full `Circle3D` edge (v→v). On-axis
+    // vertices have no rim (radius 0).
+    let mut rim_vertex: Vec<Option<VertexId>> = vec![None; n];
+    let mut rim_circle: Vec<Option<EdgeId>> = vec![None; n];
+    for (i, &p) in verts.iter().enumerate() {
+        let (r, z) = radial_axial(p, axis_origin, axis);
+        if r < lin {
+            continue;
+        }
+        let vid = topo.add_vertex(Vertex::new(p, lin));
+        let center = axis_origin + axis * z;
+        let circle = brepkit_math::curves::Circle3D::new(center, axis, r)
+            .map_err(crate::OperationsError::Math)?;
+        let eid = topo.add_edge(Edge::new(vid, vid, EdgeCurve::Circle(circle)));
+        rim_vertex[i] = Some(vid);
+        rim_circle[i] = Some(eid);
+    }
+
+    let mut faces: Vec<FaceId> = Vec::with_capacity(n);
+
+    for (idx, class) in classes.iter().enumerate() {
+        let next = (idx + 1) % n;
+        let (sp, ep, _) = &edge_pts[idx];
+        let (r0, _z0) = radial_axial(*sp, axis_origin, axis);
+        let (r1, _z1) = radial_axial(*ep, axis_origin, axis);
+
+        match class {
+            RevEdge::OnAxis => {} // no face
+            RevEdge::Plane => {
+                // A full disc (the classifier guaranteed exactly one endpoint is
+                // on the axis), bounded by the off-axis endpoint's rim circle.
+                let outer_i = if r0 >= r1 { idx } else { next };
+                let Some(outer_e) = rim_circle[outer_i] else {
+                    continue; // no rim (degenerate) — skip
+                };
+                let cap_normal = revolution_outward_axis_normal(axis, *sp, *ep, verts, idx);
+                let d = dot_normal_point(cap_normal, *sp);
+                // The rim circle is CCW about +axis, bounding a disc whose outward
+                // normal is +axis when wound forward.
+                let outer_fwd = cap_normal.dot(axis) > 0.0;
+                let cap_wire = Wire::new(vec![OrientedEdge::new(outer_e, outer_fwd)], true)
+                    .map_err(crate::OperationsError::Topology)?;
+                let cap_wid = topo.add_wire(cap_wire);
+                faces.push(topo.add_face(Face::new(
+                    cap_wid,
+                    vec![],
+                    FaceSurface::Plane {
+                        normal: cap_normal,
+                        d,
+                    },
+                )));
+            }
+            RevEdge::Cylinder { .. } | RevEdge::Cone { .. } | RevEdge::Torus { .. } => {
+                // A periodic wall closed by a seam between its two rim circles.
+                let (Some(bot_e), Some(top_e)) = (rim_circle[idx], rim_circle[next]) else {
+                    return Err(crate::OperationsError::InvalidInput {
+                        reason: "analytic revolution wall is missing a rim circle".into(),
+                    });
+                };
+                let (Some(bot_v), Some(top_v)) = (rim_vertex[idx], rim_vertex[next]) else {
+                    return Err(crate::OperationsError::InvalidInput {
+                        reason: "analytic revolution wall is missing a rim vertex".into(),
+                    });
+                };
+                let seam = topo.add_edge(Edge::new(bot_v, top_v, EdgeCurve::Line));
+                let wall_wire = Wire::new(
+                    vec![
+                        OrientedEdge::new(bot_e, true),
+                        OrientedEdge::new(seam, true),
+                        OrientedEdge::new(top_e, false),
+                        OrientedEdge::new(seam, false),
+                    ],
+                    true,
+                )
+                .map_err(crate::OperationsError::Topology)?;
+                let wall_wid = topo.add_wire(wall_wire);
+                let (surface, reversed) =
+                    revolution_wall_surface(class, axis_origin, axis, *sp, *ep)?;
+                faces.push(if reversed {
+                    topo.add_face(Face::new_reversed(wall_wid, vec![], surface))
+                } else {
+                    topo.add_face(Face::new(wall_wid, vec![], surface))
+                });
+            }
+        }
+    }
+
+    if faces.is_empty() {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "analytic revolution produced no faces".into(),
+        });
+    }
+    let shell = Shell::new(faces).map_err(crate::OperationsError::Topology)?;
+    let shell_id = topo.add_shell(shell);
+    Ok(topo.add_solid(Solid::new(shell_id, vec![])))
+}
+
+/// The outward axis-aligned normal (`+axis` or `−axis`) for a perpendicular
+/// (disc/annulus) cap edge, chosen so it points away from the solid's material.
+/// The material lies on the side of this z where the rest of the profile sits.
+fn revolution_outward_axis_normal(
+    axis: Vec3,
+    sp: Point3,
+    _ep: Point3,
+    verts: &[Point3],
+    idx: usize,
+) -> Vec3 {
+    // Only the SIGN of (z_cap − z_mid) is used, and both are axial dot products
+    // against the same reference, so the reference point is immaterial — use the
+    // origin. The cap normal points away from the material's axial centre.
+    let axial = |p: Point3| (p - Point3::new(0.0, 0.0, 0.0)).dot(axis);
+    let z_cap = axial(sp);
+    let mut sum = 0.0;
+    let mut count = 0.0;
+    for (j, &p) in verts.iter().enumerate() {
+        if j == idx {
+            continue;
+        }
+        sum += axial(p);
+        count += 1.0;
+    }
+    let z_mid = if count > 0.0 { sum / count } else { z_cap };
+    if z_cap >= z_mid { axis } else { -axis }
+}
+
+/// Build the analytic wall surface (cylinder/cone/torus) for one classified
+/// profile edge, plus the `reversed` flag that makes its outward normal point
+/// away from the axis. `sp`/`ep` are the edge endpoints (for orientation).
+fn revolution_wall_surface(
+    class: &RevEdge,
+    axis_origin: Point3,
+    axis: Vec3,
+    sp: Point3,
+    ep: Point3,
+) -> Result<(FaceSurface, bool), crate::OperationsError> {
+    // Mid-edge radial-outward direction, for orienting the wall outward.
+    let mid = Point3::new(
+        f64::midpoint(sp.x(), ep.x()),
+        f64::midpoint(sp.y(), ep.y()),
+        f64::midpoint(sp.z(), ep.z()),
+    );
+    let to_mid = mid - axis_origin;
+    let radial = to_mid - axis * to_mid.dot(axis);
+    let outward = radial.normalize().unwrap_or(axis);
+
+    match class {
+        RevEdge::Cylinder { r } => {
+            let s = brepkit_math::surfaces::CylindricalSurface::new(axis_origin, axis, *r)
+                .map_err(crate::OperationsError::Math)?;
+            let nat = s.normal(s_u_at(&s, mid), 0.0);
+            Ok((FaceSurface::Cylinder(s), nat.dot(outward) < 0.0))
+        }
+        RevEdge::Cone { apex, half_angle } => {
+            // The cone axis points apex → widening end: toward the larger-radius
+            // endpoint's axial position.
+            let (rs, zs) = radial_axial(sp, axis_origin, axis);
+            let (re, ze) = radial_axial(ep, axis_origin, axis);
+            let wide_z = if rs >= re { zs } else { ze };
+            let apex_z = axis.dot(*apex - axis_origin);
+            let cone_axis = if wide_z >= apex_z { axis } else { -axis };
+            let s = brepkit_math::surfaces::ConicalSurface::new(*apex, cone_axis, *half_angle)
+                .map_err(crate::OperationsError::Math)?;
+            // The cone's natural normal has a dominant radial component; compare it
+            // (its radial part) to the outward radial direction.
+            let nat = s.normal(0.0, 1.0);
+            let nat_radial = nat - axis * nat.dot(axis);
+            Ok((FaceSurface::Cone(s), nat_radial.dot(outward) < 0.0))
+        }
+        RevEdge::Torus {
+            center,
+            major,
+            minor,
+        } => {
+            let to_c = *center - axis_origin;
+            let axial = axis * to_c.dot(axis);
+            let torus_center = axis_origin + axial;
+            let s = brepkit_math::surfaces::ToroidalSurface::with_axis(
+                torus_center,
+                *major,
+                *minor,
+                axis,
+            )
+            .map_err(crate::OperationsError::Math)?;
+            // Orient outward at the tube's outermost point (v=0 → farthest from
+            // the axis), where the normal is radial-outward.
+            let (tu, _tv) = s.project_point(mid);
+            let nat = s.normal(tu, 0.0);
+            let nat_radial = nat - axis * nat.dot(axis);
+            Ok((FaceSurface::Torus(s), nat_radial.dot(outward) < 0.0))
+        }
+        RevEdge::Plane | RevEdge::OnAxis => Err(crate::OperationsError::InvalidInput {
+            reason: "revolution_wall_surface called on a non-wall edge".into(),
+        }),
+    }
+}
+
+/// The cylinder surface's `u` parameter at a 3D point (its angular position),
+/// for evaluating the natural normal at the band mid-arc.
+fn s_u_at(s: &brepkit_math::surfaces::CylindricalSurface, p: Point3) -> f64 {
+    let (u, _v) = s.project_point(p);
+    u
+}
+
 /// Returns `Ok(None)` — fall back to the general revolve — unless the profile
 /// is a single closed circle, the revolution is full, the axis lies in the
 /// profile plane, and the circle clears the axis (`major > minor`, so the
@@ -391,6 +923,13 @@ pub fn revolve(
     // face instead of faceting the circle into chords, which undershoots the
     // analytic volume by ~2% (gh #968).
     if let Some(solid) = try_circle_revolution_torus(topo, face, axis_origin, axis, is_full)? {
+        return Ok(solid);
+    }
+
+    // Fast exact path: a full revolution of a fully-analytic profile builds one
+    // periodic face per profile edge (cylinder/cone/torus walls + planar disc
+    // caps), matching the primitives — instead of the segmented NURBS bands.
+    if let Some(solid) = try_analytic_full_revolution(topo, face, axis_origin, axis, is_full)? {
         return Ok(solid);
     }
 
@@ -648,12 +1187,9 @@ pub fn revolve(
             let p1_start = topo.vertex(outer.ring_verts[seg][next_i])?.point();
             let p1_end = topo.vertex(outer.ring_verts[next][next_i])?.point();
 
-            let profile_is_line = matches!(
-                topo.edge(outer.input_oriented[i].edge())?.curve(),
-                EdgeCurve::Line
-            );
+            let profile_curve = topo.edge(outer.input_oriented[i].edge())?.curve().clone();
             let (surface, reversed) = revolution_band_surface(
-                profile_is_line,
+                &profile_curve,
                 p0_start,
                 p0_end,
                 p1_start,
@@ -788,6 +1324,21 @@ mod tests {
 
     use super::*;
 
+    /// Count mesh edges used by exactly one triangle (open boundary edges); 0 ⇒
+    /// watertight.
+    fn mesh_boundary_edges(mesh: &crate::tessellate::TriangleMesh) -> usize {
+        use std::collections::HashMap;
+        let mut ec: HashMap<(u32, u32), i32> = HashMap::new();
+        for t in mesh.indices.chunks(3) {
+            for k in 0..3 {
+                let (a, b) = (t[k], t[(k + 1) % 3]);
+                let key = if a < b { (a, b) } else { (b, a) };
+                *ec.entry(key).or_insert(0) += 1;
+            }
+        }
+        ec.values().filter(|&&c| c == 1).count()
+    }
+
     #[test]
     fn revolve_square_full_circle() {
         let mut topo = Topology::new();
@@ -806,31 +1357,49 @@ mod tests {
         let solid_data = topo.solid(solid).unwrap();
         let shell = topo.shell(solid_data.outer_shell()).unwrap();
 
-        // 4 profile edges × 4 arc segments = 16 side faces. Revolving the unit
-        // square around its x=0 edge yields a unit cylinder, so the x=1 edge's
-        // four bands are exact analytic cylinders (gh #968); the perpendicular
-        // caps and the degenerate on-axis edge stay NURBS.
-        assert_eq!(shell.faces().len(), 16);
+        // The unit square revolved about its x=0 edge is a unit cylinder. The
+        // periodic merge yields 3 faces (1 `Cylinder` wall + 2 `Plane` disc caps)
+        // like `make_cylinder`; the on-axis edge contributes no face.
+        assert_eq!(
+            shell.faces().len(),
+            3,
+            "merges to 3 faces like make_cylinder"
+        );
         let cyl_count = shell
             .faces()
             .iter()
             .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Cylinder(_)))
             .count();
-        assert_eq!(cyl_count, 4, "the axis-parallel wall's bands are cylinders");
+        assert_eq!(cyl_count, 1, "one periodic cylinder wall");
+        let plane_count = shell
+            .faces()
+            .iter()
+            .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Plane { .. }))
+            .count();
+        assert_eq!(plane_count, 2, "two planar disc caps");
 
-        // Revolving the unit square around its edge is a unit cylinder: V = π.
-        // The exact-cylinder walls leave only the NURBS disc caps' boundary
-        // tessellation residual (~0.006%, vs the ~2% of an all-faceted revolve).
+        // The periodic cylinder seam must tessellate watertight (gh #696).
+        for defl in [0.1_f64, 0.05, 0.02] {
+            let mesh = crate::tessellate::tessellate_solid(&topo, solid, defl).unwrap();
+            assert_eq!(
+                mesh_boundary_edges(&mesh),
+                0,
+                "watertight at deflection {defl}"
+            );
+        }
+
+        // Exact unit-cylinder volume V = π (analytic walls + analytic disc caps).
         let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
         assert!(
-            (vol - PI).abs() / PI < 1e-3,
-            "expected unit cylinder volume π, got {vol}"
+            (vol - PI).abs() / PI < 1e-9,
+            "expected exact unit cylinder volume π, got {vol}"
         );
 
-        // Full 360° revolution of a rectangle → torus-like topology (genus-1, χ=0).
-        // The profile sweeps fully around, merging start/end into a closed ring.
+        // A solid cylinder (the profile touches the axis) is genus-0 (χ=2). The
+        // segmented path's degenerate on-axis bands previously faked a genus-1
+        // χ=0; the periodic merge drops them, giving the correct genus-0.
         let chi = euler_characteristic(&topo, solid);
-        assert_eq!(chi, 0, "full revolve should have χ=0 (genus-1), got {chi}");
+        assert_eq!(chi, 2, "solid cylinder is genus-0 (χ=2), got {chi}");
     }
 
     #[test]
@@ -897,10 +1466,10 @@ mod tests {
     #[test]
     fn revolve_washer_walls_are_exact_cylinders() {
         // gh #968: a rectangular cross-section revolved a full turn (a washer)
-        // has axis-parallel inner/outer walls that must become exact analytic
-        // cylinders — the inner wall reversed (faces the hole), the outer not.
-        // The all-faceted revolve undershot by ~0.04%; the walls are now exact,
-        // leaving only the NURBS disc-cap residual.
+        // has axis-parallel inner/outer walls that become exact analytic
+        // cylinders (the inner wall reversed, facing the hole) and perpendicular
+        // top/bottom edges that become annular `Plane` discs. With the analytic
+        // disc-area volume the whole washer is exact (no disc-cap chording).
         use brepkit_topology::builder::make_polygon_wire;
 
         let mut topo = Topology::new();
@@ -941,17 +1510,236 @@ mod tests {
             .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Cylinder(_)))
             .count();
         assert_eq!(cyl_count, 8, "inner+outer walls × 4 segments are cylinders");
+        let plane_count = shell
+            .faces()
+            .iter()
+            .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Plane { .. }))
+            .count();
+        assert_eq!(
+            plane_count, 8,
+            "top+bottom annulus caps × 4 segments are planar"
+        );
 
         let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
         let expected = PI * (49.0 - 25.0) * 5.0;
         assert!(
-            (vol - expected).abs() / expected < 1e-3,
+            (vol - expected).abs() / expected < 1e-6,
             "washer volume {expected}, got {vol}"
         );
         assert!(
             crate::validate::validate_solid(&topo, solid)
                 .unwrap()
                 .is_valid()
+        );
+    }
+
+    #[test]
+    fn revolve_frustum_walls_are_exact_cones() {
+        // A full revolution of a fully-analytic frustum profile builds ONE
+        // periodic cone wall + two planar disc caps — exactly matching
+        // `make_cone` — instead of the segmented NURBS bands. Volume is exact.
+        use brepkit_topology::builder::make_polygon_wire;
+        use brepkit_topology::explorer::solid_faces;
+
+        let mut topo = Topology::new();
+        let (r_bot, r_top, h) = (6.0_f64, 2.0_f64, 12.0_f64);
+        let wire = make_polygon_wire(
+            &mut topo,
+            &[
+                Point3::new(r_bot, 0.0, 0.0),
+                Point3::new(r_top, 0.0, h),
+                Point3::new(0.0, 0.0, h),
+                Point3::new(0.0, 0.0, 0.0),
+            ],
+            1e-7,
+        )
+        .unwrap();
+        let face = topo.add_face(Face::new(
+            wire,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 1.0, 0.0),
+                d: 0.0,
+            },
+        ));
+        let solid = revolve(
+            &mut topo,
+            face,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            2.0 * PI,
+        )
+        .unwrap();
+
+        // Periodic merge → 3 faces (1 Cone + 2 Plane), matching make_cone(6,2,12).
+        let faces = solid_faces(&topo, solid).unwrap();
+        let count = |pred: fn(&FaceSurface) -> bool| {
+            faces
+                .iter()
+                .filter(|&&fid| pred(topo.face(fid).unwrap().surface()))
+                .count()
+        };
+        assert_eq!(faces.len(), 3, "frustum merges to 3 faces like make_cone");
+        assert_eq!(
+            count(|s| matches!(s, FaceSurface::Cone(_))),
+            1,
+            "one cone wall"
+        );
+        assert_eq!(
+            count(|s| matches!(s, FaceSurface::Plane { .. })),
+            2,
+            "two planar disc caps"
+        );
+        assert_eq!(
+            count(|s| matches!(s, FaceSurface::Nurbs(_))),
+            0,
+            "no NURBS bands"
+        );
+
+        // The periodic cone face's seam must tessellate watertight (gh #696).
+        for defl in [0.1_f64, 0.05, 0.02] {
+            let mesh = crate::tessellate::tessellate_solid(&topo, solid, defl).unwrap();
+            assert_eq!(
+                mesh_boundary_edges(&mesh),
+                0,
+                "frustum mesh must be watertight at deflection {defl}"
+            );
+        }
+
+        // One periodic cone wall + analytic planar disc caps ⇒ exact volume.
+        let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+        let expected = PI * h / 3.0 * r_bot.mul_add(r_bot, r_bot.mul_add(r_top, r_top * r_top));
+        assert!(
+            (vol - expected).abs() / expected < 1e-9,
+            "frustum volume {expected}, got {vol}"
+        );
+    }
+
+    #[test]
+    fn revolve_arc_profile_edge_is_torus_band() {
+        // A circular-ARC profile edge revolved a full turn sweeps an exact torus
+        // band. A half-disc profile (semicircle arc bulging away from the axis,
+        // closed by its diameter on an axis-parallel line) makes the arc bands
+        // `Torus`; Pappus gives the exact revolved volume.
+        use brepkit_math::curves::Circle3D;
+        use std::f64::consts::PI;
+
+        let mut topo = Topology::new();
+        // Semicircle centre at radius D on the axis-parallel line x = D, radius ρ,
+        // in the XZ plane (axis = Z). Arc from (D,0,−ρ) up through (D+ρ,0,0) to
+        // (D,0,ρ); diameter line closes it along x = D.
+        let (d, rho) = (10.0_f64, 3.0_f64);
+        let circ = Circle3D::new(Point3::new(d, 0.0, 0.0), Vec3::new(0.0, 1.0, 0.0), rho).unwrap();
+        // Circle3D in XZ plane (normal +Y): param 0 → +x, so endpoints at the
+        // bottom/top of the bulge are at angles −π/2 and +π/2.
+        let p_bot = circ.evaluate(-std::f64::consts::FRAC_PI_2); // (D,0,−ρ)
+        let p_top = circ.evaluate(std::f64::consts::FRAC_PI_2); // (D,0,+ρ)
+        let v_bot = topo.add_vertex(Vertex::new(p_bot, 1e-7));
+        let v_top = topo.add_vertex(Vertex::new(p_top, 1e-7));
+        // Arc edge (bulging, the +x half) and the closing diameter line.
+        let e_arc = topo.add_edge(Edge::new(v_bot, v_top, EdgeCurve::Circle(circ)));
+        let e_dia = topo.add_edge(Edge::new(v_top, v_bot, EdgeCurve::Line));
+        let wire = Wire::new(
+            vec![
+                OrientedEdge::new(e_arc, true),
+                OrientedEdge::new(e_dia, true),
+            ],
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+        let face = topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 1.0, 0.0),
+                d: 0.0,
+            },
+        ));
+        let solid = revolve(
+            &mut topo,
+            face,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            2.0 * PI,
+        )
+        .unwrap();
+
+        let shell = topo
+            .shell(topo.solid(solid).unwrap().outer_shell())
+            .unwrap();
+        let torus_count = shell
+            .faces()
+            .iter()
+            .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Torus(_)))
+            .count();
+        assert_eq!(torus_count, 4, "the arc edge's 4 bands are torus patches");
+        assert_eq!(
+            shell
+                .faces()
+                .iter()
+                .filter(|&&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Cone(_)))
+                .count(),
+            0,
+            "an arc edge must not be chorded into cone bands"
+        );
+
+        // The revolved solid is the +z half of the torus tube, with the exact
+        // closed-form volume `π²·R·ρ²` (R = D, the arc centroid's radial
+        // distance). Because the solid is fully analytic (torus walls + planar
+        // disc caps, no NURBS), the volume is integrated analytically — exact and
+        // deflection-independent, not the inscribed-mesh approximation.
+        let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+        let expected = PI * PI * d * rho * rho;
+        assert!(
+            (vol - expected).abs() / expected < 1e-9,
+            "half-torus tube volume {expected}, got {vol}"
+        );
+    }
+
+    #[test]
+    fn revolve_pointed_cone_apex_band_volume_is_exact() {
+        // A pointed cone (apex on the axis) exercises the apex-singularity guard
+        // in `analytic_cone_signed_volume`: the apex vertex has no defined angular
+        // parameter, so a per-segment band touching it must not corrupt the
+        // band's angular range (which would 2× the lateral integral, +50% volume).
+        use brepkit_topology::builder::make_polygon_wire;
+
+        let mut topo = Topology::new();
+        let (r, h) = (5.0_f64, 12.0_f64);
+        // Triangle profile: base (r,0) → apex (0,h) → axis (0,0).
+        let wire = make_polygon_wire(
+            &mut topo,
+            &[
+                Point3::new(r, 0.0, 0.0),
+                Point3::new(0.0, 0.0, h),
+                Point3::new(0.0, 0.0, 0.0),
+            ],
+            1e-7,
+        )
+        .unwrap();
+        let face = topo.add_face(Face::new(
+            wire,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 1.0, 0.0),
+                d: 0.0,
+            },
+        ));
+        let solid = revolve(
+            &mut topo,
+            face,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            2.0 * PI,
+        )
+        .unwrap();
+
+        let vol = crate::measure::solid_volume(&topo, solid, 0.01).unwrap();
+        let expected = PI * r * r * h / 3.0;
+        assert!(
+            (vol - expected).abs() / expected < 1e-3,
+            "pointed cone volume {expected}, got {vol}"
         );
     }
 
@@ -972,20 +1760,33 @@ mod tests {
         let solid_data = topo.solid(solid).unwrap();
         let shell = topo.shell(solid_data.outer_shell()).unwrap();
 
-        // 180° = 2 segments × 4 edges = 8 NURBS + 2 planar caps = 10 faces.
+        // 180° = 2 segments × 4 profile edges + 2 planar end caps = 10 faces.
+        // The unit square revolved about the Y axis has: an axis-parallel edge
+        // (x=1 wall → Cylinder), two perpendicular edges (the z-faces → annular
+        // Plane discs), and an on-axis edge (x=0 → degenerate NURBS).
         assert_eq!(shell.faces().len(), 10);
 
-        let mut planar_count = 0;
+        let mut plane_count = 0;
+        let mut cyl_count = 0;
         let mut nurbs_count = 0;
         for &fid in shell.faces() {
-            let f = topo.face(fid).unwrap();
-            match f.surface() {
-                FaceSurface::Plane { .. } => planar_count += 1,
-                _ => nurbs_count += 1,
+            match topo.face(fid).unwrap().surface() {
+                FaceSurface::Plane { .. } => plane_count += 1,
+                FaceSurface::Cylinder(_) => cyl_count += 1,
+                FaceSurface::Nurbs(_) => nurbs_count += 1,
+                _ => {}
             }
         }
-        assert_eq!(planar_count, 2, "should have 2 planar end caps");
-        assert_eq!(nurbs_count, 8, "should have 8 NURBS side faces");
+        // 4 perpendicular-edge disc bands + 2 end caps.
+        assert_eq!(plane_count, 6, "perpendicular bands + end caps are planar");
+        assert_eq!(
+            cyl_count, 2,
+            "the axis-parallel wall's 2 bands are cylinders"
+        );
+        assert_eq!(
+            nurbs_count, 2,
+            "only the degenerate on-axis bands stay NURBS"
+        );
 
         // Half revolution of a rectangle → genus-0 solid (χ=2).
         assert_euler_genus0(&topo, solid);

--- a/crates/operations/src/transform/tests.rs
+++ b/crates/operations/src/transform/tests.rs
@@ -384,47 +384,44 @@ fn transform_nurbs_solid() {
 
     let mut topo = Topology::new();
 
-    // Create a small rectangular face at x=[2,3], z=[0,1], y=0.
-    // This is offset from the Y axis so the revolve doesn't self-intersect.
-    let tol_val = 1e-10;
-    let v0 = topo.add_vertex(Vertex::new(Point3::new(2.0, 0.0, 0.0), tol_val));
-    let v1 = topo.add_vertex(Vertex::new(Point3::new(3.0, 0.0, 0.0), tol_val));
-    let v2 = topo.add_vertex(Vertex::new(Point3::new(3.0, 0.0, 1.0), tol_val));
-    let v3 = topo.add_vertex(Vertex::new(Point3::new(2.0, 0.0, 1.0), tol_val));
-
-    let e0 = topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line));
-    let e1 = topo.add_edge(Edge::new(v1, v2, EdgeCurve::Line));
-    let e2 = topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line));
-    let e3 = topo.add_edge(Edge::new(v3, v0, EdgeCurve::Line));
-
-    let wire = Wire::new(
-        vec![
-            OrientedEdge::new(e0, true),
-            OrientedEdge::new(e1, true),
-            OrientedEdge::new(e2, true),
-            OrientedEdge::new(e3, true),
-        ],
-        true,
-    )
-    .unwrap();
-    let wid = topo.add_wire(wire);
-
-    let normal = brepkit_math::vec::Vec3::new(0.0, -1.0, 0.0);
-    let rect = topo.add_face(Face::new(
-        wid,
-        vec![],
-        FaceSurface::Plane { normal, d: 0.0 },
-    ));
-
-    // Revolve 90° around the Y axis to produce NURBS faces.
-    let solid = crate::revolve::revolve(
-        &mut topo,
-        rect,
-        Point3::new(0.0, 0.0, 0.0),
-        brepkit_math::vec::Vec3::new(0.0, 1.0, 0.0),
-        std::f64::consts::FRAC_PI_2,
-    )
-    .unwrap();
+    // Build a NURBS-faced solid by lofting two offset squares: a smooth loft
+    // produces genuine NURBS side surfaces (revolve of a polygonal profile is now
+    // recognised as analytic cone/cylinder/plane bands, so it no longer yields
+    // NURBS walls — see the revolve analytic-surface recognition).
+    let square = |topo: &mut Topology, half: f64, z: f64| -> FaceId {
+        let tol_val = 1e-10;
+        let a = topo.add_vertex(Vertex::new(Point3::new(-half, -half, z), tol_val));
+        let b = topo.add_vertex(Vertex::new(Point3::new(half, -half, z), tol_val));
+        let c = topo.add_vertex(Vertex::new(Point3::new(half, half, z), tol_val));
+        let d = topo.add_vertex(Vertex::new(Point3::new(-half, half, z), tol_val));
+        let e0 = topo.add_edge(Edge::new(a, b, EdgeCurve::Line));
+        let e1 = topo.add_edge(Edge::new(b, c, EdgeCurve::Line));
+        let e2 = topo.add_edge(Edge::new(c, d, EdgeCurve::Line));
+        let e3 = topo.add_edge(Edge::new(d, a, EdgeCurve::Line));
+        let wire = Wire::new(
+            vec![
+                OrientedEdge::new(e0, true),
+                OrientedEdge::new(e1, true),
+                OrientedEdge::new(e2, true),
+                OrientedEdge::new(e3, true),
+            ],
+            true,
+        )
+        .unwrap();
+        let wid = topo.add_wire(wire);
+        topo.add_face(Face::new(
+            wid,
+            vec![],
+            FaceSurface::Plane {
+                normal: brepkit_math::vec::Vec3::new(0.0, 0.0, 1.0),
+                d: z,
+            },
+        ))
+    };
+    let p0 = square(&mut topo, 3.0, 0.0);
+    let p1 = square(&mut topo, 2.0, 2.0);
+    let p2 = square(&mut topo, 3.0, 4.0);
+    let solid = crate::loft::loft_smooth(&mut topo, &[p0, p1, p2]).unwrap();
 
     // Record a NURBS surface control point before the transform.
     let solid_data = topo.solid(solid).unwrap();


### PR DESCRIPTION
## What

Recovers **analytic surfaces of revolution** from `revolve`. Previously `revolve` produced NURBS faces (≈0.04% volume error, up to 2.3% on pointed cones) for everything except axis-parallel-line→`Cylinder`. Now every analytic profile edge becomes its exact surface of revolution with exact volume, and full-turn disc-cap convex revolutions match the primitives' face counts.

First PR of the **analytic-recovery campaign for non-boolean ops** (after the primitive-boolean campaign #1003/#1005/#1006/#1008/#1010). Revolve was the diagnosis's #1 target: genuinely closable (the closed forms already exist in `make_cone`/`make_torus`), unlike fillet/offset/sweep which *introduce* blend surfaces with no closed form.

## Recognition — all 4 profile-edge types (`revolution_band_surface`)

| profile edge | → surface | layer |
|---|---|---|
| axis-parallel line | `Cylinder` | existing |
| **oblique line** | **`Cone`** (apex + half-angle, mirroring `make_cone`) | L1 |
| **perpendicular line** | **`Plane`** annular cap | L4 |
| **circular arc** | **`Torus`** band | L2 |

A genuine NURBS/spline profile still declines to NURBS — correct, no closed form. (The decline comment at the old `revolve.rs:159` claiming "oblique lines have no simpler exact form" was factually wrong — an oblique line revolved *is* a cone.)

## Volume (coupled work)

- **`analytic_revolution_solid_volume`** — per-face analytic sum, **tightly gated** to a genuine surface of revolution (quadric walls sharing one axis line; every cap's arcs centered on that axis). The tight guard is load-bearing: a loose version (any arc-bounded planar face) **regressed 4 boolean tests 3×** (rounded-rect caps) — the axis-centered check cleanly separates revolve caps from corner caps.
- **`planar_cap_signed_volume`** — exact disc/annulus/sector area via **Green's theorem** (exact circular-arc bulge `±ρ²(|α|−sin|α|)`, never chorded). This is the prerequisite that makes the `Plane` cap arm non-regressing (boundary chording was the original reason caps stayed NURBS).
- **apex-singularity fix** — a cone band touching the apex (where the angular parameter is undefined on the axis) read a 2× angular span → **+50% volume on pointed cones**. Fixed by skipping the apex vertex's `u` (the cone analog of the #968 cylinder-integrator midpoint fix).

## Periodic-face merge

For a full revolution of a fully-analytic disc-cap profile, build **one periodic face per profile edge** (shared rim circles + seam line, mirroring `make_cylinder`/`make_cone`) instead of 4 angular segments: **frustum 16 → 3 faces** (= `make_cone`), watertight (the u=0≡2π seam reuses the primitives' proven shared-rim topology, so #696 doesn't bite). Also fixes a latent topology bug — the segmented path's degenerate on-axis bands faked χ=0; the merge gives the correct genus-0 χ=2.

## Verification

- All 4 profile types analytic + exact volume. frustum/cylinder → 3 faces, watertight (bd=0 at defl 0.1/0.05/0.02), matching `make_cone`/`make_cylinder`. Pointed cone 2.31% → **0.0000%**.
- **No regression:** `make_cone`/`make_cylinder`/`make_torus` (which revolve-fallback through this path), sweep/loft, all booleans (box∩sphere, torus−box), gridfinity `*_inmem`; full suite **2481 passed**. clippy/fmt/boundaries clean.
- Tests: cone/torus recognition + exact volume + watertight + the merged face counts; `revolve` cases added to `approx_census`.

## Deferred (noted, not blocking — all stay analytic + exact, just over-segmented)
Pointed-cone apex periodic-merge (needs a degenerate apex seam wire); annulus/washer-cap merge (inner-wall-toward-axis orientation — caught via volume verification and scoped out rather than risk it); partial-turn closed-circle → partial torus.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovered exact analytic surfaces in `revolve` (Cylinder, Cone, Plane caps, Torus) and added exact, tessellation‑free volume integration for analytic surfaces of revolution. Also fixed disc‑cap and torus seam edge cases so multi‑section revolves compute exact, deflection‑independent volume.

- **New Features**
  - Profile edge → surface: parallel line → `Cylinder`, oblique line → `Cone`, perpendicular line → `Plane` cap, circular arc → `Torus`.
  - Exact volume for analytic revolutions via per‑face integrals; planar caps use exact disc/annulus/sector area (Green’s theorem).
  - Full‑turn analytic profiles build one periodic face per edge (e.g., frustum/cylinder → 3 faces), watertight; NURBS only when needed.
  - Added a revolve survey to `approx_census`; new watertight/volume tests; `transform` NURBS test now uses `loft_smooth`.

- **Bug Fixes**
  - Fixed apex‑singularity on cone bands touching the apex (+50% volume error).
  - Closed‑circle caps now integrate (α=2π → πρ²); arc‑bulge uses the curve’s domain midpoint and is orientation‑consistent, so annular caps subtract the inner rim correctly.
  - Torus‑band minor‑range ambiguity at the v=0/2π seam now defers to tessellation to avoid mis‑integration.
  - Tight axis‑centered guard for analytic‑volume recognition; cached planar‑cap volumes; `approx_census` `surf_tags` is now exhaustive (counts `Sphere`).

<sup>Written for commit 126a0421acdc52dd0dca5b49ee993022fb590814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

