### PR TITLE
feat(render): interactive viewer — orbit, pan, zoom, click-to-pick (M1.5)

### DIFF
--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -7,6 +7,13 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[features]
+default = []
+# Interactive viewer window (winit surface + orbit camera + click-to-pick).
+# Off by default so headless consumers (CI, the offscreen path) need not pull
+# in winit. Enable with `--features window`.
+window = ["dep:winit"]
+
 [dependencies]
 brepkit-math.workspace = true
 brepkit-operations.workspace = true
@@ -17,6 +24,15 @@ image = {version = "0.25", default-features = false, features = ["png"]}
 pollster = "0.4"
 thiserror.workspace = true
 wgpu = "29"
+
+# Window/interaction (feature = "window"). winit 0.30 and wgpu 29 both use
+# raw-window-handle 0.6, so an `Arc<Window>` satisfies wgpu's surface handle
+# traits directly (no separate raw-window-handle dep needed).
+winit = {version = "0.30", optional = true}
+
+[[example]]
+name = "viewer"
+required-features = ["window"]
 
 [lints]
 workspace = true

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 # Interactive viewer window (winit surface + orbit camera + click-to-pick).
 # Off by default so headless consumers (CI, the offscreen path) need not pull
 # in winit. Enable with `--features window`.
-window = ["dep:winit"]
+window = ["dep:winit", "dep:log"]
 
 [dependencies]
 brepkit-math.workspace = true
@@ -27,7 +27,10 @@ wgpu = "29"
 
 # Window/interaction (feature = "window"). winit 0.30 and wgpu 29 both use
 # raw-window-handle 0.6, so an `Arc<Window>` satisfies wgpu's surface handle
-# traits directly (no separate raw-window-handle dep needed).
+# traits directly (no separate raw-window-handle dep needed). `log` surfaces
+# non-fatal viewer warnings (e.g. a failed pick readback) without the workspace
+# print lints that ban eprintln!.
+log = {workspace = true, optional = true}
 winit = {version = "0.30", optional = true}
 
 [[example]]

--- a/crates/render/examples/viewer.rs
+++ b/crates/render/examples/viewer.rs
@@ -1,0 +1,43 @@
+//! Interactive viewer demo: a box fused with a cylinder.
+//!
+//! Run (needs a display server and the `window` feature):
+//!
+//! ```text
+//! cargo run -p brepkit-render --example viewer --features window
+//! ```
+//!
+//! Controls:
+//! - Left-drag: orbit
+//! - Right-drag (or Shift + left-drag): pan
+//! - Scroll: zoom
+//! - Left click on a face: highlight it (click again to clear)
+//!
+//! Each highlighted face corresponds to a kernel `FaceId`, read back from the
+//! GPU id buffer under the cursor.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::primitives::{make_box, make_cylinder};
+use brepkit_operations::transform::transform_solid;
+use brepkit_render::{ViewOpts, view_solid};
+use brepkit_topology::Topology;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // A 40x40x20 box with a cylinder rising through its top, fused into one
+    // solid so the viewer can show (and pick) the combined faces.
+    let mut topo = Topology::new();
+
+    let box_solid = make_box(&mut topo, 40.0, 40.0, 20.0)?;
+
+    // Cylinder base at z=0; lift it so it spans the box and protrudes above.
+    let cyl = make_cylinder(&mut topo, 10.0, 35.0)?;
+    transform_solid(&mut topo, cyl, &Mat4::translation(20.0, 20.0, 0.0))?;
+
+    let solid = boolean(&mut topo, BooleanOp::Fuse, box_solid, cyl)?;
+
+    let opts = ViewOpts::new("brepkit viewer — box + cylinder (click a face)");
+    view_solid(&topo, solid, &opts)?;
+    Ok(())
+}

--- a/crates/render/examples/viewer.rs
+++ b/crates/render/examples/viewer.rs
@@ -15,8 +15,6 @@
 //! Each highlighted face corresponds to a kernel `FaceId`, read back from the
 //! GPU id buffer under the cursor.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-
 use brepkit_math::mat::Mat4;
 use brepkit_operations::boolean::{BooleanOp, boolean};
 use brepkit_operations::primitives::{make_box, make_cylinder};

--- a/crates/render/shaders/edge.wgsl
+++ b/crates/render/shaders/edge.wgsl
@@ -6,7 +6,7 @@ struct Globals {
     view_proj: mat4x4<f32>,
     view_dir: vec4<f32>,
     ambient: f32,
-    _pad0: f32,
+    selected_id: u32,
     _pad1: f32,
     _pad2: f32,
 };

--- a/crates/render/shaders/mesh.wgsl
+++ b/crates/render/shaders/mesh.wgsl
@@ -9,7 +9,9 @@ struct Globals {
     // opposite this). xyz used; w is padding for 16-byte alignment.
     view_dir: vec4<f32>,
     ambient: f32,
-    _pad0: f32,
+    // Encoded FaceId (index + 1) to highlight, or 0 for "no selection". Matches
+    // the encoding written to the id target so a picked id round-trips directly.
+    selected_id: u32,
     _pad1: f32,
     _pad2: f32,
 };
