### PR TITLE
feat(render): screen-space adaptive LOD for the compute-mesher (M2.1)

### DIFF
--- a/crates/render/src/compute_mesh.rs
+++ b/crates/render/src/compute_mesh.rs
@@ -71,10 +71,95 @@ impl TessFactor {
             n_v: n_v.clamp(1, MAX_TESS),
         }
     }
+}
 
-    // TODO: view-dependent (screen-space) LOD — pick (n_u, n_v) per frame from a
-    // screen-space chord-error metric (projected radius / pixel budget) instead
-    // of a caller-supplied factor. Next milestone.
+/// Default screen-space chord-error budget, in pixels.
+///
+/// Sub-pixel: the faceting of a cylinder tessellated to this bound is invisible
+/// at the rendered resolution.
+pub const DEFAULT_TARGET_PX: f64 = 0.5;
+
+/// Derive a [`TessFactor`] from the cylinder's *projected screen size* so the
+/// silhouette's chord error stays within `target_px` pixels at the given view.
+///
+/// A zoomed-in cylinder (large projected radius) gets a fine mesh; a distant one
+/// (small projected radius) gets a coarse mesh — view-dependent LOD, the payoff
+/// of meshing analytic surfaces on the GPU from their parameters.
+///
+/// # Math
+///
+/// The chord error of an `n_u`-gon inscribed in a circle of radius `r` is
+/// `ε = r·(1 − cos(π/n_u))`. Projecting `r` to pixels under perspective,
+/// `r_px = r · (H/2) / (d · tan(fov_y/2))` where `H` is the viewport height and
+/// `d = |eye − center|` is the camera distance to the cylinder. Bounding the
+/// *screen-space* error `r_px·(1 − cos(π/n_u)) ≤ target_px` and solving:
+/// `n_u = ceil(π / acos(1 − clamp(target_px / r_px, 0, 2)))`. A sub-pixel
+/// cylinder (`r_px ≤ target_px`) floors to the [`TessFactor`] minimum.
+///
+/// `n_v` is fixed at 1: a cylinder's lateral face is *ruled* (straight and of
+/// constant normal along the axis), so one axial division is geometrically and
+/// shading-exact. Sphere/torus surfaces will later need `n_v` adaptivity too,
+/// since they curve in both parametric directions.
+///
+/// The result always passes through [`TessFactor::new`], so the
+/// `[3, MAX_TESS]` clamp and the buffer-overflow guard still apply.
+#[must_use]
+pub fn screen_space_tess_factor(
+    desc: &CylinderDescriptor,
+    cam: &Camera,
+    viewport: (u32, u32),
+    target_px: f64,
+) -> TessFactor {
+    let n_u = angular_subdivisions_for_screen_error(desc, cam, viewport, target_px);
+    TessFactor::new(n_u, 1)
+}
+
+/// Angular subdivisions needed to keep the projected chord error within
+/// `target_px`. Returns a raw count (the caller clamps via [`TessFactor::new`]);
+/// degenerate inputs (zero radius/distance/fov, sub-pixel projection) collapse
+/// to the minimum or maximum so the clamp lands on a valid factor.
+fn angular_subdivisions_for_screen_error(
+    desc: &CylinderDescriptor,
+    cam: &Camera,
+    viewport: (u32, u32),
+    target_px: f64,
+) -> u32 {
+    // True for a strictly-positive finite value (false for 0, negatives, NaN,
+    // and infinities) — the precondition for every divisor below.
+    let is_pos_finite = |x: f64| x.is_finite() && x > 0.0;
+
+    let (_, height) = viewport;
+    let half_fov_tan = (cam.fov_y * 0.5).tan();
+    let dist = (cam.eye - desc.center).length();
+
+    // Guard the projection divide: a degenerate fov or a camera sitting on the
+    // cylinder makes the projected radius unbounded → request the maximum.
+    if !is_pos_finite(half_fov_tan) || !is_pos_finite(dist) || !is_pos_finite(target_px) {
+        return MAX_TESS;
+    }
+    let r_px = desc.radius * (f64::from(height) * 0.5) / (dist * half_fov_tan);
+    if !is_pos_finite(r_px) {
+        // Sub-pixel or degenerate radius: the coarsest mesh is already exact.
+        return 3;
+    }
+
+    // ratio ∈ [0, 2] keeps the acos argument (1 − ratio) in [−1, 1].
+    let ratio = (target_px / r_px).clamp(0.0, 2.0);
+    let theta = (1.0 - ratio).acos(); // half the per-facet angle bound
+    if !is_pos_finite(theta) {
+        // r_px ≤ target_px (sub-pixel facets already): minimum tessellation.
+        return 3;
+    }
+    let n = (std::f64::consts::PI / theta).ceil();
+    // n is finite and ≥ 1 here; clamp into u32 range before TessFactor re-clamps.
+    if n >= f64::from(MAX_TESS) {
+        MAX_TESS
+    } else {
+        // Safe: 1 ≤ n < MAX_TESS ≤ u32::MAX, and n is finite.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let v = n as u32;
+        v
+    }
 }
 
 /// A cylinder surface packed for GPU evaluation.
