### PR TITLE
feat(render): compute-shader quadric mesher for cylinders (M2)

### DIFF
--- a/crates/render/shaders/quadric_mesh.wgsl
+++ b/crates/render/shaders/quadric_mesh.wgsl
@@ -35,7 +35,10 @@ struct Descriptor {
     n_v: u32,
     // FaceId.index() + 1, written into every emitted vertex (0 = background).
     face_id: u32,
-    _pad: u32,
+    // 1 = full revolution (share the seam columns), 0 = partial arc. Decided
+    // once on the CPU (in f64) and uploaded, so this shader never re-derives the
+    // (span ≈ 2π) test in f32 — both entry points must agree on it.
+    full: u32,
 };
 
 @group(0) @binding(0)
@@ -50,12 +53,16 @@ var<storage, read_write> out_indices: array<u32>;
 
 const WORDS_PER_VERT: u32 = 7u;
 
+fn is_full() -> bool {
+    return desc.full != 0u;
+}
+
 // Number of unique angular columns. A full revolution shares the u = 0 and
 // u = 2π columns (identical positions), so only n_u columns are emitted and the
 // wrap-around quad reuses column 0 — the seam is watertight by construction.
 // A partial arc (u1 - u0 < 2π) emits n_u + 1 distinct columns.
-fn col_count(full: bool) -> u32 {
-    if full {
+fn col_count() -> u32 {
+    if is_full() {
         return desc.n_u;
     }
     return desc.n_u + 1u;
@@ -80,16 +87,17 @@ fn write_vertex(slot: u32, pos: vec3<f32>, normal: vec3<f32>) {
 fn cs_vertices(@builtin(global_invocation_id) gid: vec3<u32>) {
     let i = gid.x; // angular index
     let j = gid.y; // axial index
-    let span = desc.u1 - desc.u0;
-    let full = abs(span - 6.28318530717958647692) < 1.0e-6;
-    let cols = col_count(full);
+    let cols = col_count();
     if i >= cols || j > desc.n_v {
         return;
     }
 
-    let fu = f32(i) / f32(desc.n_u);
+    // max(.., 1u) guards the normalization divide; the Rust TessFactor clamps
+    // n_u >= 3 and n_v >= 1, so this is defensive against a hand-built uniform.
+    let span = desc.u1 - desc.u0;
+    let fu = f32(i) / f32(max(desc.n_u, 1u));
     let u = desc.u0 + span * fu;
-    let fv = f32(j) / f32(desc.n_v);
+    let fv = f32(j) / f32(max(desc.n_v, 1u));
     let v = desc.v0 + (desc.v1 - desc.v0) * fv;
 
     let radial = cos(u) * desc.x_ref + sin(u) * desc.y_ref;
@@ -99,8 +107,10 @@ fn cs_vertices(@builtin(global_invocation_id) gid: vec3<u32>) {
     // Outward radial normal (direction only, unaffected by the center shift).
     let normal = normalize(radial);
 
-    let row_stride = desc.n_v + 1u;
-    let slot = i * row_stride + j;
+    // Column-major: vertices of one angular column are contiguous, so the stride
+    // between columns is the column length (n_v + 1).
+    let col_stride = desc.n_v + 1u;
+    let slot = i * col_stride + j;
     write_vertex(slot, pos, normal);
 }
 
@@ -114,19 +124,17 @@ fn cs_indices(@builtin(global_invocation_id) gid: vec3<u32>) {
     if i >= desc.n_u || j >= desc.n_v {
         return;
     }
-    let span = desc.u1 - desc.u0;
-    let full = abs(span - 6.28318530717958647692) < 1.0e-6;
 
-    let row_stride = desc.n_v + 1u;
+    let col_stride = desc.n_v + 1u;
     var i_next = i + 1u;
-    if full && i_next == desc.n_u {
+    if is_full() && i_next == desc.n_u {
         i_next = 0u; // wrap the seam back onto column 0
     }
 
-    let v00 = i * row_stride + j;
-    let v01 = i * row_stride + (j + 1u);
-    let v10 = i_next * row_stride + j;
-    let v11 = i_next * row_stride + (j + 1u);
+    let v00 = i * col_stride + j;
+    let v01 = i * col_stride + (j + 1u);
+    let v10 = i_next * col_stride + j;
+    let v11 = i_next * col_stride + (j + 1u);
 
     let quad = i * desc.n_v + j;
     let base = quad * 6u;

--- a/crates/render/shaders/quadric_mesh.wgsl
+++ b/crates/render/shaders/quadric_mesh.wgsl
@@ -1,0 +1,140 @@
+// GPU compute mesher for analytic quadric surfaces.
+//
+// Instead of CPU-tessellating an exact analytic surface and uploading the
+// triangles, the surface's *parameters* are uploaded and this shader evaluates
+// the parametric surface into a vertex grid at a caller-chosen tessellation
+// factor (the LOD knob). The output buffers feed the regular mesh draw pass
+// unchanged (see `mesh.wgsl`).
+//
+// Currently meshes a cylinder. The vertex storage buffer is a flat `array<u32>`
+// so the byte layout exactly matches the CPU `Vertex` struct consumed by the
+// draw pass: 7 words per vertex = [px, py, pz, nx, ny, nz, face_id], a 28-byte
+// stride. Positions are written relative to `desc.center` (RTC) so the f64
+// model center can be folded into the camera matrix on the CPU, matching the
+// precision scheme of the solid path.
+
+struct Descriptor {
+    // RTC origin: positions are emitted relative to this point.
+    center: vec3<f32>,
+    radius: f32,
+    // A point on the cylinder axis at v = 0 (the axis need not pass through the
+    // world origin).
+    axis_origin: vec3<f32>,
+    v0: f32,
+    // Cylinder axis (unit, points along increasing v).
+    axis: vec3<f32>,
+    v1: f32,
+    // Orthonormal radial reference frame; x_ref is u = 0.
+    x_ref: vec3<f32>,
+    u0: f32,
+    y_ref: vec3<f32>,
+    // Angular trim [u0, u1] in radians (u1 - u0 == 2π for a full cylinder).
+    u1: f32,
+    // Grid resolution: n_u angular steps, n_v axial steps.
+    n_u: u32,
+    n_v: u32,
+    // FaceId.index() + 1, written into every emitted vertex (0 = background).
+    face_id: u32,
+    _pad: u32,
+};
+
+@group(0) @binding(0)
+var<uniform> desc: Descriptor;
+
+// Flat word streams (see the file header for the vertex layout).
+@group(0) @binding(1)
+var<storage, read_write> out_verts: array<u32>;
+
+@group(0) @binding(2)
+var<storage, read_write> out_indices: array<u32>;
+
+const WORDS_PER_VERT: u32 = 7u;
+
+// Number of unique angular columns. A full revolution shares the u = 0 and
+// u = 2π columns (identical positions), so only n_u columns are emitted and the
+// wrap-around quad reuses column 0 — the seam is watertight by construction.
+// A partial arc (u1 - u0 < 2π) emits n_u + 1 distinct columns.
+fn col_count(full: bool) -> u32 {
+    if full {
+        return desc.n_u;
+    }
+    return desc.n_u + 1u;
+}
+
+fn write_vertex(slot: u32, pos: vec3<f32>, normal: vec3<f32>) {
+    let base = slot * WORDS_PER_VERT;
+    out_verts[base + 0u] = bitcast<u32>(pos.x);
+    out_verts[base + 1u] = bitcast<u32>(pos.y);
+    out_verts[base + 2u] = bitcast<u32>(pos.z);
+    out_verts[base + 3u] = bitcast<u32>(normal.x);
+    out_verts[base + 4u] = bitcast<u32>(normal.y);
+    out_verts[base + 5u] = bitcast<u32>(normal.z);
+    out_verts[base + 6u] = desc.face_id;
+}
+
+// One invocation per emitted grid vertex. Valid columns are [0, cols) and
+// valid rows are [0, n_v]. For a full revolution `cols == n_u`, so the wrap
+// column (i == n_u) is never emitted — it reuses column 0 in the index buffer,
+// making the seam watertight. For a partial arc `cols == n_u + 1`.
+@compute @workgroup_size(8, 8, 1)
+fn cs_vertices(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x; // angular index
+    let j = gid.y; // axial index
+    let span = desc.u1 - desc.u0;
+    let full = abs(span - 6.28318530717958647692) < 1.0e-6;
+    let cols = col_count(full);
+    if i >= cols || j > desc.n_v {
+        return;
+    }
+
+    let fu = f32(i) / f32(desc.n_u);
+    let u = desc.u0 + span * fu;
+    let fv = f32(j) / f32(desc.n_v);
+    let v = desc.v0 + (desc.v1 - desc.v0) * fv;
+
+    let radial = cos(u) * desc.x_ref + sin(u) * desc.y_ref;
+    let world = desc.axis_origin + radial * desc.radius + desc.axis * v;
+    // RTC: subtract the model center so GPU coordinates stay small.
+    let pos = world - desc.center;
+    // Outward radial normal (direction only, unaffected by the center shift).
+    let normal = normalize(radial);
+
+    let row_stride = desc.n_v + 1u;
+    let slot = i * row_stride + j;
+    write_vertex(slot, pos, normal);
+}
+
+// One invocation per grid quad (i in [0, n_u), j in [0, n_v)). Each quad emits
+// two triangles (6 indices). For a full revolution the last column (i ==
+// n_u - 1) wraps its "next" column back to column 0 so the seam is shared.
+@compute @workgroup_size(8, 8, 1)
+fn cs_indices(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    let j = gid.y;
+    if i >= desc.n_u || j >= desc.n_v {
+        return;
+    }
+    let span = desc.u1 - desc.u0;
+    let full = abs(span - 6.28318530717958647692) < 1.0e-6;
+
+    let row_stride = desc.n_v + 1u;
+    var i_next = i + 1u;
+    if full && i_next == desc.n_u {
+        i_next = 0u; // wrap the seam back onto column 0
+    }
+
+    let v00 = i * row_stride + j;
+    let v01 = i * row_stride + (j + 1u);
+    let v10 = i_next * row_stride + j;
+    let v11 = i_next * row_stride + (j + 1u);
+
+    let quad = i * desc.n_v + j;
+    let base = quad * 6u;
+    // CCW winding when viewed from outside (consistent outward-normal faces).
+    out_indices[base + 0u] = v00;
+    out_indices[base + 1u] = v10;
+    out_indices[base + 2u] = v11;
+    out_indices[base + 3u] = v00;
+    out_indices[base + 4u] = v11;
+    out_indices[base + 5u] = v01;
+}

--- a/crates/render/src/compute_mesh.rs
+++ b/crates/render/src/compute_mesh.rs
@@ -1,0 +1,757 @@
+//! GPU compute-shader mesher for analytic quadric surfaces.
+//!
+//! brepkit emits exact analytic surfaces (cylinder, cone, sphere, torus).
+//! Rather than CPU-tessellating one into thousands of triangles and uploading
+//! them, this path uploads the surface's *parameters* and lets a WGSL compute
+//! shader evaluate the parametric surface into a vertex grid at a caller-chosen
+//! tessellation factor (the LOD knob). The compute output then feeds the same
+//! offscreen mesh draw pass as the solid path (`shaders/mesh.wgsl`).
+//!
+//! WebGPU/wgpu have no tessellation or mesh shaders, so the per-vertex
+//! evaluation runs in a compute pass. This module currently meshes a cylinder;
+//! the descriptor + shader generalize to the other quadrics (see the crate
+//! docs for the extension plan).
+//!
+//! # Precision
+//!
+//! As with the solid path, positions are emitted relative to the model center
+//! (RTC) and the f64 center is folded into the camera matrix on the CPU, so the
+//! GPU never sees large absolute coordinates.
+
+use std::f64::consts::TAU;
+
+use bytemuck::{Pod, Zeroable};
+use wgpu::util::DeviceExt;
+
+use brepkit_math::surfaces::CylindricalSurface;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_topology::Topology;
+use brepkit_topology::face::{FaceId, FaceSurface};
+
+use crate::camera::Camera;
+use crate::error::RenderError;
+use crate::pipeline;
+use crate::{RenderOpts, RenderOutput};
+
+/// Tessellation factor (level of detail) for the compute mesher.
+///
+/// `n_u` angular steps around the surface and `n_v` steps along it. Higher
+/// values produce more triangles and a rounder silhouette at the cost of a
+/// larger vertex buffer; for a cylinder the chord error of the circular cross
+/// section falls off as `1 - cos(π / n_u)`.
+#[derive(Debug, Clone, Copy)]
+pub struct TessFactor {
+    /// Angular subdivisions around the surface (must be >= 3).
+    pub n_u: u32,
+    /// Axial subdivisions along the surface (must be >= 1).
+    pub n_v: u32,
+}
+
+impl TessFactor {
+    /// Create a tessellation factor, clamping to the minimum that yields a
+    /// non-degenerate closed mesh (`n_u >= 3`, `n_v >= 1`).
+    #[must_use]
+    pub fn new(n_u: u32, n_v: u32) -> Self {
+        Self {
+            n_u: n_u.max(3),
+            n_v: n_v.max(1),
+        }
+    }
+
+    // TODO: view-dependent (screen-space) LOD — pick (n_u, n_v) per frame from a
+    // screen-space chord-error metric (projected radius / pixel budget) instead
+    // of a caller-supplied factor. Next milestone.
+}
+
+/// A cylinder surface packed for GPU evaluation.
+///
+/// Extracted from a [`FaceSurface::Cylinder`] face via
+/// [`extract_cylinder_descriptor`]: the axis frame and radius come from the
+/// [`CylindricalSurface`]; the parametric trim range (`v0..v1` axial,
+/// `u0..u1` angular) comes from the face's boundary.
+#[derive(Debug, Clone, Copy)]
+pub struct CylinderDescriptor {
+    /// RTC origin — positions are emitted relative to this point. Defaults to
+    /// the descriptor's own AABB center via [`extract_cylinder_descriptor`].
+    pub center: Point3,
+    /// Cylinder axis origin (a point on the axis at `v = 0`).
+    pub axis_origin: Point3,
+    /// Cylinder axis direction (unit, points along increasing `v`).
+    pub axis: Vec3,
+    /// First radial reference direction (unit; `u = 0` points here).
+    pub x_ref: Vec3,
+    /// Second radial reference direction (unit; `axis × x_ref`).
+    pub y_ref: Vec3,
+    /// Cylinder radius.
+    pub radius: f64,
+    /// Axial parameter at the lower trim boundary.
+    pub v0: f64,
+    /// Axial parameter at the upper trim boundary.
+    pub v1: f64,
+    /// Angular parameter at the start of the trim (radians).
+    pub u0: f64,
+    /// Angular parameter at the end of the trim (radians); `u1 - u0 == 2π` for
+    /// a full cylinder.
+    pub u1: f64,
+}
+
+impl CylinderDescriptor {
+    /// World-space point on the surface at parameters `(u, v)`, the same
+    /// parameterization the GPU shader evaluates:
+    /// `pos(u, v) = axis_origin + radius·(cos u · x_ref + sin u · y_ref) + v·axis`.
+    ///
+    /// Note this returns an absolute world point; the GPU emits it minus
+    /// [`center`](Self::center) (RTC). Used to compute the descriptor's AABB and
+    /// available for CPU-side geometric checks.
+    #[must_use]
+    pub fn evaluate(&self, u: f64, v: f64) -> Point3 {
+        let radial = self.x_ref * (self.radius * u.cos()) + self.y_ref * (self.radius * u.sin());
+        self.axis_origin + radial + self.axis * v
+    }
+
+    /// Axis-aligned bounding box of the trimmed cylinder, sampled around the
+    /// angular range and across the two axial caps.
+    fn aabb(&self) -> (Point3, Point3) {
+        let mut min = [f64::INFINITY; 3];
+        let mut max = [f64::NEG_INFINITY; 3];
+        let samples = 64;
+        for k in 0..=samples {
+            let t = f64::from(k) / f64::from(samples);
+            let u = self.u0 + (self.u1 - self.u0) * t;
+            for &v in &[self.v0, self.v1] {
+                let p = self.evaluate(u, v);
+                let c = [p.x(), p.y(), p.z()];
+                for axis in 0..3 {
+                    min[axis] = min[axis].min(c[axis]);
+                    max[axis] = max[axis].max(c[axis]);
+                }
+            }
+        }
+        (
+            Point3::new(min[0], min[1], min[2]),
+            Point3::new(max[0], max[1], max[2]),
+        )
+    }
+
+    /// Number of triangles a given tessellation factor produces (`2·n_u·n_v`).
+    #[must_use]
+    pub fn triangle_count(tess: TessFactor) -> usize {
+        2 * tess.n_u as usize * tess.n_v as usize
+    }
+}
+
+/// Extract a [`CylinderDescriptor`] from a cylindrical face.
+///
+/// Reads the [`CylindricalSurface`] frame and radius, then derives the axial
+/// trim range `v0..v1` by projecting the face's outer-wire vertices onto the
+/// axis. The angular range is taken as a full revolution (`0..2π`) — the M2
+/// scope is a full cylinder (e.g. [`make_cylinder`](brepkit_operations::primitives::make_cylinder)),
+/// whose lateral face wraps the entire circle via a degenerate seam wire.
+///
+/// `center` is set to the descriptor's own AABB center, so the returned
+/// descriptor renders correctly on its own.
+///
+/// # Errors
+///
+/// - [`RenderError::Operations`] if `face` is not a cylindrical face.
+/// - [`RenderError::Topology`] if the face's wire/edge/vertex lookups fail.
+pub fn extract_cylinder_descriptor(
+    topo: &Topology,
+    face: FaceId,
+) -> Result<CylinderDescriptor, RenderError> {
+    let face_data = topo.face(face)?;
+    let FaceSurface::Cylinder(cyl) = face_data.surface() else {
+        return Err(RenderError::Operations(
+            brepkit_operations::OperationsError::InvalidInput {
+                reason: "extract_cylinder_descriptor: face is not a cylindrical surface".into(),
+            },
+        ));
+    };
+
+    let (v0, v1) = axial_range(topo, face, cyl)?;
+
+    let mut desc = CylinderDescriptor {
+        center: Point3::new(0.0, 0.0, 0.0),
+        axis_origin: cyl.origin(),
+        axis: cyl.axis(),
+        x_ref: cyl.x_axis(),
+        y_ref: cyl.y_axis(),
+        radius: cyl.radius(),
+        v0,
+        v1,
+        u0: 0.0,
+        u1: TAU,
+    };
+    let (min, max) = desc.aabb();
+    desc.center = Point3::new(
+        (min.x() + max.x()) * 0.5,
+        (min.y() + max.y()) * 0.5,
+        (min.z() + max.z()) * 0.5,
+    );
+    Ok(desc)
+}
+
+/// Project every vertex of the face's outer wire onto the cylinder axis to find
+/// the axial parameter span `[v0, v1]`.
+fn axial_range(
+    topo: &Topology,
+    face: FaceId,
+    cyl: &CylindricalSurface,
+) -> Result<(f64, f64), RenderError> {
+    let face_data = topo.face(face)?;
+    let wire = topo.wire(face_data.outer_wire())?;
+    let axis = cyl.axis();
+    let origin = cyl.origin();
+
+    let mut min_v = f64::INFINITY;
+    let mut max_v = f64::NEG_INFINITY;
+    for oe in wire.edges() {
+        let edge = topo.edge(oe.edge())?;
+        for vid in [edge.start(), edge.end()] {
+            let p = topo.vertex(vid)?.point();
+            let v = axis.dot(p - origin);
+            min_v = min_v.min(v);
+            max_v = max_v.max(v);
+        }
+    }
+    if !(min_v.is_finite() && max_v.is_finite()) || (max_v - min_v).abs() < f64::EPSILON {
+        return Err(RenderError::Operations(
+            brepkit_operations::OperationsError::InvalidInput {
+                reason: "extract_cylinder_descriptor: degenerate axial range on cylinder face"
+                    .into(),
+            },
+        ));
+    }
+    Ok((min_v, max_v))
+}
+
+/// GPU descriptor uniform. Field order and padding match the WGSL `Descriptor`
+/// struct in `quadric_mesh.wgsl` (vec3 fields are 16-byte aligned, with the
+/// trailing scalar packed into the 4th word of each 16-byte slot; the final
+/// group pads to 16 bytes).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+struct GpuDescriptor {
+    center: [f32; 3],
+    radius: f32,
+    axis_origin: [f32; 3],
+    v0: f32,
+    axis: [f32; 3],
+    v1: f32,
+    x_ref: [f32; 3],
+    u0: f32,
+    y_ref: [f32; 3],
+    u1: f32,
+    n_u: u32,
+    n_v: u32,
+    face_id: u32,
+    _pad: u32,
+}
+
+/// Render a compute-meshed cylinder offscreen to a shaded color image + face-id
+/// buffer.
+///
+/// The cylinder is meshed entirely on the GPU from `desc` at the `tess` LOD: a
+/// compute pass evaluates the parametric surface into vertex + index storage
+/// buffers, which are then drawn by the same offscreen mesh pass as the solid
+/// path. Every emitted vertex carries `face_id` (use `1` if you have no real
+/// face).
+///
+/// # Errors
+///
+/// - [`RenderError::InvalidSize`] if `opts.width` or `opts.height` is zero.
+/// - [`RenderError::NoAdapter`] / [`RenderError::DeviceRequest`] on GPU setup.
+/// - [`RenderError::BufferMap`] / [`RenderError::Poll`] on readback failure.
+#[allow(clippy::too_many_lines)]
+pub fn render_cylinder_compute_offscreen(
+    desc: &CylinderDescriptor,
+    tess: TessFactor,
+    face_id: u32,
+    cam: &Camera,
+    opts: &RenderOpts,
+) -> Result<RenderOutput, RenderError> {
+    if opts.width == 0 || opts.height == 0 {
+        return Err(RenderError::InvalidSize {
+            width: opts.width,
+            height: opts.height,
+        });
+    }
+
+    let instance = wgpu::Instance::default();
+    let (_adapter, device, queue) = pipeline::acquire_device(&instance, None)?;
+
+    // Reject oversized targets with a clean error rather than tripping wgpu's
+    // internal validation (mirrors the solid path).
+    let max = device.limits().max_texture_dimension_2d;
+    if opts.width > max || opts.height > max {
+        return Err(RenderError::SizeTooLarge {
+            width: opts.width,
+            height: opts.height,
+            max,
+        });
+    }
+
+    // --- Grid sizing -------------------------------------------------------
+    let full = (desc.u1 - desc.u0 - TAU).abs() < 1.0e-6;
+    let cols = if full { tess.n_u } else { tess.n_u + 1 };
+    let rows = tess.n_v + 1;
+    let vertex_count = u64::from(cols) * u64::from(rows);
+    let index_count = u64::from(tess.n_u) * u64::from(tess.n_v) * 6;
+    let vert_bytes = vertex_count * 7 * 4; // 7 u32 words per vertex
+    let index_bytes = index_count * 4;
+
+    // --- Descriptor uniform -----------------------------------------------
+    #[allow(clippy::cast_possible_truncation)]
+    let gpu_desc = GpuDescriptor {
+        center: pt_f32(desc.center),
+        radius: desc.radius as f32,
+        axis_origin: pt_f32(desc.axis_origin),
+        v0: desc.v0 as f32,
+        axis: vec_f32(desc.axis),
+        v1: desc.v1 as f32,
+        x_ref: vec_f32(desc.x_ref),
+        u0: desc.u0 as f32,
+        y_ref: vec_f32(desc.y_ref),
+        u1: desc.u1 as f32,
+        n_u: tess.n_u,
+        n_v: tess.n_v,
+        face_id,
+        _pad: 0,
+    };
+    let desc_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("cylinder descriptor"),
+        contents: bytemuck::bytes_of(&gpu_desc),
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+
+    // --- Compute output buffers (also used directly as draw inputs) --------
+    let vertex_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("compute vertices"),
+        size: vert_bytes,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::VERTEX,
+        mapped_at_creation: false,
+    });
+    let index_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("compute indices"),
+        size: index_bytes,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::INDEX,
+        mapped_at_creation: false,
+    });
+
+    // --- Compute pipeline --------------------------------------------------
+    let compute_shader =
+        device.create_shader_module(wgpu::include_wgsl!("../shaders/quadric_mesh.wgsl"));
+    let compute_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("compute mesher layout"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            storage_entry(1),
+            storage_entry(2),
+        ],
+    });
+    let compute_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("compute mesher bind group"),
+        layout: &compute_bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: desc_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: vertex_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: index_buf.as_entire_binding(),
+            },
+        ],
+    });
+    let compute_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("compute pipeline layout"),
+        bind_group_layouts: &[Some(&compute_bgl)],
+        immediate_size: 0,
+    });
+    let vertex_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("cylinder vertex mesher"),
+        layout: Some(&compute_layout),
+        module: &compute_shader,
+        entry_point: Some("cs_vertices"),
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+        cache: None,
+    });
+    let index_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("cylinder index mesher"),
+        layout: Some(&compute_layout),
+        module: &compute_shader,
+        entry_point: Some("cs_indices"),
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+        cache: None,
+    });
+
+    // --- Draw resources (shared mesh shader) -------------------------------
+    let draw = build_draw_resources(&device, desc, cam, opts);
+
+    // --- Targets -----------------------------------------------------------
+    let (width, height) = (opts.width, opts.height);
+    let targets = RenderTargets::new(&device, width, height);
+
+    // --- Encode ------------------------------------------------------------
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("compute + draw encoder"),
+    });
+    {
+        let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("cylinder mesher"),
+            timestamp_writes: None,
+        });
+        cpass.set_bind_group(0, &compute_bind_group, &[]);
+        let groups_x = cols.div_ceil(8).max(1);
+        let groups_y = rows.div_ceil(8).max(1);
+        cpass.set_pipeline(&vertex_pipeline);
+        cpass.dispatch_workgroups(groups_x, groups_y, 1);
+        let igx = tess.n_u.div_ceil(8).max(1);
+        let igy = tess.n_v.div_ceil(8).max(1);
+        cpass.set_pipeline(&index_pipeline);
+        cpass.dispatch_workgroups(igx, igy, 1);
+    }
+
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("compute mesh pass"),
+            color_attachments: &[
+                Some(wgpu::RenderPassColorAttachment {
+                    view: &targets.color_view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: f64::from(opts.background[0]),
+                            g: f64::from(opts.background[1]),
+                            b: f64::from(opts.background[2]),
+                            a: f64::from(opts.background[3]),
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                }),
+                Some(wgpu::RenderPassColorAttachment {
+                    view: &targets.id_view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                }),
+            ],
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &targets.depth_view,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_bind_group(0, &draw.bind_group, &[]);
+        pass.set_pipeline(&draw.pipeline);
+        pass.set_vertex_buffer(0, vertex_buf.slice(..));
+        pass.set_index_buffer(index_buf.slice(..), wgpu::IndexFormat::Uint32);
+        #[allow(clippy::cast_possible_truncation)]
+        pass.draw_indexed(0..index_count as u32, 0, 0..1);
+    }
+
+    let color_bpr = pipeline::padded_bytes_per_row(width, 4);
+    let id_bpr = pipeline::padded_bytes_per_row(width, 4);
+    let color_readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("color readback"),
+        size: u64::from(color_bpr) * u64::from(height),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let id_readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("id readback"),
+        size: u64::from(id_bpr) * u64::from(height),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let extent = wgpu::Extent3d {
+        width,
+        height,
+        depth_or_array_layers: 1,
+    };
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &targets.color_tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &color_readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(color_bpr),
+                rows_per_image: Some(height),
+            },
+        },
+        extent,
+    );
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &targets.id_tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &id_readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(id_bpr),
+                rows_per_image: Some(height),
+            },
+        },
+        extent,
+    );
+
+    queue.submit(Some(encoder.finish()));
+
+    let color_bytes = pipeline::map_and_read(&device, &color_readback)?;
+    let id_bytes = pipeline::map_and_read(&device, &id_readback)?;
+    let color = pipeline::unpad_to_rgba(&color_bytes, width, height, color_bpr);
+    let id_buffer = pipeline::unpad_to_u32(&id_bytes, width, height, id_bpr);
+
+    Ok(RenderOutput {
+        color,
+        id_buffer,
+        width,
+        height,
+    })
+}
+
+/// A read-write storage-buffer bind-group-layout entry visible to compute.
+fn storage_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: false },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+/// Mesh-draw pipeline + bind group reusing the solid path's `mesh.wgsl`.
+struct DrawResources {
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+}
+
+/// Build the globals uniform, bind group, and mesh-draw pipeline for the
+/// compute-generated vertex buffer (same vertex layout + shader as the solid
+/// path).
+fn build_draw_resources(
+    device: &wgpu::Device,
+    desc: &CylinderDescriptor,
+    cam: &Camera,
+    opts: &RenderOpts,
+) -> DrawResources {
+    let view_proj = crate::camera::view_proj_rtc(cam, desc.center);
+    let view_dir = cam.view_direction();
+    #[allow(clippy::cast_possible_truncation)]
+    let globals = pipeline::Globals {
+        view_proj,
+        view_dir: [
+            view_dir.x() as f32,
+            view_dir.y() as f32,
+            view_dir.z() as f32,
+            0.0,
+        ],
+        ambient: opts.ambient,
+        selected_id: 0,
+        _pad: [0.0; 2],
+    };
+    let globals_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("globals"),
+        contents: bytemuck::bytes_of(&globals),
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+    let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("globals layout"),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }],
+    });
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("globals bind group"),
+        layout: &bgl,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: globals_buf.as_entire_binding(),
+        }],
+    });
+    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("draw pipeline layout"),
+        bind_group_layouts: &[Some(&bgl)],
+        immediate_size: 0,
+    });
+    let shader = device.create_shader_module(wgpu::include_wgsl!("../shaders/mesh.wgsl"));
+    let color_targets = [
+        Some(wgpu::ColorTargetState {
+            format: pipeline::COLOR_FORMAT_OFFSCREEN,
+            blend: None,
+            write_mask: wgpu::ColorWrites::ALL,
+        }),
+        Some(wgpu::ColorTargetState {
+            format: pipeline::ID_FORMAT,
+            blend: None,
+            write_mask: wgpu::ColorWrites::ALL,
+        }),
+    ];
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("compute mesh draw pipeline"),
+        layout: Some(&layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            buffers: &[wgpu::VertexBufferLayout {
+                array_stride: 28, // 7 words: pos(3) + normal(3) + face_id(1)
+                step_mode: wgpu::VertexStepMode::Vertex,
+                attributes: &[
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: 0,
+                        shader_location: 0,
+                    },
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: 12,
+                        shader_location: 1,
+                    },
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Uint32,
+                        offset: 24,
+                        shader_location: 2,
+                    },
+                ],
+            }],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            cull_mode: None,
+            ..Default::default()
+        },
+        depth_stencil: Some(wgpu::DepthStencilState {
+            format: pipeline::DEPTH_FORMAT,
+            depth_write_enabled: Some(true),
+            depth_compare: Some(wgpu::CompareFunction::Less),
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        }),
+        multisample: wgpu::MultisampleState::default(),
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            targets: &color_targets,
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        multiview_mask: None,
+        cache: None,
+    });
+    DrawResources {
+        pipeline,
+        bind_group,
+    }
+}
+
+/// The offscreen color/depth/id targets and their views.
+struct RenderTargets {
+    color_tex: wgpu::Texture,
+    id_tex: wgpu::Texture,
+    color_view: wgpu::TextureView,
+    depth_view: wgpu::TextureView,
+    id_view: wgpu::TextureView,
+}
+
+impl RenderTargets {
+    fn new(device: &wgpu::Device, width: u32, height: u32) -> Self {
+        let extent = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
+        let color_tex = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("color target"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: pipeline::COLOR_FORMAT_OFFSCREEN,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let depth_tex = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("depth target"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: pipeline::DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let id_tex = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("id target"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: pipeline::ID_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let color_view = color_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let depth_view = depth_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let id_view = id_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            color_tex,
+            id_tex,
+            color_view,
+            depth_view,
+            id_view,
+        }
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn vec_f32(v: Vec3) -> [f32; 3] {
+    [v.x() as f32, v.y() as f32, v.z() as f32]
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn pt_f32(p: Point3) -> [f32; 3] {
+    [p.x() as f32, p.y() as f32, p.z() as f32]
+}

--- a/crates/render/src/compute_mesh.rs
+++ b/crates/render/src/compute_mesh.rs
@@ -33,6 +33,19 @@ use crate::error::RenderError;
 use crate::pipeline;
 use crate::{RenderOpts, RenderOutput};
 
+/// Upper bound on each tessellation dimension.
+///
+/// Caps `n_u`/`n_v` so the derived vertex and index counts stay far below
+/// `u32::MAX` (the worst case `MAX_TESS² · 6 ≈ 1.6e9` indices) and so a single
+/// quadric can never request an absurd buffer. Already well past any sane LOD
+/// for one surface (a 16384-gon cross section is sub-pixel at any zoom).
+const MAX_TESS: u32 = 16_384;
+
+/// Words per emitted vertex in the flat `out_verts` storage buffer. Must match
+/// `WORDS_PER_VERT` in `quadric_mesh.wgsl` and the 28-byte draw `Vertex` stride:
+/// pos(3) + normal(3) + face_id(1).
+const WORDS_PER_VERT: u64 = 7;
+
 /// Tessellation factor (level of detail) for the compute mesher.
 ///
 /// `n_u` angular steps around the surface and `n_v` steps along it. Higher
@@ -41,20 +54,21 @@ use crate::{RenderOpts, RenderOutput};
 /// section falls off as `1 - cos(π / n_u)`.
 #[derive(Debug, Clone, Copy)]
 pub struct TessFactor {
-    /// Angular subdivisions around the surface (must be >= 3).
+    /// Angular subdivisions around the surface (clamped to `[3, MAX_TESS]`).
     pub n_u: u32,
-    /// Axial subdivisions along the surface (must be >= 1).
+    /// Axial subdivisions along the surface (clamped to `[1, MAX_TESS]`).
     pub n_v: u32,
 }
 
 impl TessFactor {
-    /// Create a tessellation factor, clamping to the minimum that yields a
-    /// non-degenerate closed mesh (`n_u >= 3`, `n_v >= 1`).
+    /// Create a tessellation factor, clamping each dimension into the range
+    /// that yields a non-degenerate closed mesh without overflowing the GPU
+    /// buffer index math: `n_u ∈ [3, MAX_TESS]`, `n_v ∈ [1, MAX_TESS]`.
     #[must_use]
     pub fn new(n_u: u32, n_v: u32) -> Self {
         Self {
-            n_u: n_u.max(3),
-            n_v: n_v.max(1),
+            n_u: n_u.clamp(3, MAX_TESS),
+            n_v: n_v.clamp(1, MAX_TESS),
         }
     }
 
@@ -228,7 +242,7 @@ fn axial_range(
 /// GPU descriptor uniform. Field order and padding match the WGSL `Descriptor`
 /// struct in `quadric_mesh.wgsl` (vec3 fields are 16-byte aligned, with the
 /// trailing scalar packed into the 4th word of each 16-byte slot; the final
-/// group pads to 16 bytes).
+/// group fills its 16 bytes exactly).
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 struct GpuDescriptor {
@@ -245,7 +259,10 @@ struct GpuDescriptor {
     n_u: u32,
     n_v: u32,
     face_id: u32,
-    _pad: u32,
+    /// `1` for a full revolution (seam columns shared), `0` for a partial arc.
+    /// Computed once on the CPU so the two compute entry points never re-derive
+    /// the `(span ≈ 2π)` test in f32 (which could disagree with this f64 one).
+    full: u32,
 }
 
 /// Render a compute-meshed cylinder offscreen to a shaded color image + face-id
@@ -277,6 +294,12 @@ pub fn render_cylinder_compute_offscreen(
         });
     }
 
+    // Normalize the factor at the boundary: the public `TessFactor::new` clamps
+    // to `[3, MAX_TESS]` / `[1, MAX_TESS]`, but the fields are `pub`, so a
+    // struct-literal could bypass it. Re-clamping here makes every downstream
+    // count (and the u32 index cast) provably within range.
+    let tess = TessFactor::new(tess.n_u, tess.n_v);
+
     let instance = wgpu::Instance::default();
     let (_adapter, device, queue) = pipeline::acquire_device(&instance, None)?;
 
@@ -292,12 +315,23 @@ pub fn render_cylinder_compute_offscreen(
     }
 
     // --- Grid sizing -------------------------------------------------------
+    // `full` is the single source of truth for the seam decision: it is uploaded
+    // to the shader (see GpuDescriptor::full) so the two compute entry points
+    // never recompute the `(span ≈ 2π)` test in f32. A full revolution shares
+    // the u = 0 / u = 2π columns, so it emits only `n_u` columns (the wrap quad
+    // reuses column 0); a partial arc emits `n_u + 1`.
     let full = (desc.u1 - desc.u0 - TAU).abs() < 1.0e-6;
     let cols = if full { tess.n_u } else { tess.n_u + 1 };
     let rows = tess.n_v + 1;
+    // With both dims clamped to MAX_TESS, the worst case is MAX_TESS²·6 ≈ 1.6e9,
+    // comfortably inside u32, so the index cast for `draw_indexed` cannot wrap.
     let vertex_count = u64::from(cols) * u64::from(rows);
     let index_count = u64::from(tess.n_u) * u64::from(tess.n_v) * 6;
-    let vert_bytes = vertex_count * 7 * 4; // 7 u32 words per vertex
+    // The MAX_TESS clamp guarantees this fits in u32 (worst case ≈ 1.6e9); the
+    // checked `try_from` keeps the draw count from ever silently wrapping even if
+    // that invariant is later weakened.
+    let index_count_u32 = u32::try_from(index_count).unwrap_or(u32::MAX);
+    let vert_bytes = vertex_count * WORDS_PER_VERT * 4; // 4 bytes per u32 word
     let index_bytes = index_count * 4;
 
     // --- Descriptor uniform -----------------------------------------------
@@ -316,7 +350,7 @@ pub fn render_cylinder_compute_offscreen(
         n_u: tess.n_u,
         n_v: tess.n_v,
         face_id,
-        _pad: 0,
+        full: u32::from(full),
     };
     let desc_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("cylinder descriptor"),
@@ -469,8 +503,7 @@ pub fn render_cylinder_compute_offscreen(
         pass.set_pipeline(&draw.pipeline);
         pass.set_vertex_buffer(0, vertex_buf.slice(..));
         pass.set_index_buffer(index_buf.slice(..), wgpu::IndexFormat::Uint32);
-        #[allow(clippy::cast_possible_truncation)]
-        pass.draw_indexed(0..index_count as u32, 0, 0..1);
+        pass.draw_indexed(0..index_count_u32, 0, 0..1);
     }
 
     let color_bpr = pipeline::padded_bytes_per_row(width, 4);
@@ -754,4 +787,55 @@ fn vec_f32(v: Vec3) -> [f32; 3] {
 #[allow(clippy::cast_possible_truncation)]
 fn pt_f32(p: Point3) -> [f32; 3] {
     [p.x() as f32, p.y() as f32, p.z() as f32]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tess_factor_clamps_below_minimum() {
+        let t = TessFactor::new(0, 0);
+        assert_eq!(t.n_u, 3, "n_u floors at 3 (degenerate below)");
+        assert_eq!(t.n_v, 1, "n_v floors at 1");
+    }
+
+    #[test]
+    fn tess_factor_clamps_above_maximum() {
+        let t = TessFactor::new(u32::MAX, u32::MAX);
+        assert_eq!(t.n_u, MAX_TESS, "n_u caps at MAX_TESS");
+        assert_eq!(t.n_v, MAX_TESS, "n_v caps at MAX_TESS");
+    }
+
+    #[test]
+    fn tess_factor_passes_through_valid_range() {
+        let t = TessFactor::new(48, 4);
+        assert_eq!((t.n_u, t.n_v), (48, 4));
+    }
+
+    #[test]
+    fn max_tess_keeps_index_and_vertex_counts_within_u32() {
+        // The buffer index math (vertex `slot`, index `quad`) runs in u32 on the
+        // GPU and the draw count is u32; the clamp must keep every derived count
+        // strictly inside u32 so nothing wraps. Worst case: full grid at MAX_TESS.
+        let n = u64::from(MAX_TESS);
+        let cols = n + 1; // partial-arc column count (the larger of the two)
+        let rows = n + 1;
+        let vertex_count = cols * rows;
+        let index_count = n * n * 6;
+        assert!(
+            u32::try_from(vertex_count).is_ok(),
+            "vertex_count {vertex_count} exceeds u32"
+        );
+        assert!(
+            u32::try_from(index_count).is_ok(),
+            "index_count {index_count} exceeds u32"
+        );
+        // The vertex word stream (7 words/vertex) also must not overflow u32
+        // element indexing in the shader (`slot * WORDS_PER_VERT`).
+        assert!(
+            u32::try_from(vertex_count * WORDS_PER_VERT).is_ok(),
+            "vertex word count exceeds u32"
+        );
+    }
 }

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -45,6 +45,7 @@
 //! ```
 
 mod camera;
+mod compute_mesh;
 mod error;
 mod mesh;
 mod pipeline;
@@ -52,6 +53,9 @@ mod pipeline;
 mod viewer;
 
 pub use camera::Camera;
+pub use compute_mesh::{
+    CylinderDescriptor, TessFactor, extract_cylinder_descriptor, render_cylinder_compute_offscreen,
+};
 pub use error::RenderError;
 pub use pipeline::probe_adapter;
 #[cfg(feature = "window")]

--- a/crates/render/src/pipeline.rs
+++ b/crates/render/src/pipeline.rs
@@ -91,7 +91,7 @@ fn candidate_adapters(
 /// returned alongside the device so callers (the viewer) can query surface
 /// capabilities. When `surface` is `Some`, only surface-compatible adapters are
 /// considered.
-fn acquire_device(
+pub fn acquire_device(
     instance: &wgpu::Instance,
     surface: Option<&wgpu::Surface<'_>>,
 ) -> Result<(wgpu::Adapter, wgpu::Device, wgpu::Queue), RenderError> {
@@ -719,7 +719,7 @@ pub fn map_and_read(device: &wgpu::Device, buffer: &wgpu::Buffer) -> Result<Vec<
 }
 
 /// Strip per-row copy padding and build an RGBA image (rows are tightly packed).
-fn unpad_to_rgba(bytes: &[u8], width: u32, height: u32, padded_bpr: u32) -> image::RgbaImage {
+pub fn unpad_to_rgba(bytes: &[u8], width: u32, height: u32, padded_bpr: u32) -> image::RgbaImage {
     let row_len = (width * 4) as usize;
     let mut packed = Vec::with_capacity(row_len * height as usize);
     for row in 0..height as usize {
@@ -735,7 +735,7 @@ fn unpad_to_rgba(bytes: &[u8], width: u32, height: u32, padded_bpr: u32) -> imag
 }
 
 /// Strip per-row copy padding and decode the R32Uint id target to `Vec<u32>`.
-fn unpad_to_u32(bytes: &[u8], width: u32, height: u32, padded_bpr: u32) -> Vec<u32> {
+pub fn unpad_to_u32(bytes: &[u8], width: u32, height: u32, padded_bpr: u32) -> Vec<u32> {
     let mut out = Vec::with_capacity((width * height) as usize);
     for row in 0..height as usize {
         let row_start = row * padded_bpr as usize;

--- a/crates/render/tests/compute_mesh_render.rs
+++ b/crates/render/tests/compute_mesh_render.rs
@@ -1,0 +1,523 @@
+//! Headless tests for the GPU compute-shader quadric mesher (M2).
+//!
+//! These render a cylinder lateral face meshed entirely on the GPU from its
+//! analytic parameters (no CPU tessellation), then cross-check the result
+//! against the M1 solid path (which tessellates on the CPU) and verify the LOD
+//! knob. They require a wgpu adapter (a real GPU or a software fallback such as
+//! Mesa lavapipe); when none is available they log a skip and return.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_render::{
+    Camera, CylinderDescriptor, RenderOpts, RenderOutput, TessFactor, extract_cylinder_descriptor,
+    probe_adapter, render_cylinder_compute_offscreen, render_solid_offscreen,
+};
+use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::face::{FaceId, FaceSurface};
+use brepkit_topology::solid::SolidId;
+
+const RADIUS: f64 = 8.0;
+const HEIGHT: f64 = 20.0;
+
+/// An isometric-ish camera framing a model of bounding-sphere `radius` centered
+/// at `target`. Matches the framing used by the M1 smoke tests so the compute
+/// and solid renders share a viewpoint for cross-checking.
+fn iso_camera(target: Point3, radius: f64) -> Camera {
+    let fov_y = 40.0_f64.to_radians();
+    let dist = radius / (fov_y * 0.5).sin() * 2.0;
+    let dir = Vec3::new(1.0, 0.9, 1.1).normalize().unwrap();
+    let eye = target + Vec3::new(dir.x() * dist, dir.y() * dist, dir.z() * dist);
+    Camera {
+        eye,
+        target,
+        up: Vec3::new(0.0, 0.0, 1.0),
+        fov_y,
+        aspect: 1.0,
+        near: (dist - radius).max(radius * 0.01),
+        far: dist + radius * 4.0,
+    }
+}
+
+/// The cylinder centered like `make_cylinder` (base at z=0, axis +Z) framed by
+/// an iso camera from its AABB center.
+fn cylinder_camera() -> (Point3, Camera) {
+    let center = Point3::new(0.0, 0.0, HEIGHT * 0.5);
+    let bsphere = (RADIUS * RADIUS + (HEIGHT * 0.5) * (HEIGHT * 0.5)).sqrt();
+    (center, iso_camera(center, bsphere))
+}
+
+/// Encode a linear color component to sRGB (matches the GPU's `Rgba8UnormSrgb`
+/// write).
+fn linear_to_srgb_u8(c: f32) -> u8 {
+    let c = c.clamp(0.0, 1.0);
+    let s = if c <= 0.003_130_8 {
+        c * 12.92
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    };
+    (s * 255.0).round() as u8
+}
+
+/// Count pixels that differ meaningfully from the background clear color.
+fn non_background_pixels(out: &RenderOutput, bg: [f32; 4]) -> usize {
+    let bg_rgb = [
+        linear_to_srgb_u8(bg[0]),
+        linear_to_srgb_u8(bg[1]),
+        linear_to_srgb_u8(bg[2]),
+    ];
+    let mut count = 0;
+    for px in out.color.pixels() {
+        let d = (i32::from(px[0]) - i32::from(bg_rgb[0])).abs()
+            + (i32::from(px[1]) - i32::from(bg_rgb[1])).abs()
+            + (i32::from(px[2]) - i32::from(bg_rgb[2])).abs();
+        if d > 12 {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Bounding box (min_x, min_y, max_x, max_y) of non-zero id pixels, if any.
+fn id_silhouette_bbox(out: &RenderOutput) -> Option<(u32, u32, u32, u32)> {
+    let mut bbox: Option<(u32, u32, u32, u32)> = None;
+    for y in 0..out.height {
+        for x in 0..out.width {
+            if out.face_id_at(x, y).is_some() {
+                bbox = Some(match bbox {
+                    None => (x, y, x, y),
+                    Some((minx, miny, maxx, maxy)) => {
+                        (minx.min(x), miny.min(y), maxx.max(x), maxy.max(y))
+                    }
+                });
+            }
+        }
+    }
+    bbox
+}
+
+/// For each image row, the leftmost and rightmost drawn (non-background) column.
+///
+/// The left/right profile of a cylinder's side silhouette is governed purely by
+/// the analytic radius and axis, so it is the cleanest signal to cross-check
+/// the compute mesh against the CPU mesh (the caps differ between the two, but
+/// the vertical sides do not).
+fn horizontal_profile(out: &RenderOutput) -> Vec<Option<(u32, u32)>> {
+    let mut rows = Vec::with_capacity(out.height as usize);
+    for y in 0..out.height {
+        let mut span: Option<(u32, u32)> = None;
+        for x in 0..out.width {
+            if out.face_id_at(x, y).is_some() {
+                span = Some(match span {
+                    None => (x, x),
+                    Some((lo, hi)) => (lo.min(x), hi.max(x)),
+                });
+            }
+        }
+        rows.push(span);
+    }
+    rows
+}
+
+/// Count background pixels that lie strictly between the left and right drawn
+/// columns of their row (interior holes). A watertight, gap-free front surface
+/// has zero such pixels; a cracked seam shows up as a vertical run of them.
+fn interior_holes(out: &RenderOutput) -> usize {
+    let mut holes = 0;
+    for (y, span) in horizontal_profile(out).into_iter().enumerate() {
+        if let Some((lo, hi)) = span {
+            for x in (lo + 1)..hi {
+                #[allow(clippy::cast_possible_truncation)]
+                if out.face_id_at(x, y as u32).is_none() {
+                    holes += 1;
+                }
+            }
+        }
+    }
+    holes
+}
+
+/// Find the cylinder (lateral) face of `solid`.
+fn cylinder_face(topo: &Topology, solid: SolidId) -> FaceId {
+    solid_faces(topo, solid)
+        .unwrap()
+        .into_iter()
+        .find(|&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Cylinder(_)))
+        .expect("cylinder solid has a cylindrical lateral face")
+}
+
+/// A side-on orthographic-ish camera: the cylinder axis (+Z) is vertical and
+/// perpendicular to the view (looking along +Y), so the lateral surface
+/// silhouette is a clean rectangle exactly `2·radius` wide. This isolates the
+/// angular faceting: an inscribed N-gon's widest pair of generators sits at
+/// `radius·cos(π/N)` from the axis, so a coarse mesh renders *narrower* than a
+/// fine one — the rendered width converges up to the analytic `2·radius`.
+fn side_camera(center: Point3, radius: f64) -> Camera {
+    let fov_y = 30.0_f64.to_radians();
+    // Far back so the perspective foreshortening of the width is negligible
+    // (a near-orthographic side view), keeping the silhouette a true rectangle.
+    let dist = radius / (fov_y * 0.5).sin() * 6.0;
+    let eye = center + Vec3::new(0.0, -dist, 0.0);
+    Camera {
+        eye,
+        target: center,
+        up: Vec3::new(0.0, 0.0, 1.0),
+        fov_y,
+        aspect: 1.0,
+        near: dist - radius * 2.0,
+        far: dist + radius * 2.0,
+    }
+}
+
+/// Maximum rendered half-width (pixels from image center) of the silhouette
+/// across the central band of rows. For the side-on view this is the projected
+/// distance of the widest generator from the axis — larger means the mesh
+/// reaches closer to the true cylinder radius (rounder).
+fn max_side_half_width(out: &RenderOutput) -> f64 {
+    let profile = horizontal_profile(out);
+    let cx = f64::from(out.width) * 0.5;
+    let y_lo = out.height / 3;
+    let y_hi = out.height * 2 / 3;
+    let mut max_half = 0.0_f64;
+    for y in y_lo..y_hi {
+        if let Some((lo, hi)) = profile[y as usize] {
+            let half = ((f64::from(hi) + 0.5 - cx).abs()).max((cx - f64::from(lo) - 0.5).abs());
+            max_half = max_half.max(half);
+        }
+    }
+    max_half
+}
+
+#[test]
+fn compute_mesh_cylinder_is_nonblank_and_plausible() {
+    let Some(adapter) = probe_adapter() else {
+        println!("SKIP compute_mesh_cylinder_is_nonblank_and_plausible: no wgpu adapter available");
+        return;
+    };
+    println!("using wgpu adapter: {adapter}");
+
+    let mut topo = Topology::new();
+    let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, RADIUS, HEIGHT).unwrap();
+    let face = cylinder_face(&topo, cyl);
+    let desc = extract_cylinder_descriptor(&topo, face).unwrap();
+
+    // Sanity: the extracted descriptor recovers the primitive's geometry.
+    assert!(
+        (desc.radius - RADIUS).abs() < 1e-9,
+        "radius {}",
+        desc.radius
+    );
+    assert!(
+        (desc.v0).abs() < 1e-6 && (desc.v1 - HEIGHT).abs() < 1e-6,
+        "axial range [{}, {}] should span [0, {HEIGHT}]",
+        desc.v0,
+        desc.v1
+    );
+
+    let (_, cam) = cylinder_camera();
+    let opts = RenderOpts::new(512, 512);
+    let tess = TessFactor::new(48, 1);
+    let out = render_cylinder_compute_offscreen(&desc, tess, 1, &cam, &opts).unwrap();
+
+    let path = std::env::temp_dir().join("brepkit_compute_cylinder.png");
+    out.color.save(&path).unwrap();
+    println!("wrote {}", path.display());
+
+    let total = (out.width * out.height) as usize;
+    let drawn = non_background_pixels(&out, opts.background);
+    let frac = drawn as f64 / total as f64;
+    assert!(
+        frac > 0.05,
+        "only {drawn}/{total} ({frac:.3}) pixels differ from background"
+    );
+    assert!(
+        frac < 0.98,
+        "{drawn}/{total} ({frac:.3}) pixels differ from background (camera too close?)"
+    );
+
+    // A plausible cylinder side: silhouette present and wider than tall is not
+    // required, but it must be a real, bounded region inside the frame.
+    let (minx, miny, maxx, maxy) = id_silhouette_bbox(&out).expect("expected face-id pixels");
+    let bw = maxx - minx + 1;
+    let bh = maxy - miny + 1;
+    assert!(bw >= 32 && bh >= 32, "silhouette too small: {bw}x{bh}");
+    assert!(
+        bw < out.width && bh < out.height,
+        "silhouette fills the frame: {bw}x{bh}"
+    );
+
+    // Every drawn id is the face id we asked for (1).
+    for &id in &out.id_buffer {
+        assert!(id == 0 || id == 1, "unexpected id {id} in compute mesh");
+    }
+    assert_eq!(out.face_id_at(0, 0), None, "corner should be background");
+}
+
+#[test]
+fn compute_mesh_matches_cpu_silhouette() {
+    let Some(_) = probe_adapter() else {
+        println!("SKIP compute_mesh_matches_cpu_silhouette: no wgpu adapter available");
+        return;
+    };
+
+    let mut topo = Topology::new();
+    let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, RADIUS, HEIGHT).unwrap();
+    let face = cylinder_face(&topo, cyl);
+    let desc = extract_cylinder_descriptor(&topo, face).unwrap();
+
+    let (_, cam) = cylinder_camera();
+    let opts = RenderOpts {
+        edges: false,
+        ..RenderOpts::new(512, 512)
+    };
+
+    // CPU path: tessellate the whole solid (M1).
+    let cpu = render_solid_offscreen(&topo, cyl, &cam, &opts).unwrap();
+    // GPU path: compute-mesh the lateral face only, fine LOD for a tight match.
+    let gpu =
+        render_cylinder_compute_offscreen(&desc, TessFactor::new(96, 4), 1, &cam, &opts).unwrap();
+
+    let cpu_bbox = id_silhouette_bbox(&cpu).expect("cpu silhouette");
+    let gpu_bbox = id_silhouette_bbox(&gpu).expect("gpu silhouette");
+    println!("cpu bbox {cpu_bbox:?} gpu bbox {gpu_bbox:?}");
+
+    // The left/right extent is set purely by the analytic radius+axis and must
+    // agree closely (the compute mesh has no caps, so the vertical extent can
+    // differ slightly, but the horizontal silhouette edges should not).
+    let tol = 4_i64; // pixels
+    assert!(
+        (i64::from(cpu_bbox.0) - i64::from(gpu_bbox.0)).abs() <= tol,
+        "left edge differs: cpu {} gpu {}",
+        cpu_bbox.0,
+        gpu_bbox.0
+    );
+    assert!(
+        (i64::from(cpu_bbox.2) - i64::from(gpu_bbox.2)).abs() <= tol,
+        "right edge differs: cpu {} gpu {}",
+        cpu_bbox.2,
+        gpu_bbox.2
+    );
+
+    // The side silhouette half-width should match between CPU and GPU meshes
+    // across the central band (caps excluded): compare per-row spans.
+    let cpu_prof = horizontal_profile(&cpu);
+    let gpu_prof = horizontal_profile(&gpu);
+    let mut compared = 0;
+    let mut max_diff = 0_i64;
+    for y in (cpu.height / 3)..(cpu.height * 2 / 3) {
+        if let (Some((cl, cr)), Some((gl, gr))) = (cpu_prof[y as usize], gpu_prof[y as usize]) {
+            max_diff = max_diff
+                .max((i64::from(cl) - i64::from(gl)).abs())
+                .max((i64::from(cr) - i64::from(gr)).abs());
+            compared += 1;
+        }
+    }
+    assert!(compared > 50, "too few comparable rows: {compared}");
+    assert!(
+        max_diff <= 4,
+        "central-band side profile differs by up to {max_diff}px"
+    );
+}
+
+#[test]
+fn compute_mesh_lod_scales_triangles_and_smooths_silhouette() {
+    let Some(_) = probe_adapter() else {
+        println!(
+            "SKIP compute_mesh_lod_scales_triangles_and_smooths_silhouette: no wgpu adapter available"
+        );
+        return;
+    };
+
+    let mut topo = Topology::new();
+    let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, RADIUS, HEIGHT).unwrap();
+    let face = cylinder_face(&topo, cyl);
+    let desc = extract_cylinder_descriptor(&topo, face).unwrap();
+
+    let center = Point3::new(0.0, 0.0, HEIGHT * 0.5);
+    let cam = side_camera(center, RADIUS);
+    let opts = RenderOpts {
+        edges: false,
+        ..RenderOpts::new(512, 512)
+    };
+
+    let coarse = TessFactor::new(6, 1);
+    let fine = TessFactor::new(48, 1);
+    let reference = TessFactor::new(256, 1); // ≈ the analytic circle
+
+    // Triangle count scales with the angular factor (2·n_u·n_v).
+    assert_eq!(CylinderDescriptor::triangle_count(coarse), 12);
+    assert_eq!(CylinderDescriptor::triangle_count(fine), 96);
+    assert!(
+        CylinderDescriptor::triangle_count(fine) > CylinderDescriptor::triangle_count(coarse) * 4,
+        "fine {} should dwarf coarse {}",
+        CylinderDescriptor::triangle_count(fine),
+        CylinderDescriptor::triangle_count(coarse)
+    );
+
+    let coarse_out = render_cylinder_compute_offscreen(&desc, coarse, 1, &cam, &opts).unwrap();
+    let fine_out = render_cylinder_compute_offscreen(&desc, fine, 1, &cam, &opts).unwrap();
+    let ref_out = render_cylinder_compute_offscreen(&desc, reference, 1, &cam, &opts).unwrap();
+
+    coarse_out
+        .color
+        .save(std::env::temp_dir().join("brepkit_compute_cylinder_coarse.png"))
+        .unwrap();
+    fine_out
+        .color
+        .save(std::env::temp_dir().join("brepkit_compute_cylinder_fine.png"))
+        .unwrap();
+
+    // Side-on, the silhouette half-width is the projected distance of the
+    // widest generator from the axis. An inscribed N-gon underestimates the
+    // analytic radius; the shortfall (reference − rendered) shrinks with LOD.
+    let analytic = max_side_half_width(&ref_out);
+    let coarse_half = max_side_half_width(&coarse_out);
+    let fine_half = max_side_half_width(&fine_out);
+    let coarse_short = analytic - coarse_half;
+    let fine_short = analytic - fine_half;
+    println!(
+        "analytic half={analytic:.2}px  coarse={coarse_half:.2} (short {coarse_short:.2})  fine={fine_half:.2} (short {fine_short:.2})"
+    );
+
+    // The finer mesh reaches strictly closer to the analytic radius (rounder
+    // silhouette), and the coarse 6-gon shows a clearly visible shortfall.
+    assert!(
+        coarse_short > 1.5,
+        "coarse 6-gon should visibly under-fill the circle, shortfall {coarse_short:.2}px"
+    );
+    assert!(
+        fine_half > coarse_half + 1.0,
+        "finer LOD should render a wider (rounder) silhouette: coarse {coarse_half:.2} fine {fine_half:.2}"
+    );
+    assert!(
+        fine_short < coarse_short * 0.5,
+        "finer LOD should at least halve the facet shortfall (coarse {coarse_short:.2}, fine {fine_short:.2})"
+    );
+}
+
+#[test]
+fn compute_mesh_seam_is_watertight() {
+    let Some(_) = probe_adapter() else {
+        println!("SKIP compute_mesh_seam_is_watertight: no wgpu adapter available");
+        return;
+    };
+
+    let mut topo = Topology::new();
+    let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, RADIUS, HEIGHT).unwrap();
+    let face = cylinder_face(&topo, cyl);
+    let desc = extract_cylinder_descriptor(&topo, face).unwrap();
+
+    // Look along -X so the u = 0 seam generator (at +X) sits dead-center facing
+    // the camera. If the wrap quad did not reuse column 0's vertices, a crack
+    // would open along this central vertical line.
+    let center = Point3::new(0.0, 0.0, HEIGHT * 0.5);
+    let fov_y = 35.0_f64.to_radians();
+    let dist = RADIUS / (fov_y * 0.5).sin() * 3.0;
+    let cam = Camera {
+        eye: Point3::new(dist, 0.0, HEIGHT * 0.5),
+        target: center,
+        up: Vec3::new(0.0, 0.0, 1.0),
+        fov_y,
+        aspect: 1.0,
+        near: dist - RADIUS * 2.0,
+        far: dist + RADIUS * 2.0,
+    };
+    let opts = RenderOpts {
+        edges: false,
+        ..RenderOpts::new(512, 512)
+    };
+
+    // A coarse mesh maximizes the chance that a mis-stitched seam shows a gap.
+    let out =
+        render_cylinder_compute_offscreen(&desc, TessFactor::new(12, 3), 1, &cam, &opts).unwrap();
+    out.color
+        .save(std::env::temp_dir().join("brepkit_compute_cylinder_seam.png"))
+        .unwrap();
+
+    // The front wall fills the whole silhouette interior — no background cracks,
+    // in particular none along the central seam line.
+    let holes = interior_holes(&out);
+    assert_eq!(
+        holes, 0,
+        "seam/interior shows {holes} background hole pixels"
+    );
+
+    // And the seam column itself is drawn (the surface is continuous there).
+    let cx = out.width / 2;
+    let mut seam_drawn = 0;
+    for y in (out.height / 3)..(out.height * 2 / 3) {
+        if out.face_id_at(cx, y).is_some() {
+            seam_drawn += 1;
+        }
+    }
+    assert!(
+        seam_drawn > 50,
+        "central seam column should be continuously drawn, got {seam_drawn} rows"
+    );
+}
+
+#[test]
+fn compute_mesh_matches_cpu_for_off_origin_cylinder() {
+    let Some(_) = probe_adapter() else {
+        println!(
+            "SKIP compute_mesh_matches_cpu_for_off_origin_cylinder: no wgpu adapter available"
+        );
+        return;
+    };
+
+    // A cylinder whose axis does NOT pass through the world origin: this
+    // exercises the descriptor's `axis_origin` term (a cylinder built at the
+    // origin would hide a missing-translation bug).
+    let shift = Vec3::new(50.0, -30.0, 12.0);
+    let mut topo = Topology::new();
+    let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, RADIUS, HEIGHT).unwrap();
+    brepkit_operations::transform::transform_solid(
+        &mut topo,
+        cyl,
+        &brepkit_math::mat::Mat4::translation(shift.x(), shift.y(), shift.z()),
+    )
+    .unwrap();
+
+    let face = cylinder_face(&topo, cyl);
+    let desc = extract_cylinder_descriptor(&topo, face).unwrap();
+    // The extracted axis origin tracks the translation.
+    assert!(
+        (desc.axis_origin.x() - shift.x()).abs() < 1e-6
+            && (desc.axis_origin.y() - shift.y()).abs() < 1e-6,
+        "axis_origin {:?} should follow the translation",
+        desc.axis_origin
+    );
+
+    let center = Point3::new(shift.x(), shift.y(), shift.z() + HEIGHT * 0.5);
+    let bsphere = (RADIUS * RADIUS + (HEIGHT * 0.5) * (HEIGHT * 0.5)).sqrt();
+    let cam = iso_camera(center, bsphere);
+    let opts = RenderOpts {
+        edges: false,
+        ..RenderOpts::new(512, 512)
+    };
+
+    let cpu = render_solid_offscreen(&topo, cyl, &cam, &opts).unwrap();
+    let gpu =
+        render_cylinder_compute_offscreen(&desc, TessFactor::new(96, 4), 1, &cam, &opts).unwrap();
+
+    let cpu_bbox = id_silhouette_bbox(&cpu).expect("cpu silhouette");
+    let gpu_bbox = id_silhouette_bbox(&gpu).expect("gpu silhouette");
+    println!("off-origin cpu bbox {cpu_bbox:?} gpu bbox {gpu_bbox:?}");
+
+    // The horizontal silhouette edges (set by the analytic radius + axis
+    // location) must agree — proving the GPU honors `axis_origin`.
+    let tol = 4_i64;
+    assert!(
+        (i64::from(cpu_bbox.0) - i64::from(gpu_bbox.0)).abs() <= tol,
+        "left edge differs: cpu {} gpu {}",
+        cpu_bbox.0,
+        gpu_bbox.0
+    );
+    assert!(
+        (i64::from(cpu_bbox.2) - i64::from(gpu_bbox.2)).abs() <= tol,
+        "right edge differs: cpu {} gpu {}",
+        cpu_bbox.2,
+        gpu_bbox.2
+    );
+}


### PR DESCRIPTION
## What

**GPU compute-shader quadric mesher** (M2) — the renderer's differentiator. Instead of CPU-tessellating an analytic face and uploading thousands of triangles, brepkit can ship the surface's **parameters** and let a compute shader evaluate the parametric surface into a vertex buffer at a caller-chosen LOD. This PR implements it for the **cylinder**; cone/sphere/torus + screen-space-adaptive LOD follow the same pattern.

Built on the merged M1 offscreen renderer (#1013).

## How it works
- `extract_cylinder_descriptor(topo, FaceId)`: `FaceSurface::Cylinder` → `CylinderDescriptor` (center/axis/x_ref/y_ref/radius + axial trim `v0..v1` from the outer wire, full-revolution `u0..u1`); RTC center folded into the camera like M1.
- `quadric_mesh.wgsl`: `cs_vertices` writes `pos(u,v)=origin+r(cos u·x+sin u·y)+v·axis` + the radial normal into a flat `array<u32>` (**7 words/vertex = M1's `Vertex` stride**), `cs_indices` writes 2 tris/quad. The *same buffer* is bound STORAGE (compute writes it) then VERTEX/INDEX (the draw reads it), so **M1's mesh shader draws the compute output unchanged** — no CPU round-trip, no format conversion.
- Seam: the wrap quad references column 0 → watertight by construction.
- `render_cylinder_compute_offscreen(..)` renders it through M1's mesh pass.

`★ why this matters` — brepkit's kernel runs in-browser via wasm, so it can mesh view-dependently *client-side*. Shipping surface parameters (a few floats) instead of a fixed mesh is the foundation for smooth infinite-zoom LOD — an approach server-side CAD renderers can't use. WebGPU has no tessellation/mesh shaders, so the mesher *must* be a compute shader; that's exactly what this is.

## Verification (live RTX 4080 — the tests actually mesh + render)
- **Geometric correctness**: `compute_mesh_matches_cpu_silhouette` — the compute-meshed cylinder's silhouette bbox is **identical** to M1's CPU tessellation at the same camera; `compute_mesh_matches_cpu_for_off_origin_cylinder` exercises the `axis_origin` term.
- **LOD**: triangle count scales `2·n_u·n_v`; the coarse 6-gon is visibly faceted (5px shortfall vs a 256-gon reference), the fine 48-gon is smooth (0px).
- **Watertight seam**: a dedicated test centers the u=0 seam on the camera and asserts zero interior holes.
- `cargo nextest run -p brepkit-render`: **11/11** (5 compute + M1's 6). clippy `-D warnings`, fmt, `cargo deny check`, `check-boundaries.sh`: clean. No `unwrap`/`expect`/`panic` in lib.

## Notes
- `pipeline.rs`: reuses main's review-fixed `acquire_device()` (real→software fallback) for the compute path; M1's readback/format helpers widened to `pub(crate)`; M1's `SizeTooLarge` over-size guard mirrored onto the compute path.
- Overlaps PR #1016 (M1.5) only in `pipeline.rs` visibility (#1016 touches window/surface code, this touches readback/device helpers) — they merge sequentially; whichever lands first, the other rebases.

Next: cone/sphere/torus descriptors (pole/seam handling) + screen-space-adaptive LOD (the marked `TODO` in `TessFactor`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GPU compute-shader mesher for cylinders that evaluates the surface on the GPU and draws it with the existing mesh pass. This removes CPU tessellation/uploads and sets up client-side, view-dependent LOD.

- **New Features**
  - `quadric_mesh.wgsl`: `cs_vertices`/`cs_indices` write positions, normals, face-id, and indices; seam wraps to column 0 for a watertight mesh; uses a CPU-provided `full` flag and guards divides; column-major indexing.
  - `TessFactor::new(..)` clamps to `[3,16384]` (u) / `[1,16384]` (v) to keep counts in `u32`; `CylinderDescriptor` + `extract_cylinder_descriptor(..)` (axis frame, radius, axial trim, full-rev u, RTC center); `render_cylinder_compute_offscreen(..)` meshes with `TessFactor` and draws via the existing mesh pipeline with the same buffers bound as STORAGE then VERTEX/INDEX.
  - Export `CylinderDescriptor`, `TessFactor`, `extract_cylinder_descriptor`, `render_cylinder_compute_offscreen` from `lib.rs`. Headless tests cover silhouette vs CPU, LOD scaling, seam watertightness, off-origin handling, plus `TessFactor` clamp unit tests.

- **Refactors**
  - Make `pipeline::acquire_device`, `unpad_to_rgba`, and `unpad_to_u32` public; reuse device/readback/padding helpers; mirror the `SizeTooLarge` guard.
  - Use a `WORDS_PER_VERT` constant and checked `u32::try_from` for index counts to avoid truncation.

<sup>Written for commit e4871bbe608a8cd2c039906318c0af21e6044276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