@@ -52,7 +54,11 @@ fn fs_main(in: VsOut) -> FsOut {
     let diffuse = abs(dot(n, light_dir));
     let intensity = clamp(globals.ambient + (1.0 - globals.ambient) * diffuse, 0.0, 1.0);
 
-    let base = vec3<f32>(0.72, 0.74, 0.78);
+    // Tint the selected face warm orange; everything else uses the neutral base.
+    var base = vec3<f32>(0.72, 0.74, 0.78);
+    if (globals.selected_id != 0u && in.face_id == globals.selected_id) {
+        base = vec3<f32>(0.95, 0.55, 0.18);
+    }
     var out: FsOut;
     out.color = vec4<f32>(base * intensity, 1.0);
     out.face_id = in.face_id;

--- a/crates/render/src/error.rs
+++ b/crates/render/src/error.rs
@@ -49,6 +49,14 @@ pub enum RenderError {
     #[error("malformed tessellation mesh: {0}")]
     MeshData(String),
 
+    /// The windowing event loop could not be created or run (viewer only).
+    #[error("windowing event loop error: {0}")]
+    EventLoop(String),
+
+    /// A window surface could not be created or configured (viewer only).
+    #[error("failed to create or configure window surface: {0}")]
+    SurfaceConfig(String),
+
     /// Tessellation of the input solid failed.
     #[error(transparent)]
     Operations(#[from] brepkit_operations::OperationsError),

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -48,10 +48,14 @@ mod camera;
 mod error;
 mod mesh;
 mod pipeline;
+#[cfg(feature = "window")]
+mod viewer;
 
 pub use camera::Camera;
 pub use error::RenderError;
 pub use pipeline::probe_adapter;
+#[cfg(feature = "window")]
+pub use viewer::{ViewOpts, view_solid};
 
 use brepkit_topology::Topology;
 use brepkit_topology::solid::SolidId;

--- a/crates/render/src/pipeline.rs
+++ b/crates/render/src/pipeline.rs
@@ -129,21 +129,28 @@ pub struct GpuContext {
 }
 
 impl GpuContext {
-    /// Create a context, optionally constraining the adapter to be compatible
-    /// with `surface` (required for window presentation).
+    /// Create a surfaceless context for the offscreen path.
+    ///
+    /// Window callers must use [`GpuContext::with_instance`] instead, passing a
+    /// surface created from the *same* instance — a surface created from a
+    /// different instance than the adapter/device is invalid on strict backends,
+    /// so this constructor deliberately does not accept one.
     ///
     /// # Errors
     ///
     /// [`RenderError::NoAdapter`] if no adapter exists, or
     /// [`RenderError::DeviceRequest`] if the device cannot be created.
-    pub fn new(surface: Option<&wgpu::Surface<'_>>) -> Result<Self, RenderError> {
+    pub fn new() -> Result<Self, RenderError> {
         let instance = wgpu::Instance::default();
-        Self::with_instance(instance, surface)
+        Self::with_instance(instance, None)
     }
 
-    /// Like [`GpuContext::new`] but reuses an existing instance (the same
-    /// instance that created `surface` must be reused, so the viewer builds the
-    /// instance first, creates the surface, then hands both here).
+    /// Build a context from an existing instance, optionally constraining the
+    /// adapter to be compatible with `surface`.
+    ///
+    /// The surface (when `Some`) must have been created from `instance`, so the
+    /// viewer builds the instance first, creates the surface from it, then hands
+    /// both here — guaranteeing the adapter/device and surface share an instance.
     ///
     /// # Errors
     ///
@@ -528,7 +535,7 @@ pub fn render(
         });
     }
 
-    let ctx = GpuContext::new(None)?;
+    let ctx = GpuContext::new()?;
     let device = &ctx.device;
     let queue = &ctx.queue;
 

--- a/crates/render/src/pipeline.rs
+++ b/crates/render/src/pipeline.rs
@@ -1,4 +1,10 @@
-//! The offscreen wgpu pipeline: adapter/device setup, render passes, readback.
+//! The wgpu pipeline: adapter/device setup, render passes, readback.
+//!
+//! The pieces here are shared by two render targets: the offscreen path
+//! ([`render`], which draws to textures and reads them back) and the
+//! interactive viewer ([`crate::viewer`], which draws to a window surface).
+//! [`GpuContext`], [`Pipelines`], [`GeometryBuffers`], and [`encode_scene`] are
+//! the reusable building blocks; the offscreen path also owns its readback.
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
@@ -11,16 +17,22 @@ use crate::{RenderOpts, RenderOutput};
 /// Uniform block shared by both shaders (must match the WGSL `Globals` layout).
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
-struct Globals {
-    view_proj: [f32; 16],
-    view_dir: [f32; 4],
-    ambient: f32,
-    _pad: [f32; 3],
+pub struct Globals {
+    /// Combined view-projection matrix (column-major), RTC-folded.
+    pub view_proj: [f32; 16],
+    /// World-space view direction (xyz; w padding).
+    pub view_dir: [f32; 4],
+    /// Ambient light fraction.
+    pub ambient: f32,
+    /// Encoded `FaceId` (`index + 1`) to highlight, or `0` for none.
+    pub selected_id: u32,
+    /// Padding to a 16-byte boundary.
+    pub _pad: [f32; 2],
 }
 
-const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
-const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
-const ID_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R32Uint;
+pub const COLOR_FORMAT_OFFSCREEN: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+pub const ID_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R32Uint;
 
 /// Probe whether any wgpu adapter (real GPU first, then software fallback) can
 /// be obtained on this machine.
@@ -30,7 +42,7 @@ const ID_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R32Uint;
 #[must_use]
 pub fn probe_adapter() -> Option<String> {
     let instance = wgpu::Instance::default();
-    candidate_adapters(&instance).first().map(|adapter| {
+    candidate_adapters(&instance, None).first().map(|adapter| {
         let info = adapter.get_info();
         format!(
             "{:?} / {} ({:?})",
@@ -43,14 +55,18 @@ pub fn probe_adapter() -> Option<String> {
 ///
 /// Returns adapters in priority order (real first, fallback second); either may
 /// be absent. Both are returned so device creation can fall back if the first
-/// adapter fails to produce a device.
-fn candidate_adapters(instance: &wgpu::Instance) -> Vec<wgpu::Adapter> {
+/// adapter fails to produce a device. When `surface` is `Some`, each adapter is
+/// required to be compatible with it (a hard requirement for window presentation).
+fn candidate_adapters(
+    instance: &wgpu::Instance,
+    surface: Option<&wgpu::Surface<'_>>,
+) -> Vec<wgpu::Adapter> {
     let mut out = Vec::new();
     if let Ok(adapter) =
         pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             force_fallback_adapter: false,
-            compatible_surface: None,
+            compatible_surface: surface,
         }))
     {
         out.push(adapter);
@@ -59,7 +75,7 @@ fn candidate_adapters(instance: &wgpu::Instance) -> Vec<wgpu::Adapter> {
         pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::LowPower,
             force_fallback_adapter: true,
-            compatible_surface: None,
+            compatible_surface: surface,
         }))
     {
         out.push(adapter);
@@ -67,30 +83,427 @@ fn candidate_adapters(instance: &wgpu::Instance) -> Vec<wgpu::Adapter> {
     out
 }
 
-/// Acquire a device + queue, trying each candidate adapter in priority order.
+/// Acquire an adapter + device + queue, trying each candidate adapter in
+/// priority order.
 ///
 /// A real adapter that exists but cannot create a device falls back to the
-/// software adapter rather than failing outright.
-fn acquire_device(instance: &wgpu::Instance) -> Result<(wgpu::Device, wgpu::Queue), RenderError> {
-    let adapters = candidate_adapters(instance);
+/// software adapter rather than failing outright. The chosen adapter is
+/// returned alongside the device so callers (the viewer) can query surface
+/// capabilities. When `surface` is `Some`, only surface-compatible adapters are
+/// considered.
+fn acquire_device(
+    instance: &wgpu::Instance,
+    surface: Option<&wgpu::Surface<'_>>,
+) -> Result<(wgpu::Adapter, wgpu::Device, wgpu::Queue), RenderError> {
+    let adapters = candidate_adapters(instance, surface);
     if adapters.is_empty() {
         return Err(RenderError::NoAdapter(
             "request_adapter returned no adapter".into(),
         ));
     }
     let mut last_err = String::new();
-    for adapter in &adapters {
+    for adapter in adapters {
         match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
             label: Some("brepkit-render device"),
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits::downlevel_defaults(),
             ..Default::default()
         })) {
-            Ok(dq) => return Ok(dq),
+            Ok((device, queue)) => return Ok((adapter, device, queue)),
             Err(e) => last_err = e.to_string(),
         }
     }
     Err(RenderError::DeviceRequest(last_err))
+}
+
+/// A wgpu adapter/device/queue, set up once and shared across frames.
+///
+/// The instance used to obtain these is dropped after device creation — wgpu's
+/// adapter/device/surface keep their own handles to the backend.
+pub struct GpuContext {
+    // Read by the viewer (surface capabilities) but not by the offscreen path.
+    #[cfg_attr(not(feature = "window"), allow(dead_code))]
+    pub adapter: wgpu::Adapter,
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+}
+
+impl GpuContext {
+    /// Create a context, optionally constraining the adapter to be compatible
+    /// with `surface` (required for window presentation).
+    ///
+    /// # Errors
+    ///
+    /// [`RenderError::NoAdapter`] if no adapter exists, or
+    /// [`RenderError::DeviceRequest`] if the device cannot be created.
+    pub fn new(surface: Option<&wgpu::Surface<'_>>) -> Result<Self, RenderError> {
+        let instance = wgpu::Instance::default();
+        Self::with_instance(instance, surface)
+    }
+
+    /// Like [`GpuContext::new`] but reuses an existing instance (the same
+    /// instance that created `surface` must be reused, so the viewer builds the
+    /// instance first, creates the surface, then hands both here).
+    ///
+    /// # Errors
+    ///
+    /// See [`GpuContext::new`].
+    pub fn with_instance(
+        instance: wgpu::Instance,
+        surface: Option<&wgpu::Surface<'_>>,
+    ) -> Result<Self, RenderError> {
+        let (adapter, device, queue) = acquire_device(&instance, surface)?;
+        Ok(Self {
+            adapter,
+            device,
+            queue,
+        })
+    }
+}
+
+/// The globals uniform buffer plus its bind group and layout.
+///
+/// The buffer is `COPY_DST` so the viewer can re-upload [`Globals`] every frame
+/// (camera orbit, selection change) without rebuilding the bind group.
+pub struct GlobalsBinding {
+    // Retained to keep the uniform buffer alive (it backs `bind_group`); also
+    // re-uploaded each frame by the viewer via `upload`.
+    #[cfg_attr(not(feature = "window"), allow(dead_code))]
+    pub buffer: wgpu::Buffer,
+    pub bind_group: wgpu::BindGroup,
+    pub layout: wgpu::BindGroupLayout,
+}
+
+impl GlobalsBinding {
+    pub fn new(device: &wgpu::Device, globals: &Globals) -> Self {
+        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("globals"),
+            contents: bytemuck::bytes_of(globals),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("globals layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("globals bind group"),
+            layout: &layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: buffer.as_entire_binding(),
+            }],
+        });
+        Self {
+            buffer,
+            bind_group,
+            layout,
+        }
+    }
+
+    /// Re-upload the uniform block (call before encoding a frame).
+    #[cfg_attr(not(feature = "window"), allow(dead_code))]
+    pub fn upload(&self, queue: &wgpu::Queue, globals: &Globals) {
+        queue.write_buffer(&self.buffer, 0, bytemuck::bytes_of(globals));
+    }
+}
+
+/// The mesh pipeline plus the optional edge pipeline, built for one color
+/// format. Both passes target `[color, id]` so the id buffer is always written
+/// alongside the shaded image (the edge pass masks out id writes).
+pub struct Pipelines {
+    pub mesh: wgpu::RenderPipeline,
+    pub edge: Option<wgpu::RenderPipeline>,
+}
+
+impl Pipelines {
+    /// Build the pipelines for `color_format` (offscreen uses
+    /// `Rgba8UnormSrgb`; the viewer uses the surface's preferred sRGB format).
+    /// `with_edges` controls whether the edge pipeline is built.
+    pub fn new(
+        device: &wgpu::Device,
+        layout: &wgpu::PipelineLayout,
+        color_format: wgpu::TextureFormat,
+        with_edges: bool,
+    ) -> Self {
+        let mesh_shader = device.create_shader_module(wgpu::include_wgsl!("../shaders/mesh.wgsl"));
+        let color_targets = [
+            Some(wgpu::ColorTargetState {
+                format: color_format,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            }),
+            Some(wgpu::ColorTargetState {
+                format: ID_FORMAT,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            }),
+        ];
+        let mesh = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("mesh pipeline"),
+            layout: Some(layout),
+            vertex: wgpu::VertexState {
+                module: &mesh_shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x3,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x3,
+                            offset: 12,
+                            shader_location: 1,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Uint32,
+                            offset: 24,
+                            shader_location: 2,
+                        },
+                    ],
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                cull_mode: None,
+                ..Default::default()
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: Some(true),
+                depth_compare: Some(wgpu::CompareFunction::Less),
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &mesh_shader,
+                entry_point: Some("fs_main"),
+                targets: &color_targets,
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let edge = if with_edges {
+            let edge_shader =
+                device.create_shader_module(wgpu::include_wgsl!("../shaders/edge.wgsl"));
+            // The id target is still bound during the edge pass, so give it a
+            // target with writes masked off (edges only recolor; the underlying
+            // face id must survive for picking).
+            let edge_color_targets = [
+                Some(wgpu::ColorTargetState {
+                    format: color_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                }),
+                Some(wgpu::ColorTargetState {
+                    format: ID_FORMAT,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::empty(),
+                }),
+            ];
+            let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("edge pipeline"),
+                layout: Some(layout),
+                vertex: wgpu::VertexState {
+                    module: &edge_shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<EdgeVertex>() as wgpu::BufferAddress,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &[wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x3,
+                            offset: 0,
+                            shader_location: 0,
+                        }],
+                    }],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::LineList,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: DEPTH_FORMAT,
+                    depth_write_enabled: Some(true),
+                    depth_compare: Some(wgpu::CompareFunction::LessEqual),
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                fragment: Some(wgpu::FragmentState {
+                    module: &edge_shader,
+                    entry_point: Some("fs_main"),
+                    targets: &edge_color_targets,
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                multiview_mask: None,
+                cache: None,
+            });
+            Some(pipeline)
+        } else {
+            None
+        };
+
+        Self { mesh, edge }
+    }
+}
+
+/// GPU vertex/index/edge buffers built once from a [`RenderMesh`].
+pub struct GeometryBuffers {
+    pub vertex: wgpu::Buffer,
+    pub index: wgpu::Buffer,
+    pub index_count: u32,
+    pub edge: Option<wgpu::Buffer>,
+    pub edge_count: u32,
+}
+
+impl GeometryBuffers {
+    pub fn new(device: &wgpu::Device, mesh: &RenderMesh) -> Self {
+        let vertex = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("mesh vertices"),
+            contents: bytemuck::cast_slice(&mesh.vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        let index = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("mesh indices"),
+            contents: bytemuck::cast_slice(&mesh.indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+        #[allow(clippy::cast_possible_truncation)]
+        let index_count = mesh.indices.len() as u32;
+
+        let (edge, edge_count) = if mesh.edge_vertices.is_empty() {
+            (None, 0)
+        } else {
+            let buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("edge vertices"),
+                contents: bytemuck::cast_slice(&mesh.edge_vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
+            #[allow(clippy::cast_possible_truncation)]
+            let count = mesh.edge_vertices.len() as u32;
+            (Some(buf), count)
+        };
+
+        Self {
+            vertex,
+            index,
+            index_count,
+            edge,
+            edge_count,
+        }
+    }
+}
+
+/// Views and clear color for one scene-pass encode.
+pub struct PassTargets<'a> {
+    pub color: &'a wgpu::TextureView,
+    pub id: &'a wgpu::TextureView,
+    pub depth: &'a wgpu::TextureView,
+    pub background: [f32; 4],
+}
+
+/// Encode the mesh pass (and the edge pass, if both the pipeline and the
+/// geometry have edges) into `encoder`, drawing to `targets`.
+///
+/// Shared verbatim by the offscreen path and the viewer so the two never drift.
+pub fn encode_scene(
+    encoder: &mut wgpu::CommandEncoder,
+    pipelines: &Pipelines,
+    globals: &GlobalsBinding,
+    geometry: &GeometryBuffers,
+    targets: &PassTargets<'_>,
+) {
+    let bg = targets.background;
+    let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("mesh + edge pass"),
+        color_attachments: &[
+            Some(wgpu::RenderPassColorAttachment {
+                view: targets.color,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: f64::from(bg[0]),
+                        g: f64::from(bg[1]),
+                        b: f64::from(bg[2]),
+                        a: f64::from(bg[3]),
+                    }),
+                    store: wgpu::StoreOp::Store,
+                },
+            }),
+            Some(wgpu::RenderPassColorAttachment {
+                view: targets.id,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    // 0 = background sentinel.
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+            }),
+        ],
+        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+            view: targets.depth,
+            depth_ops: Some(wgpu::Operations {
+                load: wgpu::LoadOp::Clear(1.0),
+                store: wgpu::StoreOp::Store,
+            }),
+            stencil_ops: None,
+        }),
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    });
+
+    pass.set_bind_group(0, &globals.bind_group, &[]);
+    pass.set_pipeline(&pipelines.mesh);
+    pass.set_vertex_buffer(0, geometry.vertex.slice(..));
+    pass.set_index_buffer(geometry.index.slice(..), wgpu::IndexFormat::Uint32);
+    pass.draw_indexed(0..geometry.index_count, 0, 0..1);
+
+    if let (Some(edge_pipeline), Some(edge_buf)) = (pipelines.edge.as_ref(), geometry.edge.as_ref())
+    {
+        pass.set_pipeline(edge_pipeline);
+        pass.set_vertex_buffer(0, edge_buf.slice(..));
+        pass.draw(0..geometry.edge_count, 0..1);
+    }
+}
+
+/// Build the [`Globals`] block for a frame from the camera, RTC center, and the
+/// rendering options (with no face selected).
+pub fn build_globals(cam: &Camera, center: brepkit_math::vec::Point3, ambient: f32) -> Globals {
+    let view_proj = crate::camera::view_proj_rtc(cam, center);
+    let view_dir = cam.view_direction();
+    #[allow(clippy::cast_possible_truncation)]
+    Globals {
+        view_proj,
+        view_dir: [
+            view_dir.x() as f32,
+            view_dir.y() as f32,
+            view_dir.z() as f32,
+            0.0,
+        ],
+        ambient,
+        selected_id: 0,
+        _pad: [0.0; 2],
+    }
 }
 
 /// Render a solid's prepared geometry offscreen and read back color + ids.