@@ -575,6 +660,29 @@ pub fn render_cylinder_compute_offscreen(
     })
 }
 
+/// Render a compute-meshed cylinder with the tessellation chosen automatically
+/// from its projected screen size (view-dependent LOD).
+///
+/// Computes a [`screen_space_tess_factor`] from `cam` and the render dimensions
+/// in `opts` (bounding the silhouette chord error to `target_px` pixels — pass
+/// [`DEFAULT_TARGET_PX`] for the sub-pixel default), then meshes and renders
+/// exactly as [`render_cylinder_compute_offscreen`]. A near view yields a fine
+/// mesh, a far view a coarse one, both staying within the pixel budget.
+///
+/// # Errors
+///
+/// Same as [`render_cylinder_compute_offscreen`].
+pub fn render_cylinder_compute_screen_lod(
+    desc: &CylinderDescriptor,
+    face_id: u32,
+    cam: &Camera,
+    opts: &RenderOpts,
+    target_px: f64,
+) -> Result<RenderOutput, RenderError> {
+    let tess = screen_space_tess_factor(desc, cam, (opts.width, opts.height), target_px);
+    render_cylinder_compute_offscreen(desc, tess, face_id, cam, opts)
+}
+
 /// A read-write storage-buffer bind-group-layout entry visible to compute.
 fn storage_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
     wgpu::BindGroupLayoutEntry {
@@ -837,5 +945,107 @@ mod tests {
             u32::try_from(vertex_count * WORDS_PER_VERT).is_ok(),
             "vertex word count exceeds u32"
         );
+    }
+
+    /// A unit cylinder of `radius` centered at the origin, axis +Z.
+    fn unit_cylinder(radius: f64) -> CylinderDescriptor {
+        CylinderDescriptor {
+            center: Point3::new(0.0, 0.0, 0.0),
+            axis_origin: Point3::new(0.0, 0.0, -1.0),
+            axis: Vec3::new(0.0, 0.0, 1.0),
+            x_ref: Vec3::new(1.0, 0.0, 0.0),
+            y_ref: Vec3::new(0.0, 1.0, 0.0),
+            radius,
+            v0: 0.0,
+            v1: 2.0,
+            u0: 0.0,
+            u1: TAU,
+        }
+    }
+
+    /// A camera at distance `dist` along +X looking back at the origin.
+    fn camera_at(dist: f64) -> Camera {
+        Camera {
+            eye: Point3::new(dist, 0.0, 0.0),
+            target: Point3::new(0.0, 0.0, 0.0),
+            up: Vec3::new(0.0, 0.0, 1.0),
+            fov_y: 45.0_f64.to_radians(),
+            aspect: 1.0,
+            near: 0.1,
+            far: dist * 10.0,
+        }
+    }
+
+    #[test]
+    fn screen_lod_increases_when_closer() {
+        let desc = unit_cylinder(5.0);
+        let viewport = (512, 512);
+        let near = screen_space_tess_factor(&desc, &camera_at(20.0), viewport, 0.5);
+        let far = screen_space_tess_factor(&desc, &camera_at(200.0), viewport, 0.5);
+        assert!(
+            near.n_u > far.n_u,
+            "closer camera should subdivide more: near {} far {}",
+            near.n_u,
+            far.n_u
+        );
+        assert_eq!(near.n_v, 1, "ruled axial direction stays at 1");
+        assert_eq!(far.n_v, 1);
+    }
+
+    #[test]
+    fn screen_lod_increases_with_radius() {
+        let viewport = (512, 512);
+        let cam = camera_at(50.0);
+        let small = screen_space_tess_factor(&unit_cylinder(2.0), &cam, viewport, 0.5);
+        let large = screen_space_tess_factor(&unit_cylinder(40.0), &cam, viewport, 0.5);
+        assert!(
+            large.n_u > small.n_u,
+            "larger projected radius should subdivide more: small {} large {}",
+            small.n_u,
+            large.n_u
+        );
+    }
+
+    #[test]
+    fn screen_lod_floors_at_minimum_when_subpixel() {
+        // A tiny cylinder very far away projects to under a pixel: the coarsest
+        // mesh (the TessFactor minimum) already satisfies any sane budget.
+        let desc = unit_cylinder(0.01);
+        let t = screen_space_tess_factor(&desc, &camera_at(5_000.0), (256, 256), 0.5);
+        assert_eq!(t.n_u, 3, "sub-pixel cylinder floors at the minimum");
+    }
+
+    #[test]
+    fn screen_lod_tighter_budget_subdivides_more() {
+        let desc = unit_cylinder(5.0);
+        let cam = camera_at(40.0);
+        let coarse = screen_space_tess_factor(&desc, &cam, (512, 512), 2.0);
+        let fine = screen_space_tess_factor(&desc, &cam, (512, 512), 0.25);
+        assert!(
+            fine.n_u > coarse.n_u,
+            "a tighter pixel budget should subdivide more: coarse {} fine {}",
+            coarse.n_u,
+            fine.n_u
+        );
+    }
+
+    #[test]
+    fn screen_lod_handles_degenerate_inputs() {
+        let desc = unit_cylinder(5.0);
+        let viewport = (512, 512);
+        // Camera sitting on the cylinder center: projection diverges → MAX_TESS.
+        let mut on_center = camera_at(40.0);
+        on_center.eye = desc.center;
+        let t = screen_space_tess_factor(&desc, &on_center, viewport, 0.5);
+        assert_eq!(t.n_u, MAX_TESS, "zero distance requests the maximum LOD");
+
+        // Zero / non-finite target budget must not produce NaN; it caps out.
+        let t0 = screen_space_tess_factor(&desc, &camera_at(40.0), viewport, 0.0);
+        assert_eq!(
+            t0.n_u, MAX_TESS,
+            "zero pixel budget requests the maximum LOD"
+        );
+        let t_nan = screen_space_tess_factor(&desc, &camera_at(40.0), viewport, f64::NAN);
+        assert_eq!(t_nan.n_u, MAX_TESS, "NaN budget falls back to maximum");
     }
 }

