### PR TITLE
ci: force HTTP/1.1 + retries for crates.io fetches (fix HTTP/2 download flake)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,15 @@ xtask = "run --manifest-path xtask/Cargo.toml --"
 # via xtask (disable with --no-simd). Not set here because rustflags in
 # config.toml overrides (doesn't append to) env RUSTFLAGS, and CI sets
 # RUSTFLAGS=-Dwarnings globally.
+
+# crates.io dependency downloads intermittently fail on CI runners with
+# "[16] Error in the HTTP2 framing layer" (criterion's transitive deps —
+# cast/alloca/oorandom/itertools — and others), reddening otherwise-passing
+# jobs. Force HTTP/1.1 (sidesteps the HTTP/2 multiplexing fault) and retry
+# transient network failures so dependency fetches are reliable. Downloads
+# only matter on a cold cache (mostly CI), so the local-dev cost is negligible.
+[http]
+multiplexing = false
+
+[net]
+retry = 10


### PR DESCRIPTION
## What
Add `[http] multiplexing = false` + `[net] retry = 10` to `.cargo/config.toml` so dependency fetches stop reddening CI.

## Why
crates.io downloads on the runners intermittently fail with `[16] Error in the HTTP2 framing layer` while fetching `criterion`'s transitive deps (`cast`, `alloca`, `oorandom`, `itertools`) and others. **Today alone this flaked Coverage, Test, MSRV (1.88), Boolean perf, and WASM Size Report across the render + revolve PRs** — each a spurious red that only cleared on a manual re-run.

## The fix
- `[http] multiplexing = false` — cargo uses HTTP/1.1 instead of HTTP/2, sidestepping the HTTP/2 framing fault that causes the resets.
- `[net] retry = 10` — retries transient network failures.

## Tradeoff
HTTP/1.1 has no connection multiplexing, so cold-cache fetches open more connections (marginally slower). Downloads only happen on a cold cargo cache — almost always CI — so local-dev impact is negligible, and the reliability win removes a recurring class of spurious CI failures + manual re-runs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force HTTP/1.1 and add retries for Cargo dependency downloads to stop crates.io HTTP/2 flakiness in CI. This removes intermittent red jobs without affecting local dev.

- **Bug Fixes**
  - Set `[http] multiplexing = false` to use HTTP/1.1 for fetches.
  - Set `[net] retry = 10` to retry transient network errors.
  - Stabilizes Coverage, Test, MSRV, Boolean perf, and WASM Size jobs; only minor cold-cache slowdown in CI.

<sup>Written for commit 3243e4d426f337795a7da8a696803ad34e1eaaf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