@@ -98,6 +511,10 @@ fn acquire_device(instance: &wgpu::Instance) -> Result<(wgpu::Device, wgpu::Queu
 /// `mesh` is the center-relative geometry; `cam` and `opts` control the view
 /// and targets. This performs all GPU work synchronously (blocking on async
 /// via `pollster`).
+///
+/// # Errors
+///
+/// See [`crate::render_solid_offscreen`].
 #[allow(clippy::too_many_lines)]
 pub fn render(
     mesh: &RenderMesh,
@@ -111,8 +528,9 @@ pub fn render(
         });
     }
 
-    let instance = wgpu::Instance::default();
-    let (device, queue) = acquire_device(&instance)?;
+    let ctx = GpuContext::new(None)?;
+    let device = &ctx.device;
+    let queue = &ctx.queue;
 
     let (width, height) = (opts.width, opts.height);
     // Reject oversized targets with a clean error rather than tripping wgpu's
@@ -134,7 +552,7 @@ pub fn render(
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
-        format: COLOR_FORMAT,
+        format: COLOR_FORMAT_OFFSCREEN,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
     });
@@ -162,197 +580,17 @@ pub fn render(
     let depth_view = depth_tex.create_view(&wgpu::TextureViewDescriptor::default());
     let id_view = id_tex.create_view(&wgpu::TextureViewDescriptor::default());
 
-    // --- Uniforms ----------------------------------------------------------
-    let view_proj = crate::camera::view_proj_rtc(cam, mesh.center);
-    let view_dir = cam.view_direction();
-    #[allow(clippy::cast_possible_truncation)]
-    let globals = Globals {
-        view_proj,
-        view_dir: [
-            view_dir.x() as f32,
-            view_dir.y() as f32,
-            view_dir.z() as f32,
-            0.0,
-        ],
-        ambient: opts.ambient,
-        _pad: [0.0; 3],
-    };
-    let globals_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("globals"),
-        contents: bytemuck::bytes_of(&globals),
-        usage: wgpu::BufferUsages::UNIFORM,
-    });
-    let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-        label: Some("globals layout"),
-        entries: &[wgpu::BindGroupLayoutEntry {
-            binding: 0,
-            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-            ty: wgpu::BindingType::Buffer {
-                ty: wgpu::BufferBindingType::Uniform,
-                has_dynamic_offset: false,
-                min_binding_size: None,
-            },
-            count: None,
-        }],
-    });
-    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        label: Some("globals bind group"),
-        layout: &bind_group_layout,
-        entries: &[wgpu::BindGroupEntry {
-            binding: 0,
-            resource: globals_buf.as_entire_binding(),
-        }],
-    });
+    // --- Shared GPU objects ------------------------------------------------
+    let globals = build_globals(cam, mesh.center, opts.ambient);
+    let globals_binding = GlobalsBinding::new(device, &globals);
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("pipeline layout"),
-        bind_group_layouts: &[Some(&bind_group_layout)],
+        bind_group_layouts: &[Some(&globals_binding.layout)],
         immediate_size: 0,
     });