--- a/crates/render/src/compute_mesh.rs
+++ b/crates/render/src/compute_mesh.rs
@@ -91,10 +91,13 @@ pub const DEFAULT_TARGET_PX: f64 = 0.5;
 /// The chord error of an `n_u`-gon inscribed in a circle of radius `r` is
 /// `ε = r·(1 − cos(π/n_u))`. Projecting `r` to pixels under perspective,
 /// `r_px = r · (H/2) / (d · tan(fov_y/2))` where `H` is the viewport height and
-/// `d = |eye − center|` is the camera distance to the cylinder. Bounding the
+/// `d` is the center's *view-space depth* (its projection onto the view
+/// direction, `view_dir · (center − eye)`) — not the Euclidean eye distance, so
+/// an off-axis cylinder at the same depth is not under-tessellated. Bounding the
 /// *screen-space* error `r_px·(1 − cos(π/n_u)) ≤ target_px` and solving:
 /// `n_u = ceil(π / acos(1 − clamp(target_px / r_px, 0, 2)))`. A sub-pixel
-/// cylinder (`r_px ≤ target_px`) floors to the [`TessFactor`] minimum.
+/// cylinder (`r_px ≤ target_px`) floors to the [`TessFactor`] minimum; a cylinder
+/// engulfing the camera (`r_px → ∞`) requests the maximum.
 ///
 /// `n_v` is fixed at 1: a cylinder's lateral face is *ruled* (straight and of
 /// constant normal along the axis), so one axial division is geometrically and
@@ -115,38 +118,51 @@ pub fn screen_space_tess_factor(
 }
 
 /// Angular subdivisions needed to keep the projected chord error within
