### PR TITLE
feat(render): brepkit-render M1 — offscreen wgpu renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Strict layered Cargo workspace. Each layer depends only on layers below it.
 
 ```
 L4: brepkit-wasm        → JS bindings (wasm-bindgen)
+L4: brepkit-render      → Offscreen GPU rendering (wgpu) to image + face-id buffer
 L3: brepkit-io          → STEP, 3MF, STL, IGES, OBJ, PLY, glTF import/export
 L3: brepkit-operations  → Booleans, fillets, extrusions, tessellation
 L2: brepkit-algo        → GFA boolean engine, classification, intersection
@@ -40,6 +41,7 @@ Enforced by `scripts/check-boundaries.sh` — run before pushing:
 | `sketch` | *(none — no workspace deps)* |
 | `operations` | `math`, `topology`, `algo`, `blend`, `heal`, `check`, `geometry`, `offset`, `sketch` |
 | `io` | `math`, `topology`, `operations` |
+| `render` | `math`, `topology`, `operations` (leaf L4 — nothing depends on it) |
 | `wasm` | all crates (`blend` only transitively, via `operations`) |
 
 The script checks `[dependencies]` in each `Cargo.toml`. A violation fails the pre-push hook.
@@ -56,6 +58,7 @@ The script checks `[dependencies]` in each `Cargo.toml`. A violation fails the p
 - `sketch/src/**` → only `std`, external crates
 - `operations/src/**` → `brepkit_math::*`, `brepkit_topology::*`, `brepkit_geometry::*`, `brepkit_algo::*`, `brepkit_blend::*`, `brepkit_heal::*`, `brepkit_check::*`, `brepkit_offset::*`, `brepkit_sketch::*`
 - `io/src/**` → `brepkit_math::*`, `brepkit_topology::*`, `brepkit_operations::*`
+- `render/src/**` → `brepkit_math::*`, `brepkit_topology::*`, `brepkit_operations::*`
 - `wasm/src/**` → all `brepkit_*`
 
 ## Module Map

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Enforced by `scripts/check-boundaries.sh` — run before pushing:
 | `sketch` | *(none — no workspace deps)* |
 | `operations` | `math`, `topology`, `algo`, `blend`, `heal`, `check`, `geometry`, `offset`, `sketch` |
 | `io` | `math`, `topology`, `operations` |
-| `render` | `math`, `topology`, `operations` (leaf L4 — nothing depends on it) |
+| `render` | `math`, `topology`, `operations` (L4 leaf — the script also rejects any crate that depends on `render`) |
 | `wasm` | all crates (`blend` only transitively, via `operations`) |
 
 The script checks `[dependencies]` in each `Cargo.toml`. A violation fails the pre-push hook.

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+description = "Offscreen GPU renderer for brepkit B-Rep solids"
+edition.workspace = true
+license.workspace = true
+name = "brepkit-render"
+repository.workspace = true
+rust-version.workspace = true
+version = "0.1.0"
+
+[dependencies]
+brepkit-math.workspace = true
+brepkit-operations.workspace = true
+brepkit-topology.workspace = true
+
+bytemuck = {version = "1", features = ["derive"]}
+image = {version = "0.25", default-features = false, features = ["png"]}
+pollster = "0.4"
+thiserror.workspace = true
+wgpu = "29"
+
+[lints]
+workspace = true

--- a/crates/render/shaders/edge.wgsl
+++ b/crates/render/shaders/edge.wgsl
@@ -29,7 +29,19 @@ fn vs_main(@location(0) position: vec3<f32>) -> VsOut {
     return out;
 }
 
+struct FsOut {
+    @location(0) color: vec4<f32>,
+    // The render pass keeps the id target bound, so the fragment must declare an
+    // output for it to satisfy the multi-render-target contract (WebGPU/strict
+    // drivers reject a missing location). The pipeline write-masks this target
+    // off, so edges leave the underlying face ids untouched.
+    @location(1) face_id: u32,
+};
+
 @fragment
-fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
-    return vec4<f32>(0.05, 0.05, 0.06, 1.0);
+fn fs_main(in: VsOut) -> FsOut {
+    var out: FsOut;
+    out.color = vec4<f32>(0.05, 0.05, 0.06, 1.0);
+    out.face_id = 0u;
+    return out;
 }

--- a/crates/render/shaders/edge.wgsl
+++ b/crates/render/shaders/edge.wgsl
@@ -1,0 +1,35 @@
+// Edge pass: draw topological edge polylines as dark lines over the mesh.
+// A small depth bias (applied to clip-space z) lifts the lines toward the
+// camera so they sit on top of the shaded surface instead of z-fighting it.
+
+struct Globals {
+    view_proj: mat4x4<f32>,
+    view_dir: vec4<f32>,
+    ambient: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+};
+
+@group(0) @binding(0)
+var<uniform> globals: Globals;
+
+struct VsOut {
+    @builtin(position) clip_position: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@location(0) position: vec3<f32>) -> VsOut {
+    var out: VsOut;
+    var clip = globals.view_proj * vec4<f32>(position, 1.0);
+    // Pull edges toward the near plane by a fraction of w (perspective-correct
+    // bias). Without this the lines coincide with surface fragments and flicker.
+    clip.z = clip.z - 0.0002 * clip.w;
+    out.clip_position = clip;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    return vec4<f32>(0.05, 0.05, 0.06, 1.0);
+}

--- a/crates/render/shaders/mesh.wgsl
+++ b/crates/render/shaders/mesh.wgsl
@@ -1,0 +1,60 @@
+// Mesh pass: MVP transform + Lambert headlight shading.
+// Writes shaded color to the color target and the triangle's FaceId to the
+// id target. Positions arrive relative to the model center (RTC); the f64
+// center is already folded into `view_proj` on the CPU.
+
+struct Globals {
+    view_proj: mat4x4<f32>,
+    // World-space direction the camera looks along (the headlight points
+    // opposite this). xyz used; w is padding for 16-byte alignment.
+    view_dir: vec4<f32>,
+    ambient: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+};
+
+@group(0) @binding(0)
+var<uniform> globals: Globals;
+
+struct VsIn {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) face_id: u32,
+};
+
+struct VsOut {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) normal: vec3<f32>,
+    @location(1) @interpolate(flat) face_id: u32,
+};
+
+struct FsOut {
+    @location(0) color: vec4<f32>,
+    @location(1) face_id: u32,
+};
+
+@vertex
+fn vs_main(in: VsIn) -> VsOut {
+    var out: VsOut;
+    out.clip_position = globals.view_proj * vec4<f32>(in.position, 1.0);
+    out.normal = in.normal;
+    out.face_id = in.face_id;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> FsOut {
+    let n = normalize(in.normal);
+    // Headlight points along -view_dir (toward the camera). Two-sided so
+    // back-facing triangles still receive light rather than going black.
+    let light_dir = -normalize(globals.view_dir.xyz);
+    let diffuse = abs(dot(n, light_dir));
+    let intensity = clamp(globals.ambient + (1.0 - globals.ambient) * diffuse, 0.0, 1.0);
+
+    let base = vec3<f32>(0.72, 0.74, 0.78);
+    var out: FsOut;
+    out.color = vec4<f32>(base * intensity, 1.0);
+    out.face_id = in.face_id;
+    return out;
+}

--- a/crates/render/src/camera.rs
+++ b/crates/render/src/camera.rs
@@ -96,6 +96,24 @@ impl Mat4d {
     }
 }
 
+/// Pick a world axis to use as an "up" vector that is not parallel to `f`.
+///
+/// Returns the axis (`X`, `Y`, or `Z`) whose alignment with `f` is smallest,
+/// so the subsequent `f x up` cross product is well-conditioned regardless of
+/// the view direction.
+fn fallback_up(f: Vec3) -> Vec3 {
+    let ax = f.x().abs();
+    let ay = f.y().abs();
+    let az = f.z().abs();
+    if ax <= ay && ax <= az {
+        Vec3::new(1.0, 0.0, 0.0)
+    } else if ay <= az {
+        Vec3::new(0.0, 1.0, 0.0)
+    } else {
+        Vec3::new(0.0, 0.0, 1.0)
+    }
+}
+
 /// Right-handed look-at view matrix operating on center-relative positions.
 ///
 /// `eye`, `target`, and `center` are absolute world points; subtracting
@@ -108,7 +126,14 @@ fn look_at_rh_rtc(eye: Point3, target: Point3, up: Vec3, center: Point3) -> Mat4
     let f = (target - eye)
         .normalize()
         .unwrap_or(Vec3::new(0.0, 0.0, -1.0));
-    let s = f.cross(up).normalize().unwrap_or(Vec3::new(1.0, 0.0, 0.0));
+    // If `up` is parallel (or anti-parallel) to the view direction, f x up
+    // collapses to ~zero and the basis is degenerate. Fall back to whichever
+    // world axis is least aligned with f, which is guaranteed non-parallel.
+    let s = f.cross(up).normalize().unwrap_or_else(|_| {
+        f.cross(fallback_up(f))
+            .normalize()
+            .unwrap_or(Vec3::new(1.0, 0.0, 0.0))
+    });
     let u = s.cross(f);
 
     // Eye expressed relative to the model center.
@@ -132,7 +157,28 @@ fn look_at_rh_rtc(eye: Point3, target: Point3, up: Vec3, center: Point3) -> Mat4
 
 /// Right-handed perspective projection mapping NDC z to `[0, 1]` (wgpu/WebGPU
 /// depth convention, "zero-to-one").
+///
+/// Inputs are clamped to finite, well-conditioned ranges so a malformed
+/// [`Camera`] (zero FOV, zero/negative near or aspect, `far <= near`) yields a
+/// usable matrix instead of one full of NaNs/infinities.
 fn perspective_rh_zo(fov_y: f64, aspect: f64, near: f64, far: f64) -> Mat4d {
+    let fov_y = fov_y.clamp(1.0e-4, std::f64::consts::PI - 1.0e-4);
+    let aspect = if aspect.is_finite() && aspect > 0.0 {
+        aspect
+    } else {
+        1.0
+    };
+    let near = if near.is_finite() && near > 0.0 {
+        near
+    } else {
+        1.0e-3
+    };
+    let far = if far.is_finite() && far > near {
+        far
+    } else {
+        near * 1000.0
+    };
+
     let f = 1.0 / (fov_y * 0.5).tan();
     let nf = 1.0 / (near - far);
 
@@ -143,5 +189,68 @@ fn perspective_rh_zo(fov_y: f64, aspect: f64, near: f64, far: f64) -> Mat4d {
             [0.0, 0.0, far * nf, -1.0],
             [0.0, 0.0, far * near * nf, 0.0],
         ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_finite(m: &[f32; 16]) -> bool {
+        m.iter().all(|v| v.is_finite())
+    }
+
+    #[test]
+    fn degenerate_up_parallel_to_view_stays_finite() {
+        // up parallel to the view direction would collapse f x up to zero; the
+        // fallback-up path must still yield a finite, usable view matrix.
+        let cam = Camera {
+            eye: Point3::new(0.0, 0.0, 10.0),
+            target: Point3::new(0.0, 0.0, 0.0),
+            up: Vec3::new(0.0, 0.0, 1.0), // parallel to view dir (-Z)
+            fov_y: 45.0_f64.to_radians(),
+            aspect: 1.0,
+            near: 0.1,
+            far: 100.0,
+        };
+        let m = view_proj_rtc(&cam, Point3::new(0.0, 0.0, 0.0));
+        assert!(all_finite(&m), "view-proj must be finite for parallel up");
+    }
+
+    #[test]
+    fn fallback_up_is_not_parallel_to_view() {
+        // For each principal view direction, the chosen fallback up must not be
+        // (anti-)parallel to it, so the basis cross product is well-conditioned.
+        for f in [
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+        ] {
+            let up = fallback_up(f);
+            assert!(
+                f.cross(up).length() > 0.5,
+                "fallback up {up:?} too aligned with view dir {f:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn projection_guards_degenerate_inputs() {
+        // Zero FOV, zero aspect, zero near, and far <= near must all be clamped
+        // to produce a finite matrix rather than NaNs/infinities.
+        let cam = Camera {
+            eye: Point3::new(5.0, 5.0, 5.0),
+            target: Point3::new(0.0, 0.0, 0.0),
+            up: Vec3::new(0.0, 0.0, 1.0),
+            fov_y: 0.0,
+            aspect: 0.0,
+            near: 0.0,
+            far: 0.0,
+        };
+        let m = view_proj_rtc(&cam, Point3::new(0.0, 0.0, 0.0));
+        assert!(
+            all_finite(&m),
+            "projection must be finite for degenerate inputs"
+        );
     }
 }

--- a/crates/render/src/camera.rs
+++ b/crates/render/src/camera.rs
@@ -1,0 +1,147 @@
+//! Camera and view/projection matrices.
+//!
+//! All camera state is kept in f64. The render-relative-to-center (RTC)
+//! precision scheme uploads vertex positions as f32 offsets from the model
+//! AABB center; the f64 center is folded into the view matrix here so the GPU
+//! never sees large absolute coordinates.
+
+use brepkit_math::vec::{Point3, Vec3};
+
+/// A perspective camera defined in world space (all coordinates in f64).
+#[derive(Debug, Clone, Copy)]
+pub struct Camera {
+    /// Eye (camera) position in world space.
+    pub eye: Point3,
+    /// Point the camera looks at, in world space.
+    pub target: Point3,
+    /// Up direction (need not be exactly orthogonal to the view direction).
+    pub up: Vec3,
+    /// Vertical field of view, in radians.
+    pub fov_y: f64,
+    /// Aspect ratio (width / height).
+    pub aspect: f64,
+    /// Near clip plane distance (> 0).
+    pub near: f64,
+    /// Far clip plane distance (> near).
+    pub far: f64,
+}
+
+impl Camera {
+    /// World-space direction the camera looks along (`target - eye`, normalized).
+    ///
+    /// Falls back to `-Z` if eye and target coincide.
+    #[must_use]
+    pub fn view_direction(&self) -> Vec3 {
+        (self.target - self.eye)
+            .normalize()
+            .unwrap_or_else(|_| Vec3::new(0.0, 0.0, -1.0))
+    }
+}
+
+/// Build the combined view-projection matrix for `cam`, with `center` folded
+/// into the translation so it operates on RTC (center-relative) positions.
+///
+/// The result, as a 16-element column-major f32 array, maps a center-relative
+/// world position directly to wgpu clip space (NDC z in `[0, 1]`).
+pub fn view_proj_rtc(cam: &Camera, center: Point3) -> [f32; 16] {
+    let view = look_at_rh_rtc(cam.eye, cam.target, cam.up, center);
+    let proj = perspective_rh_zo(cam.fov_y, cam.aspect, cam.near, cam.far);
+    proj.mul(&view).to_cols_array()
+}
+
+/// A column-major 4x4 f32 matrix laid out for direct upload to WGSL.
+///
+/// WGSL `mat4x4<f32>` is column-major, so `cols[i]` is the i-th column. This
+/// type is constructed from f64 math and converted to f32 only at the end,
+/// after the large model-center translation has been removed (RTC).
+#[derive(Debug, Clone, Copy)]
+struct Mat4f {
+    cols: [[f32; 4]; 4],
+}
+
+impl Mat4f {
+    /// Flatten to the 16-element column-major array WGSL expects.
+    fn to_cols_array(self) -> [f32; 16] {
+        let c = &self.cols;
+        [
+            c[0][0], c[0][1], c[0][2], c[0][3], c[1][0], c[1][1], c[1][2], c[1][3], c[2][0],
+            c[2][1], c[2][2], c[2][3], c[3][0], c[3][1], c[3][2], c[3][3],
+        ]
+    }
+}
+
+/// A column-major 4x4 f64 matrix used for the intermediate camera math.
+#[derive(Debug, Clone, Copy)]
+struct Mat4d {
+    cols: [[f64; 4]; 4],
+}
+
+impl Mat4d {
+    /// `self * rhs`, returning an f32 matrix ready for upload.
+    fn mul(self, rhs: &Self) -> Mat4f {
+        let mut out = [[0.0_f64; 4]; 4];
+        for col in 0..4 {
+            for row in 0..4 {
+                let mut sum = 0.0;
+                for k in 0..4 {
+                    sum += self.cols[k][row] * rhs.cols[col][k];
+                }
+                out[col][row] = sum;
+            }
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        Mat4f {
+            cols: std::array::from_fn(|c| std::array::from_fn(|r| out[c][r] as f32)),
+        }
+    }
+}
+
+/// Right-handed look-at view matrix operating on center-relative positions.
+///
+/// `eye`, `target`, and `center` are absolute world points; subtracting
+/// `center` from both eye and the translated origin keeps every quantity small
+/// (RTC), so the f64 -> f32 conversion at upload time loses no meaningful
+/// precision even for models far from the origin.
+fn look_at_rh_rtc(eye: Point3, target: Point3, up: Vec3, center: Point3) -> Mat4d {
+    // Camera basis (right-handed): f points from eye toward target, s is right,
+    // u is the recomputed up.
+    let f = (target - eye)
+        .normalize()
+        .unwrap_or(Vec3::new(0.0, 0.0, -1.0));
+    let s = f.cross(up).normalize().unwrap_or(Vec3::new(1.0, 0.0, 0.0));
+    let u = s.cross(f);
+
+    // Eye expressed relative to the model center.
+    let eye_rel = eye - center; // Vec3
+
+    // View matrix rows dot the basis vectors; translation = -(basis . eye_rel).
+    let tx = -s.dot(eye_rel);
+    let ty = -u.dot(eye_rel);
+    let tz = f.dot(eye_rel);
+
+    // Column-major: column 3 holds the translation.
+    Mat4d {
+        cols: [
+            [s.x(), u.x(), -f.x(), 0.0],
+            [s.y(), u.y(), -f.y(), 0.0],
+            [s.z(), u.z(), -f.z(), 0.0],
+            [tx, ty, tz, 1.0],
+        ],
+    }
+}
+
+/// Right-handed perspective projection mapping NDC z to `[0, 1]` (wgpu/WebGPU
+/// depth convention, "zero-to-one").
+fn perspective_rh_zo(fov_y: f64, aspect: f64, near: f64, far: f64) -> Mat4d {
+    let f = 1.0 / (fov_y * 0.5).tan();
+    let nf = 1.0 / (near - far);
+
+    Mat4d {
+        cols: [
+            [f / aspect, 0.0, 0.0, 0.0],
+            [0.0, f, 0.0, 0.0],
+            [0.0, 0.0, far * nf, -1.0],
+            [0.0, 0.0, far * near * nf, 0.0],
+        ],
+    }
+}

--- a/crates/render/src/error.rs
+++ b/crates/render/src/error.rs
@@ -1,0 +1,39 @@
+//! Error type for the offscreen renderer.
+
+/// Errors that can occur while rendering a solid offscreen.
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    /// No wgpu adapter could be obtained (neither a real GPU nor a software
+    /// fallback). The crate is still usable on machines that do provide one.
+    #[error("no wgpu adapter available (tried real GPU then software fallback): {0}")]
+    NoAdapter(String),
+
+    /// The adapter could not provide a device/queue matching the request.
+    #[error("failed to request wgpu device: {0}")]
+    DeviceRequest(String),
+
+    /// A GPU buffer could not be mapped for readback.
+    #[error("failed to map GPU buffer for readback: {0}")]
+    BufferMap(String),
+
+    /// Polling the device for readback completion failed.
+    #[error("failed to poll wgpu device: {0}")]
+    Poll(String),
+
+    /// The requested render dimensions were invalid (zero width or height).
+    #[error("invalid render size: width and height must be non-zero, got {width}x{height}")]
+    InvalidSize {
+        /// Requested width in pixels.
+        width: u32,
+        /// Requested height in pixels.
+        height: u32,
+    },
+
+    /// Tessellation of the input solid failed.
+    #[error(transparent)]
+    Operations(#[from] brepkit_operations::OperationsError),
+
+    /// Topology traversal of the input solid failed.
+    #[error(transparent)]
+    Topology(#[from] brepkit_topology::TopologyError),
+}

--- a/crates/render/src/error.rs
+++ b/crates/render/src/error.rs
@@ -29,6 +29,26 @@ pub enum RenderError {
         height: u32,
     },
 
+    /// The requested render dimensions exceed the adapter's maximum 2D texture
+    /// size, so a render would fail GPU validation.
+    #[error(
+        "render size {width}x{height} exceeds the device limit of {max}x{max} (max 2D texture dimension)"
+    )]
+    SizeTooLarge {
+        /// Requested width in pixels.
+        width: u32,
+        /// Requested height in pixels.
+        height: u32,
+        /// The adapter's `max_texture_dimension_2d`.
+        max: u32,
+    },
+
+    /// The tessellation produced a mesh that violates a renderer invariant
+    /// (e.g. an index buffer length not divisible by 3, an out-of-range vertex
+    /// index, or grouped face offsets that do not cover every triangle).
+    #[error("malformed tessellation mesh: {0}")]
+    MeshData(String),
+
     /// Tessellation of the input solid failed.
     #[error(transparent)]
     Operations(#[from] brepkit_operations::OperationsError),

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -1,0 +1,153 @@
+//! Offscreen GPU renderer for brepkit B-Rep solids.
+//!
+//! [`render_solid_offscreen`] tessellates a [`Solid`](brepkit_topology::solid)
+//! and rasterizes it to images with [`wgpu`], entirely off-screen (render to
+//! texture + read back). No window or display is required, so it runs in
+//! headless CI given any wgpu adapter — a real GPU or a software fallback
+//! (e.g. Mesa lavapipe via the Vulkan backend).
+//!
+//! # Outputs
+//!
+//! Each render produces a shaded color image plus a parallel face-id buffer:
+//! every pixel carries the [`FaceId`](brepkit_topology::face::FaceId) of the
+//! face drawn there (`0` = background). Use [`RenderOutput::face_id_at`] for
+//! pixel picking.
+//!
+//! # Precision (render-relative-to-center)
+//!
+//! Geometry is tessellated in f64. To keep f32 GPU coordinates accurate even
+//! for models far from the origin, vertex positions are uploaded relative to
+//! the model's AABB center; the f64 center is folded into the camera's view
+//! matrix on the CPU.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use brepkit_render::{Camera, RenderOpts, render_solid_offscreen};
+//! use brepkit_math::vec::{Point3, Vec3};
+//! use brepkit_topology::Topology;
+//!
+//! let mut topo = Topology::new();
+//! let solid = brepkit_operations::primitives::make_box(&mut topo, 20.0, 20.0, 20.0)?;
+//! let cam = Camera {
+//!     eye: Point3::new(60.0, 50.0, 70.0),
+//!     target: Point3::new(10.0, 10.0, 10.0),
+//!     up: Vec3::new(0.0, 0.0, 1.0),
+//!     fov_y: 45.0_f64.to_radians(),
+//!     aspect: 1.0,
+//!     near: 0.1,
+//!     far: 1000.0,
+//! };
+//! let opts = RenderOpts::new(512, 512);
+//! let out = render_solid_offscreen(&topo, solid, &cam, &opts)?;
+//! out.color.save("box.png")?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+mod camera;
+mod error;
+mod mesh;
+mod pipeline;
+
+pub use camera::Camera;
+pub use error::RenderError;
+pub use pipeline::probe_adapter;
+
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+/// Default linear chord tolerance used when [`RenderOpts`] does not override it.
+pub const DEFAULT_DEFLECTION: f64 = 0.05;
+
+/// Options controlling an offscreen render.
+#[derive(Debug, Clone, Copy)]
+pub struct RenderOpts {
+    /// Output width in pixels (must be non-zero).
+    pub width: u32,
+    /// Output height in pixels (must be non-zero).
+    pub height: u32,
+    /// Draw topological edges as crisp dark lines over the shaded mesh.
+    pub edges: bool,
+    /// Background clear color as linear RGBA in `[0, 1]`.
+    pub background: [f32; 4],
+    /// Ambient light fraction in `[0, 1]` added to the Lambert headlight term.
+    pub ambient: f32,
+    /// Linear chord tolerance for tessellation (smaller = finer mesh).
+    pub deflection: f64,
+}
+
+impl RenderOpts {
+    /// Create options for a `width` x `height` render with sensible defaults
+    /// (edges on, light-gray background, modest ambient term).
+    #[must_use]
+    pub fn new(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            edges: true,
+            background: [0.11, 0.12, 0.14, 1.0],
+            ambient: 0.25,
+            deflection: DEFAULT_DEFLECTION,
+        }
+    }
+}
+
+/// The result of an offscreen render.
+pub struct RenderOutput {
+    /// Shaded color image (sRGB, RGBA8).
+    pub color: image::RgbaImage,
+    /// Per-pixel face id, row-major (`width * height` entries). `0` is
+    /// background; otherwise the value is `FaceId.index() + 1`.
+    pub id_buffer: Vec<u32>,
+    /// Image width in pixels.
+    pub width: u32,
+    /// Image height in pixels.
+    pub height: u32,
+}
+
+impl RenderOutput {
+    /// Face id at pixel `(x, y)`, or `None` for background or out-of-bounds.
+    ///
+    /// The returned value is `FaceId.index() + 1` (the same encoding stored in
+    /// [`RenderOutput::id_buffer`]); `0`/background maps to `None`.
+    #[must_use]
+    pub fn face_id_at(&self, x: u32, y: u32) -> Option<u32> {
+        if x >= self.width || y >= self.height {
+            return None;
+        }
+        let idx = (y * self.width + x) as usize;
+        match self.id_buffer.get(idx).copied() {
+            Some(0) | None => None,
+            Some(v) => Some(v),
+        }
+    }
+}
+
+/// Render a solid offscreen to a shaded color image and a face-id buffer.
+///
+/// Tessellates `solid`, sets up a wgpu device (trying a real GPU first, then a
+/// software fallback), rasterizes the mesh (and edges, if
+/// [`RenderOpts::edges`]) into off-screen targets, and reads them back.
+///
+/// # Errors
+///
+/// - [`RenderError::InvalidSize`] if `opts.width` or `opts.height` is zero.
+/// - [`RenderError::NoAdapter`] if no wgpu adapter (GPU or software) exists.
+/// - [`RenderError::DeviceRequest`] / [`RenderError::BufferMap`] /
+///   [`RenderError::Poll`] on GPU setup or readback failure.
+/// - [`RenderError::Operations`] if tessellating the solid fails.
+pub fn render_solid_offscreen(
+    topo: &Topology,
+    solid: SolidId,
+    cam: &Camera,
+    opts: &RenderOpts,
+) -> Result<RenderOutput, RenderError> {
+    if opts.width == 0 || opts.height == 0 {
+        return Err(RenderError::InvalidSize {
+            width: opts.width,
+            height: opts.height,
+        });
+    }
+    let render_mesh = mesh::RenderMesh::build(topo, solid, opts.deflection)?;
+    pipeline::render(&render_mesh, cam, opts)
+}

--- a/crates/render/src/mesh.rs
+++ b/crates/render/src/mesh.rs
@@ -57,8 +57,10 @@ impl RenderMesh {
     ///
     /// # Errors
     ///
-    /// Returns [`RenderError::Operations`] if tessellation or topology
-    /// traversal fails.
+    /// Returns [`RenderError::Operations`] / [`RenderError::Topology`] if
+    /// tessellation or topology traversal fails, or [`RenderError::MeshData`]
+    /// if the tessellation violates a mesh invariant (index buffer not a whole
+    /// number of triangles, an out-of-range index, or incomplete face offsets).
     pub fn build(topo: &Topology, solid: SolidId, deflection: f64) -> Result<Self, RenderError> {
         let angular_tol = brepkit_math::chord::DEFAULT_ANGULAR_TOL;
         let (mesh, face_offsets) =
@@ -87,27 +89,46 @@ impl RenderMesh {
             })
             .collect();
 
+        // A triangle mesh's index buffer must be a whole number of triangles.
+        if mesh.indices.len() % 3 != 0 {
+            return Err(RenderError::MeshData(format!(
+                "index buffer length {} is not divisible by 3",
+                mesh.indices.len()
+            )));
+        }
+        let tri_count = mesh.indices.len() / 3;
+
+        // The grouped tessellator returns one offset per face plus a final
+        // sentinel, so `face_offsets[i]..face_offsets[i + 1]` is face i's range.
+        // A short array would silently mis-attribute triangles, so require it.
+        if face_offsets.len() != faces.len() + 1 {
+            return Err(RenderError::MeshData(format!(
+                "face_offsets has {} entries, expected {} (one per face + sentinel)",
+                face_offsets.len(),
+                faces.len() + 1
+            )));
+        }
+
         // A vertex shared between two faces would need two different face ids,
         // so we cannot reuse the welded index buffer directly. Expand to
         // non-indexed-per-face: one fresh vertex per triangle corner, tagged
         // with that triangle's owning face. (Edges still come from topology.)
-        let tri_count = mesh.indices.len() / 3;
         let mut vertices: Vec<Vertex> = Vec::with_capacity(tri_count * 3);
         let mut indices: Vec<u32> = Vec::with_capacity(tri_count * 3);
 
-        // The grouped tessellator lays out each face's triangles contiguously,
-        // so walk faces in lockstep with the index buffer rather than searching
-        // per triangle: `face_offsets[i]..face_offsets[i + 1]` is face i's range.
+        // Walk faces in lockstep with the index buffer rather than searching
+        // per triangle.
         let mut tri_face_ids = vec![0_u32; tri_count];
         for (i, face) in faces.iter().enumerate() {
-            let start = face_offsets.get(i).copied().unwrap_or(0) as usize / 3;
-            let end = face_offsets
-                .get(i + 1)
-                .copied()
-                .map_or(tri_count, |o| o as usize / 3);
+            let start = face_offsets[i] as usize / 3;
+            let end = face_offsets[i + 1] as usize / 3;
             #[allow(clippy::cast_possible_truncation)]
             let id = face.index() as u32 + 1;
-            for slot in tri_face_ids.iter_mut().take(end.min(tri_count)).skip(start) {
+            for slot in tri_face_ids
+                .iter_mut()
+                .take(end.min(tri_count))
+                .skip(start.min(tri_count))
+            {
                 *slot = id;
             }
         }
@@ -116,8 +137,15 @@ impl RenderMesh {
             let face_id = tri_face_ids[t];
             for k in 0..3 {
                 let vi = mesh.indices[t * 3 + k] as usize;
-                let position = positions_rtc.get(vi).copied().unwrap_or([0.0; 3]);
-                let normal = normals.get(vi).copied().unwrap_or([0.0, 0.0, 1.0]);
+                // Out-of-range indices mean a corrupt tessellation; fail rather
+                // than substituting placeholder geometry / picking ids.
+                let (Some(&position), Some(&normal)) = (positions_rtc.get(vi), normals.get(vi))
+                else {
+                    return Err(RenderError::MeshData(format!(
+                        "triangle index {vi} is out of range ({} vertices)",
+                        positions_rtc.len()
+                    )));
+                };
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = vertices.len() as u32;
                 vertices.push(Vertex {

--- a/crates/render/src/mesh.rs
+++ b/crates/render/src/mesh.rs
@@ -1,0 +1,197 @@
+//! Convert a tessellated solid into GPU-ready vertex/index/edge buffers.
+//!
+//! Tessellation runs in f64. Positions are uploaded as f32 offsets from the
+//! model AABB center (RTC); the f64 center travels separately into the camera
+//! matrix (see [`crate::camera`]).
+
+use brepkit_math::vec::Point3;
+use brepkit_operations::tessellate::{
+    EdgeLines, sample_solid_edges, tessellate_solid_grouped_with_tolerance,
+};
+use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::solid::SolidId;
+
+use crate::error::RenderError;
+
+/// A single mesh vertex as uploaded to the GPU.
+///
+/// `position` is relative to the model center (RTC). `face_id` is the owning
+/// face's arena index **plus one** so the id target's `0` clear value is an
+/// unambiguous "background" sentinel.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Vertex {
+    /// Center-relative position (f32).
+    pub position: [f32; 3],
+    /// Per-vertex normal (f32, world-space direction).
+    pub normal: [f32; 3],
+    /// `FaceId.index() + 1`; `0` is reserved for background.
+    pub face_id: u32,
+}
+
+/// A single edge-line vertex (center-relative position only).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct EdgeVertex {
+    /// Center-relative position (f32).
+    pub position: [f32; 3],
+}
+
+/// CPU-side render geometry derived from a solid.
+pub struct RenderMesh {
+    /// Interleaved mesh vertices (position, normal, face id).
+    pub vertices: Vec<Vertex>,
+    /// Triangle indices into `vertices`.
+    pub indices: Vec<u32>,
+    /// Line-list vertices for the topological edges (pairs form segments).
+    pub edge_vertices: Vec<EdgeVertex>,
+    /// Model AABB center in f64 world space (the RTC origin).
+    pub center: Point3,
+}
+
+impl RenderMesh {
+    /// Tessellate `solid` and build center-relative GPU geometry.
+    ///
+    /// `deflection` is the linear chord tolerance passed to the tessellator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RenderError::Operations`] if tessellation or topology
+    /// traversal fails.
+    pub fn build(topo: &Topology, solid: SolidId, deflection: f64) -> Result<Self, RenderError> {
+        let angular_tol = brepkit_math::chord::DEFAULT_ANGULAR_TOL;
+        let (mesh, face_offsets) =
+            tessellate_solid_grouped_with_tolerance(topo, solid, deflection, angular_tol)?;
+        let faces = solid_faces(topo, solid)?;
+
+        let center = aabb_center(&mesh.positions);
+
+        // Per-vertex base data in RTC. Normals are direction-only, so they are
+        // unaffected by the center subtraction.
+        let positions_rtc: Vec<[f32; 3]> = mesh
+            .positions
+            .iter()
+            .map(|&p| {
+                let d = p - center;
+                #[allow(clippy::cast_possible_truncation)]
+                [d.x() as f32, d.y() as f32, d.z() as f32]
+            })
+            .collect();
+        let normals: Vec<[f32; 3]> = mesh
+            .normals
+            .iter()
+            .map(|&n| {
+                #[allow(clippy::cast_possible_truncation)]
+                [n.x() as f32, n.y() as f32, n.z() as f32]
+            })
+            .collect();
+
+        // A vertex shared between two faces would need two different face ids,
+        // so we cannot reuse the welded index buffer directly. Expand to
+        // non-indexed-per-face: one fresh vertex per triangle corner, tagged
+        // with that triangle's owning face. (Edges still come from topology.)
+        let tri_count = mesh.indices.len() / 3;
+        let mut vertices: Vec<Vertex> = Vec::with_capacity(tri_count * 3);
+        let mut indices: Vec<u32> = Vec::with_capacity(tri_count * 3);
+
+        // The grouped tessellator lays out each face's triangles contiguously,
+        // so walk faces in lockstep with the index buffer rather than searching
+        // per triangle: `face_offsets[i]..face_offsets[i + 1]` is face i's range.
+        let mut tri_face_ids = vec![0_u32; tri_count];
+        for (i, face) in faces.iter().enumerate() {
+            let start = face_offsets.get(i).copied().unwrap_or(0) as usize / 3;
+            let end = face_offsets
+                .get(i + 1)
+                .copied()
+                .map_or(tri_count, |o| o as usize / 3);
+            #[allow(clippy::cast_possible_truncation)]
+            let id = face.index() as u32 + 1;
+            for slot in tri_face_ids.iter_mut().take(end.min(tri_count)).skip(start) {
+                *slot = id;
+            }
+        }
+
+        for t in 0..tri_count {
+            let face_id = tri_face_ids[t];
+            for k in 0..3 {
+                let vi = mesh.indices[t * 3 + k] as usize;
+                let position = positions_rtc.get(vi).copied().unwrap_or([0.0; 3]);
+                let normal = normals.get(vi).copied().unwrap_or([0.0, 0.0, 1.0]);
+                #[allow(clippy::cast_possible_truncation)]
+                let idx = vertices.len() as u32;
+                vertices.push(Vertex {
+                    position,
+                    normal,
+                    face_id,
+                });
+                indices.push(idx);
+            }
+        }
+
+        let edges = sample_solid_edges(topo, solid, deflection)?;
+        let edge_vertices = build_edge_lines(&edges, center);
+
+        Ok(Self {
+            vertices,
+            indices,
+            edge_vertices,
+            center,
+        })
+    }
+}
+
+/// Build a line-list (segment-pair) vertex buffer from edge polylines.
+///
+/// Each polyline of `n` points becomes `n - 1` segments, i.e. `2 * (n - 1)`
+/// vertices, so the GPU `LineList` topology draws every span.
+fn build_edge_lines(edges: &EdgeLines, center: Point3) -> Vec<EdgeVertex> {
+    let mut out = Vec::new();
+    let n_edges = edges.offsets.len();
+    for e in 0..n_edges {
+        let start = edges.offsets[e];
+        let end = edges
+            .offsets
+            .get(e + 1)
+            .copied()
+            .unwrap_or(edges.positions.len());
+        let pts = &edges.positions[start..end];
+        for w in pts.windows(2) {
+            for &p in w {
+                let d = p - center;
+                #[allow(clippy::cast_possible_truncation)]
+                out.push(EdgeVertex {
+                    position: [d.x() as f32, d.y() as f32, d.z() as f32],
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Compute the center of the axis-aligned bounding box of a point set.
+///
+/// Returns the origin for an empty set so the RTC math stays well-defined.
+fn aabb_center(positions: &[Point3]) -> Point3 {
+    if positions.is_empty() {
+        return Point3::new(0.0, 0.0, 0.0);
+    }
+    let mut min = [f64::INFINITY; 3];
+    let mut max = [f64::NEG_INFINITY; 3];
+    for p in positions {
+        let c = [p.x(), p.y(), p.z()];
+        for i in 0..3 {
+            if c[i] < min[i] {
+                min[i] = c[i];
+            }
+            if c[i] > max[i] {
+                max[i] = c[i];
+            }
+        }
+    }
+    Point3::new(
+        (min[0] + max[0]) * 0.5,
+        (min[1] + max[1]) * 0.5,
+        (min[2] + max[2]) * 0.5,
+    )
+}

--- a/crates/render/src/pipeline.rs
+++ b/crates/render/src/pipeline.rs
@@ -30,7 +30,7 @@ const ID_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R32Uint;
 #[must_use]
 pub fn probe_adapter() -> Option<String> {
     let instance = wgpu::Instance::default();
-    request_any_adapter(&instance).map(|adapter| {
+    candidate_adapters(&instance).first().map(|adapter| {
         let info = adapter.get_info();
         format!(
             "{:?} / {} ({:?})",
@@ -39,22 +39,58 @@ pub fn probe_adapter() -> Option<String> {
     })
 }
 
-/// Request a real adapter, falling back to a software adapter.
-fn request_any_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
-    let real = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        force_fallback_adapter: false,
-        compatible_surface: None,
-    }));
-    if let Ok(adapter) = real {
-        return Some(adapter);
+/// Request the preferred (real GPU) adapter, then the software fallback.
+///
+/// Returns adapters in priority order (real first, fallback second); either may
+/// be absent. Both are returned so device creation can fall back if the first
+/// adapter fails to produce a device.
+fn candidate_adapters(instance: &wgpu::Instance) -> Vec<wgpu::Adapter> {
+    let mut out = Vec::new();
+    if let Ok(adapter) =
+        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+    {
+        out.push(adapter);
     }
-    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::LowPower,
-        force_fallback_adapter: true,
-        compatible_surface: None,
-    }))
-    .ok()
+    if let Ok(adapter) =
+        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: true,
+            compatible_surface: None,
+        }))
+    {
+        out.push(adapter);
+    }
+    out
+}
+
+/// Acquire a device + queue, trying each candidate adapter in priority order.
+///
+/// A real adapter that exists but cannot create a device falls back to the
+/// software adapter rather than failing outright.
+fn acquire_device(instance: &wgpu::Instance) -> Result<(wgpu::Device, wgpu::Queue), RenderError> {
+    let adapters = candidate_adapters(instance);
+    if adapters.is_empty() {
+        return Err(RenderError::NoAdapter(
+            "request_adapter returned no adapter".into(),
+        ));
+    }
+    let mut last_err = String::new();
+    for adapter in &adapters {
+        match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("brepkit-render device"),
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::downlevel_defaults(),
+            ..Default::default()
+        })) {
+            Ok(dq) => return Ok(dq),
+            Err(e) => last_err = e.to_string(),
+        }
+    }
+    Err(RenderError::DeviceRequest(last_err))
 }
 
 /// Render a solid's prepared geometry offscreen and read back color + ids.
@@ -76,18 +112,15 @@ pub fn render(
     }
 
     let instance = wgpu::Instance::default();
-    let adapter = request_any_adapter(&instance)
-        .ok_or_else(|| RenderError::NoAdapter("request_adapter returned no adapter".into()))?;
-
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        label: Some("brepkit-render device"),
-        required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults(),
-        ..Default::default()
-    }))
-    .map_err(|e| RenderError::DeviceRequest(e.to_string()))?;
+    let (device, queue) = acquire_device(&instance)?;
 
     let (width, height) = (opts.width, opts.height);
+    // Reject oversized targets with a clean error rather than tripping wgpu's
+    // internal validation (which surfaces as a device-error/panic path).
+    let max = device.limits().max_texture_dimension_2d;
+    if width > max || height > max {
+        return Err(RenderError::SizeTooLarge { width, height, max });
+    }
     let extent = wgpu::Extent3d {
         width,
         height,

--- a/crates/render/src/pipeline.rs
+++ b/crates/render/src/pipeline.rs
@@ -1,0 +1,519 @@
+//! The offscreen wgpu pipeline: adapter/device setup, render passes, readback.
+
+use bytemuck::{Pod, Zeroable};
+use wgpu::util::DeviceExt;
+
+use crate::camera::Camera;
+use crate::error::RenderError;
+use crate::mesh::{EdgeVertex, RenderMesh, Vertex};
+use crate::{RenderOpts, RenderOutput};
+
+/// Uniform block shared by both shaders (must match the WGSL `Globals` layout).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+struct Globals {
+    view_proj: [f32; 16],
+    view_dir: [f32; 4],
+    ambient: f32,
+    _pad: [f32; 3],
+}
+
+const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+const ID_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R32Uint;
+
+/// Probe whether any wgpu adapter (real GPU first, then software fallback) can
+/// be obtained on this machine.
+///
+/// Renders never run when this returns `false`; useful for gating tests in
+/// headless environments. Returns the adapter backend/name on success.
+#[must_use]
+pub fn probe_adapter() -> Option<String> {
+    let instance = wgpu::Instance::default();
+    request_any_adapter(&instance).map(|adapter| {
+        let info = adapter.get_info();
+        format!(
+            "{:?} / {} ({:?})",
+            info.backend, info.name, info.device_type
+        )
+    })
+}
+
+/// Request a real adapter, falling back to a software adapter.
+fn request_any_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    let real = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        force_fallback_adapter: false,
+        compatible_surface: None,
+    }));
+    if let Ok(adapter) = real {
+        return Some(adapter);
+    }
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::LowPower,
+        force_fallback_adapter: true,
+        compatible_surface: None,
+    }))
+    .ok()
+}
+
+/// Render a solid's prepared geometry offscreen and read back color + ids.
+///
+/// `mesh` is the center-relative geometry; `cam` and `opts` control the view
+/// and targets. This performs all GPU work synchronously (blocking on async
+/// via `pollster`).
+#[allow(clippy::too_many_lines)]
+pub fn render(
+    mesh: &RenderMesh,
+    cam: &Camera,
+    opts: &RenderOpts,
+) -> Result<RenderOutput, RenderError> {
+    if opts.width == 0 || opts.height == 0 {
+        return Err(RenderError::InvalidSize {
+            width: opts.width,
+            height: opts.height,
+        });
+    }
+
+    let instance = wgpu::Instance::default();
+    let adapter = request_any_adapter(&instance)
+        .ok_or_else(|| RenderError::NoAdapter("request_adapter returned no adapter".into()))?;
+
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("brepkit-render device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults(),
+        ..Default::default()
+    }))
+    .map_err(|e| RenderError::DeviceRequest(e.to_string()))?;
+
+    let (width, height) = (opts.width, opts.height);
+    let extent = wgpu::Extent3d {
+        width,
+        height,
+        depth_or_array_layers: 1,
+    };
+
+    // --- Targets -----------------------------------------------------------
+    let color_tex = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("color target"),
+        size: extent,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: COLOR_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let depth_tex = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("depth target"),
+        size: extent,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: DEPTH_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let id_tex = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("id target"),
+        size: extent,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: ID_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let color_view = color_tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let depth_view = depth_tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let id_view = id_tex.create_view(&wgpu::TextureViewDescriptor::default());
+
+    // --- Uniforms ----------------------------------------------------------
+    let view_proj = crate::camera::view_proj_rtc(cam, mesh.center);
+    let view_dir = cam.view_direction();
+    #[allow(clippy::cast_possible_truncation)]
+    let globals = Globals {
+        view_proj,
+        view_dir: [
+            view_dir.x() as f32,
+            view_dir.y() as f32,
+            view_dir.z() as f32,
+            0.0,
+        ],
+        ambient: opts.ambient,
+        _pad: [0.0; 3],
+    };
+    let globals_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("globals"),
+        contents: bytemuck::bytes_of(&globals),
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+    let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("globals layout"),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }],
+    });
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("globals bind group"),
+        layout: &bind_group_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: globals_buf.as_entire_binding(),
+        }],
+    });
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("pipeline layout"),
+        bind_group_layouts: &[Some(&bind_group_layout)],
+        immediate_size: 0,
+    });
+
+    // --- Geometry buffers --------------------------------------------------
+    let vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("mesh vertices"),
+        contents: bytemuck::cast_slice(&mesh.vertices),
+        usage: wgpu::BufferUsages::VERTEX,
+    });
+    let index_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("mesh indices"),
+        contents: bytemuck::cast_slice(&mesh.indices),
+        usage: wgpu::BufferUsages::INDEX,
+    });
+
+    // --- Mesh pipeline -----------------------------------------------------
+    let mesh_shader = device.create_shader_module(wgpu::include_wgsl!("../shaders/mesh.wgsl"));
+    let color_targets = [
+        Some(wgpu::ColorTargetState {
+            format: COLOR_FORMAT,
+            blend: None,
+            write_mask: wgpu::ColorWrites::ALL,
+        }),
+        Some(wgpu::ColorTargetState {
+            format: ID_FORMAT,
+            blend: None,
+            write_mask: wgpu::ColorWrites::ALL,
+        }),
+    ];
+    let mesh_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("mesh pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &mesh_shader,
+            entry_point: Some("vs_main"),
+            buffers: &[wgpu::VertexBufferLayout {
+                array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+                step_mode: wgpu::VertexStepMode::Vertex,
+                attributes: &[
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: 0,
+                        shader_location: 0,
+                    },
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: 12,
+                        shader_location: 1,
+                    },
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Uint32,
+                        offset: 24,
+                        shader_location: 2,
+                    },
+                ],
+            }],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            cull_mode: None,
+            ..Default::default()
+        },
+        depth_stencil: Some(wgpu::DepthStencilState {
+            format: DEPTH_FORMAT,
+            depth_write_enabled: Some(true),
+            depth_compare: Some(wgpu::CompareFunction::Less),
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        }),
+        multisample: wgpu::MultisampleState::default(),
+        fragment: Some(wgpu::FragmentState {
+            module: &mesh_shader,
+            entry_point: Some("fs_main"),
+            targets: &color_targets,
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        multiview_mask: None,
+        cache: None,
+    });
+
+    // --- Edge pipeline (optional) -----------------------------------------
+    let edge_resources = if opts.edges && !mesh.edge_vertices.is_empty() {
+        let edge_shader = device.create_shader_module(wgpu::include_wgsl!("../shaders/edge.wgsl"));
+        let edge_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("edge vertices"),
+            contents: bytemuck::cast_slice(&mesh.edge_vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        // The id target is still bound during the edge pass, so give it a
+        // write target (edges keep the underlying face id; they only recolor).
+        let edge_color_targets = [
+            Some(wgpu::ColorTargetState {
+                format: COLOR_FORMAT,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            }),
+            Some(wgpu::ColorTargetState {
+                format: ID_FORMAT,
+                blend: None,
+                write_mask: wgpu::ColorWrites::empty(),
+            }),
+        ];
+        let edge_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("edge pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &edge_shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<EdgeVertex>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: 0,
+                        shader_location: 0,
+                    }],
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineList,
+                ..Default::default()
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: Some(true),
+                depth_compare: Some(wgpu::CompareFunction::LessEqual),
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &edge_shader,
+                entry_point: Some("fs_main"),
+                targets: &edge_color_targets,
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
+        #[allow(clippy::cast_possible_truncation)]
+        let edge_count = mesh.edge_vertices.len() as u32;
+        Some((edge_pipeline, edge_buf, edge_count))
+    } else {
+        None
+    };
+
+    // --- Readback buffers --------------------------------------------------
+    // Bytes per row must be a multiple of COPY_BYTES_PER_ROW_ALIGNMENT (256).
+    let color_bpp = 4_u32; // Rgba8
+    let id_bpp = 4_u32; // R32Uint
+    let color_padded_bpr = padded_bytes_per_row(width, color_bpp);
+    let id_padded_bpr = padded_bytes_per_row(width, id_bpp);
+
+    let color_readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("color readback"),
+        size: u64::from(color_padded_bpr) * u64::from(height),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let id_readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("id readback"),
+        size: u64::from(id_padded_bpr) * u64::from(height),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    // --- Encode ------------------------------------------------------------
+    let bg = opts.background;
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("encoder"),
+    });
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("mesh + edge pass"),
+            color_attachments: &[
+                Some(wgpu::RenderPassColorAttachment {
+                    view: &color_view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: f64::from(bg[0]),
+                            g: f64::from(bg[1]),
+                            b: f64::from(bg[2]),
+                            a: f64::from(bg[3]),
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                }),
+                Some(wgpu::RenderPassColorAttachment {
+                    view: &id_view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        // 0 = background sentinel.
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                }),
+            ],
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &depth_view,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.set_pipeline(&mesh_pipeline);
+        pass.set_vertex_buffer(0, vertex_buf.slice(..));
+        pass.set_index_buffer(index_buf.slice(..), wgpu::IndexFormat::Uint32);
+        #[allow(clippy::cast_possible_truncation)]
+        let index_count = mesh.indices.len() as u32;
+        pass.draw_indexed(0..index_count, 0, 0..1);
+
+        if let Some((edge_pipeline, edge_buf, edge_count)) = edge_resources.as_ref() {
+            pass.set_pipeline(edge_pipeline);
+            pass.set_vertex_buffer(0, edge_buf.slice(..));
+            pass.draw(0..*edge_count, 0..1);
+        }
+    }
+
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &color_tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &color_readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(color_padded_bpr),
+                rows_per_image: Some(height),
+            },
+        },
+        extent,
+    );
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &id_tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &id_readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(id_padded_bpr),
+                rows_per_image: Some(height),
+            },
+        },
+        extent,
+    );
+
+    queue.submit(Some(encoder.finish()));
+
+    // --- Map + read --------------------------------------------------------
+    let color_bytes = map_and_read(&device, &color_readback)?;
+    let id_bytes = map_and_read(&device, &id_readback)?;
+
+    let color = unpad_to_rgba(&color_bytes, width, height, color_padded_bpr);
+    let id_buffer = unpad_to_u32(&id_bytes, width, height, id_padded_bpr);
+
+    Ok(RenderOutput {
+        color,
+        id_buffer,
+        width,
+        height,
+    })
+}
+
+/// Round `width * bpp` up to the next multiple of the row-copy alignment.
+fn padded_bytes_per_row(width: u32, bytes_per_pixel: u32) -> u32 {
+    let unpadded = width * bytes_per_pixel;
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    unpadded.div_ceil(align) * align
+}
+
+/// Map a readback buffer (blocking) and copy its bytes out.
+fn map_and_read(device: &wgpu::Device, buffer: &wgpu::Buffer) -> Result<Vec<u8>, RenderError> {
+    use std::sync::mpsc;
+    let (tx, rx) = mpsc::channel();
+    buffer.slice(..).map_async(wgpu::MapMode::Read, move |res| {
+        let _ = tx.send(res);
+    });
+    device
+        .poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })
+        .map_err(|e| RenderError::Poll(e.to_string()))?;
+    match rx.recv() {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(RenderError::BufferMap(e.to_string())),
+        Err(e) => return Err(RenderError::BufferMap(e.to_string())),
+    }
+    let data = buffer.slice(..).get_mapped_range().to_vec();
+    buffer.unmap();
+    Ok(data)
+}
+
+/// Strip per-row copy padding and build an RGBA image (rows are tightly packed).
+fn unpad_to_rgba(bytes: &[u8], width: u32, height: u32, padded_bpr: u32) -> image::RgbaImage {
+    let row_len = (width * 4) as usize;
+    let mut packed = Vec::with_capacity(row_len * height as usize);
+    for row in 0..height as usize {
+        let start = row * padded_bpr as usize;
+        if let Some(slice) = bytes.get(start..start + row_len) {
+            packed.extend_from_slice(slice);
+        } else {
+            packed.resize(packed.len() + row_len, 0);
+        }
+    }
+    image::RgbaImage::from_raw(width, height, packed)
+        .unwrap_or_else(|| image::RgbaImage::new(width, height))
+}
+
+/// Strip per-row copy padding and decode the R32Uint id target to `Vec<u32>`.
+fn unpad_to_u32(bytes: &[u8], width: u32, height: u32, padded_bpr: u32) -> Vec<u32> {
+    let mut out = Vec::with_capacity((width * height) as usize);
+    for row in 0..height as usize {
+        let row_start = row * padded_bpr as usize;
+        for col in 0..width as usize {
+            let off = row_start + col * 4;
+            let v = bytes
+                .get(off..off + 4)
+                .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .unwrap_or(0);
+            out.push(v);
+        }
+    }
+    out
+}

--- a/crates/render/tests/offscreen_render.rs
+++ b/crates/render/tests/offscreen_render.rs
@@ -5,7 +5,12 @@
 //! log a skip message and return rather than failing, so the suite stays green
 //! on machines without any GPU stack.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::print_stdout,
+    clippy::panic
+)]
 
 use std::collections::HashSet;
 
@@ -216,7 +221,7 @@ fn render_box_and_cylinder_offscreen() {
 
 #[test]
 fn invalid_size_is_rejected() {
-    // Size validation does not need a GPU, so it always runs.
+    // Zero-size validation short-circuits before any GPU work, so it always runs.
     let mut topo = Topology::new();
     let cube = brepkit_operations::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
     let cam = iso_camera(Point3::new(5.0, 5.0, 5.0), 9.0);
@@ -229,4 +234,24 @@ fn invalid_size_is_rejected() {
         err,
         Err(brepkit_render::RenderError::InvalidSize { .. })
     ));
+}
+
+#[test]
+fn oversized_render_is_rejected() {
+    // The texture-limit check runs after device creation, so it needs an adapter.
+    let Some(_adapter) = probe_adapter() else {
+        println!("SKIP oversized_render_is_rejected: no wgpu adapter available");
+        return;
+    };
+    let mut topo = Topology::new();
+    let cube = brepkit_operations::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let cam = iso_camera(Point3::new(5.0, 5.0, 5.0), 9.0);
+    // 1_000_000 px far exceeds any real `max_texture_dimension_2d` (typically
+    // 8192-16384), so this must be a clean error rather than a wgpu panic.
+    let opts = RenderOpts::new(1_000_000, 1_000_000);
+    match render_solid_offscreen(&topo, cube, &cam, &opts) {
+        Err(brepkit_render::RenderError::SizeTooLarge { .. }) => {}
+        Err(other) => panic!("expected SizeTooLarge, got {other:?}"),
+        Ok(_) => panic!("expected SizeTooLarge, got Ok"),
+    }
 }

--- a/crates/render/tests/offscreen_render.rs
+++ b/crates/render/tests/offscreen_render.rs
@@ -1,0 +1,232 @@
+//! Headless offscreen-render smoke tests.
+//!
+//! These tests require a wgpu adapter (a real GPU or a software fallback such
+//! as Mesa lavapipe via the Vulkan backend). When no adapter is available they
+//! log a skip message and return rather than failing, so the suite stays green
+//! on machines without any GPU stack.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
+
+use std::collections::HashSet;
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_render::{Camera, RenderOpts, RenderOutput, probe_adapter, render_solid_offscreen};
+use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::solid::SolidId;
+
+/// An isometric-ish camera framing a model of bounding-sphere `radius` centered
+/// at `target`, pulled back far enough to fit the model with margin.
+fn iso_camera(target: Point3, radius: f64) -> Camera {
+    let fov_y = 40.0_f64.to_radians();
+    // Distance so a sphere of `radius` subtends ~half the vertical FOV (a ~2x
+    // framing margin), keeping the silhouette comfortably inside the frame.
+    let dist = radius / (fov_y * 0.5).sin() * 2.0;
+    // Isometric-ish unit direction from target to eye.
+    let dir = Vec3::new(1.0, 0.9, 1.1).normalize().unwrap();
+    let eye = target + Vec3::new(dir.x() * dist, dir.y() * dist, dir.z() * dist);
+    Camera {
+        eye,
+        target,
+        up: Vec3::new(0.0, 0.0, 1.0),
+        fov_y,
+        aspect: 1.0,
+        near: (dist - radius).max(radius * 0.01),
+        far: dist + radius * 4.0,
+    }
+}
+
+/// Encode a linear color component to sRGB (matches the GPU's `Rgba8UnormSrgb`
+/// write), so background comparison uses the byte the GPU actually stored.
+fn linear_to_srgb_u8(c: f32) -> u8 {
+    let c = c.clamp(0.0, 1.0);
+    let s = if c <= 0.003_130_8 {
+        c * 12.92
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    };
+    (s * 255.0).round() as u8
+}
+
+/// Count pixels that differ meaningfully from the background clear color.
+fn non_background_pixels(out: &RenderOutput, bg: [f32; 4]) -> usize {
+    let bg_rgb = [
+        linear_to_srgb_u8(bg[0]),
+        linear_to_srgb_u8(bg[1]),
+        linear_to_srgb_u8(bg[2]),
+    ];
+    let mut count = 0;
+    for px in out.color.pixels() {
+        let d = (i32::from(px[0]) - i32::from(bg_rgb[0])).abs()
+            + (i32::from(px[1]) - i32::from(bg_rgb[1])).abs()
+            + (i32::from(px[2]) - i32::from(bg_rgb[2])).abs();
+        // Tolerate sRGB-encoding rounding around the clear color.
+        if d > 12 {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Bounding box (min_x, min_y, max_x, max_y) of non-zero id pixels, if any.
+fn id_silhouette_bbox(out: &RenderOutput) -> Option<(u32, u32, u32, u32)> {
+    let mut bbox: Option<(u32, u32, u32, u32)> = None;
+    for y in 0..out.height {
+        for x in 0..out.width {
+            if out.face_id_at(x, y).is_some() {
+                bbox = Some(match bbox {
+                    None => (x, y, x, y),
+                    Some((minx, miny, maxx, maxy)) => {
+                        (minx.min(x), miny.min(y), maxx.max(x), maxy.max(y))
+                    }
+                });
+            }
+        }
+    }
+    bbox
+}
+
+/// Render one solid, write a PNG to the scratch dir, and assert the image is a
+/// plausible non-blank silhouette whose ids map back to real faces.
+fn check_render(topo: &Topology, solid: SolidId, name: &str) {
+    let faces = solid_faces(topo, solid).unwrap();
+    let valid_ids: HashSet<u32> = faces
+        .iter()
+        .map(|f| u32::try_from(f.index()).unwrap() + 1)
+        .collect();
+
+    // Frame the model from its AABB center.
+    let (min, max) = solid_aabb(topo, solid);
+    let center = Point3::new(
+        (min.x() + max.x()) * 0.5,
+        (min.y() + max.y()) * 0.5,
+        (min.z() + max.z()) * 0.5,
+    );
+    let radius =
+        ((max.x() - min.x()).powi(2) + (max.y() - min.y()).powi(2) + (max.z() - min.z()).powi(2))
+            .sqrt()
+            * 0.5;
+
+    let cam = iso_camera(center, radius);
+    let opts = RenderOpts::new(512, 512);
+    let out = render_solid_offscreen(topo, solid, &cam, &opts).unwrap();
+
+    assert_eq!(out.width, 512);
+    assert_eq!(out.height, 512);
+    assert_eq!(out.id_buffer.len(), (512 * 512) as usize);
+
+    let path = std::env::temp_dir().join(format!("brepkit_render_{name}.png"));
+    out.color.save(&path).unwrap();
+    println!("wrote {}", path.display());
+
+    // 1. The image is non-blank: a meaningful fraction of pixels differ from bg.
+    let total = (out.width * out.height) as usize;
+    let drawn = non_background_pixels(&out, opts.background);
+    let frac = drawn as f64 / total as f64;
+    assert!(
+        frac > 0.05,
+        "{name}: only {drawn}/{total} ({frac:.3}) pixels differ from background; expected a visible solid"
+    );
+    assert!(
+        frac < 0.98,
+        "{name}: {drawn}/{total} ({frac:.3}) pixels differ from background; silhouette fills the whole frame (camera too close?)"
+    );
+
+    // 2. The id silhouette is plausible: present, but not the entire frame.
+    let bbox = id_silhouette_bbox(&out).expect("expected at least one face-id pixel");
+    let (minx, miny, maxx, maxy) = bbox;
+    let bw = maxx - minx + 1;
+    let bh = maxy - miny + 1;
+    assert!(
+        bw >= 32 && bh >= 32,
+        "{name}: id silhouette too small: {bw}x{bh}"
+    );
+    assert!(
+        bw < out.width && bh < out.height,
+        "{name}: id silhouette fills the entire frame: {bw}x{bh}"
+    );
+
+    // 3. Every non-background id maps to a real face of the solid, and at least
+    //    one face is actually visible.
+    let mut seen: HashSet<u32> = HashSet::new();
+    for &id in &out.id_buffer {
+        if id != 0 {
+            assert!(
+                valid_ids.contains(&id),
+                "{name}: id buffer holds {id}, which is not a face of the solid"
+            );
+            seen.insert(id);
+        }
+    }
+    assert!(
+        !seen.is_empty(),
+        "{name}: no face-id pixels mapped to a real FaceId"
+    );
+
+    // 4. Background pixels really are 0 (the corners of an iso view are empty).
+    assert_eq!(
+        out.face_id_at(0, 0),
+        None,
+        "{name}: top-left corner should be background (id 0)"
+    );
+}
+
+/// Axis-aligned bounding box of a solid via its tessellation positions.
+fn solid_aabb(topo: &Topology, solid: SolidId) -> (Point3, Point3) {
+    let (mesh, _) = brepkit_operations::tessellate::tessellate_solid_grouped_with_tolerance(
+        topo,
+        solid,
+        0.05,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+    )
+    .unwrap();
+    let mut min = [f64::INFINITY; 3];
+    let mut max = [f64::NEG_INFINITY; 3];
+    for p in &mesh.positions {
+        let c = [p.x(), p.y(), p.z()];
+        for i in 0..3 {
+            min[i] = min[i].min(c[i]);
+            max[i] = max[i].max(c[i]);
+        }
+    }
+    (
+        Point3::new(min[0], min[1], min[2]),
+        Point3::new(max[0], max[1], max[2]),
+    )
+}
+
+#[test]
+fn render_box_and_cylinder_offscreen() {
+    let Some(adapter) = probe_adapter() else {
+        println!(
+            "SKIP render_box_and_cylinder_offscreen: no wgpu adapter available (no GPU or software fallback in this environment)"
+        );
+        return;
+    };
+    println!("using wgpu adapter: {adapter}");
+
+    let mut topo = Topology::new();
+    let cube = brepkit_operations::primitives::make_box(&mut topo, 20.0, 20.0, 20.0).unwrap();
+    check_render(&topo, cube, "box");
+
+    let mut topo = Topology::new();
+    let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, 8.0, 20.0).unwrap();
+    check_render(&topo, cyl, "cylinder");
+}
+
+#[test]
+fn invalid_size_is_rejected() {
+    // Size validation does not need a GPU, so it always runs.
+    let mut topo = Topology::new();
+    let cube = brepkit_operations::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+    let cam = iso_camera(Point3::new(5.0, 5.0, 5.0), 9.0);
+    let opts = RenderOpts {
+        width: 0,
+        ..RenderOpts::new(0, 256)
+    };
+    let err = render_solid_offscreen(&topo, cube, &cam, &opts);
+    assert!(matches!(
+        err,
+        Err(brepkit_render::RenderError::InvalidSize { .. })
+    ));
+}

--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,9 @@ unmaintained = "workspace"
 yanked = "warn"
 
 [licenses]
-allow = ["Apache-2.0", "MIT", "Zlib", "Unicode-3.0"]
+# CC0-1.0 (hexf-parse) and ISC (libloading) enter via the wgpu/naga dependency
+# tree; both are permissive (public-domain-equivalent / MIT-like).
+allow = ["Apache-2.0", "MIT", "Zlib", "Unicode-3.0", "CC0-1.0", "ISC"]
 
 [bans]
 multiple-versions = "warn"

--- a/scripts/check-boundaries.sh
+++ b/scripts/check-boundaries.sh
@@ -36,7 +36,7 @@ check_deps() {
   local deps_section
   deps_section=$(sed -n '/^\[dependencies\]/,/^\[/p' "$cargo_toml" 2>/dev/null || true)
 
-  for dep in brepkit-math brepkit-topology brepkit-algo brepkit-blend brepkit-heal brepkit-check brepkit-geometry brepkit-offset brepkit-sketch brepkit-operations brepkit-io; do
+  for dep in brepkit-math brepkit-topology brepkit-algo brepkit-blend brepkit-heal brepkit-check brepkit-geometry brepkit-offset brepkit-sketch brepkit-operations brepkit-io brepkit-render; do
     if echo "$deps_section" | grep -q "${dep}"; then
       local is_allowed=false
       for a in "${allowed[@]}"; do

--- a/scripts/check-boundaries.sh
+++ b/scripts/check-boundaries.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 #   L2   (sketch)     — no workspace deps
 #   L3   (operations) — depends on math, topology, algo, blend, heal, check, geometry, offset, sketch
 #   L3   (io)         — depends on math, topology, operations
+#   L4   (render)     — depends on math, topology, operations
 #   L4   (wasm)       — depends on all
 
 FAIL=0
@@ -65,6 +66,7 @@ check_deps "offset"     "brepkit-math" "brepkit-topology" "brepkit-geometry"
 check_deps "sketch"
 check_deps "operations" "brepkit-math" "brepkit-topology" "brepkit-algo" "brepkit-blend" "brepkit-heal" "brepkit-check" "brepkit-geometry" "brepkit-offset" "brepkit-sketch"
 check_deps "io"         "brepkit-math" "brepkit-topology" "brepkit-operations"
+check_deps "render"     "brepkit-math" "brepkit-topology" "brepkit-operations"
 check_deps "wasm"       "brepkit-math" "brepkit-topology" "brepkit-algo" "brepkit-blend" "brepkit-heal" "brepkit-check" "brepkit-geometry" "brepkit-offset" "brepkit-sketch" "brepkit-operations" "brepkit-io"
 
 if [ $FAIL -ne 0 ]; then


### PR DESCRIPTION
## What

**Milestone 1 of a GPU renderer for brepkit** — a new `crates/render` (`brepkit-render`) leaf crate that renders a B-Rep `Solid` **offscreen** via wgpu: Lambert-shaded mesh + crisp topological edges + a per-pixel `FaceId` buffer for picking. Offscreen-first so it's verifiable headlessly (and independently useful for thumbnails / server-side renders / tessellator visual-regression tests).

Verified working — box and cylinder render correctly (shaded, correctly framed, crisp edges), reproducible via the test (writes PNGs to the temp dir).

## API
```rust
render_solid_offscreen(topo, solid, &Camera, &RenderOpts) -> Result<RenderOutput, RenderError>
// RenderOutput { color: image::RgbaImage, id_buffer: Vec<u32>, width, height }
//   .face_id_at(x, y) -> Option<u32>   // 0 = background
```

## Pipeline (consumes existing brepkit output — no kernel changes)
- `tessellate_solid_grouped_with_tolerance` → positions/normals/indices + **`face_offsets`** → per-triangle `FaceId`.
- `sample_solid_edges` → topological edges as crisp depth-biased lines.
- **RTC precision:** tessellate in f64, upload f32 **relative to the model-center origin**, fold the f64 center into the view matrix.
- Three targets: `Rgba8UnormSrgb` color, `Depth32Float`, **`R32Uint` id** (each face's triangles write its `FaceId`); two-sided Lambert mesh pass + optional edge pass.
- **Raw wgpu + pollster** (per the renderer research: not Bevy's f32-Transform game shape, not archived rend3, not WebGL-only three-d).

## Roadmap (this is M1)
M1 offscreen renderer (this PR) → M1.5 interactive winit window → **M2 analytic-quadric view-dependent compute meshing** (the differentiator — ship surface parameters, mesh per-frame at LOD) → M3 direct quadric ray-cast → later WebGPU/wasm. Rationale ([research](.claude/agent-memory-local/researcher/cad-gpu-renderer-landscape.md)): brepkit's kernel runs **in-browser via wasm**, so it can mesh view-dependently client-side — an architecture neither Zoo (server-side GPU + pixel streaming) nor Onshape (server tessellation) can use.

## Verification
- Box + cylinder render non-blank, silhouette plausible, shaded with crisp edges; `id_buffer` maps every non-background pixel to a real `FaceId`. 2 tests, **gated on GPU-adapter availability** (skip cleanly if the runner has no GPU/software-Vulkan).
- clippy `-D warnings`, fmt, `check-boundaries.sh`, doctest, whole-workspace build all clean; no `unwrap`/`expect`/`panic` in lib code.

## Consideration for review
The heavy `wgpu` dep tree is isolated to this leaf crate (nothing depends on it), but `cargo build --workspace` (and CI) will now compile it. If kernel-CI time matters, we can later move `render` out of the default workspace build (or to its own workspace). Flagging rather than deciding unilaterally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new leaf crate `brepkit-render` that renders B‑Rep solids offscreen via `wgpu`, producing a Lambert‑shaded image and a per‑pixel face‑id buffer for picking. Hardened with strict size checks, adapter fallback, and MRT correctness for reliable headless runs.

- New Features
  - API: `render_solid_offscreen(topo, solid, &Camera, &RenderOpts) -> RenderOutput { color, id_buffer, width, height }` with `face_id_at(x, y)`.
  - Pipeline: RTC upload (f64 tessellation → f32 positions around model center), two‑sided Lambert mesh pass, optional edge pass, and R32 `id` target (0 = background).
  - Tests: box and cylinder offscreen; gated on adapter via `probe_adapter`; write PNGs to the temp dir.

- Bug Fixes
  - Robustness: reject zero and oversized renders (`InvalidSize`, `SizeTooLarge`), fall back from real GPU to software adapter for device creation, stricter mesh validation (indices/face offsets/ranges), and guarded camera math (degenerate up, projection clamps) with unit tests.
  - Edge pass: add write‑masked `@location(1)` id output to satisfy multi‑render‑target rules; picking unchanged.
  - Tooling: `deny.toml` allowlist updated for `wgpu` transitive licenses; `check-boundaries.sh` and `CLAUDE.md` enforce `render` as an L4 leaf.

<sup>Written for commit 91a0e83ac3752e846e329367761db73138315010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