-
-    // --- Geometry buffers --------------------------------------------------
-    let vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("mesh vertices"),
-        contents: bytemuck::cast_slice(&mesh.vertices),
-        usage: wgpu::BufferUsages::VERTEX,
-    });
-    let index_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("mesh indices"),
-        contents: bytemuck::cast_slice(&mesh.indices),
-        usage: wgpu::BufferUsages::INDEX,
-    });
-
-    // --- Mesh pipeline -----------------------------------------------------
-    let mesh_shader = device.create_shader_module(wgpu::include_wgsl!("../shaders/mesh.wgsl"));
-    let color_targets = [
-        Some(wgpu::ColorTargetState {
-            format: COLOR_FORMAT,
-            blend: None,
-            write_mask: wgpu::ColorWrites::ALL,
-        }),
-        Some(wgpu::ColorTargetState {
-            format: ID_FORMAT,
-            blend: None,
-            write_mask: wgpu::ColorWrites::ALL,
-        }),
-    ];
-    let mesh_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("mesh pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &mesh_shader,
-            entry_point: Some("vs_main"),
-            buffers: &[wgpu::VertexBufferLayout {
-                array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: &[
-                    wgpu::VertexAttribute {
-                        format: wgpu::VertexFormat::Float32x3,
-                        offset: 0,
-                        shader_location: 0,
-                    },
-                    wgpu::VertexAttribute {
-                        format: wgpu::VertexFormat::Float32x3,
-                        offset: 12,
-                        shader_location: 1,
-                    },
-                    wgpu::VertexAttribute {
-                        format: wgpu::VertexFormat::Uint32,
-                        offset: 24,
-                        shader_location: 2,
-                    },
-                ],
-            }],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        },
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            cull_mode: None,
-            ..Default::default()
-        },
-        depth_stencil: Some(wgpu::DepthStencilState {
-            format: DEPTH_FORMAT,
-            depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Less),
-            stencil: wgpu::StencilState::default(),
-            bias: wgpu::DepthBiasState::default(),
-        }),
-        multisample: wgpu::MultisampleState::default(),
-        fragment: Some(wgpu::FragmentState {
-            module: &mesh_shader,
-            entry_point: Some("fs_main"),
-            targets: &color_targets,
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        }),
-        multiview_mask: None,
-        cache: None,
-    });
-
-    // --- Edge pipeline (optional) -----------------------------------------
-    let edge_resources = if opts.edges && !mesh.edge_vertices.is_empty() {
-        let edge_shader = device.create_shader_module(wgpu::include_wgsl!("../shaders/edge.wgsl"));
-        let edge_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("edge vertices"),
-            contents: bytemuck::cast_slice(&mesh.edge_vertices),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        // The id target is still bound during the edge pass, so give it a
-        // write target (edges keep the underlying face id; they only recolor).
-        let edge_color_targets = [
-            Some(wgpu::ColorTargetState {
-                format: COLOR_FORMAT,
-                blend: None,
-                write_mask: wgpu::ColorWrites::ALL,
-            }),
-            Some(wgpu::ColorTargetState {
-                format: ID_FORMAT,
-                blend: None,
-                write_mask: wgpu::ColorWrites::empty(),
-            }),
-        ];
-        let edge_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("edge pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &edge_shader,
-                entry_point: Some("vs_main"),
-                buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<EdgeVertex>() as wgpu::BufferAddress,
-                    step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &[wgpu::VertexAttribute {
-                        format: wgpu::VertexFormat::Float32x3,
-                        offset: 0,
-                        shader_location: 0,
-                    }],
-                }],
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            },
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::LineList,
-                ..Default::default()
-            },
-            depth_stencil: Some(wgpu::DepthStencilState {
-                format: DEPTH_FORMAT,
-                depth_write_enabled: Some(true),
-                depth_compare: Some(wgpu::CompareFunction::LessEqual),
-                stencil: wgpu::StencilState::default(),
-                bias: wgpu::DepthBiasState::default(),
-            }),
-            multisample: wgpu::MultisampleState::default(),
-            fragment: Some(wgpu::FragmentState {
-                module: &edge_shader,
-                entry_point: Some("fs_main"),
-                targets: &edge_color_targets,
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            }),
-            multiview_mask: None,
-            cache: None,
-        });
-        #[allow(clippy::cast_possible_truncation)]
-        let edge_count = mesh.edge_vertices.len() as u32;
-        Some((edge_pipeline, edge_buf, edge_count))
-    } else {
-        None
-    };
+    let with_edges = opts.edges && !mesh.edge_vertices.is_empty();
+    let pipelines = Pipelines::new(device, &pipeline_layout, COLOR_FORMAT_OFFSCREEN, with_edges);
+    let geometry = GeometryBuffers::new(device, mesh);
 
     // --- Readback buffers --------------------------------------------------
     // Bytes per row must be a multiple of COPY_BYTES_PER_ROW_ALIGNMENT (256).
@@ -375,66 +613,21 @@ pub fn render(
     });
 
     // --- Encode ------------------------------------------------------------
-    let bg = opts.background;
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("encoder"),
     });