-/// `target_px`. Returns a raw count (the caller clamps via [`TessFactor::new`]);
-/// degenerate inputs (zero radius/distance/fov, sub-pixel projection) collapse
-/// to the minimum or maximum so the clamp lands on a valid factor.
+/// `target_px`. Returns a raw count (the caller clamps via [`TessFactor::new`]).
+///
+/// Edge cases collapse so the clamp lands on a valid factor: an unbounded
+/// projection (`r_px → ∞`, the camera engulfed by the surface) → the maximum;
+/// a sub-pixel projection, a center behind the camera, or a non-finite/≤0 budget
+/// → the minimum.
 fn angular_subdivisions_for_screen_error(
     desc: &CylinderDescriptor,
     cam: &Camera,
     viewport: (u32, u32),
     target_px: f64,
 ) -> u32 {
-    // True for a strictly-positive finite value (false for 0, negatives, NaN,
-    // and infinities) — the precondition for every divisor below.
-    let is_pos_finite = |x: f64| x.is_finite() && x > 0.0;
-
     let (_, height) = viewport;
-    let half_fov_tan = (cam.fov_y * 0.5).tan();
-    let dist = (cam.eye - desc.center).length();
 
-    // Guard the projection divide: a degenerate fov or a camera sitting on the
-    // cylinder makes the projected radius unbounded → request the maximum.
-    if !is_pos_finite(half_fov_tan) || !is_pos_finite(dist) || !is_pos_finite(target_px) {
+    // Clamp the FOV into the valid open interval `(0, π)` so `tan(fov/2)` is
+    // always finite-positive (matching a sane render); an out-of-range fov must
+    // not poison the projection.
+    let fov_y = cam.fov_y.clamp(1.0e-4, std::f64::consts::PI - 1.0e-4);
+    let half_fov_tan = (fov_y * 0.5).tan();
+
+    // Perspective scale is set by the *view-space depth* of the center (its
+    // projection onto the view axis), not the Euclidean eye distance: an
+    // off-axis cylinder at the same depth must not be under-tessellated.
+    let depth = cam.view_direction().dot(desc.center - cam.eye);
+
+    // A non-finite or non-positive budget can't bound anything → max detail.
+    if !(target_px.is_finite() && target_px > 0.0) {
         return MAX_TESS;
     }
-    let r_px = desc.radius * (f64::from(height) * 0.5) / (dist * half_fov_tan);
-    if !is_pos_finite(r_px) {
-        // Sub-pixel or degenerate radius: the coarsest mesh is already exact.
+    let r_px = desc.radius * (f64::from(height) * 0.5) / (depth * half_fov_tan);
+    // Classify the projected radius:
+    //   +∞  → the surface engulfs/fills the screen (depth → 0): finest mesh.
+    //   ≤ 0 or NaN → behind the camera or degenerate: won't render → coarsest.
+    //   finite > 0 → the normal screen-size formula below.
+    if r_px.is_infinite() && r_px > 0.0 {
+        return MAX_TESS;
+    }
+    if !(r_px.is_finite() && r_px > 0.0) {
         return 3;
     }
 
     // ratio ∈ [0, 2] keeps the acos argument (1 − ratio) in [−1, 1].
     let ratio = (target_px / r_px).clamp(0.0, 2.0);
     let theta = (1.0 - ratio).acos(); // half the per-facet angle bound
-    if !is_pos_finite(theta) {
+    if !(theta.is_finite() && theta > 0.0) {
         // r_px ≤ target_px (sub-pixel facets already): minimum tessellation.
         return 3;
     }
@@ -1033,13 +1049,8 @@ mod tests {
     fn screen_lod_handles_degenerate_inputs() {
         let desc = unit_cylinder(5.0);
         let viewport = (512, 512);
-        // Camera sitting on the cylinder center: projection diverges → MAX_TESS.
-        let mut on_center = camera_at(40.0);
-        on_center.eye = desc.center;
-        let t = screen_space_tess_factor(&desc, &on_center, viewport, 0.5);
-        assert_eq!(t.n_u, MAX_TESS, "zero distance requests the maximum LOD");
 
-        // Zero / non-finite target budget must not produce NaN; it caps out.
+        // Zero / non-finite target budget can't bound anything → max detail.
         let t0 = screen_space_tess_factor(&desc, &camera_at(40.0), viewport, 0.0);
         assert_eq!(
             t0.n_u, MAX_TESS,
@@ -1047,5 +1058,63 @@ mod tests {
         );
         let t_nan = screen_space_tess_factor(&desc, &camera_at(40.0), viewport, f64::NAN);
         assert_eq!(t_nan.n_u, MAX_TESS, "NaN budget falls back to maximum");
+    }
+
+    #[test]
+    fn screen_lod_engulfing_camera_requests_maximum() {
+        // A camera engulfed by / sitting on the cylinder has zero view-space
+        // depth, so the projected radius is unbounded (r_px → +∞): it must
+        // tessellate FINELY (max), not coarsely (the bug this guards against —
+        // the prior code treated +∞ as sub-pixel and returned the minimum).
+        let desc = unit_cylinder(5.0);
+        let viewport = (512, 512);
+        let mut on_center = camera_at(40.0);
+        on_center.eye = desc.center;
+        assert_eq!(
+            screen_space_tess_factor(&desc, &on_center, viewport, 0.5).n_u,
+            MAX_TESS,
+            "a camera engulfed by the cylinder (depth 0) must request the maximum LOD"
+        );
+    }
+
+    #[test]
+    fn screen_lod_clamps_extreme_fov_to_bounded_high_lod() {
+        // A near-zero FOV (extreme telephoto zoom) is clamped to a valid minimum
+        // rather than poisoning the projection: it yields a high but *bounded*
+        // tessellation, not a degenerate one.
+        let desc = unit_cylinder(5.0);
+        let viewport = (512, 512);
+        let mut tiny_fov = camera_at(40.0);
+        tiny_fov.fov_y = 1.0e-12;
+        let normal = screen_space_tess_factor(&desc, &camera_at(40.0), viewport, 0.5);
+        let zoomed = screen_space_tess_factor(&desc, &tiny_fov, viewport, 0.5);
+        assert!(
+            zoomed.n_u > normal.n_u,
+            "extreme zoom should subdivide far more than the normal fov: zoomed {} normal {}",
+            zoomed.n_u,
+            normal.n_u
+        );
+    }
+
+    #[test]
+    fn screen_lod_behind_camera_floors_at_minimum() {
+        // The cylinder behind the camera (negative view-space depth) does not
+        // render meaningfully → the coarsest mesh. `camera_at` looks down −X at
+        // the origin, so a center placed further down +X is behind the eye.
+        let viewport = (512, 512);
+        let mut desc = unit_cylinder(5.0);
+        let cam = camera_at(40.0); // eye at (40,0,0) looking toward −X
+        desc.center = Point3::new(80.0, 0.0, 0.0); // behind the camera
+        desc.axis_origin = Point3::new(80.0, 0.0, -1.0);
+        let depth_is_negative = cam.view_direction().dot(desc.center - cam.eye) < 0.0;
+        assert!(
+            depth_is_negative,
+            "test setup: center should be behind the camera"
+        );
+        assert_eq!(
+            screen_space_tess_factor(&desc, &cam, viewport, 0.5).n_u,
+            3,
+            "a cylinder behind the camera floors at the minimum LOD"
+        );
     }
 }

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -54,7 +54,9 @@ mod viewer;
 
 pub use camera::Camera;
 pub use compute_mesh::{
-    CylinderDescriptor, TessFactor, extract_cylinder_descriptor, render_cylinder_compute_offscreen,
+    CylinderDescriptor, DEFAULT_TARGET_PX, TessFactor, extract_cylinder_descriptor,
+    render_cylinder_compute_offscreen, render_cylinder_compute_screen_lod,
+    screen_space_tess_factor,
 };
 pub use error::RenderError;
 pub use pipeline::probe_adapter;

--- a/crates/render/tests/compute_mesh_lod.rs
+++ b/crates/render/tests/compute_mesh_lod.rs
@@ -1,0 +1,250 @@
+//! Headless tests for screen-space adaptive LOD (M2.1).
+//!
+//! The compute mesher's tessellation is derived per-frame from the cylinder's
+//! projected screen size, so a near view gets a fine mesh and a far view a
+//! coarse one — both bounded to a target pixel chord error. These tests render
+//! the same cylinder from near/far cameras and verify the triangle count scales
+//! with distance and the rendered silhouette stays within the pixel budget of
+//! the analytic circle. They require a wgpu adapter; without one they skip.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_render::{
+    Camera, CylinderDescriptor, RenderOpts, RenderOutput, TessFactor, extract_cylinder_descriptor,
+    probe_adapter, render_cylinder_compute_offscreen, render_cylinder_compute_screen_lod,
+    screen_space_tess_factor,
+};
+use brepkit_topology::Topology;
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::face::{FaceId, FaceSurface};
+use brepkit_topology::solid::SolidId;
+
+const RADIUS: f64 = 8.0;
+const HEIGHT: f64 = 20.0;
+const VIEWPORT: u32 = 512;
+const TARGET_PX: f64 = 0.5;
+
+/// A side-on near-orthographic camera at `dist` along +Y, axis (+Z) vertical and
+/// perpendicular to the view, so the lateral silhouette is a clean rectangle
+/// exactly `2·radius` wide. Far back enough that width foreshortening is tiny.
+fn side_camera(center: Point3, dist: f64) -> Camera {
+    let fov_y = 30.0_f64.to_radians();
+    Camera {
+        eye: center + Vec3::new(0.0, -dist, 0.0),
+        target: center,
+        up: Vec3::new(0.0, 0.0, 1.0),
+        fov_y,
+        aspect: 1.0,
+        near: (dist - RADIUS * 2.0).max(0.01),
+        far: dist + RADIUS * 2.0,
+    }
+}
+
+/// Find the cylinder (lateral) face of `solid`.
+fn cylinder_face(topo: &Topology, solid: SolidId) -> FaceId {
+    solid_faces(topo, solid)
+        .unwrap()
+        .into_iter()
+        .find(|&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Cylinder(_)))
+        .expect("cylinder solid has a cylindrical lateral face")
+}
+
+/// The default cylinder descriptor (base at z=0, axis +Z), centered on its AABB.
+fn cylinder_descriptor() -> (CylinderDescriptor, Point3) {
+    let mut topo = Topology::new();
+    let cyl = brepkit_operations::primitives::make_cylinder(&mut topo, RADIUS, HEIGHT).unwrap();
+    let face = cylinder_face(&topo, cyl);
+    let desc = extract_cylinder_descriptor(&topo, face).unwrap();
+    (desc, desc.center)
+}
+
+/// For each image row, the leftmost and rightmost drawn (non-background) column.
+fn horizontal_profile(out: &RenderOutput) -> Vec<Option<(u32, u32)>> {
+    let mut rows = Vec::with_capacity(out.height as usize);
+    for y in 0..out.height {
+        let mut span: Option<(u32, u32)> = None;
+        for x in 0..out.width {
+            if out.face_id_at(x, y).is_some() {
+                span = Some(match span {
+                    None => (x, x),
+                    Some((lo, hi)) => (lo.min(x), hi.max(x)),
+                });
+            }
+        }
+        rows.push(span);
+    }
+    rows
+}
+
+/// Maximum silhouette half-width (pixels from image center) over the central
+/// band of rows, for the side-on view.
+///
+/// All generators of a side-on cylinder sit at radius `r`, so the silhouette
+/// edge is the *outermost projected generator*: an inscribed `n_u`-gon renders
+/// this at `r_px·cos(φ)` where `φ ∈ [0, π/n_u]` is the offset of the nearest
+/// generator to the silhouette tangent. The worst case (an edge facing the
+/// silhouette) is `r_px·cos(π/n_u)`, so `r_px − max_half` is the rendered chord
+/// error. Using the *max* (not min) avoids the vertical taper of the rounded
+/// caps, which would otherwise contaminate a min-based metric at small scales.
+fn side_max_half_width(out: &RenderOutput) -> f64 {
+    let profile = horizontal_profile(out);
+    let cx = f64::from(out.width) * 0.5;
+    let y_lo = out.height / 3;
+    let y_hi = out.height * 2 / 3;
+    let mut max_half = 0.0_f64;
+    for y in y_lo..y_hi {
+        if let Some((lo, hi)) = profile[y as usize] {
+            let half = ((f64::from(hi) + 0.5 - cx).abs()).max((cx - f64::from(lo) - 0.5).abs());
+            max_half = max_half.max(half);
+        }
+    }
+    max_half
+}
+
+/// The cylinder radius projected to pixels at `cam`, matching the formula
+/// `screen_space_tess_factor` uses: `r_px = r · (H/2) / (d · tan(fov_y/2))`.
+fn analytic_projected_radius(desc: &CylinderDescriptor, cam: &Camera, viewport_h: u32) -> f64 {
+    let d = (cam.eye - desc.center).length();
+    desc.radius * (f64::from(viewport_h) * 0.5) / (d * (cam.fov_y * 0.5).tan())
+}
+
+/// Rendered chord error in pixels: how far the silhouette edge falls inside the
+/// analytic projected circle (`r_px − rendered max half-width`).
+fn chord_error_px(desc: &CylinderDescriptor, cam: &Camera, out: &RenderOutput) -> f64 {
+    let r_px = analytic_projected_radius(desc, cam, out.height);
+    (r_px - side_max_half_width(out)).max(0.0)
+}
+
+#[test]
+fn screen_lod_triangle_count_scales_with_distance() {
+    let Some(adapter) = probe_adapter() else {
+        println!("SKIP screen_lod_triangle_count_scales_with_distance: no wgpu adapter available");
+        return;
+    };
+    println!("using wgpu adapter: {adapter}");
+
+    let (desc, center) = cylinder_descriptor();
+    let opts = RenderOpts {
+        edges: false,
+        ..RenderOpts::new(VIEWPORT, VIEWPORT)
+    };
+
+    // Near: the cylinder fills much of the frame (but stays fully inside it, so
+    // the silhouette is not clipped by the viewport edge). Far: it is small.
+    let near_cam = side_camera(center, RADIUS * 6.5);
+    let far_cam = side_camera(center, RADIUS * 40.0);
+
+    let near_tess = screen_space_tess_factor(&desc, &near_cam, (VIEWPORT, VIEWPORT), TARGET_PX);
+    let far_tess = screen_space_tess_factor(&desc, &far_cam, (VIEWPORT, VIEWPORT), TARGET_PX);
+    let near_tris = CylinderDescriptor::triangle_count(near_tess);
+    let far_tris = CylinderDescriptor::triangle_count(far_tess);
+    println!(
+        "near n_u={} ({near_tris} tris)  far n_u={} ({far_tris} tris)",
+        near_tess.n_u, far_tess.n_u
+    );
+
+    assert!(
+        near_tris > far_tris,
+        "near view should produce more triangles than far: near {near_tris} far {far_tris}"
+    );
+
+    // Render both via the screen-LOD entry; write PNGs and confirm both are
+    // non-blank, bounded silhouettes.
+    let near = render_cylinder_compute_screen_lod(&desc, 1, &near_cam, &opts, TARGET_PX).unwrap();
+    let far = render_cylinder_compute_screen_lod(&desc, 1, &far_cam, &opts, TARGET_PX).unwrap();
+    let near_path = std::env::temp_dir().join("brepkit_lod_near.png");
+    let far_path = std::env::temp_dir().join("brepkit_lod_far.png");
+    near.color.save(&near_path).unwrap();
+    far.color.save(&far_path).unwrap();
+    println!("wrote {} and {}", near_path.display(), far_path.display());
+
+    // Both silhouettes stay within ~target_px of the analytic circle: the
+    // rendered silhouette edge is within the pixel budget of the projected
+    // radius (plus ~1px rasterization slack).
+    for (label, cam, out) in [("near", near_cam, &near), ("far", far_cam, &far)] {
+        let r_px = analytic_projected_radius(&desc, &cam, VIEWPORT);
+        // Guard: the cross-check is only valid if the silhouette is fully inside
+        // the frame (otherwise the viewport edge, not the mesh, bounds it).
+        assert!(
+            r_px < f64::from(VIEWPORT) * 0.5 - 4.0,
+            "{label}: projected radius {r_px:.1}px would clip the {VIEWPORT}px frame"
+        );
+        let err = chord_error_px(&desc, &cam, out);
+        println!("{label}: r_px≈{r_px:.2}px  chord error {err:.2}px");
+        assert!(
+            err <= TARGET_PX + 1.0,
+            "{label}: silhouette chord error {err:.2}px exceeds budget {TARGET_PX}px"
+        );
+    }
+}
+
+#[test]
+fn screen_lod_bound_holds_and_is_not_wasteful() {
+    let Some(_) = probe_adapter() else {
+        println!("SKIP screen_lod_bound_holds_and_is_not_wasteful: no wgpu adapter available");
+        return;
+    };
+
+    let (desc, center) = cylinder_descriptor();
+    let opts = RenderOpts {
+        edges: false,
+        ..RenderOpts::new(VIEWPORT, VIEWPORT)
+    };
+
+    // A fixed moderate framing.
+    let cam = side_camera(center, RADIUS * 8.0);
+    let tess = screen_space_tess_factor(&desc, &cam, (VIEWPORT, VIEWPORT), TARGET_PX);
+    println!("chosen n_u={}", tess.n_u);
+
+    // The chosen LOD keeps the measured chord error within budget.
+    let out = render_cylinder_compute_screen_lod(&desc, 1, &cam, &opts, TARGET_PX).unwrap();
+    let r_px = analytic_projected_radius(&desc, &cam, VIEWPORT);
+    let err = chord_error_px(&desc, &cam, &out);
+    println!("r_px≈{r_px:.2}px  chosen chord error {err:.2}px");
+    assert!(
+        err <= TARGET_PX + 1.0,
+        "chord error {err:.2}px exceeds budget {TARGET_PX}px"
+    );
+
+    // ...and is not wastefully high: a much coarser mesh would visibly violate
+    // the budget. Quartering n_u must produce a measurably worse chord error,
+    // confirming the chosen factor is near the budget rather than excessive.
+    let coarser = TessFactor::new(tess.n_u / 4, 1);
+    if coarser.n_u < tess.n_u {
+        let coarse_out = render_cylinder_compute_offscreen(&desc, coarser, 1, &cam, &opts).unwrap();
+        let coarse_err = chord_error_px(&desc, &cam, &coarse_out);
+        println!("coarser n_u={} chord error {coarse_err:.2}px", coarser.n_u);
+        assert!(
+            coarse_err > err,
+            "the chosen LOD should be near-minimal: quartering n_u ({}) did not worsen the error ({coarse_err:.2} vs {err:.2})",
+            coarser.n_u
+        );
+    }
+}
+
+#[test]
+fn screen_lod_render_entry_matches_manual_factor() {
+    let Some(_) = probe_adapter() else {
+        println!("SKIP screen_lod_render_entry_matches_manual_factor: no wgpu adapter available");
+        return;
+    };
+
+    let (desc, center) = cylinder_descriptor();
+    let opts = RenderOpts {
+        edges: false,
+        ..RenderOpts::new(VIEWPORT, VIEWPORT)
+    };
+    let cam = side_camera(center, RADIUS * 6.0);
+
+    // The screen-LOD entry must pick the same factor the standalone fn reports,
+    // so its output equals rendering with that factor explicitly.
+    let tess = screen_space_tess_factor(&desc, &cam, (VIEWPORT, VIEWPORT), TARGET_PX);
+    let via_entry = render_cylinder_compute_screen_lod(&desc, 1, &cam, &opts, TARGET_PX).unwrap();
+    let via_manual = render_cylinder_compute_offscreen(&desc, tess, 1, &cam, &opts).unwrap();
+
+    assert_eq!(
+        via_entry.id_buffer, via_manual.id_buffer,
+        "screen-LOD entry should render identically to the explicitly-chosen factor"
+    );
+}

--- a/crates/render/tests/compute_mesh_lod.rs
+++ b/crates/render/tests/compute_mesh_lod.rs
@@ -103,10 +103,12 @@ fn side_max_half_width(out: &RenderOutput) -> f64 {
 }
 
 /// The cylinder radius projected to pixels at `cam`, matching the formula
-/// `screen_space_tess_factor` uses: `r_px = r · (H/2) / (d · tan(fov_y/2))`.
+/// `screen_space_tess_factor` uses: `r_px = r · (H/2) / (d · tan(fov_y/2))`,
+/// where `d` is the center's view-space depth (these side-on test cameras look
+/// straight at the center, so depth equals the eye distance).
 fn analytic_projected_radius(desc: &CylinderDescriptor, cam: &Camera, viewport_h: u32) -> f64 {
-    let d = (cam.eye - desc.center).length();
-    desc.radius * (f64::from(viewport_h) * 0.5) / (d * (cam.fov_y * 0.5).tan())
+    let depth = cam.view_direction().dot(desc.center - cam.eye);
+    desc.radius * (f64::from(viewport_h) * 0.5) / (depth * (cam.fov_y * 0.5).tan())
 }
 
 /// Rendered chord error in pixels: how far the silhouette edge falls inside the


### PR DESCRIPTION
## What

**Screen-space adaptive LOD** (M2.1) — the compute-mesher now derives its tessellation factor **per-frame from the cylinder's projected pixel size**, so detail tracks zoom under a target chord-error budget. This replaces the caller-supplied `TessFactor` (the `// TODO: view-dependent LOD` marker from M2) and is the payoff of the compute-mesher: ship the surface's *parameters* and mesh at exactly the detail the current view needs.

## The math
- Projected radius (perspective): `r_px = r · (H/2) / (d · tan(fov_y/2))`, where `d = |cam.eye − desc.center|`, `H` = viewport height.
- An inscribed `n_u`-gon has chord error `ε = r·(1 − cos(π/n_u))`. Bounding the *screen-space* error by `target_px` and solving: `n_u = ceil(π / acos(1 − clamp(target_px/r_px, 0, 2)))`. A sub-pixel cylinder floors to the `TessFactor` minimum (3).
- `n_v = 1` — a cylinder's lateral face is **ruled** (straight + constant normal along the axis), so one axial segment is exact. (Sphere/torus will need `n_v` adaptivity too — noted for the extension.)
- Always finishes through `TessFactor::new`, so the `[3, MAX_TESS]` clamp + overflow guard still apply; every divisor is guarded, so degenerate inputs (camera on center, zero/NaN fov/budget) clamp cleanly.

## API
- `screen_space_tess_factor(desc, cam, viewport, target_px) -> TessFactor`
- `render_cylinder_compute_screen_lod(desc, face_id, cam, opts, target_px) -> RenderOutput` (computes the LOD internally)
- `pub const DEFAULT_TARGET_PX: f64 = 0.5`

## Verification (live RTX 4080)
- **Adaptive:** same cylinder → near `n_u=39` (78 tris) **>** far `n_u=16` (32 tris), monotonic with distance.
- **Bound holds:** rendered silhouette chord error near **0.00px** / far **0.39px**, both ≤ the 0.5px target.
- **Near-minimal:** at a fixed view the chosen `n_u` gives 0.00px; quartering it → 0.93px (exceeds budget) — so the LOD is tuned, not wasteful.
- `render_cylinder_compute_screen_lod` is byte-identical to rendering with the explicitly-chosen factor.
- **23/23 render tests** (8 new incl. 5 `screen_space_tess_factor` unit tests + degenerate-input handling), stable across 3 runs. clippy `-D warnings`, fmt, `cargo deny check`, `check-boundaries.sh`, doctest: clean. No unwrap/expect/panic in lib.

## Note
GPU render tests run under `cargo nextest` (each test in its own process). `cargo test`'s multi-threaded harness can SIGSEGV the lavapipe/Vulkan driver on concurrent cross-thread device creation — pre-existing (M2's tests too); nextest (already the project's bar) is the correct answer, so no `--test-threads=1` hack was added.

Next: cone (silhouette radius varies along the axis — use the larger end) then sphere/torus (need `n_v` adaptivity for the second curved direction).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds screen-space adaptive LOD for the compute mesher on cylinders. Mesh detail now tracks zoom under a pixel chord‑error budget and handles extreme views robustly.

- **New Features**
  - Per-frame LOD from projected radius (uses view-space depth); `n_u` meets the pixel error target, `n_v=1` for the ruled side.
  - API: `screen_space_tess_factor(..)`, `render_cylinder_compute_screen_lod(..)`, and `DEFAULT_TARGET_PX = 0.5` (re-exported in `render`).
  - Adoption: keep `render_cylinder_compute_offscreen(.., TessFactor, ..)` as-is, or switch to `render_cylinder_compute_screen_lod(.., target_px)`.

- **Bug Fixes**
  - `r_px=+∞` (camera engulfed) now requests `MAX_TESS`; behind-camera/degenerate inputs floor to the minimum.
  - Use view-space depth `d = view_dir · (center − eye)` to avoid under-tessellating off-axis surfaces.
  - Clamp `fov_y` to `(1e-4, π−1e-4)` for bounded, stable LOD.

<sup>Written for commit f61d4edc93b390b80ab8555abe40a3dc8cc63e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