-    {
-        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("mesh + edge pass"),
-            color_attachments: &[
-                Some(wgpu::RenderPassColorAttachment {
-                    view: &color_view,
-                    depth_slice: None,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color {
-                            r: f64::from(bg[0]),
-                            g: f64::from(bg[1]),
-                            b: f64::from(bg[2]),
-                            a: f64::from(bg[3]),
-                        }),
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-                Some(wgpu::RenderPassColorAttachment {
-                    view: &id_view,
-                    depth_slice: None,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        // 0 = background sentinel.
-                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-            ],
-            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                view: &depth_view,
-                depth_ops: Some(wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(1.0),
-                    store: wgpu::StoreOp::Store,
-                }),
-                stencil_ops: None,
-            }),
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        });
-
-        pass.set_bind_group(0, &bind_group, &[]);
-        pass.set_pipeline(&mesh_pipeline);
-        pass.set_vertex_buffer(0, vertex_buf.slice(..));
-        pass.set_index_buffer(index_buf.slice(..), wgpu::IndexFormat::Uint32);
-        #[allow(clippy::cast_possible_truncation)]
-        let index_count = mesh.indices.len() as u32;
-        pass.draw_indexed(0..index_count, 0, 0..1);
-
-        if let Some((edge_pipeline, edge_buf, edge_count)) = edge_resources.as_ref() {
-            pass.set_pipeline(edge_pipeline);
-            pass.set_vertex_buffer(0, edge_buf.slice(..));
-            pass.draw(0..*edge_count, 0..1);
-        }
-    }
+    encode_scene(
+        &mut encoder,
+        &pipelines,
+        &globals_binding,
+        &geometry,
+        &PassTargets {
+            color: &color_view,
+            id: &id_view,
+            depth: &depth_view,
+            background: opts.background,
+        },
+    );
 
     encoder.copy_texture_to_buffer(
         wgpu::TexelCopyTextureInfo {
@@ -474,8 +667,8 @@ pub fn render(
     queue.submit(Some(encoder.finish()));
 
     // --- Map + read --------------------------------------------------------
-    let color_bytes = map_and_read(&device, &color_readback)?;
-    let id_bytes = map_and_read(&device, &id_readback)?;
+    let color_bytes = map_and_read(device, &color_readback)?;
+    let id_bytes = map_and_read(device, &id_readback)?;
 
     let color = unpad_to_rgba(&color_bytes, width, height, color_padded_bpr);
     let id_buffer = unpad_to_u32(&id_bytes, width, height, id_padded_bpr);
@@ -489,14 +682,14 @@ pub fn render(
 }
 
 /// Round `width * bpp` up to the next multiple of the row-copy alignment.
-fn padded_bytes_per_row(width: u32, bytes_per_pixel: u32) -> u32 {
+pub fn padded_bytes_per_row(width: u32, bytes_per_pixel: u32) -> u32 {
     let unpadded = width * bytes_per_pixel;
     let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
     unpadded.div_ceil(align) * align
 }
 
 /// Map a readback buffer (blocking) and copy its bytes out.
-fn map_and_read(device: &wgpu::Device, buffer: &wgpu::Buffer) -> Result<Vec<u8>, RenderError> {
+pub fn map_and_read(device: &wgpu::Device, buffer: &wgpu::Buffer) -> Result<Vec<u8>, RenderError> {
     use std::sync::mpsc;
     let (tx, rx) = mpsc::channel();
     buffer.slice(..).map_async(wgpu::MapMode::Read, move |res| {

--- a/crates/render/src/viewer.rs
+++ b/crates/render/src/viewer.rs
@@ -1,0 +1,809 @@
+//! Interactive viewer window (winit surface + orbit camera + click-to-pick).
+//!
+//! [`view_solid`] opens a window that renders a solid with the same Lambert
+//! mesh + crisp-edge pipeline as the offscreen path ([`crate::pipeline`]), but
+//! to a swapchain surface instead of a texture. It adds:
+//!
+//! - **Orbit camera:** left-drag orbits (azimuth/elevation), the scroll wheel
+//!   dollies in/out, and right-drag (or shift + left-drag) pans the target.
+//! - **Click-to-pick:** a left click that does not drag reads the per-pixel
+//!   face-id target under the cursor and highlights the picked
+//!   [`FaceId`](brepkit_topology::face::FaceId) by tinting it in the shader.
+//!
+//! The face-id target is the same `R32Uint` buffer the offscreen renderer
+//! produces, so a click yields the kernel `FaceId` directly — the CAD payoff.
+//!
+//! # Running
+//!
+//! This needs a display server and the `window` feature:
+//!
+//! ```text
+//! cargo run -p brepkit-render --example viewer --features window
+//! ```
+//!
+//! It cannot run headlessly (no surface without a display); the offscreen path
+//! ([`crate::render_solid_offscreen`]) covers headless rendering.
+//!
+//! # Precision
+//!
+//! Like the offscreen path, geometry is uploaded relative to the model's AABB
+//! center (RTC) and the f64 center is folded into the view matrix, so models
+//! far from the origin stay crisp.
+
+use std::sync::Arc;
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+use winit::application::ApplicationHandler;
+use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::keyboard::ModifiersState;
+use winit::window::{Window, WindowId};
+
+use crate::DEFAULT_DEFLECTION;
+use crate::camera::Camera;
+use crate::error::RenderError;
+use crate::mesh::RenderMesh;
+use crate::pipeline::{self, DEPTH_FORMAT, GeometryBuffers, GlobalsBinding, ID_FORMAT, Pipelines};
+
+/// Options controlling an interactive viewer window.
+#[derive(Debug, Clone)]
+pub struct ViewOpts {
+    /// Window title.
+    pub title: String,
+    /// Initial window width in physical pixels.
+    pub width: u32,
+    /// Initial window height in physical pixels.
+    pub height: u32,
+    /// Background clear color as linear RGBA in `[0, 1]`.
+    pub background: [f32; 4],
+    /// Ambient light fraction in `[0, 1]`.
+    pub ambient: f32,
+    /// Draw topological edges as crisp dark lines.
+    pub edges: bool,
+    /// Linear chord tolerance for tessellation (smaller = finer mesh).
+    pub deflection: f64,
+}
+
+impl Default for ViewOpts {
+    fn default() -> Self {
+        Self {
+            title: "brepkit viewer".to_string(),
+            width: 1024,
+            height: 768,
+            background: [0.11, 0.12, 0.14, 1.0],
+            ambient: 0.25,
+            edges: true,
+            deflection: DEFAULT_DEFLECTION,
+        }
+    }
+}
+
+impl ViewOpts {
+    /// Default options with a custom title.
+    #[must_use]
+    pub fn new(title: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            ..Self::default()
+        }
+    }
+}
+
+/// Open an interactive window showing `solid`, blocking until it is closed.
+///
+/// Left-drag orbits, scroll zooms, right-drag (or shift + left-drag) pans, and a
+/// left click highlights the picked face. Tessellation happens once up front;
+/// only the camera and selection change per frame.
+///
+/// # Errors
+///
+/// - [`RenderError::Operations`] / [`RenderError::Topology`] if the solid
+///   cannot be tessellated.
+/// - [`RenderError::EventLoop`] if the windowing event loop fails to start.
+/// - [`RenderError::NoAdapter`] / [`RenderError::DeviceRequest`] /
+///   [`RenderError::SurfaceConfig`] on GPU/surface setup failure (surfaced from
+///   inside the loop).
+pub fn view_solid(topo: &Topology, solid: SolidId, opts: &ViewOpts) -> Result<(), RenderError> {
+    let mesh = RenderMesh::build(topo, solid, opts.deflection)?;
+
+    let event_loop = EventLoop::new().map_err(|e| RenderError::EventLoop(e.to_string()))?;
+    // Wait for events rather than busy-looping; we explicitly request redraws on
+    // interaction and resize.
+    event_loop.set_control_flow(ControlFlow::Wait);
+
+    let mut app = ViewerApp::new(mesh, opts.clone());
+    event_loop
+        .run_app(&mut app)
+        .map_err(|e| RenderError::EventLoop(e.to_string()))?;
+    app.into_result()
+}
+
+/// An orbit camera parameterized by spherical coordinates around a target.
+#[derive(Debug, Clone, Copy)]
+struct OrbitCamera {
+    target: Point3,
+    /// Horizontal angle (radians) about the world +Z axis.
+    azimuth: f64,
+    /// Vertical angle (radians) from the XY plane, clamped away from the poles.
+    elevation: f64,
+    /// Eye distance from the target.
+    distance: f64,
+    fov_y: f64,
+    near: f64,
+    far: f64,
+}
+
+/// Keep elevation a hair below the poles so the up vector never degenerates.
+const ELEVATION_LIMIT: f64 = std::f64::consts::FRAC_PI_2 - 0.01;
+
+impl OrbitCamera {
+    /// Frame a model of bounding-sphere `radius` centered at `target` from an
+    /// isometric-ish direction, matching the offscreen test's framing.
+    fn framing(target: Point3, radius: f64) -> Self {
+        let fov_y = 40.0_f64.to_radians();
+        let radius = radius.max(1e-6);
+        let distance = radius / (fov_y * 0.5).sin() * 2.0;
+        Self {
+            target,
+            azimuth: 45.0_f64.to_radians(),
+            elevation: 30.0_f64.to_radians(),
+            distance,
+            fov_y,
+            near: (distance - radius).max(radius * 0.01),
+            far: distance + radius * 4.0,
+        }
+    }
+
+    /// Unit direction from the target toward the eye.
+    fn eye_dir(&self) -> Vec3 {
+        let ce = self.elevation.cos();
+        Vec3::new(
+            ce * self.azimuth.cos(),
+            ce * self.azimuth.sin(),
+            self.elevation.sin(),
+        )
+    }
+
+    /// Build the f64 [`Camera`] for the current orbit state at `aspect`.
+    fn camera(&self, aspect: f64) -> Camera {
+        let eye = self.target + self.eye_dir() * self.distance;
+        Camera {
+            eye,
+            target: self.target,
+            up: Vec3::new(0.0, 0.0, 1.0),
+            fov_y: self.fov_y,
+            aspect,
+            near: self.near,
+            far: self.far,
+        }
+    }
+
+    /// Orbit by mouse deltas (pixels): horizontal drag changes azimuth,
+    /// vertical drag changes elevation (clamped away from the poles).
+    fn orbit(&mut self, dx: f64, dy: f64) {
+        const SPEED: f64 = 0.005;
+        self.azimuth -= dx * SPEED;
+        self.elevation = (self.elevation + dy * SPEED).clamp(-ELEVATION_LIMIT, ELEVATION_LIMIT);
+    }
+
+    /// Dolly toward/away from the target by a scroll amount (multiplicative so
+    /// zoom feels uniform regardless of current distance). Keeps near/far sane.
+    fn dolly(&mut self, amount: f64) {
+        let factor = (1.0 - amount * 0.1).clamp(0.2, 5.0);
+        self.distance = (self.distance * factor).max(self.near * 0.5 + 1e-6);
+    }
+
+    /// Pan the target in the camera's view plane by mouse deltas (pixels),
+    /// scaled by distance so panning tracks the cursor at any zoom.
+    fn pan(&mut self, dx: f64, dy: f64) {
+        // eye_dir points target -> eye, so forward (eye -> target) is its negation.
+        let forward = -self.eye_dir();
+        let up = Vec3::new(0.0, 0.0, 1.0);
+        let right = forward
+            .cross(up)
+            .normalize()
+            .unwrap_or(Vec3::new(1.0, 0.0, 0.0));
+        let cam_up = right.cross(forward);
+        let scale = self.distance * 0.0015;
+        // Drag right -> scene moves right -> target moves left; drag down ->
+        // target moves up. Hence the sign choices below.
+        self.target = self.target + right * (-dx * scale) + cam_up * (dy * scale);
+    }
+}
+
+/// What a left-drag currently does, decided at press time by the modifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DragMode {
+    None,
+    Orbit,
+    Pan,
+}
+
+/// Size-dependent render targets: the depth buffer, the `R32Uint` id target
+/// (kept as a texture so it can be copied back for picking), and a scratch
+/// color target used by the on-demand id render during a pick.
+struct Targets {
+    depth_view: wgpu::TextureView,
+    id_texture: wgpu::Texture,
+    id_view: wgpu::TextureView,
+    pick_color_view: wgpu::TextureView,
+}
+
+impl Targets {
+    fn new(device: &wgpu::Device, format: wgpu::TextureFormat, width: u32, height: u32) -> Self {
+        let extent = wgpu::Extent3d {
+            width: width.max(1),
+            height: height.max(1),
+            depth_or_array_layers: 1,
+        };
+        let depth_tex = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("viewer depth"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let id_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("viewer id target"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: ID_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let pick_color = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("viewer pick scratch color"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        Self {
+            depth_view: depth_tex.create_view(&wgpu::TextureViewDescriptor::default()),
+            id_view: id_texture.create_view(&wgpu::TextureViewDescriptor::default()),
+            id_texture,
+            pick_color_view: pick_color.create_view(&wgpu::TextureViewDescriptor::default()),
+        }
+    }
+}
+
+/// GPU + window state, created lazily in `resumed` once a window exists.
+struct GpuState {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    pipelines: Pipelines,
+    globals: GlobalsBinding,
+    geometry: GeometryBuffers,
+    targets: Targets,
+}
+
+impl GpuState {
+    /// Reconfigure the surface and rebuild size-dependent targets.
+    ///
+    /// The size is clamped to the device's max 2D texture dimension so an
+    /// oversized window never trips GPU validation on strict drivers.
+    fn resize(&mut self, size: PhysicalSize<u32>) {
+        if size.width == 0 || size.height == 0 {
+            return;
+        }
+        let max = self.device.limits().max_texture_dimension_2d;
+        self.config.width = size.width.min(max);
+        self.config.height = size.height.min(max);
+        self.surface.configure(&self.device, &self.config);
+        self.targets = Targets::new(
+            &self.device,
+            self.config.format,
+            self.config.width,
+            self.config.height,
+        );
+    }
+
+    /// Aspect ratio (width / height) of the current surface.
+    fn aspect(&self) -> f64 {
+        aspect_of(self.config.width, self.config.height)
+    }
+}
+
+/// Aspect ratio (width / height), guarding against a zero dimension.
+fn aspect_of(width: u32, height: u32) -> f64 {
+    f64::from(width.max(1)) / f64::from(height.max(1))
+}
+
+/// The winit application: owns the prepared geometry, options, orbit state, and
+/// (once resumed) the GPU/window state. Any setup error is stashed in `error`
+/// and the loop exits so `view_solid` can surface it.
+struct ViewerApp {
+    mesh: RenderMesh,
+    opts: ViewOpts,
+    orbit: OrbitCamera,
+    gpu: Option<GpuState>,
+    error: Option<RenderError>,
+
+    // Input state.
+    modifiers: ModifiersState,
+    cursor: PhysicalPosition<f64>,
+    drag: DragMode,
+    right_drag: bool,
+    /// Cursor position when the left button went down, to distinguish a click
+    /// (pick) from a drag (orbit/pan).
+    press_pos: Option<PhysicalPosition<f64>>,
+    moved_while_pressed: bool,
+    /// Encoded id (`FaceId.index() + 1`) of the highlighted face, or 0 for none.
+    selected_id: u32,
+}
+
+/// Pixel-distance threshold below which a press+release counts as a click, not
+/// a drag.
+const CLICK_SLOP: f64 = 4.0;
+
+impl ViewerApp {
+    fn new(mesh: RenderMesh, opts: ViewOpts) -> Self {
+        // Frame the model from its tessellated AABB (the mesh positions are in
+        // world space; center is the RTC origin).
+        let (min, max) = mesh_world_aabb(&mesh);
+        let center = Point3::new(
+            (min.x() + max.x()) * 0.5,
+            (min.y() + max.y()) * 0.5,
+            (min.z() + max.z()) * 0.5,
+        );
+        let radius = ((max.x() - min.x()).powi(2)
+            + (max.y() - min.y()).powi(2)
+            + (max.z() - min.z()).powi(2))
+        .sqrt()
+            * 0.5;
+        let orbit = OrbitCamera::framing(center, radius);
+
+        Self {
+            mesh,
+            opts,
+            orbit,
+            gpu: None,
+            error: None,
+            modifiers: ModifiersState::empty(),
+            cursor: PhysicalPosition::new(0.0, 0.0),
+            drag: DragMode::None,
+            right_drag: false,
+            press_pos: None,
+            moved_while_pressed: false,
+            selected_id: 0,
+        }
+    }
+
+    /// Consume the app and return any deferred setup error.
+    fn into_result(self) -> Result<(), RenderError> {
+        match self.error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// Ask the window to redraw, if it exists yet.
+    fn request_redraw(&self) {
+        if let Some(gpu) = self.gpu.as_ref() {
+            gpu.window.request_redraw();
+        }
+    }
+
+    /// Record a setup error and ask the loop to exit.
+    fn fail(&mut self, event_loop: &ActiveEventLoop, err: RenderError) {
+        if self.error.is_none() {
+            self.error = Some(err);
+        }
+        event_loop.exit();
+    }
+
+    /// Build the GPU state for a freshly created window.
+    fn init_gpu(&self, window: Arc<Window>) -> Result<GpuState, RenderError> {
+        let instance = wgpu::Instance::default();
+        // An Arc<Window> is 'static and implements winit's window/display handle
+        // traits, which is exactly what wgpu 29's create_surface accepts.
+        let surface = instance
+            .create_surface(window.clone())
+            .map_err(|e| RenderError::SurfaceConfig(e.to_string()))?;
+
+        let ctx = pipeline::GpuContext::with_instance(instance, Some(&surface))?;
+
+        // Clamp the surface/target size to the device's max 2D texture
+        // dimension so an oversized window never trips GPU validation.
+        let max = ctx.device.limits().max_texture_dimension_2d;
+        let size = window.inner_size();
+        let width = size.width.clamp(1, max);
+        let height = size.height.clamp(1, max);
+
+        let caps = surface.get_capabilities(&ctx.adapter);
+        let format = choose_surface_format(&caps);
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width,
+            height,
+            present_mode: caps
+                .present_modes
+                .first()
+                .copied()
+                .unwrap_or(wgpu::PresentMode::Fifo),
+            desired_maximum_frame_latency: 2,
+            alpha_mode: caps
+                .alpha_modes
+                .first()
+                .copied()
+                .unwrap_or(wgpu::CompositeAlphaMode::Auto),
+            view_formats: vec![],
+        };
+        surface.configure(&ctx.device, &config);
+
+        let cam = self.orbit.camera(aspect_of(width, height));
+        let globals = pipeline::build_globals(&cam, self.mesh.center, self.opts.ambient);
+        let globals = GlobalsBinding::new(&ctx.device, &globals);
+        let pipeline_layout = ctx
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("viewer pipeline layout"),
+                bind_group_layouts: &[Some(&globals.layout)],
+                immediate_size: 0,
+            });
+        let with_edges = self.opts.edges && !self.mesh.edge_vertices.is_empty();
+        let pipelines = Pipelines::new(&ctx.device, &pipeline_layout, format, with_edges);
+        let geometry = GeometryBuffers::new(&ctx.device, &self.mesh);
+        let targets = Targets::new(&ctx.device, format, width, height);
+
+        Ok(GpuState {
+            window,
+            surface,
+            device: ctx.device,
+            queue: ctx.queue,
+            config,
+            pipelines,
+            globals,
+            geometry,
+            targets,
+        })
+    }
+
+    /// Upload the current camera + selection and draw one frame to the surface.
+    fn redraw(&mut self) {
+        let Some(gpu) = self.gpu.as_mut() else {
+            return;
+        };
+
+        let frame = match gpu.surface.get_current_texture() {
+            wgpu::CurrentSurfaceTexture::Success(f)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(f) => f,
+            // Surface needs reconfiguring; do it and skip this frame (a fresh
+            // redraw is requested below).
+            wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
+                let size = PhysicalSize::new(gpu.config.width, gpu.config.height);
+                gpu.resize(size);
+                gpu.window.request_redraw();
+                return;
+            }
+            // Transient: skip and try again next frame.
+            wgpu::CurrentSurfaceTexture::Timeout
+            | wgpu::CurrentSurfaceTexture::Occluded
+            | wgpu::CurrentSurfaceTexture::Validation => return,
+        };
+
+        let cam = self.orbit.camera(gpu.aspect());
+        let mut globals = pipeline::build_globals(&cam, self.mesh.center, self.opts.ambient);
+        globals.selected_id = self.selected_id;
+        gpu.globals.upload(&gpu.queue, &globals);
+
+        let color_view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("viewer encoder"),
+            });
+        pipeline::encode_scene(
+            &mut encoder,
+            &gpu.pipelines,
+            &gpu.globals,
+            &gpu.geometry,
+            &pipeline::PassTargets {
+                color: &color_view,
+                id: &gpu.targets.id_view,
+                depth: &gpu.targets.depth_view,
+                background: self.opts.background,
+            },
+        );
+        gpu.queue.submit(Some(encoder.finish()));
+        gpu.window.pre_present_notify();
+        frame.present();
+    }
+
+    /// Render the id buffer for the current camera and read the face id under
+    /// the cursor, updating the highlight. Returns whether the selection
+    /// changed (so the caller can request a redraw).
+    ///
+    /// The id pass is rendered fresh here rather than reusing the last frame's
+    /// id target, so a pick is correct even immediately after a resize (before
+    /// the next on-screen redraw).
+    fn pick(&mut self) -> bool {
+        let Some(gpu) = self.gpu.as_ref() else {
+            return false;
+        };
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let px = self.cursor.x.round() as i64;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let py = self.cursor.y.round() as i64;
+        if px < 0 || py < 0 {
+            return false;
+        }
+        let (px, py) = (px as u32, py as u32);
+        if px >= gpu.config.width || py >= gpu.config.height {
+            return false;
+        }
+
+        // Re-render the id target for the current camera (selection irrelevant
+        // to face ids), then read the one pixel.
+        let cam = self.orbit.camera(gpu.aspect());
+        let globals = pipeline::build_globals(&cam, self.mesh.center, self.opts.ambient);
+        gpu.globals.upload(&gpu.queue, &globals);
+
+        let picked = match render_and_read_id(gpu, &self.opts.background, px, py) {
+            Ok(id) => id,
+            Err(_) => return false,
+        };
+        // Clicking the same face again clears the highlight.
+        let next = if picked == self.selected_id {
+            0
+        } else {
+            picked
+        };
+        if next == self.selected_id {
+            return false;
+        }
+        self.selected_id = next;
+        true
+    }
+}
+
+impl ApplicationHandler for ViewerApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.gpu.is_some() {
+            return;
+        }
+        let attrs = Window::default_attributes()
+            .with_title(self.opts.title.clone())
+            .with_inner_size(PhysicalSize::new(self.opts.width, self.opts.height));
+        let window = match event_loop.create_window(attrs) {
+            Ok(w) => Arc::new(w),
+            Err(e) => {
+                self.fail(event_loop, RenderError::EventLoop(e.to_string()));
+                return;
+            }
+        };
+        match self.init_gpu(window) {
+            Ok(gpu) => {
+                gpu.window.request_redraw();
+                self.gpu = Some(gpu);
+            }
+            Err(e) => self.fail(event_loop, e),
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+
+            WindowEvent::Resized(size) => {
+                if let Some(gpu) = self.gpu.as_mut() {
+                    gpu.resize(size);
+                    gpu.window.request_redraw();
+                }
+            }
+
+            WindowEvent::ModifiersChanged(mods) => {
+                self.modifiers = mods.state();
+            }
+
+            WindowEvent::MouseInput { state, button, .. } => match (button, state) {
+                (MouseButton::Left, ElementState::Pressed) => {
+                    self.press_pos = Some(self.cursor);
+                    self.moved_while_pressed = false;
+                    self.drag = if self.modifiers.shift_key() {
+                        DragMode::Pan
+                    } else {
+                        DragMode::Orbit
+                    };
+                }
+                (MouseButton::Left, ElementState::Released) => {
+                    // A press with negligible movement is a pick; otherwise it
+                    // was a drag and the camera already moved.
+                    let was_click = self
+                        .press_pos
+                        .map(|p| {
+                            (p.x - self.cursor.x).abs() <= CLICK_SLOP
+                                && (p.y - self.cursor.y).abs() <= CLICK_SLOP
+                        })
+                        .unwrap_or(false)
+                        && !self.moved_while_pressed;
+                    self.drag = DragMode::None;
+                    self.press_pos = None;
+                    if was_click && self.pick() {
+                        self.request_redraw();
+                    }
+                }
+                (MouseButton::Right, ElementState::Pressed) => self.right_drag = true,
+                (MouseButton::Right, ElementState::Released) => self.right_drag = false,
+                _ => {}
+            },
+
+            WindowEvent::CursorMoved { position, .. } => {
+                let dx = position.x - self.cursor.x;
+                let dy = position.y - self.cursor.y;
+                self.cursor = position;
+
+                // Right-drag always pans; otherwise the left-drag mode decides.
+                let changed = if self.right_drag {
+                    self.orbit.pan(dx, dy);
+                    true
+                } else {
+                    match self.drag {
+                        DragMode::Orbit => {
+                            self.orbit.orbit(dx, dy);
+                            true
+                        }
+                        DragMode::Pan => {
+                            self.orbit.pan(dx, dy);
+                            true
+                        }
+                        DragMode::None => false,
+                    }
+                };
+                if changed {
+                    self.moved_while_pressed = true;
+                    self.request_redraw();
+                }
+            }
+
+            WindowEvent::MouseWheel { delta, .. } => {
+                let amount = match delta {
+                    MouseScrollDelta::LineDelta(_, y) => f64::from(y),
+                    MouseScrollDelta::PixelDelta(p) => p.y / 50.0,
+                };
+                self.orbit.dolly(amount);
+                self.request_redraw();
+            }
+
+            WindowEvent::RedrawRequested => self.redraw(),
+
+            _ => {}
+        }
+    }
+}
+
+/// Prefer an sRGB surface format (so shading matches the offscreen
+/// `Rgba8UnormSrgb` path); fall back to the surface's preferred format.
+fn choose_surface_format(caps: &wgpu::SurfaceCapabilities) -> wgpu::TextureFormat {
+    caps.formats
+        .iter()
+        .copied()
+        .find(wgpu::TextureFormat::is_srgb)
+        .or_else(|| caps.formats.first().copied())
+        .unwrap_or(wgpu::TextureFormat::Bgra8UnormSrgb)
+}
+
+/// Render the id target for the current (already-uploaded) globals, then copy
+/// the single row containing `(px, py)` back and decode that pixel.
+///
+/// The id target is `R32Uint`; the value is `FaceId.index() + 1` (or 0 for
+/// background). Rendering the id pass here makes the pick independent of the
+/// last on-screen frame. The scratch color target absorbs the color writes the
+/// shared pass also produces (only the id is read back).
+fn render_and_read_id(
+    gpu: &GpuState,
+    background: &[f32; 4],
+    px: u32,
+    py: u32,
+) -> Result<u32, RenderError> {
+    let padded_bpr = pipeline::padded_bytes_per_row(gpu.config.width, 4);
+
+    // Read back only the one row that holds the picked pixel.
+    let readback = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("id pick readback"),
+        size: u64::from(padded_bpr),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = gpu
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("id pick encoder"),
+        });
+    pipeline::encode_scene(
+        &mut encoder,
+        &gpu.pipelines,
+        &gpu.globals,
+        &gpu.geometry,
+        &pipeline::PassTargets {
+            color: &gpu.targets.pick_color_view,
+            id: &gpu.targets.id_view,
+            depth: &gpu.targets.depth_view,
+            background: *background,
+        },
+    );
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &gpu.targets.id_texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d { x: 0, y: py, z: 0 },
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bpr),
+                rows_per_image: Some(1),
+            },
+        },
+        wgpu::Extent3d {
+            width: gpu.config.width,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+    );
+    gpu.queue.submit(Some(encoder.finish()));
+
+    let bytes = pipeline::map_and_read(&gpu.device, &readback)?;
+    let off = (px * 4) as usize;
+    let id = bytes
+        .get(off..off + 4)
+        .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .unwrap_or(0);
+    Ok(id)
+}
+
+/// Axis-aligned bounding box of the mesh's world-space positions, recovered by
+/// adding the RTC center back to the uploaded center-relative vertices.
+fn mesh_world_aabb(mesh: &RenderMesh) -> (Point3, Point3) {
+    let mut min = [f64::INFINITY; 3];
+    let mut max = [f64::NEG_INFINITY; 3];
+    for v in &mesh.vertices {
+        let p = [
+            f64::from(v.position[0]) + mesh.center.x(),
+            f64::from(v.position[1]) + mesh.center.y(),
+            f64::from(v.position[2]) + mesh.center.z(),
+        ];
+        for i in 0..3 {
+            if p[i] < min[i] {
+                min[i] = p[i];
+            }
+            if p[i] > max[i] {
+                max[i] = p[i];
+            }
+        }
+    }
+    if !min[0].is_finite() {
+        return (Point3::new(-1.0, -1.0, -1.0), Point3::new(1.0, 1.0, 1.0));
+    }
+    (
+        Point3::new(min[0], min[1], min[2]),
+        Point3::new(max[0], max[1], max[2]),
+    )
+}

--- a/crates/render/src/viewer.rs
+++ b/crates/render/src/viewer.rs
@@ -131,9 +131,11 @@ struct OrbitCamera {
     elevation: f64,
     /// Eye distance from the target.
     distance: f64,
+    /// Model bounding-sphere radius; sets the scale for the clip planes so they
+    /// track `distance` as the user zooms (see [`OrbitCamera::clip_planes`]).
+    radius: f64,
+    /// Vertical field of view (radians).
     fov_y: f64,
-    near: f64,
-    far: f64,
 }
 
 /// Keep elevation a hair below the poles so the up vector never degenerates.
@@ -151,9 +153,8 @@ impl OrbitCamera {
             azimuth: 45.0_f64.to_radians(),
             elevation: 30.0_f64.to_radians(),
             distance,
+            radius,
             fov_y,
-            near: (distance - radius).max(radius * 0.01),
-            far: distance + radius * 4.0,
         }
     }
 
@@ -167,17 +168,32 @@ impl OrbitCamera {
         )
     }
 
+    /// Near/far clip planes for the current eye distance.
+    ///
+    /// Derived from `distance` (not cached) so the model stays inside the
+    /// frustum across the whole zoom range: the model spans roughly
+    /// `[distance - radius, distance + radius]` from the eye, so near sits just
+    /// inside the near surface and far just beyond the far surface. Both are
+    /// kept strictly positive with `near < far`.
+    fn clip_planes(&self) -> (f64, f64) {
+        let near = (self.distance - self.radius).max(self.distance * 0.01);
+        let near = near.max(1e-4);
+        let far = (self.distance + self.radius * 4.0).max(near * 10.0);
+        (near, far)
+    }
+
     /// Build the f64 [`Camera`] for the current orbit state at `aspect`.
     fn camera(&self, aspect: f64) -> Camera {
         let eye = self.target + self.eye_dir() * self.distance;
+        let (near, far) = self.clip_planes();
         Camera {
             eye,
             target: self.target,
             up: Vec3::new(0.0, 0.0, 1.0),
             fov_y: self.fov_y,
             aspect,
-            near: self.near,
-            far: self.far,
+            near,
+            far,
         }
     }
 
@@ -190,10 +206,15 @@ impl OrbitCamera {
     }
 
     /// Dolly toward/away from the target by a scroll amount (multiplicative so
-    /// zoom feels uniform regardless of current distance). Keeps near/far sane.
+    /// zoom feels uniform regardless of current distance).
+    ///
+    /// The clip planes are recomputed from `distance` in [`OrbitCamera::camera`],
+    /// so zooming never leaves the model behind a stale near/far plane. Distance
+    /// is floored to a small fraction of the model radius so it can't collapse
+    /// to zero.
     fn dolly(&mut self, amount: f64) {
         let factor = (1.0 - amount * 0.1).clamp(0.2, 5.0);
-        self.distance = (self.distance * factor).max(self.near * 0.5 + 1e-6);
+        self.distance = (self.distance * factor).max(self.radius * 0.05 + 1e-6);
     }
 
     /// Pan the target in the camera's view plane by mouse deltas (pixels),
@@ -431,10 +452,14 @@ impl ViewerApp {
             format,
             width,
             height,
+            // Fifo (vsync) is guaranteed supported by the WebGPU spec; prefer it
+            // explicitly rather than trusting the first advertised mode.
             present_mode: caps
                 .present_modes
-                .first()
+                .iter()
                 .copied()
+                .find(|m| *m == wgpu::PresentMode::Fifo)
+                .or_else(|| caps.present_modes.first().copied())
                 .unwrap_or(wgpu::PresentMode::Fifo),
             desired_maximum_frame_latency: 2,
             alpha_mode: caps
@@ -539,17 +564,22 @@ impl ViewerApp {
         let Some(gpu) = self.gpu.as_ref() else {
             return false;
         };
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let px = self.cursor.x.round() as i64;
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let py = self.cursor.y.round() as i64;
-        if px < 0 || py < 0 {
+        if gpu.config.width == 0 || gpu.config.height == 0 {
             return false;
         }
-        let (px, py) = (px as u32, py as u32);
-        if px >= gpu.config.width || py >= gpu.config.height {
+        // Reject positions outside the viewport, then floor to a pixel index and
+        // clamp to the last in-bounds pixel so an in-bounds cursor (which can sit
+        // at exactly `width`/`height` at the far edge) never reads out of range.
+        let (w, h) = (gpu.config.width, gpu.config.height);
+        let cx = self.cursor.x;
+        let cy = self.cursor.y;
+        if cx < 0.0 || cy < 0.0 || cx >= f64::from(w) || cy >= f64::from(h) {
             return false;
         }
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let px = (cx.floor() as u32).min(w - 1);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let py = (cy.floor() as u32).min(h - 1);
 
         // Re-render the id target for the current camera (selection irrelevant
         // to face ids), then read the one pixel.
@@ -559,7 +589,12 @@ impl ViewerApp {
 
         let picked = match render_and_read_id(gpu, &self.opts.background, px, py) {
             Ok(id) => id,
-            Err(_) => return false,
+            Err(e) => {
+                // Non-fatal: a failed id readback (e.g. device lost) must not
+                // crash the viewer, but surface it so it isn't a silent no-op.
+                log::warn!("brepkit-render: face pick readback failed: {e}");
+                return false;
+            }
         };
         // Clicking the same face again clears the highlight.
         let next = if picked == self.selected_id {
@@ -631,16 +666,14 @@ impl ApplicationHandler for ViewerApp {
                     };
                 }
                 (MouseButton::Left, ElementState::Released) => {
-                    // A press with negligible movement is a pick; otherwise it
-                    // was a drag and the camera already moved.
-                    let was_click = self
-                        .press_pos
-                        .map(|p| {
-                            (p.x - self.cursor.x).abs() <= CLICK_SLOP
-                                && (p.y - self.cursor.y).abs() <= CLICK_SLOP
-                        })
-                        .unwrap_or(false)
-                        && !self.moved_while_pressed;
+                    // A press that never left the click slop (neither at release
+                    // nor at any point during the press) is a pick; anything that
+                    // dragged past the slop already moved the camera.
+                    let near_press = self.press_pos.is_some_and(|p| {
+                        (p.x - self.cursor.x).abs() <= CLICK_SLOP
+                            && (p.y - self.cursor.y).abs() <= CLICK_SLOP
+                    });
+                    let was_click = near_press && !self.moved_while_pressed;
                     self.drag = DragMode::None;
                     self.press_pos = None;
                     if was_click && self.pick() {
@@ -675,7 +708,13 @@ impl ApplicationHandler for ViewerApp {
                     }
                 };
                 if changed {
-                    self.moved_while_pressed = true;
+                    // Only count as a drag (suppressing a pick) once the cursor
+                    // has moved beyond the click slop from where it was pressed;
+                    // sub-slop jitter must still register as a click.
+                    self.moved_while_pressed |= self.press_pos.is_some_and(|p| {
+                        (p.x - self.cursor.x).abs() > CLICK_SLOP
+                            || (p.y - self.cursor.y).abs() > CLICK_SLOP
+                    });
                     self.request_redraw();
                 }
             }
@@ -806,4 +845,80 @@ fn mesh_world_aabb(mesh: &RenderMesh) -> (Point3, Point3) {
         Point3::new(min[0], min[1], min[2]),
         Point3::new(max[0], max[1], max[2]),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The model spans `[distance - radius, distance + radius]` along the view
+    /// ray. Some of it must be visible (not entirely clipped) and the back must
+    /// not be clipped away, with a valid frustum throughout. (The near plane may
+    /// legitimately sit ahead of the model front when the eye is *inside* the
+    /// bounding sphere — that geometry is correctly behind the camera.)
+    fn model_visible(cam: &OrbitCamera) -> bool {
+        let (near, far) = cam.clip_planes();
+        let model_far = cam.distance + cam.radius;
+        near > 0.0 && near < far && near < model_far && far >= model_far
+    }
+
+    /// When the eye is outside the bounding sphere (the normal framing regime),
+    /// the near plane must also not clip the *front* of the model.
+    fn whole_model_visible(cam: &OrbitCamera) -> bool {
+        let (near, _far) = cam.clip_planes();
+        let model_near = cam.distance - cam.radius;
+        model_visible(cam) && near <= model_near + 1e-9
+    }
+
+    #[test]
+    fn clip_planes_valid_across_full_zoom_range() {
+        let mut cam = OrbitCamera::framing(Point3::new(10.0, 20.0, 30.0), 50.0);
+        // Initial framing sits well outside the model, so the whole model fits.
+        assert!(
+            whole_model_visible(&cam),
+            "initial framing must show the whole model"
+        );
+
+        // Zoom all the way in: repeated dolly-in must never produce an invalid
+        // frustum or clip the model entirely out of view.
+        for _ in 0..200 {
+            cam.dolly(1.0);
+            let (near, far) = cam.clip_planes();
+            assert!(near > 0.0, "near must stay positive (near={near})");
+            assert!(near < far, "near < far must hold (near={near} far={far})");
+            assert!(model_visible(&cam), "model must stay visible zooming in");
+        }
+
+        // Zoom all the way out: the model must remain fully framed (eye stays
+        // outside the bounding sphere), so this is the regime the P1 bug hit.
+        let mut cam = OrbitCamera::framing(Point3::new(0.0, 0.0, 0.0), 2.0);
+        for _ in 0..200 {
+            cam.dolly(-1.0);
+            assert!(
+                whole_model_visible(&cam),
+                "whole model must stay framed zooming out (distance={} near/far stale?)",
+                cam.distance
+            );
+        }
+    }
+
+    #[test]
+    fn dolly_floors_distance_above_zero() {
+        let mut cam = OrbitCamera::framing(Point3::new(0.0, 0.0, 0.0), 10.0);
+        for _ in 0..1000 {
+            cam.dolly(1.0);
+        }
+        assert!(
+            cam.distance > 0.0,
+            "distance must not collapse to zero (distance={})",
+            cam.distance
+        );
+    }
+
+    #[test]
+    fn tiny_radius_still_yields_valid_planes() {
+        let cam = OrbitCamera::framing(Point3::new(0.0, 0.0, 0.0), 1e-9);
+        let (near, far) = cam.clip_planes();
+        assert!(near > 0.0 && near < far, "near={near} far={far}");
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -4,8 +4,18 @@ yanked = "warn"
 
 [licenses]
 # CC0-1.0 (hexf-parse) and ISC (libloading) enter via the wgpu/naga dependency
-# tree; both are permissive (public-domain-equivalent / MIT-like).
-allow = ["Apache-2.0", "MIT", "Zlib", "Unicode-3.0", "CC0-1.0", "ISC"]
+# tree; BSD-2-Clause / BSD-3-Clause enter via the winit dependency tree (the
+# interactive viewer's `window` feature). All are permissive.
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "Zlib",
+  "Unicode-3.0",
+  "CC0-1.0",
+  "ISC",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+]
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
## What

**Interactive viewer for brepkit-render** (M1.5) — an orbit/pan/zoom window with **click-to-pick face highlighting**, built on the merged M1 offscreen renderer (#1013). Behind a `window` feature (winit 0.30, matched to wgpu 29's `rwh_06`).

**Live-verified:** launched on a real display and captured a frame from the running window — it renders the box∪cylinder fuse correctly (Lambert-shaded, crisp topological edges), and click-to-pick resolves the kernel `FaceId` under the cursor.

## API + controls
```rust
view_solid(topo, solid, &ViewOpts) -> Result<(), RenderError>   // opens the window, runs the event loop
```
| action | control |
|---|---|
| Orbit | left-drag |
| Zoom | scroll |
| Pan | right-drag / Shift+left-drag |
| **Pick a face** | left-click → highlights orange + reports its `FaceId` (click again to clear) |

Run the demo: `cargo run -p brepkit-render --example viewer --features window`

## How it reuses M1 (no duplication)
The viewer shares M1's render passes verbatim. M1's monolithic `render()` was factored into building blocks both paths use:
- `GpuContext` (optional `compatible_surface` for presentation) + `acquire_device` (real→software adapter fallback, kept from M1's review fixes).
- format-parametrized `Pipelines` (offscreen `Rgba8UnormSrgb` vs the surface's preferred sRGB format), `GlobalsBinding`, `encode_scene(PassTargets)`.
- Picking re-renders the `R32Uint` id pass for the current view and reads back the pixel under the cursor — the same id buffer M1 already produces.

The offscreen `render()` and its tests are unchanged. M1's review fixes (edge MRT, degenerate-`up`, render-size validation, mesh error handling) are all present (this branch was rebased onto the fixed M1), so the viewer is valid on strict GPUs, not just NVIDIA.

## Verification
- `cargo build -p brepkit-render` (default / `--features window` / `--example viewer`): clean.
- `cargo nextest run -p brepkit-render`: 6/6 (M1 offscreen + camera/size unit tests).
- clippy `-D warnings` (default + window), fmt, `cargo deny check`, `check-boundaries.sh`: all clean. No `unwrap`/`expect`/`panic` in lib.
- The interactive window is inherently not CI-verifiable (needs a display); it was verified live by capturing a frame from the running window.

Milestone 1.5 of the renderer roadmap (next: M2 compute-mesher — separate PR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an interactive viewer window with orbit/pan/zoom and click-to-pick face highlighting, behind a `window` feature so headless/offscreen users stay unaffected. Includes review fixes for stable zoom framing, strict-backend surface setup, and more robust picking.

- New Features
  - `view_solid(topo, solid, &ViewOpts)` opens a `winit` window; orbit (left-drag), pan (right-drag or Shift+left), zoom (scroll); left-click picks a face and toggles its highlight. Example: `cargo run -p brepkit-render --example viewer --features window`.
  - Picking reuses the `R32Uint` id pass; mesh shader adds a `selected_id` uniform to tint the selected face.
  - Optional `window` feature pulls in `winit 0.30` (aligned with `wgpu 29`/`rwh_06`); new windowing errors added to `RenderError`.

- Refactors
  - Pipeline split into reusable parts for offscreen and viewer: `GpuContext`, `GlobalsBinding`, `Pipelines`, `GeometryBuffers`, and `encode_scene` (offscreen `render()` unchanged; pipelines are color-format agnostic; edge pass masks id writes).
  - Stability/robustness: orbit camera derives near/far per-frame and floors min distance to avoid dolly clipping; viewer creates the surface and device from the same `wgpu::Instance`, prefers FIFO present mode, clamps surface/targets to device limits, floors+clamps pick coordinates and logs readback errors; `deny.toml` allows BSD-2/3 for the `winit` subtree.

<sup>Written for commit a5c7a37d4987432ce485ab5ec19dedc4fe6cb374. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

