### PR TITLE
docs(skills): add engineering skill library under .claude/skills

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,55 @@
+# brepkit Skill Library
+
+Distilled working knowledge for building, debugging, and shipping the brepkit B-Rep kernel:
+each skill captures the method and traps for one recurring class of task. Written for
+engineers and agents working in this repo (plus `~/Git/brepjs` for cross-repo work), with
+only this repo and CLAUDE.md as context.
+
+## Index
+
+| Skill | Reach for it when |
+|-------|-------------------|
+| [roadmap](roadmap/SKILL.md) | Picking work in an autonomous session: what is open, what is terminal, the chase filters, and the acceptance bar. |
+| [debugging-doctrine](debugging-doctrine/SKILL.md) | Any hard geometry bug where the first diagnosis did not hold, or before a multi-pass investigation. |
+| [solid-verification](solid-verification/SKILL.md) | Deciding whether a solid is actually correct: watertight, manifold, right volume, and whether a "passing" check proves anything. |
+| [boolean-debugging](boolean-debugging/SKILL.md) | A fuse, cut, or intersect mesh-falls-back, loses faces, gives wrong volume, fails validation, or varies across runs. |
+| [fillet-blend](fillet-blend/SKILL.md) | A fillet or chamfer leaves free edges, opens the shell, silently changes nothing, or you must decide whether the deprecated v1 fillet code is safe to touch. |
+| [analytic-preservation](analytic-preservation/SKILL.md) | An operation degrades exact analytic geometry to NURBS or a mesh, face counts explode, or you are triaging the approx census. |
+| [numerical-robustness](numerical-robustness/SKILL.md) | Results flip under tiny input nudges, seams and periodic geometry misbehave, or code compares, hashes, or buckets floats. |
+| [tessellation](tessellation/SKILL.md) | Mesh cracks at face boundaries, boundary edges or non-manifold edges appear, or you are adding a face mesher in `crates/operations/src/tessellate/`. |
+| [add-operation](add-operation/SKILL.md) | Adding or extending a modeling operation in `crates/operations`, end to end through tests and wasm exposure. |
+| [layer-boundaries](layer-boundaries/SKILL.md) | Adding a workspace dep, placing new code in a crate, adding an `EdgeCurve` or `FaceSurface` variant, or fixing a boundaries CI failure. |
+| [wasm-bindings](wasm-bindings/SKILL.md) | Adding `BrepKernel` methods, wiring `executeBatch`, building the wasm package, or debugging wasm-only failures. |
+| [io-formats](io-formats/SKILL.md) | A STEP or other file imports wrong (dropped solids, all-NURBS, hard entity errors), verifying writer round-trips, capturing a faithful fixture, or adding a format in `crates/io`. |
+| [render-verify](render-verify/SKILL.md) | Working on `brepkit-render` or visually verifying a solid, including headless capture of a live viewer window. |
+| [testing](testing/SKILL.md) | Writing or placing tests, building a faithful regression fixture, handling golden mismatches, or ending a session with unverified work. |
+| [profiling](profiling/SKILL.md) | An operation or benchmark is slow, a criterion bench misbehaves, or a PR needs before/after perf numbers. |
+| [parity-benchmarking](parity-benchmarking/SKILL.md) | Proving brepkit matches or beats the reference kernel, overlaying a local build into the gridfinity tool, or quoting any perf or parity claim. |
+| [pr-workflow](pr-workflow/SKILL.md) | Committing, pushing, opening, or merging a PR; hook failures, commitlint, the AI-review merge gate, worktrees. |
+| [release-flow](release-flow/SKILL.md) | Landing a merged brepkit change in brepjs: npm release, wasm pin bump, type sync, adapter update. |
+
+## Suggested reading order for a new engineer
+
+1. Doctrine and verification: `roadmap`, `debugging-doctrine`, `solid-verification`, `numerical-robustness`, `testing`.
+2. The engine: `boolean-debugging`, `fillet-blend`, `analytic-preservation`, `tessellation`.
+3. Building: `layer-boundaries`, `add-operation`, `wasm-bindings`, `io-formats`, `render-verify`.
+4. Shipping: `pr-workflow`, `profiling`, `parity-benchmarking`, `release-flow`.
+
+## Glossary
+
+- **GFA**: the General Fuse Algorithm, the boolean engine in `crates/algo` (`gfa.rs` is the orchestrator).
+- **PaveFiller**: the GFA intersection phase (`crates/algo/src/pave_filler/`). It finds all pairwise interferences between the operands before any faces are split.
+- **FF/EE/VF phases**: PaveFiller sub-phases, one per entity pair type: vertex-vertex, vertex-edge, edge-edge, vertex-face, edge-face, face-face. See `pave_filler/phase_*.rs`.
+- **Pave**: an intersection point on an edge, stored with its curve parameter.
+- **Pave block**: the edge segment between two consecutive paves; the unit the builder splits edges into.
+- **SD (same-domain)**: two faces (or edges) from different operands that occupy the same geometry. They must be detected and merged to one representative or booleans produce duplicates and open shells.
+- **PCurve**: the 2D curve in a face's UV parameter space that traces a 3D edge on that surface. Face splitting and classification run in UV space, so a wrong pcurve breaks them.
+- **Analytic vs NURBS**: analytic means an exact typed surface or curve (plane, cylinder, cone, sphere, torus, line, circle, ellipse). NURBS is the free-form spline representation. Keeping results analytic is brepkit's differentiator: exact downstream math, compact data, GPU meshing from parameters.
+- **Mesh fallback**: when a boolean cannot assemble a valid B-Rep, it degrades to a triangle-mesh boolean and re-imports the triangles as many small planar faces. Always a defect to investigate, never an acceptable result.
+- **Watertight**: the tessellated mesh has zero boundary edges; every triangle edge is shared by exactly two triangles.
+- **Manifold**: at the B-Rep level, every edge is used by exactly two faces with consistent orientation.
+- **Euler check**: the V - E + F consistency check in solid validation; a cheap topological invariant that catches missing or duplicated entities.
+- **Seam**: the edge where a closed surface's parameterization wraps around (u=0 meets u=2*pi on a cylinder). Seam edges appear twice in a face's UV boundary.
+- **Periodic surface**: a surface closed in one or both parameter directions (cylinder, cone, sphere, torus). Periodic wrap-around is a standing source of seam and interval bugs.
+- **Deflection**: the maximum allowed chord deviation between a mesh and the true surface; the knob that controls tessellation density.
+- **The reference kernel**: the established C++ CAD kernel brepkit benchmarks against through the brepjs harness. Parity with it, then beating it, is the project's acceptance bar; see `parity-benchmarking` for how to run the head-to-head.

--- a/.claude/skills/add-operation/SKILL.md
+++ b/.claude/skills/add-operation/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: add-operation
+description: Use when adding a new modeling operation to crates/operations (a new pub fn taking &mut Topology and returning a SolidId or similar), when extending an existing operation with a new code path, or when an operation's tests need to prove correctness before shipping. Covers implementation traps, error handling, test placement, wasm exposure, and the verification bar.
+---
+
+# Adding an Operation to brepkit
+
+## When to use
+
+You are creating or substantially extending an operation in `crates/operations/src/` (extrude/revolve/sweep class, a measure, a transform, a new primitive). CLAUDE.md Recipe 3 gives the file scaffolding. This skill adds what Recipe 3 omits: the verification bar, where tests go, and the correctness traps that produce compiles-but-wrong geometry.
+
+## Quick reference
+
+| Step | Command / API | Expect |
+|------|---------------|--------|
+| Scaffold | CLAUDE.md Recipe 3 | file, fn, `lib.rs` module, wasm binding, batch dispatch |
+| Measure | `crate::measure::solid_volume(&topo, solid, 0.001)` | relative error < 1% vs closed form |
+| Validate | `crate::validate::validate_solid(&topo, solid)` | `report.is_valid()` true |
+| Watertight | `tessellate_solid_with_tolerance` + `tessellate::is_watertight` | 0 boundary + 0 non-manifold edges (index-based); also re-check with the positional-weld helper from `tessellate_watertight.rs` |
+| Census | `cargo run --release --example approx_census -p brepkit-operations` | no new `brepkit_approx` probe fires for your op |
+| Gate | `cargo clippy --all-targets -- -D warnings && cargo fmt --all && ./scripts/check-boundaries.sh` | clean |
+
+## Procedure
+
+1. **Scaffold per CLAUDE.md Recipe 3.** Signature `pub fn op_name(topo: &mut Topology, ...) -> Result<SolidId, OperationsError>`.
+2. **Walk faces correctly.** Any solid-scoped loop over faces must use `brepkit_topology::explorer::solid_faces` (there is also `solid_edges`). See CLAUDE.md "Walking faces in a solid" for the exception rule for per-shell operations. Iterating only `outer_shell()` compiles, passes on simple boxes, and silently skips cavity faces on hollow solids.
+3. **Respect the borrow pattern and error rules.** Snapshot-then-allocate and closure return type annotations: see CLAUDE.md Common Pitfalls. The workspace denies `unwrap_used`, `panic`, and `unsafe_code` in production code; test modules opt out with `#![allow(clippy::unwrap_used, clippy::expect_used)]`.
+4. **If your op copies edges that may carry periodic curves** (`EdgeCurve::Circle` or `Ellipse`), read reference.md "Periodic edge copies" before writing the copy loop. Getting this wrong recovers the complementary arc (minor instead of major) and only reversed edges expose it.
+5. **Write tests** (placement below). Every geometry-producing op needs at least: a volume-vs-closed-form test, a `validate_solid` test, and a watertight-tessellation test.
+6. **Run the verification bar** (reference.md "Verification bar" has the exact APIs and checkpoint expectations). If the op touches analytic geometry, run the approx census; a fallback probe firing for your op means you degraded analytic surfaces to NURBS or mesh, see the analytic-preservation skill.
+7. **Expose to wasm** per CLAUDE.md Recipe 4; details in the wasm-bindings skill (binding module choice, `batch_*` companion, contract tests via `execute_batch()`).
+8. **Run the gate commands** from the quick reference before pushing.
+
+## Where tests go
+
+CLAUDE.md's Testing section reads as if golden and integration tests live at the repo root. They do not; the root dirs hold data and docs only.
+
+| Kind | Location | Pattern |
+|------|----------|---------|
+| Unit tests | `crates/operations/src/<op>/tests.rs`, declared via `mod tests;` at the bottom of `<op>.rs` | `extrude.rs` + `extrude/tests.rs` |
+| Crate integration | `crates/operations/tests/*.rs` | `tessellate_watertight.rs`, `boolean_invariants.rs`, `proptest_operations.rs` |
+| Golden | `crates/operations/tests/golden_regression.rs`, data in `tests/golden/data/` | regenerate: `UPDATE_GOLDEN=1 cargo test --workspace golden` |
+| Wasm contract | wasm crate, via `execute_batch()` only | see wasm-bindings skill |
+
+Do not add standalone test files under the root `tests/integration/` or `tests/golden/`; both READMEs there confirm tests are crate-level.
+
+## Pitfalls: what NOT to conclude
+
+| Observation | Wrong conclusion | Reality |
+|-------------|------------------|---------|
+| Volume matches closed form | Geometry is correct | Volume can read high on arc-edged results and a nearly-unmodified solid can pass. Also classify interior/exterior probe points with `crate::classify::classify_point` (ray-cast). Never trust the winding classifier for faceted or NURBS solids. |
+| Census reports exact analytic | Op is correct | It only proves no approximation fallback fired, not that the geometry is right. A wrong-but-analytic result passes the census. |
+| Mesh indices share vertices | Mesh is watertight | Watertightness is geometric: weld vertices by quantized position first, then check edge sharing. Use `tessellate::is_watertight` / `boundary_edge_count`, or copy the `boundary_edges` helper from `crates/operations/tests/tessellate_watertight.rs`. |
+| Box test passes | Face walk is complete | Boxes have no inner shells. Add a hollow-solid case (shell_op or boolean-cut cavity) if the op walks faces. |
+| Forward-edge arc test passes | Periodic edge copy is correct | Only a reversed `OrientedEdge` swaps stored vertex order vs curve parameterization. Add a reversed-half-circle test (see reference.md). |
+| Volume of an off-origin primitive is wrong | The measure is broken | Primitives place their base at z = 0, not centered. Check your expected value first. |
+| Cone surface points land off the cone | ConicalSurface is broken | `half_angle` is measured from the radial plane, not from the axis. See reference.md "Cone conventions". |
+
+## Sibling skills
+
+- **wasm-bindings**: binding module, `js_name`, input validation helpers, batch dispatch, contract tests.
+- **testing**: fixtures, proptest, golden data regeneration, test layout in depth.
+- **solid-verification**: the full verification bar in depth (measure, validate, watertight, classifiers, census).
+- **analytic-preservation**: keeping results as typed analytic surfaces instead of NURBS.
+- **layer-boundaries**: which crates your op may `use`; `./scripts/check-boundaries.sh` enforces it.
+
+## Reference
+
+Detailed APIs, checkpoints, and the periodic-edge treatment: [reference.md](reference.md).

--- a/.claude/skills/add-operation/reference.md
+++ b/.claude/skills/add-operation/reference.md
@@ -1,0 +1,135 @@
+# add-operation reference
+
+Verified against the current repo. Locate symbols with the given `rg` patterns; line numbers rot, symbols do not.
+
+## Verification bar
+
+Run checks 1-3 for every geometry-producing op, check 4 when the op touches analytic geometry, and the gate (5) before pushing. The solid-verification skill covers each in depth; this is the operational summary.
+
+### 1. Measure
+
+```rust
+let vol = crate::measure::solid_volume(&topo, solid, 0.001)?;
+```
+
+`rg -n 'pub fn solid_volume' crates/operations/src/measure/volume.rs`
+
+- Picks its own path: exact closed form for recognized primitives, exact per-face Gauss quadrature when every face is analytic, tessellation otherwise. Do not route around it to another integrator; call it and let it choose.
+- Deflection is internally clamped relative to the bbox diagonal, so a coarse deflection cannot silently undercount. Volume can still read high on arc-edged results.
+- Test pattern (from `crates/operations/src/extrude/tests.rs`): assert relative error under 1% against a hand-computed closed form. Compute the closed form for the base-at-z=0 placement, not a centered one.
+- Volume agreement is necessary, not sufficient. Also probe points that must be inside and outside:
+
+```rust
+use crate::classify::{classify_point, PointClassification};
+let c = classify_point(&topo, solid, probe, 0.01, 1e-6)?;
+assert_eq!(c, PointClassification::Inside);
+```
+
+This is the ray-cast classifier. The winding-number classifier exists both in `brepkit-check` (`classify/winding.rs`) and as `classify_point_winding` / `classify_point_robust` in the same `crates/operations/src/classify.rs`; none of these are valid verification oracles for faceted or NURBS solids. Use `classify_point` only.
+
+### 2. Validate
+
+```rust
+let report = crate::validate::validate_solid(&topo, solid)?;
+assert!(report.is_valid(), "{:?}", report.issues);
+```
+
+`rg -n 'pub fn validate_solid' crates/operations/src/validate.rs`
+
+- Checks include Euler-Poincare consistency, closed shells, edge/face consistency, connectivity. `is_valid()` means no `Severity::Error` issue.
+- For ops that produce NURBS faces (fillet, shell, offset class), the default tolerances can false-positive. Use `validate_solid_with_options` with `ValidationOptions { tolerance_scale: 10.0, .. }` (the scale is clamped to [0.1, 1000]). There is also `validate_solid_relaxed`.
+
+### 3. Tessellate and check watertightness
+
+```rust
+use crate::tessellate::{tessellate_solid_with_tolerance, is_watertight, boundary_edge_count, non_manifold_edge_count};
+```
+
+`rg -n 'pub fn tessellate_solid' crates/operations/src/tessellate/solid.rs` and `rg -n 'pub fn is_watertight' crates/operations/src/tessellate/mesh_ops.rs`
+
+- Watertight means: after welding vertices by quantized position, every undirected edge is shared by exactly two triangles.
+- `is_watertight` operates on the `TriangleMesh` as built; the gold-standard integration test `crates/operations/tests/tessellate_watertight.rs` additionally welds by position at 1e-6 quantization before counting, which catches meshes that are watertight geometrically but not by index, and vice versa. Copy its `boundary_edges` helper for a new op's watertight test.
+- A boundary edge count above zero means a hole; an STL consumer (slicer) will reject the export.
+
+### 4. Approx census (only if the op touches analytic geometry)
+
+```
+cargo run --release --example approx_census -p brepkit-operations
+```
+
+- Installs a logger that captures `brepkit_approx` debug probes and prints per-op rows: exact analytic vs which approximation fallback fired, plus wall clock and face count. Probe-site catalog: analytic-preservation skill, reference section 1.
+- Bar: an op that re-creates existing analytic surface types (extrude of a circle should make a Cylinder, revolve of a line should make a Cone, and so on) must not light a probe. If it does, you converted analytic geometry to NURBS or fell back to the mesh boolean; see the analytic-preservation skill.
+- Do NOT conclude correctness from a clean census. It proves only that no fallback fired. A documented near-miss: a slot cut read 1.4% high on volume and almost passed while the slot had not actually been carved. Volume + census + classify_point probes together are the minimum.
+- If you add a new operation with fallback paths, add a census scenario for it in `crates/operations/examples/approx_census.rs`.
+
+### 5. Gate
+
+```
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test -p brepkit-operations
+./scripts/check-boundaries.sh
+```
+
+Pre-push runs the full test suite and cargo-deny; do not skip hooks.
+
+## Periodic edge copies (extrude/revolve/loft/sweep class)
+
+The trap: `EdgeCurve::Circle` and `EdgeCurve::Ellipse` are periodic. An edge stores start and end vertices; the parameter span is recovered by `EdgeCurve::domain_with_endpoints(start, end)` (`rg -n 'pub fn domain_with_endpoints' crates/topology/src/edge.rs`). Its contract:
+
+- start and end coincident (within ~1e-9): full period `[0, 2*PI]`.
+- otherwise: project both points onto the curve and take the CCW span from start.
+
+So if a new edge's stored vertex order is swapped relative to the curve's parameterization, the CCW rule recovers the complementary sub-arc: you asked for the 90-degree arc and got the 270-degree one. Everything still compiles, validates, and often tessellates without holes.
+
+Why it hides: for a forward `OrientedEdge`, stored order equals wire order and the span comes out right. Only a reversed edge in the source wire swaps the endpoints. A test suite with only forward arcs passes forever.
+
+The fixed instance to copy from: `extrude_wire_vertices_with` in `crates/operations/src/extrude.rs` (`rg -n 'reverse_edge_curve' crates/operations/src/extrude.rs`). It builds the top edge's curve via `translate_edge_curve`, then:
+
+```rust
+if !oriented[i].is_forward() {
+    top_curve = reverse_edge_curve(&top_curve)?;
+}
+```
+
+`reverse_edge_curve` flips a circle/ellipse's normal and v-axis so projection maps theta to minus theta, and reverses a NURBS curve's control points, weights, and mirrored knots.
+
+Rule for a new op: if it copies an edge and preserves its curve type, either store the vertices in the order matching the copied curve's parameterization, or reverse the curve for reversed source edges as extrude does. Ops that rebuild connector edges as `EdgeCurve::Line` or as fresh arcs from vertex positions do not hit this.
+
+Required guard test: extrude (or apply your op to) a half-circle profile where the arc edge enters the wire reversed, and assert volume within 1% of the closed form. Live examples: `extrude_half_circle_reversed_edge_volume` and `extrude_half_ellipse_reversed_edge_volume` in `crates/operations/src/extrude/tests.rs`.
+
+## Cone conventions
+
+`rg -n 'radial plane' crates/math/src/surfaces.rs` and `rg -n 'atan2' crates/operations/src/primitives.rs`
+
+- `ConicalSurface` in `crates/math/src/surfaces.rs`: `P(u,v) = apex + v*(cos(half_angle)*radial(u) + sin(half_angle)*axis)`. `half_angle` is measured from the radial plane to the generator, NOT from the axis. The constructor rejects values outside `(0, PI/2)`.
+- `make_cone` in `crates/operations/src/primitives.rs`: pointed cone `half_angle = height.atan2(r_big)`; frustum `(axial_to_apex + height).atan2(r_big)` with `axial_to_apex = r_small * height / (r_big - r_small)`. The surface axis points from apex toward the base.
+- Degenerate half-angles (at or beyond the `(0, PI/2)` bounds) fall back to revolving a trapezoid profile.
+- If you construct boundary vertices for a face on an analytic surface, they must lie ON that surface. The all-analytic volume fast path integrates the surface, not the vertices, so off-surface vertices produce a plausible-looking volume that masks the placement error.
+
+## Primitive placement
+
+All primitives in `crates/operations/src/primitives.rs` place their base at z = 0: `make_cylinder` extends from z = 0 to z = height; `make_cone` has `bottom_radius` at z = 0. Nothing is centered on the origin. Wrong expected volumes and bboxes in tests usually trace to assuming centered placement.
+
+## OperationsError shape
+
+`rg -n 'error\(transparent\)' crates/operations/src/lib.rs`
+
+`OperationsError` has multiple `#[error(transparent)] #[from]` variants (topology, math, and others). Two consequences:
+
+- `?` works directly on lower-layer results; do not hand-wrap.
+- Closures that return a `Result` need an explicit annotation, `|x| -> Result<_, OperationsError> { ... }`, because inference cannot pick among the `From` impls (CLAUDE.md Common Pitfalls has the snippet).
+
+## Symptom-to-cause table
+
+| Symptom | Likely cause | Check |
+|---------|--------------|-------|
+| Volume ~3x expected on an arc profile, or 1/3 | Complementary periodic arc recovered | Reversed-edge handling; see "Periodic edge copies" |
+| Op correct on solid box, wrong on hollow solid | Face walk used `outer_shell()` only | Switch to `explorer::solid_faces` |
+| Volume slightly high but classify says probe points are Outside where material should be | Op did not actually modify the solid, or a face was dropped | classify_point probes + face count before/after |
+| `validate_solid` errors only on NURBS-faced results | Default tolerance too tight for approximated faces | `validate_solid_with_options`, tolerance_scale ~10 |
+| Watertight by `is_watertight` but a slicer sees holes | Index-shared but positionally split vertices, or the reverse | Positional-weld check from `tessellate_watertight.rs` |
+| Census shows a fallback for an op that should be analytic | Surface type degraded during the op | analytic-preservation skill |
+| Cone face normal or point evaluation off by a complement | half_angle treated as angle from axis | "Cone conventions" above |
+| Borrow-checker fight when copying entities | Reading and allocating in one expression | Snapshot-then-allocate, CLAUDE.md Common Pitfalls |
+| Volume off by a translation-dependent amount | Assumed centered primitive | Base is at z = 0 |

--- a/.claude/skills/analytic-preservation/SKILL.md
+++ b/.claude/skills/analytic-preservation/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: analytic-preservation
+description: Use when a boolean, revolve, offset, or other operation degrades exact analytic geometry (planes, cylinders, cones, spheres, tori, circles) to NURBS or a mesh fallback, when face counts explode from a handful to hundreds, when running or interpreting the approx_census, when adding an exact analytic-analytic intersection arm, or when deciding whether an analytic-recovery task is worth chasing at all.
+---
+
+# Analytic Preservation
+
+Core product doctrine: operations must preserve exact analytic geometry
+(`FaceSurface::Plane/Cylinder/Cone/Sphere/Torus`, `EdgeCurve::Line/Circle/Ellipse`)
+instead of degrading to NURBS approximation or the boolean mesh fallback.
+
+Terms used below (GFA, FF phase, marcher, mesh fallback, SD, seam): glossary in
+[reference.md](reference.md) section 6.
+
+## Why it matters
+
+- An analytic face is a few floats; a mesh-fallback face is baked triangles. Analytic
+  surfaces can be shipped as parameters and meshed on the GPU per frame at adaptive LOD
+  (`crates/render/src/compute_mesh.rs`). Baked triangles can never re-LOD.
+- Analytic results are exactly measurable (closed-form volume, area) and tiny
+  (single digits to tens of faces vs hundreds to thousands of planar facets).
+- Analytic paths beat the mesh fallback by one to two orders of magnitude on the same
+  inputs; the census prints per-row timings, so the margin is cheap to regenerate. One
+  git-history example (#1006): box-sphere intersect went from 190 ms and 956 mesh faces
+  to under 2 ms and 8 analytic faces. This margin is why brepkit beats the reference
+  kernel head to head. Re-measure via the parity-benchmarking skill before quoting any
+  number.
+
+## Quick reference
+
+```bash
+# The census: which operations degrade, and via which path
+cargo run --release --example approx_census -p brepkit-operations
+
+# Where the boolean mesh fallback (the one path that loses analytic types) fires
+rg -n 'analytic surface types will be lost' crates/operations/src/boolean/mod.rs
+
+# All degradation probe sites (log target "brepkit_approx")
+rg -l 'brepkit_approx' crates/
+```
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| Face count jumps from ~10 to hundreds, all planar | Boolean mesh fallback fired | `mesh_boolean_fallback` in `boolean/mod.rs`; the gate is `euler_ok && open_shell_ok && validate_boolean_result` (rg `open_shell_ok`) |
+| Clean circular rim comes back as many short NURBS pieces | Generic marcher ran instead of an exact arm | `crates/math/src/analytic_intersection.rs`; see reference.md section 2 |
+| Result has free edges after a curved boolean | Operands not split at the same crossing vertices, or a co-endpoint arc pair collapsed | reference.md sections 3c and 3d |
+| Closed rim wrap-trimmed, out-of-domain evals | Rim emitted as closed NURBS instead of `EdgeCurve::Circle` | reference.md section 3a |
+| Census says "exact analytic" but volume is wrong | The census only checks probes; it does not check correctness | See "The census caveat" below |
+
+## Procedure: run and read the census
+
+1. `cargo run --release --example approx_census -p brepkit-operations`
+2. Expect one row per operation, shaped like:
+   `boolean   sphere-cyl cut   0.84ms  faces=3   exact analytic`
+   or `... FALLBACK xN: <probe texts>` or `[ERR]` rows.
+3. `exact analytic` means no `brepkit_approx` probe fired during that op.
+   `FALLBACK xN` lists which degradation path ran.
+4. The final "remaining paths" section deliberately fires every approximation path;
+   fallbacks there are expected, not regressions.
+5. If a row regressed from exact to FALLBACK, the probe text names the path; map it to
+   a probe site via reference.md section 1.
+
+**The census caveat (critical):** "exact analytic" does NOT mean geometrically correct.
+Precedents exist of results that were fully analytic and still wrong: a revolved cone
+band touching the apex read double the angular span, inflating volume by half (fixed
+in #1012), and a bored-sphere band over-integrated the removed polar cap while the
+mesh skinned over the tunnel mouth, so it also rendered non-watertight (fixed in
+#1005). Every analytic-preservation change must ship
+with independent verification: volume vs exact or reference value, free edges == 0,
+manifold check, and a regression fixture. Template fixture:
+`crates/io/tests/gridfinity_wallcut_seq_inmem.rs` (asserts `free == 0`, `over == 0`,
+and a minimum curved-face count). See the solid-verification skill.
+
+## Doctrine (details and code locations in [reference.md](reference.md))
+
+1. **Closed rims are `EdgeCurve::Circle`, never closed NURBS.** Downstream seam
+   adoption and whole-loop handling pattern-match the Circle variant. (ref. section 3a)
+2. **Add exact arms in `crates/math/src/analytic_intersection.rs`** instead of letting
+   the generic marcher fragment a clean circle. Gate each arm to the tractable
+   configuration and return `None` otherwise. (ref. section 2)
+3. **Watertight seams require BOTH operands split at the SAME exact crossing
+   vertices.** Resolve endpoints through the shared-crossing registry. (ref. section 3c)
+4. **Co-endpoint seam arcs get a splitter-side midpoint split.** Never make
+   `merge_duplicate_edges` smarter; control the geometry you emit. (ref. section 3d)
+5. **Sequential booleans preserve analytic surfaces.** Split lateral bands, do not
+   tessellate them. (ref. section 3e)
+
+## Scoping filter: what to chase, what to skip
+
+A boolean result face is a trimmed patch of an INPUT surface, so it is always closable
+with the right split. Fillet, sweep, loft, and NURBS offset INTRODUCE a new blend
+surface with no closed form.
+
+- **Chase:** operations that RE-CREATE existing analytic surface types. Example:
+  revolve maps analytic profile edges to exact Cone/Plane/Cylinder/Torus bands
+  (`revolution_band_surface` in `crates/operations/src/revolve.rs`).
+- **Do not chase:** fillet walls beyond the analytic fast paths, general sweep/loft
+  side faces, offsets of NURBS input. Their output is inherently approximate.
+- **Solve the NARROW problem.** Every merged exact arm is gated (coaxial-only, one
+  perpendicular case) and defers to the marcher otherwise. An exact arm never has to
+  be general to be shippable. Full table: reference.md section 4.
+
+## Terminal and open cases (do not re-burn effort)
+
+- **Perpendicular cylinder-union render is terminal.** The exact Steinmetz seam is
+  singular (figure-eight pinch); exact curves make the topology WORSE. The shipped
+  B-Rep with exact closed-form volume stands. `exact_cylinder_cylinder` does not exist
+  in the codebase; do not go looking for it. (ref. section 5)
+- **Plane-through-sphere across the seam is SOLVED** and is the reusable pattern:
+  never test exact curves against discretized boundary chords; reconstruct the exact
+  boundary curve and intersect analytically. (ref. section 5)
+- `intersect_plane_torus` is still a grid march plus fit, not the exact quartic; the
+  FF phase (GFA's surface-surface intersection stage,
+  `crates/algo/src/pave_filler/phase_ff.rs`) compensates by snapping arc endpoints to
+  exact crossings.
+
+## Anti-patterns
+
+- Do NOT conclude a change is correct because the census says "exact analytic".
+- Do NOT add type-based or deviation-threshold keys to `merge_duplicate_edges`; both
+  directions are load-bearing for different shapes (ref. section 3d).
+- Do NOT write a general surface-surface exact intersector; gate to the narrow case.
+- Do NOT chase analytic recovery for blend/offset-of-NURBS surfaces.
+- Do NOT trust in-code comments about which cases "fall back to mesh"; some predate
+  later fixes. Re-run the census and check face counts instead.
+
+## Related skills
+
+boolean-debugging (when the fallback fires and you need to know why GFA, the native
+boolean engine in `crates/algo/src/gfa.rs`, failed),
+solid-verification (the mandatory correctness pairing), tessellation (curved-band
+meshing that analytic splits expose), numerical-robustness (seam crossings,
+quantized merges, chord discretization), parity-benchmarking (head-to-head
+harness), add-operation (wiring a new op so it stays analytic from day one).

--- a/.claude/skills/analytic-preservation/reference.md
+++ b/.claude/skills/analytic-preservation/reference.md
@@ -1,0 +1,234 @@
+# Analytic Preservation: Reference
+
+Deep catalog for the analytic-preservation skill. All symbols verified against the
+current tree; cite symbol plus rg pattern, never line numbers.
+
+## 1. Degradation probe sites and the census
+
+Every degradation site carries a permanent `log::debug!(target: "brepkit_approx", ...)`
+probe. The census example (`crates/operations/examples/approx_census.rs`) installs an
+in-process logger filtering on that target and drains events per operation.
+
+Probe sites (`rg -l 'brepkit_approx' crates/`):
+
+| File | Path that degrades |
+|---|---|
+| `crates/operations/src/boolean/mod.rs` | Boolean mesh (co-refinement) fallback. The ONLY path that loses analytic surface types entirely. `rg -n 'analytic surface types will be lost'` |
+| `crates/blend/src/fillet_builder.rs` | Newton-Raphson walker NURBS blend when analytic fast paths decline |
+| `crates/blend/src/chamfer_builder.rs` | Chamfer v1 unsupported surface (instrumented hard error, no walker fallback) |
+| `crates/offset/src/offset.rs` | Sampled-NURBS surface refit for `FaceSurface::Nurbs` input |
+| `crates/operations/src/fillet/rolling_ball.rs` | Rolling-ball planar corner patch |
+| `crates/operations/src/offset_face.rs` | Per-face offset degradation |
+| `crates/operations/src/offset_trim.rs` | Grid-sampling offset trim |
+
+Census sections run by `main()`: `boolean_matrix()`, `offset_matrix()`,
+`nurbs_section()`, `revolve_matrix()` (prints a per-solid surface-type breakdown),
+`blend_matrix()`, `remaining_paths()` (deliberately fires all seven paths).
+
+Output per row: `<op> <name> <ms> faces=<n>` then either `exact analytic` (no probe
+fired) or `FALLBACK xN: <deduped probe texts>`. Errors append `[ERR]` to the name with
+the error as a pseudo-event.
+
+The boolean gate that decides analytic vs fallback (`crates/operations/src/boolean/mod.rs`,
+`rg -n 'open_shell_ok'`): the GFA result is accepted only if
+`euler_ok && open_shell_ok && validate_boolean_result(topo, result).is_ok()`; otherwise
+`mesh_boolean_fallback` runs. So a fallback is usually a symptom of a GFA correctness
+failure upstream (see the boolean-debugging skill), not a reason to relax the gate.
+
+## 2. Exact analytic-analytic intersection arms
+
+File: `crates/math/src/analytic_intersection.rs`. Inventory
+(`rg -n 'pub fn (exact_|intersect_)' crates/math/src/analytic_intersection.rs`):
+
+| Symbol | Case | Notes |
+|---|---|---|
+| `exact_plane_analytic` | plane vs any, dispatch over `pub enum AnalyticSurface` | calls private `exact_plane_cylinder` / `exact_plane_sphere` / `exact_plane_cone` |
+| `intersect_plane_analytic` | plane vs any, public dispatch over `AnalyticSurface` | thin dispatcher to the `intersect_plane_*` variants below; used by the offset engine (`crates/offset/src/inter3d.rs`) |
+| `intersect_plane_cylinder` / `intersect_plane_sphere` / `intersect_plane_cone` | public plane-x variants | exact circles/ellipses/lines |
+| `intersect_plane_torus` | plane vs torus | STILL a 128x128 grid march plus fit, not the exact quartic; the FF phase compensates by snapping arc endpoints to exact crossings |
+| `intersect_line_torus` | line vs torus, real quartic roots | up to four `t` roots; the FF-phase section trimmer uses it to snap a plane-torus oval's endpoints to the exact box-edge crossings (caller in `crates/algo/src/pave_filler/phase_ff.rs`) |
+| `exact_cone_cone` | coaxial only | defers (`None`) otherwise |
+| `exact_cone_cylinder` | coaxial only | the gridfinity lip knife-edge case |
+| `exact_sphere_cylinder` | coaxial only | template arm; test `exact_sphere_cylinder_non_coaxial_defers` proves deferral is deliberate |
+| `intersect_analytic_analytic` / `_bounded` | generic marcher entry | returns fitted NURBS; the thing exact arms exist to bypass |
+
+**Adding a new arm (procedure):**
+
+1. Follow the `exact_sphere_cylinder` template: gate to the tractable configuration
+   (coaxiality, perpendicularity, tangency class), return `Option<...>`, `None` defers
+   to the marcher.
+2. Add a deferral test alongside the exact-case test (pattern:
+   `exact_sphere_cylinder_non_coaxial_defers`).
+3. Wire the arm into `compute_raw_curves`
+   (`rg -n 'fn compute_raw_curves' crates/algo/src/pave_filler/phase_ff.rs`) so it
+   emits `RawCurve { curve: EdgeCurve::Circle(...), .. }`, matching the existing
+   cone-cone / cone-cylinder / sphere-cylinder arms there.
+4. Verify: census row for the new pair flips to `exact analytic`, AND run
+   solid-verification (volume, free edges, manifold). Checkpoint: face count should be
+   single digits, not hundreds.
+
+Note: `crates/math/src/analytic_intersection.rs` is one of the ripple sites when
+adding a `FaceSurface` variant (see CLAUDE.md, Ripple-Effect Checklists).
+
+## 3. Doctrine items with code evidence
+
+### 3a. Closed rims are `EdgeCurve::Circle`, never closed NURBS
+
+Emission: the exact arms in `compute_raw_curves` (`crates/algo/src/pave_filler/phase_ff.rs`)
+build `RawCurve { curve: EdgeCurve::Circle(circle), .. }`. Consumers in the same file
+pattern-match the variant:
+
+- Closed-circle split: `if let EdgeCurve::Circle(circle) = &raw.curve` leading to
+  `closed_circle_boundary_crossings` and `emit_split_circle_arcs`.
+- Seam adoption: the `adopted_seam` match keys on `EdgeCurve::Circle(c)`
+  (`rg -n 'adopted_seam' crates/algo/src/pave_filler/phase_ff.rs`).
+- `restrict_curves_to_faces` keeps closed loops whole ONLY for Circles:
+  `!matches!(raw.curve, EdgeCurve::Circle(_))` gates the wrap-trim path. A closed NURBS
+  in the same position gets wrap-trimmed and has produced out-of-domain evaluations.
+
+Consequence: an exact rim that arrives as a closed NURBS silently loses seam adoption
+and whole-loop handling. Emit the Circle.
+
+### 3b. Prefer exact arms over the marcher
+
+The marcher fragments a clean circle into micro-curve pieces that then need fitting,
+trimming, and dedup, each a failure source. Section 2 is the procedure.
+
+### 3c. Watertight seams: both operands split at the SAME exact crossing vertices
+
+- `emit_exact_arc` (`rg -n 'fn emit_exact_arc' crates/algo/src/pave_filler/phase_ff.rs`)
+  resolves endpoints through the shared-crossing registry first, so the adjacent
+  face's arc ending at the same crossing reuses the same vertex.
+- The plane-torus oval trim snaps arc endpoints to the exact box-edge/torus crossings
+  so the box wall trimmed against the same edge shares those vertices.
+- Lens arcs are emitted as ONE shared FF section so both consumers (the kept band and
+  the wall sub-face) see the same midpoint vertex.
+
+Symptom of violating this: free edges along the seam after the boolean, even though
+both faces look correct in isolation. Check with the solid-verification skill.
+
+### 3d. Splitter-side midpoint split for co-endpoint seam arcs
+
+Problem: a diametric semicircle pair, or a chord plus arc, share BOTH endpoints.
+`merge_duplicate_edges` (`rg -n 'fn merge_duplicate_edges' crates/algo/src/builder/builder_solid.rs`)
+groups edges by quantized endpoint pair ONLY, so co-endpoint arcs collapse to one edge.
+
+That endpoint-only behavior is load-bearing in BOTH directions:
+
+- The gridfinity lip ring NEEDS a Line chord and a Circle arc with the same endpoints
+  (deviating up to ~2.4 mm) to collapse to one edge.
+- The torus lens NEEDS a Line and a co-endpoint arc to stay distinct.
+
+Same local configuration, opposite required outcome. No merge-key discriminant can
+exist: a type-only key and a deviation-threshold key were both tried and both
+regressed gridfinity to non-manifold.
+
+**Doctrine: control the geometry you EMIT (splitter-side); never make the shared merge
+smarter.** Implementations in `phase_ff.rs`:
+
+- `emit_split_circle_arcs` computes
+  `n_sub = (arc_span / (PI * 0.999)).ceil()` (`rg -n 'PI \* 0\.999' crates/algo/src/pave_filler/phase_ff.rs`)
+  so any span of pi or more gets a midpoint vertex and no two sub-arcs share both
+  endpoints.
+- Torus lens arcs are always split at their midpoint into two sub-arcs with a distinct
+  middle vertex.
+
+### 3e. Sequential booleans preserve analytic surfaces
+
+Fixture: `crates/io/tests/gridfinity_wallcut_seq_inmem.rs`, a `Cut(Cut(body, c0), c1)`
+on a captured real-world bin. Historically the second cut dropped a coincident
+same-domain wall, produced free edges, and the next cut mesh-fell-back, losing the
+analytic lip cones and corner cylinders. Assertions to copy for any new sequential
+fixture: `free == 0`, `over == 0`, and `curved_count(...) >= N` with a message naming
+the surfaces that must survive.
+
+Capturing operands: the `serializeSolid` wasm binding exports live-tool solids into
+faithful in-memory fixtures (pattern used by all `crates/io/tests/*_inmem.rs`).
+
+Durable lesson: closing a curved boolean is three fixes, not one. The boolean fix, the
+curved-band tessellation, and the measurement. The analytic split EXPOSES downstream
+tessellation and volume gaps that the mesh fallback used to mask. Budget for all three.
+
+## 4. Scoping filter table
+
+Conceptual test: does the operation's output face lie on an INPUT surface (trimmed
+patch, always closable) or on a NEW surface it constructs (no closed form)?
+
+| Operation | Verdict | Evidence |
+|---|---|---|
+| Booleans on analytic solids | CHASE | Result faces are trimmed input patches; GFA plus exact arms |
+| Revolve | CHASED, done | `revolution_band_surface` (`crates/operations/src/revolve.rs`): oblique line -> Cone, perpendicular line -> Plane cap, parallel line -> Cylinder, circular arc -> Torus band. Exact volume: `analytic_revolution_solid_volume` and `planar_cap_signed_volume` in `crates/operations/src/measure/volume.rs` (note: the volume helpers live in measure, not revolve). The volume gate is tight on purpose; a loose guard regressed unrelated boolean caps |
+| Fillet/chamfer beyond analytic fast paths | DO NOT CHASE | `try_analytic_fillet` / `try_analytic_chamfer` (`crates/blend/src/analytic.rs`) decline torus pairs, cyl-cone, perpendicular cyl-cyl, non-coaxial cone-cone; the walker's blend surface has no closed form |
+| Offset/shell of analytic input | Already exact | All five analytic types stay exact; only `FaceSurface::Nurbs` input degrades (`crates/offset/src/offset.rs` probe) |
+| Offset of NURBS | DO NOT CHASE | General NURBS offset has no closed form |
+| Sweep/loft side faces | DO NOT CHASE | NURBS by construction |
+| Extrude of ellipse arcs | Type-system limit | There is no elliptical-cylinder `FaceSurface` variant; not a bug |
+
+Narrowness rule: every merged exact arm is gated (coaxial-only, one specific
+configuration) and defers otherwise. Ship the narrow case; leave the marcher as the
+general fallback.
+
+## 5. Terminal and open cases
+
+### Perpendicular cylinder union render: TERMINAL
+
+The exact Steinmetz seam is two ellipses touching at two points. On each cylinder wall
+the hole boundary is a figure-eight pinching to a point, so the true union boundary is
+genuinely non-manifold at the touch points (odd Euler count is correct, not a bug).
+The shipped B-Rep is manifold only because its marched-NURBS seam loops sit about 0.11
+apart and dodge the touch. Pursuing exact curves here makes the topology WORSE.
+Confirmed over many measured attempts. Missing primitives that would reopen it: a
+face-split at a boundary self-touch pinch on a periodic wall, or a periodic-seam-aware
+crossing-holes tessellator. The shipped state (analytic faces plus exact closed-form
+volume, render deferred) stands. `exact_cylinder_cylinder` does NOT exist in the
+codebase; the prototype was reverted.
+
+### Plane through sphere across the seam: SOLVED, reuse the pattern
+
+Why it was hard: the sphere's seam wire is a chord polygon inscribed in the seam
+circle. Exact section arcs land off the chords by the sagitta, so chord-crossing tests
+find nothing. Fix (merged, PR #1006 as a git-history pointer):
+
+- `sphere_seam_plane_crossings` (`rg -n 'fn sphere_seam_plane_crossings' crates/algo/src/pave_filler/phase_ff.rs`):
+  Newell-fit plane intersected with the exact seam circle, facet-independent.
+- `split_noseam_by_arrangement` (`rg -n 'fn split_noseam_by_arrangement' crates/algo/src/builder/face_splitter/special_cases.rs`):
+  reconstructs the seam as its exact circle, splits it at the crossings, and traces
+  the seam-arcs plus section-arcs arrangement in UV.
+
+Portable lesson: never test exact curves against discretized boundary chords.
+Reconstruct the exact boundary curve and intersect analytically.
+
+### Genuinely open (low priority, fine to leave)
+
+- `intersect_plane_torus` is a grid march plus fit, not the exact quartic.
+- `crates/io/tests/dovetail_cornerclip_intersect_inmem.rs` is ignored: coincident-wall
+  plus analytic-corner intersect drops the boundary.
+- Revolve follow-ups are over-segmentation only (pointed-cone apex periodic merge,
+  annulus-cap merge, partial-turn torus); results stay analytic and exact.
+- Some older comments in `phase_ff.rs` describe mesh fallbacks that later fixes
+  closed. Verify against a census run before trusting any "falls back" comment.
+
+## 6. Glossary
+
+- **Analytic surface/curve**: exact parametric primitive
+  (`FaceSurface::Plane/Cylinder/Cone/Sphere/Torus` in `crates/topology/src/face.rs`,
+  `EdgeCurve::Line/Circle/Ellipse` in `crates/topology/src/edge.rs`) vs the `Nurbs`
+  variants.
+- **GFA**: the native boolean engine (`crates/algo/src/gfa.rs`): intersect, split,
+  classify, reassemble.
+- **PaveFiller / FF phase**: GFA's intersection orchestrator
+  (`crates/algo/src/pave_filler/`); `phase_ff.rs` computes surface-surface section
+  curves. Nearly all rim and seam doctrine lives there.
+- **Mesh fallback**: the boolean's last resort; tessellate both operands and
+  co-refine triangles. All-planar result, analytic types lost.
+- **SD (same-domain)**: detection that faces from opposite operands lie on the same
+  surface region; mis-detection drops or duplicates walls.
+- **Seam edge**: the u=0 equivalent to u=2pi boundary of a closed periodic face.
+- **Marcher**: the generic numeric surface-surface intersector; returns fitted NURBS.
+- **Free edge / watertight**: a boundary edge used by exactly one face; watertight
+  means zero free edges. The cheap correctness proxy fixtures assert.
+- **Splitter-side split**: giving an emitted section arc its own midpoint vertex so
+  the endpoint-keyed duplicate-edge merge cannot collapse co-endpoint arcs.
+- **The reference kernel**: the incumbent C++ CAD kernel brepkit benchmarks against.
+  Head-to-head harness lives in the sibling repo `~/Git/brepjs` (see the
+  parity-benchmarking skill).

--- a/.claude/skills/boolean-debugging/SKILL.md
+++ b/.claude/skills/boolean-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: boolean-debugging
+description: Diagnose and fix failures of the GFA boolean engine (fuse, cut, intersect). Use when a boolean result mesh-falls-back to hundreds of all-planar faces, comes out non-manifold or open-shelled, is missing faces, has wrong volume, fails the Euler or validation gates, errors in shell assembly, or gives different results across runs.
+---
+
+# Boolean Debugging (GFA engine)
+
+Glossary of GFA terms (PaveFiller, FF sections, SD, paves) and the bug-class catalog live in [reference.md](reference.md).
+
+## When to use
+
+A boolean via `brepkit_operations::boolean::boolean` (or wasm `fuse`/`cut`/`intersect`) produces: silent mesh fallback, non-manifold or open shell, a vanished face, wrong volume, `AssemblyFailed`, or cross-process nondeterminism.
+
+## Quick reference
+
+| Symptom | First move | Detail |
+|---|---|---|
+| Result has hundreds of all-planar faces | It mesh-fell-back. Find WHY the gate rejected the GFA result | Step 1, Step 2 |
+| Result looks fine but volume is off | Do NOT trust volume. Ray-cast classify points in the cut region | Prior 3 |
+| Coincident-contact fuse/cut wrong | Suspect the classifier, not same-domain detection | Prior 1 |
+| `AssemblyFailed("no outer shell found...")` | Shell sign or a never-created face; dump per-face data upstream | reference.md catalog |
+| Non-manifold + inflated volume | Wire spur; check for consecutive same-edge opposite-orientation pairs | reference.md catalog |
+| Differs across processes, stable within one | HashMap iteration order; sort the driving iteration | Step 6 |
+| Bug only reproduces in the consuming tool | Unfaithful repro; export real operands as STEP or arena bytes | Step 5 |
+
+## Step 1: Detect mesh fallback. Face count is the ONLY reliable signal
+
+A clean analytic result is roughly 3 to 80 faces with curved surface types present. A mesh fallback is hundreds to thousands of faces, all `Plane`. Do not threshold high: a 190-face fallback has slipped past a ">500" heuristic. Zero curved faces on operands that had cylinders/cones/spheres is the tell.
+
+Triangle count and validity checks BOTH mask fallback: the fallback result is watertight and valid (it only passes `validate_boolean_result_lenient`). Volume masks it too. Only the face census tells the truth.
+
+Rust probe:
+```rust
+let (f, e, v) = brepkit_topology::explorer::solid_entity_counts(&topo, solid)?;
+for fid in brepkit_topology::explorer::solid_faces(&topo, solid)? {
+    let tag = topo.face(fid)?.surface().type_tag();
+}
+```
+`{plane: 439}` and nothing else = fallback. `{plane: 41, cylinder: 24, cone: 12}` = analytic.
+
+Tool probe (wasm kernel, `crates/wasm/src/bindings/query.rs`): `getEntityCounts(solid)` returns `[faces, edges, vertices]`; `getSolidFaces(solid)` + `getSurfaceType(face)` gives the census (`"plane" | "cylinder" | ... | "bspline"`; NURBS that exactly represent analytics are recognized). Re-probe face count on your known cases after EVERY GFA change; a fix for one case can silently regress another.
+
+## Step 2: Understand the gate in `crates/operations/src/boolean/mod.rs`
+
+Flow (verify current condition names with `rg -n 'euler_ok|open_shell_ok|hollow_ok' crates/operations/src/boolean/mod.rs`):
+
+1. Pre-GFA shortcuts: identical-solid, containment (`EmptyResult`, `build_contained_cut_hollow`), planar-NURBS flattening (`flatten_planar_nurbs_faces`).
+2. GFA runs: `brepkit_algo::gfa::boolean`. Two `BooleanOp` enums exist (engine: `crates/algo/src/bop.rs`; public: `crates/operations/src/boolean/types.rs`); operations converts.
+3. On `Ok`, heals run BEFORE gating: `remove_degenerate_edges`, `heal::remove_wire_spurs`, `unify_coincident_boundary_edges` (only if free edges), `merge_result_vertices`, up to 3x `heal::unify_faces`.
+4. Gates: `open_shell_ok` (Intersect rejects free edges; Cut/Fuse tolerate them), `hollow_ok` (inner shells require closed manifold), `euler_ok` (hole-aware `euler_balanced`, cavity-shell surplus subtracted). Accept = `euler_ok && open_shell_ok && validate_boolean_result(..).is_ok()`.
+5. Reject or GFA `Err`: `log::warn!` "falling back", then for Cut with a multi-component input A a `cut_multi_region_input` retry (per-component cuts, recombined), then a `log::debug!(target: "brepkit_approx", ...)` probe and `mesh_boolean_fallback`.
+
+So when you see fallback, run with `RUST_LOG=debug` to learn which path fired, then find which gate condition failed and why the GFA output violated it.
+
+## Step 3: The debugging loop
+
+1. Reproduce with a MINIMAL primitive case (extend `crates/operations/examples/debug_boolean.rs`, see reference.md for what it prints and how to extend it). Run: `cargo run --release --example debug_boolean -p brepkit-operations`.
+2. Bypass the operations layer: call `brepkit_algo::gfa::boolean` directly. Raw GFA output and post-heal output diverge; isolate at the raw layer first.
+3. Dump LITERAL data, never reason from theory: face count per surface type, per-face reversed/inner_wires/area, Euler V-E+F, edge-usage counts (1 = free, 3+ = non-manifold; `has_free_edges`/`is_closed_manifold` are private to boolean/mod.rs, reimplement the short usage-count loop), wire-edge traversal per face, per-face signed volume.
+4. Vary ONE variable per run (one dimension, one offset, one primitive swap).
+5. Fix at the layer that owns the artifact (a bad section curve is a phase_ff bug, not an assembler bug). Trust no "this alone closes it" claim without a raw-GFA face trace; multi-bug chains are the norm.
+
+The approximation census: `cargo run --release --example approx_census -p brepkit-operations` runs a boolean matrix over primitives and reports exact vs fallback per op. Caution: census "exact" only proves no fallback probe fired, NOT that the geometry is correct.
+
+## Step 4: Priors that save days
+
+1. Coincident-contact bugs: suspect the CLASSIFIER, not same-domain detection. Instrument `detect_same_domain` (`crates/algo/src/builder/same_domain.rs`) FIRST to rule SD out. Twice an SD diagnosis was wrong and the pairs were present both times; the real roots were classification (interior sample on a coincident rim). Two interior-sample paths exist and must BOTH be checked: `sample_face_interior` (`crates/algo/src/builder/mod.rs`, unsplit faces) and `interior_point_3d` (`crates/algo/src/builder/face_splitter/mod.rs`, split faces).
+2. Verify the boolean INPUTS for malformed faces before blaming the engine. An "engine bug" has turned out to be a wrong-face input shell. Run the face census and validation on both operands first (see the solid-verification skill).
+3. Verify cut geometry with the ray-cast classifier, NEVER with volume. Tessellation volume can read HIGH and nearly mask an un-carved slot. Use `brepkit_check::classify::classify_point(topo, solid, point, &ClassifyOptions::default())` on points that must be Inside/Outside after the op. The winding-number classifier (`classify_point_winding`/`classify_point_robust`) is categorically WRONG for non-analytic or faceted solids; do not use it here.
+
+## Step 5: Faithful repro discipline
+
+Export the ACTUAL failing operands from the consuming tool (brepjs: `k.unwrap(k.exportSTEP(operand))`), read back with `brepkit_io::step::reader::read_step(input: &str, topo) -> Result<Vec<SolidId>, IoError>`, then confirm the round-trip is ANALYTIC (faces cylinder/cone/plane, edges circle, not bspline). If STEP normalizes the bug away (sub-ULP vertex noise), use byte-exact arena serialization: wasm `serializeSolid`/`deserializeSolid` and native `brepkit_io::arena_io::{serialize_solid, deserialize_solid}`. Capture per-step OPERANDS, not batch results. Full recipe and precedent fixtures: reference.md, "Faithful repro".
+
+## Step 6: Nondeterminism signature
+
+Identical within a process but varying across processes = std `HashMap` random seed driving iteration order into downstream branching. Fix by sorting the iteration at the point that feeds branching (`sort_unstable_by_key`; precedents in `crates/algo/src/builder/same_domain.rs`). Do not reach for tolerance theories when the signature is process-boundary-shaped.
+
+## Anti-patterns: what NOT to conclude
+
+- "Triangle counts match and the mesh is watertight, so the boolean worked." Fallback results are watertight. Check the face census.
+- "Volume is within 2%, so the cut happened." Volume can read high on an un-carved cut. Ray-cast classify.
+- "Same-domain detection missed the coincident pair." Instrument `detect_same_domain` before believing this; it has been present both times it was blamed.
+- "The winding classifier says Outside, so the point is outside." Not on faceted or stepped solids.
+- "This one fix closes the case." Assume a chain of bugs until a raw-GFA trace on the real operands is clean.
+- "My synthetic nudge repro behaves like the tool's case." Validate any native proxy against the real tool operands first.
+- "The census says exact, so the result is correct." It only says no fallback fired.
+
+Related skills: solid-verification (validity and volume checks), analytic-preservation (keeping curved surface types through ops), debugging-doctrine (the general vary-one-variable method), tessellation (mesh-side issues).

--- a/.claude/skills/boolean-debugging/reference.md
+++ b/.claude/skills/boolean-debugging/reference.md
@@ -1,0 +1,130 @@
+# Boolean debugging reference
+
+Companion to [SKILL.md](SKILL.md). Symbols are the durable locators; line numbers rot, so
+find everything with `rg -n 'fn <symbol>' crates/...`.
+
+## Glossary
+
+- **GFA**: the boolean engine in `crates/algo` (general-fuse family). Entry `brepkit_algo::gfa::boolean(topo, op, a, b)`. Pipeline: PaveFiller, then Builder, then select/assemble.
+- **PaveFiller** (`crates/algo/src/pave_filler/`): computes pairwise interferences between the operands' sub-shapes in phases VV/VE/EE/VF/EF/FF (vertex/edge/face pairs), producing paves and pave blocks.
+- **Pave / PaveBlock** (`crates/algo/src/ds/pave.rs`): a split point on an edge / the edge fragment between two paves.
+- **FF phase / sections** (`pave_filler/phase_ff.rs`): face x face intersection; produces the section curves along which faces are split. Most boolean bugs live here or just downstream.
+- **Builder / face splitter** (`crates/algo/src/builder/`): splits each face in UV space along its sections (`face_splitter/`), classifies sub-faces In/Out/On against the opposing solid, then selects and assembles shells (`builder_solid.rs`, `assemble.rs`).
+- **SD (same-domain)**: detection of coincident overlapping faces across operands, `detect_same_domain` in `builder/same_domain.rs`, so ops can dedupe or cancel them.
+- **Mesh fallback**: `mesh_boolean_fallback` in `operations/src/boolean/mod.rs`, co-refinement on tessellated triangles; result is all-planar, all analytic surface types lost.
+- **Euler check**: V-E+F acceptance, hole-aware (a face with L inner wires raises V-E+F by L) and hollow-aware (each cavity shell adds a surplus of 2); `euler_balanced` in `boolean/mod.rs`.
+- **Free edge / over-shared edge**: edge used by exactly 1 face (open shell) / 3+ faces (non-manifold). Closed manifold means every edge used exactly twice.
+- **Seam edge**: the u=0 equivalent u=2pi closure edge of a periodic surface. Closed edges have start == end, which breaks any endpoint-based logic.
+- **Classifiers**: analytic closed-form (`algo/src/classifier/analytic.rs`), ray-cast parity (`check/src/classify/mod.rs::classify_point`, mirrored by `algo/src/classifier/ray_cast.rs`), winding number (`classify_point_winding`, wrong for faceted solids).
+- **`brepkit_approx` probe**: `log::debug!` target fired whenever an approximation path is taken; captured by the `approx_census` example.
+- **Arena serialization**: byte-exact solid capture/replay (`crates/io/src/arena_io.rs`, wasm `serializeSolid`) for repros that STEP's ~15-sig-fig serialization would normalize away.
+
+## Bug-class catalog
+
+Match your symptom here before inventing a new theory. "Fix location" is where the class was
+owned and fixed; recurrences of the same class usually land in the same file.
+
+| Bug class | Symptom | Root cause | Fix location / doctrine |
+|---|---|---|---|
+| Wire spurs | Fused solid non-manifold with inflated volume; wire traversal shows a consecutive same-edge forward-then-reverse pair; an edge shared by 3+ faces | GFA wire builder emits an out-and-back excursion on a face with a single-opening notch; zero area, but the edge is counted twice | `remove_wire_spurs` in `crates/operations/src/heal.rs`, called from the boolean gate. Always sound to strip. Caveat: a spur can mask a genuine missing adjacency; after stripping, the edge may drop to free, proving a deeper hole |
+| Coincident-ring vertex weld | Coincident-contact fuse comes out non-manifold or free-edged; volume wrong only for asymmetric footprints; near-duplicate vertices ~1e-6 apart | PaveFiller places ring vertices slightly off pre-existing vertices; `merge_duplicate_edges` quantizes endpoints at `MERGE_TOL` (1e-7) so near-twins land in different cells and the boundary never unifies | `weld_coincident_vertices` in `crates/algo/src/builder/builder_solid.rs` (snap radius 10x MERGE_TOL, runs before edge split/merge) |
+| Face-AABB collapse on closed edges | Faces perpendicular to a cylinder/cone axis vanish (free edges trace the missing rim) while axis-parallel walls survive; or `AssemblyFailed("no faces selected")` on a full torus | Face AABB built from boundary edge endpoints only; a closed circular edge has start == end so its box collapses to a point, and curved faces bulge past their boundary polygon | Surface-aware `compute_face_bbox` in `pave_filler/phase_ff.rs`, plus arc-trim AABBs in `emit_split_circle_arcs`. Doctrine: closed boundary edges (Circle, closed NURBS) must be sampled ALONG the curve, never endpoint-checked |
+| Closed-circle sections emitted as NURBS | A coaxial analytic boolean mesh-falls-back; the section wire on a shared rim is full of tiny arcs or closed-NURBS loops; a wall loses its bottom boundary | The seam-adopt path (phase_ff closed-circle handling plus `pave_filler/link_existing.rs`) is gated on `EdgeCurve::Circle`; a NURBS rim gets adopted as a redundant fresh edge instead. The general marcher also fragments near-tangent circles into ~100 micro-curves | Emit exact circles from `crates/math/src/analytic_intersection.rs` and construct `EdgeCurve::Circle` in phase_ff. `exact_cone_cone` and `exact_sphere_cylinder` are `pub`; `exact_plane_cone` and `algebraic_cylinder_cylinder` are private, reached via the public dispatchers `exact_plane_analytic` and `intersect_analytic_analytic`. See the analytic-preservation skill for adding an exact arm |
+| `merge_duplicate_edges` co-endpoint collapse | A circle split into two half-arcs sharing BOTH endpoints collapses to one edge; E is too small, Euler off, gate rejects, fallback | `merge_duplicate_edges` (`builder_solid.rs`) keys on quantized endpoint pairs only, with no curve discriminator | Doctrine fix is SPLITTER-SIDE: give co-endpoint seam arcs a midpoint vertex (the pi * 0.999 split divisor in `emit_split_circle_arcs`) so no two edges ever share both endpoints. Do NOT make the merge key smarter (type key or deviation threshold): that provably conflicts with the gridfinity lip case, where a chord and an arc with the same endpoints and millimeter-scale deviation MUST merge |
+| Thin-face FF filters drop valid sections | A razor-thin face (~0.03 to 1 mm wide) that should split becomes ONE full-width sub-face, gets one classify sample, and is kept or dropped wholesale; a fuse shows a hole where the thin strip's center is missing while a thicker parallel strip split fine | Several conservative filters in `phase_ff.rs` reject sections on thin faces: the uniform-sample AABB pre-filter, the midpoint-in-both test (midpoint evaluated outside the thin band), the ellipse-only section gate | `restrict_curves_to_faces` and `trim_ellipse_to_boundary_crossings` in `phase_ff.rs`. Fixes are case-by-case and regression-prone; re-run the full parity probes after any change here |
+| Interior sample lands on a coincident rim | Coincident-contact cut/fuse where an analytic cavity or contact wall vanishes; the analytic classifier returns None exactly on the rim, the ray-cast fallback says Outside, face dropped | A periodic wall's UV boundary polygon is lopsided, so the 2D interior sample lands on a v-extreme, which IS the shared rim | Two paths, check BOTH: `sample_face_interior` (`builder/mod.rs`, unsplit faces, mid-v sampling for periodic walls) and `interior_point_3d` (`builder/face_splitter/mod.rs`, split faces, snap-to-mid-v). A hazard fixed in one has historically stayed open in the other |
+| Sphere chord-discretized equator seam | plane x sphere sections fail to split a hemisphere: true crossing points sit off the inscribed-polygon seam chords by the sagitta, far beyond tolerance | Spheres are built as two hemispheres joined along a CHORD-discretized equator seam; every 3D layer then fights the chords | Partially closed: `sphere_seam_plane_crossings` in `phase_ff.rs` (Newell-plane crossings, facet-independent) plus the `split_noseam_by_arrangement` DCEL walk in `face_splitter/special_cases.rs`. Known open residual: a lone plane x sphere halfspace cut never reaches the 2D splitter (section-creation gap in the pavefiller). Identified right architecture: a UV-space arrangement splitter, where the equator is a clean v=0 line and the problem is degeneracy-free. That is a dedicated multi-day component, not yet built |
+| Degenerate FF sections | Open shell / inside-out / Euler-unbalanced result on a fuse with contact faces | Zero-span arc PaveBlock remnants, or open arcs re-tracing an existing inner-wire hole, injected as sections | `build_section_edges` in `builder/fill_images_faces.rs`. The shell/Euler symptoms were all downstream: dump each contact face's INPUT sections before instrumenting the assembler |
+| Phantom arrangement chord-breaks | A convex arc boundary gains break points that are not on it, producing a keyhole loop and fallback | `split_plane_face_by_arrangement` (`face_splitter/mod.rs`) registered chord intersections as breaks on the arc itself | Gated by the `chord_break_on_arc` check in the same file. Related trap: `evaluate_with_endpoints` takes the curve's NATIVE parameter (radians, knots), not a normalized [0,1] |
+| Shell sign / "no outer shell found (all shells classified as holes)" | `AssemblyFailed` with that exact message from `builder_solid.rs`; the recurring assembler death | Shell orientation sign taken from raw wire winding instead of the geometric surface normal, or a genuinely never-created face leaves large free-edge gaps so no shell closes | `signed_volume_of_shell` in `builder_solid.rs` (sign by surface normal). If free-edge gaps are large (millimeter scale, not near-twin vertices), the missing face is upstream in section creation, not a weld problem |
+
+## `debug_boolean.rs`: what it does and how to extend it
+
+`crates/operations/examples/debug_boolean.rs`. Run:
+
+```bash
+cargo run --release --example debug_boolean -p brepkit-operations
+```
+
+Current behavior: builds `make_box(50,30,10)` and `make_cylinder(5,20)`, translates the
+cylinder to the box center with `Mat4::translation(25,15,-5)` (primitives put their base at
+z=0), runs `boolean(Cut)` through the FULL operations gate, then prints:
+
+- face count and per-face surface type (exhaustive `FaceSurface` match; Plane printed with normal and d), `reversed`, `inner_wires` count, area
+- per-face signed volume via the divergence theorem over the tessellation, and the total
+- `measure::solid_volume` vs the closed-form expected value
+
+Caveat: it iterates `outer_shell()` only. For hollow results, switch to
+`brepkit_topology::explorer::solid_faces` (CLAUDE.md, "Walking faces in a solid").
+
+Extensions, in the order you usually need them:
+
+1. **Swap operands.** Replace the primitives/transform with your repro. One variable per run.
+2. **Bypass the gate.** Call `brepkit_algo::gfa::boolean(&mut topo, algo_op, a, b)` directly
+   (op enum from `crates/algo/src/bop.rs`). This skips the operations-layer shortcuts, heal
+   passes, and fallback, so you see the raw GFA artifact.
+3. **Edge-usage census.** `has_free_edges` and `is_closed_manifold` are private to
+   `operations/src/boolean/mod.rs`; reimplement: walk every face's wires, count usages per
+   `EdgeId` in a map, report edges with count 1 (free) and count >= 3 (non-manifold).
+4. **Wire traversal dump.** For each face, print the ordered (edge id, orientation) list per
+   wire. A consecutive same-edge forward-then-reverse pair is a spur.
+5. **Logger.** Add `env_logger::init()` at the top of `main` (already a dev-dependency;
+   pattern in `examples/profile_boolean.rs`) and run with `RUST_LOG=debug` to see the
+   "falling back" warnings and `brepkit_approx` probes.
+
+The census example: `cargo run --release --example approx_census -p brepkit-operations` runs
+`boolean_matrix()` over overlapping primitives plus offset/fillet/chamfer, captures the
+`brepkit_approx` log target in-process, and reports exact vs which-fallback, wall time, and
+face count per op. A census "exact" verdict only proves no fallback probe fired; the geometry
+can still be wrong (an un-carved cut has scored "exact"). Follow with the ray-cast check.
+
+## Faithful repro: full recipe
+
+The fixture-tier catalog (native repro, STEP, arena `.bin`) and test templates live in the
+testing skill. Boolean-specific rules on top of it:
+
+1. Export each failing boolean's OPERANDS from the tool, one file per operand per step:
+   `k.unwrap(k.exportSTEP(operand))`. Never capture a serialized batch result; a mid-bisect
+   intermediate looks plausible and burns a full pass.
+2. Read back with `brepkit_io::step::reader::read_step(input: &str, &mut topo)`: it takes
+   the file CONTENTS as `&str` and returns `Result<Vec<SolidId>, IoError>`, unlike the
+   generic reader shape in the CLAUDE.md cookbook.
+3. **Gate: confirm the round-trip is analytic.** Run the face census (Rust `type_tag`, or
+   tool-side `getSurfaceType`/`getEdgeCurveType`). Expect cylinder/cone/plane faces and
+   Circle edges. NURBS where the source had analytics means the fixture is unfaithful and
+   any fix derived on it will overfit and not transfer. Bugs that depend on sub-ULP vertex
+   noise that STEP rounds away need the arena tier (`serializeSolid`,
+   `brepkit_io::arena_io`); see the testing skill.
+4. Replay the boolean on the imported operands via `gfa::boolean` direct, then via
+   `operations::boolean`, and compare.
+5. If you built a synthetic proxy instead (e.g. a hand-placed 1e-13 nudge), validate that it
+   flips the same way as the real tool case BEFORE deep-debugging on it. Proxies have
+   diverged from the real case and cost multiple non-transferring iterations.
+
+## Gate internals worth knowing when a gate rejects
+
+All in `crates/operations/src/boolean/mod.rs`; locate with
+`rg -n 'euler_ok|open_shell_ok|hollow_ok|euler_balanced|inner_shell_surplus' crates/operations/src/boolean/mod.rs`.
+
+- `open_shell_ok`: `op != Intersect || !has_free_edges`. Cut and Fuse deliberately accept
+  open shells because an open GFA shell usually loses less than the mesh fallback would.
+- `euler_eff`: V-E+F minus `inner_shell_surplus` (2 per cavity shell). `euler_balanced(euler, inner_wires)`
+  accepts genus >= 0 with the inner-wire correction.
+- `hollow_ok`: results with inner shells must be closed manifold.
+- Accept: `euler_ok && open_shell_ok && validate_boolean_result(..)` (validator in
+  `boolean/assembly.rs`).
+- Multi-region Cut: accepted separately when components are disjoint, Euler is 2 per
+  component, the result is closed manifold, AND `cut_safe` holds. The `cut_safe` check
+  (each component center classifies as Outside operand B, so the tool's interior piece
+  cannot survive) only runs when `try_build_analytic_classifier(topo, b)` succeeds. For a
+  non-analytic B it defaults to true and the interior-piece guard is skipped.
+- There is no heal-retry after a reject. The `unify_faces` (up to 3x) and
+  `remove_wire_spurs` heals run pre-gate only. The real post-reject path: for Cut, when the
+  INPUT solid A has two or more disjoint components, `boolean()` retries via
+  `cut_multi_region_input` (per-component cuts, recombined); every other rejected or errored
+  case goes straight to `mesh_boolean_fallback`.
+
+When `euler_ok` fails, the productive question is which term is off: E too small points at
+edge over-merging (co-endpoint collapse row above); F too small points at dropped faces
+(AABB collapse, thin-face filters, rim misclassification rows); free edges point at a
+never-created section or a weld miss.

--- a/.claude/skills/debugging-doctrine/SKILL.md
+++ b/.claude/skills/debugging-doctrine/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: debugging-doctrine
+description: The meta-method for debugging hard geometry bugs in brepkit, used when a boolean, fillet, offset, or tessellation produces wrong volume, wrong face count, open or non-manifold shells, mesh fallback, misclassified points, or any failure where the first diagnosis did not immediately hold. Also applies before starting any multi-pass investigation, when a repro behaves differently from the real case, or when successive root-cause theories keep overturning each other.
+---
+
+# Debugging Doctrine
+
+The method that separates a converging investigation from a thrashing one. Every rule below was paid for: static guesses that skipped instrumentation were wrong, unfaithful repros burned ten-pass detours, and plausible diagnoses pointed at code that never executed.
+
+For concrete GFA phase-by-phase instrumentation recipes, see the **boolean-debugging** skill. For watertightness and volume verification, see **solid-verification**. Detailed catalogs live in [reference.md](reference.md).
+
+## Quick reference
+
+```bash
+cargo run --release --example debug_boolean -p brepkit-operations   # canonical dump harness, edit in place
+cargo run --release --example approx_census -p brepkit-operations   # which ops fall back to mesh/NURBS
+cargo test -p brepkit-io --test lipfuse_fixture                     # fixture-replay template
+```
+
+| Symptom | First suspect | Not this |
+|---|---|---|
+| Hundreds of all-planar faces | Mesh fallback fired: the GFA (general fuse algorithm, the boolean engine in `crates/algo`) result failed the gate in `crates/operations/src/boolean/mod.rs` | "Tessellation is broken" |
+| Coincident-contact boolean wrong | Classification (interior sample on a rim) | Same-domain (SD) detection. Instrument `detect_same_domain` only to rule it out; it has been wrongly blamed twice |
+| Boolean output malformed | The operation INPUTS (dump both operands first) | The boolean itself |
+| Volume slightly off | Un-carved or double-counted region masked by tessellation error | "Measure is imprecise". Volume is never ground truth |
+| Point classified OUT that looks inside | Winding classifier on a faceted solid | The solid. Use `classify_point` (ray-cast) as ground truth |
+| Shell open / inside-out / Euler off after fuse | Degenerate SECTION inputs, two layers up (`build_section_edges`) | The shell assembler |
+| Fix looks right but case unchanged | The patched path never executes | "The fix needs more work" |
+
+## The procedure
+
+### 1. Build a faithful repro, then VALIDATE it (before any debugging)
+
+A repro that does not reproduce the real case is worse than none: it manufactures red herrings. A proxy with corner radius 5 once straddled a wall the real radius 1.485 never touches; ten passes of findings applied only to geometry the real case never produces.
+
+- Capture the ACTUAL failing operands. STEP path: export from the tool (`k.exportSTEP` in a brepjs vitest), replay via `brepkit_io::step::reader::read_step`. Template: `crates/io/tests/lipfuse_fixture.rs`.
+- If STEP renumbers away the failure (in-memory id-layout bugs) use the lossless arena snapshot: `serialize_solid` / `deserialize_solid` in `crates/io/src/arena_io.rs` (JS: `serializeSolid` / `deserializeSolid`). The `*_inmem.rs` tests in `crates/io/tests/` are the pattern.
+- Checkpoint: repro must match the real case on operand surface types (analytic, not NURBS-reconstructed), face counts, and the exact failure signature. If any differ, fix the repro first. See [reference.md, Faithful fixtures](reference.md#faithful-fixtures).
+
+### 2. Dump literal data before theorizing
+
+Never reason from the symptom alone. Dump: total volume, per-face surface type and area, per-face signed volume, entity counts (V, E, F), free-edge and over-shared-edge counts, literal wire-edge traversals. `crates/operations/examples/debug_boolean.rs` is the editable template; expected output shape and every dump helper are in [reference.md, Instrumentation catalog](reference.md#instrumentation-catalog).
+
+### 3. Vary ONE variable at a time
+
+When a theory involves a parameter, sweep that parameter alone on a pristine primitive (`operations/src/primitives.rs`, bases at z=0) inside a `debug_boolean.rs`-style harness. Changing radius AND pocket-presence together once produced a bogus theory that a clean radius sweep on a bare box collapsed to a two-line repro.
+
+### 4. Confirm the suspect path FIRES
+
+Before trusting a diagnosis, gate the candidate code behind a temporary flag or early-return and check whether the failing case changes at all. A plausible static diagnosis once blamed an arc-split branch that executed zero times; the real fix was elsewhere in the same file. When toggling, check INTERMEDIATE state (shell closed, signed volume), not just the final error string. Checkpoint: toggle changes nothing observable means wrong code path, go back to step 2.
+
+### 5. Trace below the gate
+
+`operations::boolean::boolean` runs GFA, then an acceptance gate (`euler_ok && open_shell_ok && validate_boolean_result`), and on failure substitutes a mesh fallback (a warning is logged, but callers see Ok). An operations-level result can look plausible while the real GFA output was rejected. Verify at BOTH levels: `brepkit_algo::gfa::boolean` directly (below the gate) and through the full pipeline. Trust no "this one fix closes it" prediction, including from a subagent, until a direct raw-engine trace on the real operands confirms it; one such trace turned a single predicted fix into five.
+
+### 6. Expect layers; peel and re-instrument
+
+Hard cases are routinely three to five stacked bugs, each fix exposing the next (one cut needed five successive correct diagnoses). Peeling layers is normal progress, not failure, but only if you re-dump at every layer. Never assume the previous dump still describes the state after a fix.
+
+### 7. Treat diagnosis instability as a finding
+
+If several rigorous passes each overturn the previous root cause, you are in a multi-bug region or your repro is unfaithful. Stop. Do not run another same-shaped pass. Build better tooling instead: a lossless fixture (arena snapshot), targeted instrumentation, an intermediate-state dump. The arena serializer itself was built as the exit from exactly this trap, and it worked. Symptom chases that instrument the last stage (the assembler) while the bug is two layers up (section construction) look like instability; dump each stage's INPUTS first.
+
+## Anti-patterns (do not conclude)
+
+- "Volume matches, so the boolean is correct." Volume is tessellation-based (`measure/volume.rs`, deflection clamped to bbox_diag * 5e-5) and has masked a fully un-carved slot. Face count per surface type is the reliable tell.
+- "Triangle count and validity look fine, so no fallback." Both mask mesh fallback. Only face count exposes it.
+- "The winding classifier says OUT, so the point is outside." Wrong on faceted, stepped, and NURBS-heavy solids. Ground truth is `brepkit_check::classify::classify_point`.
+- "Same-domain detection must have missed the overlap." Check the classifier first; SD was innocent both times it was blamed.
+- "The fix compiles and the theory is coherent, so ship it." Verify the path fires (step 4) and the case closes on the real fixture, or revert. Unshippable partial progress goes to a branch, never to main.
+- "Generalize while we are here." Solve the narrow problem. A general merge-key primitive was provably impossible where a per-case splitter-side midpoint split worked; two callers needed opposite behavior from the same key.
+- "Handle the planar case now, curved later." No shortcuts in CAD algorithms: cover periodic, closed, degenerate, and inner-wire cases, or split into complete sub-components. Never ship an incomplete whole.
+- Effort commentary. Report the technical situation only: what is wrong, what the fix is, what is verified. Keep driving until solved or genuinely blocked (blocked means a user decision or credential is needed).
+
+## Priors worth memorizing
+
+- Coincident-contact boolean bug: classification before same-domain. Two interior-sample paths exist (`sample_face_interior` in `builder/mod.rs` for unsplit faces, `interior_point_3d` in `builder/face_splitter/mod.rs` for split ones); a hazard fixed in one can be open in the other.
+- Malformed boolean output: verify the INPUTS before blaming the operation. A "boolean bug" was once a malformed shell fed in.
+- Simple fix at the layer that owns the artifact beats a clever fix at the wrong layer.
+- Scorecards and face-count baselines go stale: re-probe after every GFA change.
+
+Case studies, dump recipes, and the glossary: [reference.md](reference.md).

--- a/.claude/skills/debugging-doctrine/reference.md
+++ b/.claude/skills/debugging-doctrine/reference.md
@@ -1,0 +1,137 @@
+# Debugging Doctrine: Reference
+
+Companion to [SKILL.md](SKILL.md). All symbols verified against the repo; locate them with the `rg` patterns given (line numbers rot, symbols survive).
+
+## Faithful fixtures
+
+Capture mechanics, the three fixture tiers (native primitive repro, STEP, arena `.bin`), and templates to copy: see the testing skill. The doctrine-level rules:
+
+- STEP tier: replay via `brepkit_io::step::reader::read_step`; full template `crates/io/tests/lipfuse_fixture.rs`. **Faithfulness gate before debugging:** iterate the imported faces and match on `FaceSurface`. Cylinder/Cone/Plane coming back as `Nurbs` means the export went lossy, the numbers differ, and any fix will overfit the fixture. This gate is the exact difference between a tractable case (lip fuse: analytic round trip) and a thrash (scoop: lossy NURBS reconstruction).
+- Arena tier: failures living in the in-memory id layout (edge/vertex ordering, arena numbering) vanish under STEP renumbering. Snapshot losslessly with `serialize_solid` / `deserialize_solid` in `crates/io/src/arena_io.rs` (JS: `serializeSolid` / `deserializeSolid`); the `*_inmem.rs` tests in `crates/io/tests/` are the pattern. This tooling exists because a five-pass thrash proved "no stable repro" was the real blocker. When you hit the same wall, capture, do not attempt another debugging pass on a proxy.
+
+### Faithfulness checklist
+
+Before spending a single pass, the repro must match the real case on ALL of:
+
+- [ ] Same operands (captured, not rebuilt from remembered parameters; a wrongly remembered corner radius cost ten passes)
+- [ ] Same surface types per face (analytic stays analytic)
+- [ ] Same face/edge/vertex counts on the inputs
+- [ ] Same failure signature (same error, same wrong volume, same open-edge count)
+
+## Instrumentation catalog
+
+### The canonical dump harness
+
+`crates/operations/examples/debug_boolean.rs`. Edit it in place for the investigation at hand (swap in your fixture load, your op). Run:
+
+```bash
+cargo run --release --example debug_boolean -p brepkit-operations
+```
+
+What it dumps and the output shape:
+
+```
+Box volume: 15000
+Result has 7 faces
+  Face 0: Plane(n=0.00,0.00,-1.00 d=-0.00)  reversed=false  inner_wires=1  area=1421.46
+  Face 6: Cylinder  reversed=true  inner_wires=0  area=314.16
+Per-face signed volume (divergence theorem):
+  Face 0: signed_vol = 0.00  (38 tris)
+Total signed volume: 14214.60
+measure volume:  14214.60
+Expected volume: 14214.60
+```
+
+Per-face signed volume is the sharpest tool here: a face contributing the wrong sign or a wildly wrong magnitude localizes the bad face immediately, where a total volume only says "something is off".
+
+Caveat: the example walks `outer_shell()` only. For hollow solids use `brepkit_topology::explorer::solid_faces` (see CLAUDE.md, "Walking faces in a solid").
+
+### Edge-incidence dump (free / over-shared edges)
+
+Pattern: `edge_use` in `crates/io/tests/lipfuse_fixture.rs` (`rg -n 'fn edge_use' crates/io/tests/lipfuse_fixture.rs`). Counts wire-edge uses keyed by a quantized, orientation-independent endpoint pair. `free` = used by exactly 1 face (open shell), `over` = used by 3+ (non-manifold). Watertight-manifold means both are 0.
+
+Subtlety recorded in its doc comment: the quantization grid matters. Too coarse (1e-5) false-merges legitimate sub-micron corner arcs into phantom over-shares; 1e-6 is the working value. If the dump reports over-shares on tiny arcs, suspect your grid before the topology.
+
+### Entity counts and Euler
+
+- Rust: `brepkit_topology::explorer::solid_entity_counts` returns `(faces, edges, vertices)`.
+- JS: `getEntityCounts` returns `[faces, edges, vertices]`, `getSurfaceType` per face (`crates/wasm/src/bindings/query.rs`).
+
+**Face count is the only reliable mesh-fallback tell.** A clean analytic boolean result has roughly 3 to 80 faces with the expected curved types; mesh fallback produces hundreds of faces, all planar, zero curved. Triangle count and mesh validity both MASK the fallback (this exact trap silently invalidated a parity scorecard). Re-probe face counts after every GFA change.
+
+### Wire-traversal dump and spurs
+
+Dump each face's wire as the literal ordered edge list with orientations. The spur signature: a wire that walks the same edge forward then immediately reversed (consecutive out-and-back pair). Zero area contribution, but the edge is counted twice, producing a phantom 3-face edge and inflated volume. Sound repair exists: `remove_wire_spurs` (`rg -n 'pub fn remove_wire_spurs' crates/operations/src/heal.rs`), but dump first, repair second: a spur is a symptom of an upstream splitter bug.
+
+### Raw-engine trace vs the gated pipeline
+
+The full boolean pipeline is:
+
+```
+operations::boolean::boolean
+  -> brepkit_algo::gfa::boolean          (the real GFA engine)
+  -> gate: euler_ok && open_shell_ok && validate_boolean_result(...)
+  -> on gate failure, Cut only: multi-region acceptance (N disjoint closed
+     manifolds, Euler = 2N, plus a B-interior component check)
+  -> then, Cut only: per-component retry (cut_multi_region_input) when the
+     INPUT solid is already multi-region
+  -> last resort: mesh_boolean_fallback (logs a warning, returns Ok;
+     silent to callers)
+```
+
+`rg -n 'pub fn boolean' crates/algo/src/gfa.rs` and `rg -n 'fn mesh_boolean_fallback|euler_ok && open_shell_ok' crates/operations/src/boolean/mod.rs`.
+
+Consequences:
+
+- To see what the engine actually produced, call `gfa::boolean` directly and dump faces, surface types, Euler. The gated result can look plausible (it is a valid mesh) while the GFA output was rejected and discarded.
+- A predicted fix must be validated with a raw trace on the real operands. One diagnosis agent predicted a single AABB fix would close a sphere-minus-cylinder case; the raw trace showed the post-fix result had 3 faces, all cylinder, sphere entirely dropped at split/keep. The trace re-scoped one fix into five.
+
+For phase-by-phase PaveFiller and section dumps, see the **boolean-debugging** skill.
+
+### Temporary flag-gating (does the path fire?)
+
+Technique, not infrastructure: add a temporary early-return, a counter, or an `if false` around the suspect branch; rebuild; rerun the fixture. There are deliberately no permanent env-var toggles in the engine, so add and remove the gate within the investigation.
+
+- If the failing case is byte-identical with the branch disabled, the branch never fires for this case. The diagnosis is wrong regardless of how plausible it reads. (Real case: an arc-split branch in `crates/algo/src/builder/builder_solid.rs` was blamed; a counter showed zero executions; the actual fix was `weld_coincident_vertices` in the same file.)
+- Compare INTERMEDIATE state across the toggle (shell-closed, per-face signed volume, edge-incidence), not just the final error string. A final-error-only comparison once missed the real isolation signal entirely.
+
+## Ground truth: point classification
+
+- **Use:** `brepkit_check::classify::classify_point(topo, solid, point, &ClassifyOptions::default())` in `crates/check/src/classify/mod.rs`. Ray casting along three irrational directions with majority vote. This is the ground truth for in/out/on.
+- **Never:** `classify_point_winding` / `classify_point_robust` on faceted, stepped, or NURBS-heavy solids. They return OUT for points clearly inside such solids; that behavior sent three debugging agents down a wrong "multi-surface envelope" theory. The GFA builder itself uses ray casting (`crates/algo/src/classifier/ray_cast.rs`) for the same reason.
+- **Never volume as ground truth.** `measure::solid_volume` is tessellation-based with deflection clamped to `bbox_diag * 5e-5` (`crates/operations/src/measure/volume.rs`); it once read 1.4 percent HIGH and nearly masked a fully un-carved slot. It also has four short-circuit paths, tried in order inside `solid_volume`: closed-form analytic (`try_analytic_solid_volume`), per-face analytic Gauss quadrature (`analytic_faces_solid_volume`), analytic surface-of-revolution (`analytic_revolution_solid_volume`), then tessellation. "Volume looks right" can mean the wrong path answered.
+
+## Case studies (layered bugs and misdirection)
+
+### Coaxial cone-cone cut: five successive correct diagnoses
+
+Each fix exposed the next layer. In order: same-domain handling; face keep/discard selection; classification (the interior sample of `interior_point_3d` landed exactly on a coincident rim, returned nothing, and the fallback classified Outside); the cone-cone intersection marcher emitting ~97 garbage micro-curves instead of one circle (fixed via `exact_cone_cone` in `crates/math/src/analytic_intersection.rs`); and finally emitting that circle as `EdgeCurve::Circle` rather than NURBS so the FF phase's seam-adoption logic recognizes it. Lesson: re-dump after every fix; the layer-N dump says nothing about layer N+1.
+
+### Sphere minus cylinder: five bugs in sequence
+
+Missing exact (Sphere, Cylinder) intersection arm (`exact_sphere_cylinder`, same file); `split_noseam_face_direct` skipping full circles (`crates/algo/src/builder/face_splitter/special_cases.rs`); both hemisphere interior sample points degenerating to the north pole; the outer-wire-only same-domain hash false-merging two distinct bands (`detect_same_domain`, `crates/algo/src/builder/same_domain.rs`); volume over-integration in tessellation. The initial diagnosis predicted bug one alone would close the case.
+
+### The nine-pass symptom chase (fuse)
+
+"Shell open", "inside-out", "Euler unbalanced" were all DOWNSTREAM symptoms. Nine passes instrumented the shell assembler; the bugs were two layers up: two sources of degenerate sections in `build_section_edges` (`rg -n 'fn build_section_edges' crates/algo/src/builder/fill_images_faces.rs`), zero-length or zero-span sections and sections coinciding with a face's own inner-wire boundary. Durable rule: when a fuse shell is non-manifold and inside-out, dump each contact face's INPUT sections before touching the assembler.
+
+### Classifier, not same-domain (twice)
+
+Two separate coincident-contact failures were confidently diagnosed as "same-domain detection missed the overlap". Instrumenting `detect_same_domain` showed the pairs WERE detected both times. The real bugs were in classification: an interior sample landing on a coincident rim, whose failed evaluation fell back to a ray cast that answered Outside. Two interior-sample paths exist and must both be checked: `sample_face_interior` (`crates/algo/src/builder/mod.rs`, unsplit faces) and `interior_point_3d` (`crates/algo/src/builder/face_splitter/mod.rs`, split sub-faces). A rim-avoidance defense in one can be absent in the other. Instrument SD first only to RULE IT OUT, then move to the classifier.
+
+### Narrow beats general
+
+A general "arc-identity merge key" for duplicate-edge merging is provably impossible here: the stacking-lip ring needs co-endpoint seam arcs to COLLAPSE to one edge, while a torus-minus-box lens needs the same-signature pair kept DISTINCT. No local key discriminates; the difference is global. The shipped solution was per-case and upstream: a splitter-side midpoint split, controlling the geometry emitted instead of patching the shared merge. When a "general primitive" keeps breaking a second caller as you fix the first, that is the same signal: solve the narrow problem.
+
+## Glossary
+
+- **GFA**: brepkit's general fuse algorithm, the boolean engine in `crates/algo`. Raw entry `gfa::boolean`; `operations::boolean::boolean` wraps it with the acceptance gate and mesh fallback.
+- **PaveFiller**: GFA phase computing pairwise interferences (VV/VE/EE/VF/EF/FF) and splitting edges at intersection parameters. `crates/algo/src/pave_filler/`.
+- **FF phase**: face-face intersection (`pave_filler/phase_ff.rs`), producing section curves. Historically the richest bug habitat.
+- **Section**: an FF intersection curve threaded into a face's splitting arrangement (`build_section_edges`). Degenerate sections poison everything downstream.
+- **Same-domain (SD)**: detection of coincident overlapping faces across operands (`builder/same_domain.rs`) so they merge to one representative.
+- **Mesh fallback**: triangle-mesh re-run when the GFA result fails the gate. Logs a warning but returns Ok, so it is silent to callers. Correct-ish geometry, hundreds of all-planar faces. Face count is the tell.
+- **Free / over-shared edge**: edge used by exactly 1 face (open) or 3+ faces (non-manifold). Both zero means watertight-manifold.
+- **Spur**: consecutive out-and-back same-edge pair in a wire. Zero area, breaks manifoldness.
+- **Faithful fixture**: the real failing operands captured losslessly (STEP if analytic round trip holds, arena snapshot otherwise) and replayed in a Rust test.
+- **The reference kernel**: the incumbent C++ B-Rep kernel brepkit replaces. Its source may be consulted for algorithm structure (see the fuse note: it keeps sub-blocks whose midpoint classifies in-or-on both faces, rather than clipping to the opposing polygon). Never name it in commits, PRs, code, or docs. For head-to-head benchmarks, use the brepjs harness (see the **parity-benchmarking** skill).

--- a/.claude/skills/fillet-blend/SKILL.md
+++ b/.claude/skills/fillet-blend/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: fillet-blend
+description: Diagnose fillet and chamfer bugs by locating which engine owns them, debug the v2 walking blend, and avoid the silent no-op success in the public fillet binding. Use when a fillet or chamfer leaves free edges, produces an open or non-manifold shell, silently changes nothing, degrades a cylindrical wall to NURBS, or when deciding whether to touch the deprecated v1 fillet code.
+---
+
+# Fillet and Blend
+
+The full engine map, module roles, and open-bug catalog live in [reference.md](reference.md).
+
+## When to use
+
+You are working on `fillet`, `chamfer`, `filletV2`, `chamferV2`, `chamferDistanceAngle`, or `filletVariable` (wasm), or on `crates/operations/src/fillet/`, `crates/operations/src/chamfer.rs`, `crates/operations/src/blend_ops.rs`, or `crates/blend/`. The result leaves free edges, opens the shell, silently returns the input, or you must decide whether the deprecated v1 code is safe to change.
+
+## Quick reference
+
+| Symptom | First move | Detail |
+|---|---|---|
+| `fillet` "succeeded" but shape looks unchanged | Compare (F,E,V) and volume before/after; equal = silent no-op | Step 2 |
+| Bug in default `fillet` / batch `fillet` | It chains THREE engines; find which one produced the result | Step 1 |
+| Bug only in `filletV2`/`chamferV2` | Pure `crates/blend` walking engine | Step 4 |
+| `chamfer` (no V2) rejects curved faces | Flat-bevel engine in `chamfer.rs` is planar-only, not blend | reference.md |
+| Full closed rim fillet leaves free edges | Known open bug (rolling-ball); single-edge case works | reference.md |
+| Filleted lip goes non-manifold at cap planes | Latent v2-trimmer edge-sharing risk (not the passing d5 guard) | reference.md |
+| Straight-edge fillet wall came out as NURBS | Regression: it should be a `CylindricalFace` | Step 5 |
+| Want to delete/reorder v1 fillet code | Do NOT. It backs the live public API | Step 3 |
+
+## Step 1: Identify the engine (there are three fillet paths, not two)
+
+The default `fillet` binding does NOT map to one engine. `fillet_solid` (`crates/wasm/src/bindings/operations.rs`) calls `try_fillet` (`crates/wasm/src/helpers.rs`), which tries three engines in order and accepts the first whose outer shell passes `validate_shell_closed`:
+
+1. `fillet::fillet_rolling_ball` (v1 rolling-ball, real rounded blend faces)
+2. `blend_ops::fillet_v2` (v2 walking engine, `crates/blend`)
+3. `fillet::fillet` (v1 flat-bevel, last resort, planar neighbors only)
+
+Map from a bug report to code:
+
+| JS binding | Engine |
+|---|---|
+| `fillet`, `filletWithEvolution`, batch `fillet` | `try_fillet` chain: rolling-ball → v2 → bevel |
+| `filletV2` | pure v2 `blend_ops::fillet_v2` |
+| `chamferV2`, `chamferDistanceAngle` | pure v2 `blend_ops::chamfer_v2` / `chamfer_distance_angle` |
+| `chamfer` | flat-bevel engine `chamfer::chamfer` (planar-only, separate code) |
+| `filletVariable` | v1 `fillet::fillet_variable` |
+
+Checkpoint: for a default `fillet` bug, instrument `try_fillet` to log which of the three branches returned. Do not debug `crates/blend` for a bug that the rolling-ball branch actually produced.
+
+## Step 2: The silent no-op trap (verify this FIRST on any "it did nothing" report)
+
+`fillet` can return the ORIGINAL solid as a successful result when every edge fails. Two layers cause it:
+
+- `try_fillet` returns `Ok(solid_id)` unchanged when `filter_filletable_edges` drops all edges, and again at its final line when no engine produced a closed shell.
+- `fillet_solid` (`operations.rs`, in the `try_fillet` else-branch) returns `solid_id` when `try_fillet` errs and no planar edges remain, then `Ok(solid_id_to_u32(solid))` reports success.
+
+It slips through sign-off because no error is thrown and `validateSolid` / `isClosed` / Euler all pass: the INPUT was already a valid solid. "Ran without error" plus "solid verifies" both green-light a no-op. This is the poster case for the solid-verification skill.
+
+Detection recipe. A real fillet MUST change topology and volume. Assert change, do not assert success:
+
+```rust
+let before = brepkit_topology::explorer::solid_entity_counts(&topo, solid)?; // (F,E,V)
+// ... fillet ...
+let after = brepkit_topology::explorer::solid_entity_counts(&topo, solid)?;
+assert_ne!(before, after, "fillet was a silent no-op");
+```
+
+- Identical `(F,E,V)` means no blend faces/edges/vertices were added: no-op.
+- Identical volume means no material moved. A convex edge rounds material away (volume drops); a concave edge adds it.
+- In wasm, if the returned handle equals the input handle AND counts are unchanged, treat it as failure, not success.
+
+## Step 3: Deprecation entanglement (what is safe to touch)
+
+Both v1 fillet functions carry `#[deprecated]` AND are still wired into the live public API:
+
+- `fillet_rolling_ball` (`#[deprecated(since = "2.44.0")]`) is engine #1 in `try_fillet`.
+- `fillet::fillet` (`#[deprecated(since = "0.8.0")]`) is engine #3 in `try_fillet`.
+
+Internal callers suppress the warning with `#[allow(deprecated)]` (the attribute lives on `try_fillet` in `helpers.rs`, plus benches, tests, and a re-export in `fillet/mod.rs`).
+
+Removing or auto-migrating v1 is a BEHAVIOR and public-API change, not safe cleanup: it changes what the actively-used rolling-ball fillet ships to JS. This was left for a product decision.
+
+- Safe: improving `crates/blend`, adding tests, fixing bugs inside an engine, editing comments.
+- Not safe without a product decision: deleting either deprecated fn, reordering or removing engines in `try_fillet`, changing which engine a binding resolves to.
+
+## Step 4: Debugging the v2 walking engine (`crates/blend`)
+
+Module roles: `radius_law.rs` (radius vs arc-length), `spine.rs` (edge chain + arc-length parameterization), `section.rs`/`stripe.rs` (cross-section and fillet band), `blend_func.rs` (constraint functions), `walker.rs` (Newton-Raphson; `newton_solve` returns `None` on non-convergence, `max_newton_iters` default 20), `analytic.rs` (fast paths: `try_analytic_fillet` dispatches to `plane_plane_fillet`, `plane_cylinder_fillet`, `cylinder_cylinder_fillet`, etc.; unsupported pairs fall to the walker → NURBS wall), `corner.rs` + `spherical_triangle.rs` (vertex blend where stripes meet), `trimmer.rs` (trims neighbor faces along contact curves), `fillet_builder.rs`/`chamfer_builder.rs` (orchestration, plus a dedicated closed-rim path with a fallback).
+
+Failure modes: walker divergence (`newton_solve` returns `None`), trimmer `split_edge_at` leaving a shared cap-face boundary edge unsplit so two faces stop sharing an edge (latent risk, see reference.md (b)), closed-rim fillets emitting free edges.
+
+Instrument at the symptom layer (see debugging-doctrine). Dump `(F,E,V,euler)` and `validate_shell_closed` before and after; count and locate boundary edges (they cluster at the geometric feature); log which `try_analytic_*` arm fired versus the walker fallback; for divergence log `newton_solve` failures with the spine parameter and initial guess. Start from the smallest repro (one edge on a box) and add edges until it breaks.
+
+## Step 5: Scope. What is inherently approximate versus what must be exact
+
+- The blend WALL of a curved-neighbor fillet or chamfer is a NURBS surface with no closed form. Do NOT chase exact-analytic recovery of it (the analytic-preservation skill is for ops that RE-CREATE analytic types, not ops that invent a blend surface).
+- Fillet TOPOLOGY and contact curves must still be watertight and correct. The open bugs in reference.md are topology defects and are always in scope.
+- Cylindrical fillet walls of STRAIGHT edges ARE analytic and must stay so: the rolling-ball engine emits them as `FaceSpec::CylindricalFace` (defined in `crates/operations/src/boolean/types.rs`), and the blend `analytic.rs` fast paths emit exact typed surfaces for supported pairs. A straight-edge cylindrical wall degrading to NURBS is a regression, not "inherently approximate."
+
+Fillets frequently feed booleans (a lip is Cut(outer, inner) then filleted), so a fillet that leaves free edges will fail the downstream boolean. See boolean-debugging.
+
+Related skills: debugging-doctrine (the method), solid-verification (the no-op trap, before/after F,E,V and volume), boolean-debugging (fillets feed booleans), testing (regression fixtures; the d5 lip test is a live passing guard).

--- a/.claude/skills/fillet-blend/reference.md
+++ b/.claude/skills/fillet-blend/reference.md
@@ -1,0 +1,96 @@
+# Fillet and Blend reference
+
+Deep catalog for the fillet-blend skill. All paths and symbols verified against the working tree. Prefer symbol names and `rg` anchors over line numbers, which drift.
+
+## The full engine map
+
+There are three fillet code paths and two chamfer paths. "v1 vs v2" is a simplification: the production `fillet` binding chains three engines.
+
+### Fillet engines
+
+- **v1 rolling-ball** `crates/operations/src/fillet/rolling_ball.rs`, `pub fn fillet_rolling_ball`. Emits real rounded blend faces: NURBS walls for curved neighbors, `FaceSpec::CylindricalFace` for straight edges. `#[deprecated(since = "2.44.0", note = "Use brepkit_blend::fillet_builder::FilletBuilder (via blend_ops::fillet_v2) instead.")]`, yet still the primary production path. G1 chain propagation is internal; `fillet_rolling_ball_propagate_g1` (`fillet/g1_chain.rs`) just delegates.
+- **v1 flat-bevel** `crates/operations/src/fillet/mod.rs`, `pub fn fillet`. `#[deprecated(since = "0.8.0", note = "Use fillet_rolling_ball for true rounded fillets")]`. Replaces each edge with a flat bevel; planar neighbors only. Last-resort fallback.
+- **v1 variable** `fillet/mod.rs`, `pub fn fillet_variable` with `FilletRadiusLaw` (Constant / Linear / SCurve).
+- **v2 walking (blend)** `crates/blend/` wrapped by `crates/operations/src/blend_ops.rs`: `fillet_v2`, `chamfer_v2`, `chamfer_distance_angle` construct `FilletBuilder` / `ChamferBuilder`.
+
+### Chamfer engines
+
+- **flat-bevel chamfer** `crates/operations/src/chamfer.rs`, `pub fn chamfer` → `chamfer_core` → `FaceSpec` assembly (`assemble_solid_mixed`). Planar-only. NOT the blend engine and NOT the same code as the v1 fillet bevel. If a `chamfer` (no V2) bug is "refuses NURBS faces," it is this engine.
+- **v2 chamfer** `blend_ops::chamfer_v2` and `chamfer_distance_angle` in `crates/blend`.
+
+### The dispatcher
+
+`crates/wasm/src/helpers.rs`, `pub fn try_fillet` (carries `#[allow(deprecated)]`). Tries engines in preference order and accepts the first whose outer shell passes `validate_shell_closed`:
+
+1. `fillet::fillet_rolling_ball`
+2. `blend_ops::fillet_v2`
+3. `fillet::fillet`
+
+If `filter_filletable_edges` drops all edges, or no engine yields a closed shell, it returns `Ok(solid_id)` unchanged. That unchanged return is Layer A of the silent no-op trap.
+
+### Public wasm bindings (`crates/wasm/src/bindings/operations.rs`)
+
+| JS name | Rust fn | Engine |
+|---|---|---|
+| `fillet` | `fillet_solid` | `try_fillet` chain (rolling-ball → v2 → bevel) |
+| `filletWithEvolution` | `fillet_with_evolution` | `try_fillet` (same chain) |
+| `filletVariable` | `fillet_variable` | v1 `fillet::fillet_variable` |
+| `chamfer` | `chamfer_solid` → `chamfer::chamfer` | flat-bevel chamfer (planar-only) |
+| `filletV2` | `fillet_v2` | v2 `blend_ops::fillet_v2` |
+| `chamferV2` | `chamfer_v2` | v2 `blend_ops::chamfer_v2` |
+| `chamferDistanceAngle` | `chamfer_distance_angle` | v2 `blend_ops::chamfer_distance_angle` |
+
+`executeBatch` (`bindings/batch.rs`) mirrors this: op `"fillet"` → `try_fillet`, `"chamfer"` → `chamfer::chamfer`, `"filletVariable"` → `fillet::fillet_variable`.
+
+## The silent no-op trap, both layers
+
+- **Layer A, `try_fillet`.** Returns the input `solid_id` unchanged when all edges are filtered out, and again when all three engines fail the closed-shell check. No error.
+- **Layer B, `fillet_solid`.** In the `else` branch after `try_fillet` errs, `filter_planar_edges` is retried; if that set is empty the binding sets `solid = solid_id` (the original) and returns `Ok(solid_id_to_u32(solid))` as success.
+
+Both `validateSolid` and Euler pass because the input was valid. Detection: assert `(F,E,V)` and volume changed, per Step 2 of the SKILL. This is the concrete case behind solid-verification's "a passing check that proves nothing."
+
+## v2 module roles (`crates/blend/src/`)
+
+| File | Role |
+|---|---|
+| `radius_law.rs` | Radius as a function of spine arc-length (constant, linear, s-curve, custom). |
+| `spine.rs` | Edge chain + arc-length parameterization (Line = linear; Circle/Ellipse/NURBS via projection). |
+| `section.rs` | Cross-section: contact points, center, radius. |
+| `stripe.rs` | Fillet band: contact curves + pcurves. |
+| `blend_func.rs` | Blend constraint functions the walker solves. |
+| `walker.rs` | Newton-Raphson walker. `WalkerConfig::max_newton_iters` default 20, `min_step` failure floor. `newton_solve` returns `None` on non-convergence. |
+| `analytic.rs` | Analytic fast paths. `try_analytic_fillet` / `try_analytic_chamfer` route to typed closed-form arms (`plane_plane_fillet`, `plane_cylinder_fillet`, `plane_cone_fillet`, `plane_sphere_fillet`, `cylinder_cylinder_fillet`, `cone_cone_coaxial_fillet`, plus chamfer variants). Pairs with no arm (anything × torus, cyl × cone, perpendicular cyl × cyl, non-coaxial cone × cone) fall to the walker → NURBS blend. |
+| `corner.rs`, `spherical_triangle.rs` | Vertex/corner blend where several stripes meet. |
+| `trimmer.rs` | Trims neighbor faces along contact curves. `trim_face`, `trim_face_general`, private `split_edge_at`. |
+| `fillet_builder.rs`, `chamfer_builder.rs` | Orchestration: spine → stripe (analytic or walker) → trim → corner → assemble. `fillet_builder.rs` has a closed-rim path with a fallback (`rg "closed-rim assembly failed"`). |
+
+## Known open bug classes
+
+Frame these as symptom signatures, not solved recipes.
+
+### (a) Closed rounded-rect rim, all peak edges → free edges. Engine: v1 rolling-ball.
+
+`crates/operations/src/fillet/rolling_ball.rs`. Filleting all peak-rim edges of a rounded-rectangle lip in one call produces free edges around the closed loop. The single lip-peak fillet was fixed by emitting cylindrical fillet faces as `FaceSpec::CylindricalFace` (preserve arcs, do not flatten to chords). The all-edges closed-loop case is still open. Signature: single-edge fillets are fine; the full-rim fillet leaves free edges.
+
+### (b) Latent trimmer cap-face edge-sharing risk. Engine: v2 blend.
+
+This is a code-level risk in `crates/blend/src/trimmer.rs`, not a currently-failing repro.
+
+`split_edge_at` (called from `trim_face`) splits the trimmed face's boundary edge into two new edges and rebuilds only that face's wire. It does not update a neighbor (cap) face that also referenced the original edge. If both faces shared that edge, they can stop sharing it: each side becomes a boundary edge and the shell goes non-manifold and unclosed with the Euler count dropping. When walking or reordering `crates/blend` trim code, this is the failure it can produce.
+
+The boolean pipeline reconciles this class of problem with `refine_boundary_edges` (`crates/operations/src/boolean/assembly.rs`); the blend path has no equivalent (blend may only depend on math + topology). There is no `reconcile.rs` in the tree, so treat a blend-side reconciliation pass as an approach to design, not existing code.
+
+The gridfinity D5 lip is the closest real exercise of a filleted closed rim: `crates/wasm/src/bindings/gridfinity_tests.rs::gridfinity_d5_box_with_filleted_lip`. It is a LIVE, non-ignored `#[test]` that PASSES, and it guards the fix: it fillets a peak rim edge via the default `fillet` op (the `try_fillet` chain, so rolling-ball first, not the pure v2 path) and asserts the filleted lip stays watertight and genus-0 (`lip_euler >= 2`, `lip_val <= 2`), then fuses it onto the box. The test comment attributes the closure to the fillet's arc-runout closure plus arc-preserving reassembly. Do not hunt for an open non-manifold d5 bug: the test asserts the opposite. Use it as the regression guard when touching the fillet chain, and re-run it after any trimmer change to catch a regression back into the edge-sharing failure described above.
+
+## Scope reminders
+
+- The blend WALL of a curved-neighbor fillet is a NURBS surface with no closed form. Do not chase exact-analytic recovery of it.
+- Straight-edge cylindrical fillet walls ARE analytic (`FaceSpec::CylindricalFace`, `crates/operations/src/boolean/types.rs`, assembled in `boolean/assembly.rs`); a degrade to NURBS there is a regression.
+- Fillet topology and contact curves must be watertight. The open rim bug (a) is a topology defect and is in scope; risk (b) is a latent trimmer hazard, not a live failure.
+
+## Cross-references
+
+- `debugging-doctrine`: instrument at the symptom layer, vary one variable, start from the smallest repro.
+- `solid-verification`: the no-op trap is its poster child; before/after (F,E,V) plus volume.
+- `boolean-debugging`: fillets feed booleans; `refine_boundary_edges` is the reconciliation the blend path lacks.
+- `testing`: regression fixtures. The d5 lip test is a live passing guard, not an ignored ready-repro.

--- a/.claude/skills/io-formats/SKILL.md
+++ b/.claude/skills/io-formats/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: io-formats
+description: Use when a STEP or other file imports wrong (missing solids, all-NURBS where analytic was expected, hard UnsupportedEntity errors), when verifying writer output round-trips, when capturing a faithful fixture from a real file, or when adding or extending a format in crates/io. Covers the format matrix, STEP reader anatomy, the analytic round-trip check, and heal-after-import.
+---
+
+# I/O Formats
+
+The `brepkit-io` crate (L3) reads and writes STEP, IGES, STL, 3MF, OBJ, PLY, glTF,
+and a native binary. Treat it as a product surface: a real file that imports wrong
+poisons every downstream skill, because most debugging fixtures come from importing
+a file. The reader must be trustworthy first.
+
+## When to use
+
+- A STEP import drops solids, errors on an entity, or returns NURBS where you expected
+  cylinders/planes.
+- Proving a written file re-reads with its geometry intact (writer conformance).
+- Capturing a fixture from a real file and confirming it is faithful (analytic, not lossy).
+- Adding or extending a format (deltas over CLAUDE.md Recipe 2 are here).
+
+## Format matrix
+
+`find crates/io/src -type f` for the modules. Signatures verified against current source.
+
+| Format | Kind | Analytic fidelity | Reader entry | Writer entry |
+|--------|------|-------------------|--------------|--------------|
+| STEP | B-Rep | Faithful: all 6 `FaceSurface` + 4 `EdgeCurve` variants round-trip | `step::reader::read_step(&str, &mut Topology) -> Vec<SolidId>` | `step::write_step(&Topology, &[SolidId]) -> String` |
+| IGES | B-Rep in name only | Not trustworthy (see below) | `iges::reader::read_iges(&str, &mut Topology) -> Vec<SolidId>` | `iges::writer::write_iges(&Topology, &[SolidId]) -> String` |
+| STL | Mesh-only by design | n/a (faceted) | `stl::read_stl(&[u8]) -> TriangleMesh`; `stl::read_stl_solid(topo, data, tol)` | `stl::write_stl(topo, solids, deflection, StlFormat)` |
+| 3MF | Mesh-only by design | n/a | `threemf::read_threemf(data)`; `read_threemf_solid(topo, data, tol)` | `threemf::write_threemf(topo, solids, deflection)` |
+| OBJ | Mesh-only by design | n/a | `obj::read_obj(&str)`; `read_obj_solid(topo, input, tol)` | `obj::write_obj(topo, solids, deflection)` |
+| PLY | Mesh-only by design | n/a | `ply::read_ply(data)`; `read_ply_solid(topo, data, tol)` | `ply::write_ply(topo, solids, deflection, PlyFormat)` |
+| glTF (GLB) | Mesh-only by design | n/a | `gltf::read_glb(data)`; `read_glb_solid(topo, data, tol)` | `gltf::write_glb(topo, solids, deflection)` |
+| arena (native) | B-Rep, lossless binary | Faithful (full arena dump) | `arena_io::deserialize_solid(bytes, topo)` | `arena_io::serialize_solid(topo, solid_id)` |
+
+**Mesh-only is by design, not a bug.** All five mesh `*_solid` readers delegate to
+`stl::import::import_mesh` (`crates/io/src/stl/import.rs`), which welds vertices by
+tolerance and auto-flips winding by signed volume. The result is a solid whose every
+face is a planar triangle. A high-face-count all-planar solid out of STL/OBJ/PLY/3MF/GLB
+is correct output. Do not file it as analytic degradation.
+
+**IGES is write-partial / read-stub.** The writer emits planes, NURBS, and lines but
+drops Cylinder/Cone/Sphere/Torus (placeholder comment) and approximates Circle edges as
+a 32-segment polyline. The reader reconstructs only entity 108 planes, and builds a
+fixed unit square face (0.5 half-extent) per plane "for visualization." IGES round-trips do not
+preserve real geometry. Use STEP or the arena format for anything load-bearing.
+
+`StlFormat` has variants `Binary` and `Ascii` (`rg -n 'enum StlFormat'
+crates/io/src/stl/writer.rs`). `PlyFormat` has variants `Ascii` and
+`BinaryLittleEndian` (not `Binary`) (`rg -n 'enum PlyFormat'
+crates/io/src/ply/writer.rs`). Errors
+are one enum `IoError` in `crates/io/src/lib.rs` (`ParseError`, `UnsupportedEntity`,
+`InvalidTopology`, plus transparent `Topology`/`Operations`/`Io`/`Zip`).
+
+## STEP reader in one screen
+
+Full anatomy in [reference.md](reference.md) section 1. The load-bearing facts:
+
+- **Only `MANIFOLD_SOLID_BREP` becomes a solid** (`rg -n 'MANIFOLD_SOLID_BREP'
+  crates/io/src/step/reader.rs`). `SHELL_BASED_SURFACE_MODEL`, `GEOMETRIC_SET`,
+  `BREP_WITH_VOIDS`, wireframe reps are silently dropped: the #1 "STEP dropped my solids"
+  cause. Fewer solids returned, no error.
+- **Analytic surfaces round-trip as their exact type.** `PLANE`, `CYLINDRICAL_SURFACE`,
+  `CONICAL_SURFACE`, `SPHERICAL_SURFACE`, `TOROIDAL_SURFACE` map to the matching
+  `FaceSurface`; `LINE`/`CIRCLE`/`ELLIPSE` to `EdgeCurve`; `B_SPLINE_*` to NURBS.
+- **Unsupported entity = hard error, whole import fails.** `build_surface` and
+  `build_curve_geometry` end in `_ => Err(IoError::UnsupportedEntity {..})`. One
+  `SURFACE_OF_REVOLUTION` or offset surface aborts the entire file. No best-effort mode.
+- **No pcurves, no units.** Trimming is topological (vertex endpoints + edge-loop order);
+  pcurve/seam records are ignored and recomputed downstream. Unit context is not parsed, so
+  an inches-authored file imports at wrong scale silently.
+- **Top-level solid order is nondeterministic** (brep ids from HashMap iteration). Sort if
+  you depend on order. The reader does **no healing**: parse and build only.
+
+## Procedure: "this STEP imports wrong"
+
+Goal is to separate three failure classes: reader bug/gap, unhealed geometry, genuinely
+bad file. Checkpoints in brackets.
+
+1. **Read and census.** `let solids = step::reader::read_step(&s, &mut topo)?;`
+   [If `solids.len()` is short of the file's `MANIFOLD_SOLID_BREP` count, the rest were
+   dropped reps: reader gap, not your geometry.] Census surface types by walking
+   `brepkit_topology::explorer::solid_faces(&topo, sid)?` and matching `face.surface()`
+   (or the `type_tag` / `is_analytic` delegates from `math/src/traits.rs`).
+   [All-NURBS where you expected analytic means either a lossy source file or the file
+   genuinely stored B-splines; go to step 5.]
+2. **Validate.** `brepkit_operations::validate::validate_solid(&topo, sid)?`; check
+   `report.is_valid()`. [Errors here with surfaces that imported fine means unhealed
+   geometry, go to step 6.]
+3. **Tessellate and watertight-check.** `brepkit_operations::tessellate::tessellate_solid`
+   then `is_watertight` / `boundary_edge_count`. See the solid-verification and
+   tessellation siblings.
+4. **Classify.** Use ray-cast `brepkit_check::classify::classify_point`
+   (`crates/check/src/classify/mod.rs`). [Never trust `classify_point_winding` /
+   `classify_point_robust` on faceted or NURBS solids; that mistake has cost prior
+   debuggers a wrong theory.]
+5. **Classify the failure:**
+   - *Reader bug/gap*: `IoError::UnsupportedEntity { entity }` (grep the name against the
+     `build_surface` / `build_curve_geometry` arms), or fewer solids than the file's brep
+     count.
+   - *Unhealed geometry*: imports, but `validate_solid` flags gaps/orientation, or
+     surfaces came in as NURBS. Heal after import (step 6).
+   - *Genuinely bad file*: open it in an external STEP viewer; if malformed there too,
+     it is the file.
+6. **Heal after import** (verified names, `crates/operations/src/heal.rs`):
+   - `heal_solid` / `repair_solid`: gaps, orientation, degenerate edges, coincident
+     vertices, wire spurs.
+   - `convert_to_elementary(topo, solid, tolerance)`: analytic recovery, the inverse of
+     convert-to-bspline. Recovers Cylinder/Cone/Sphere/Torus/Plane and Circle/Line/Ellipse
+     from NURBS that were exported by systems that emit everything as B-splines. Caveat:
+     recognition is tolerance-driven and can reconstruct slightly different parameters than
+     the original (overfit risk), and it is non-transactional (checkpoint first if you need
+     atomicity).
+   - `brepkit_heal::upgrade::unify_same_domain::unify_same_domain`: merge coplanar /
+     co-cylindrical adjacent faces (wasm `unifyFaces`).
+
+## The analytic round-trip check (why the reader must be trustworthy)
+
+Write, read back, assert the surface/curve *type* survived. Canonical test:
+`step_roundtrip_cylinder_surface_type` in `crates/io/tests/cross_format.rs` writes a
+cylinder, `read_step`s it, asserts a face `matches!(.., FaceSurface::Cylinder(_))`.
+
+Why it matters: fixtures for every other skill lean on the reader. The workflow is build a
+case in the brepjs tool, `exportSTEP(operand)` to a file, `read_step` it, debug the real
+geometry. **Before trusting a STEP fixture, confirm the operands round-trip analytic
+(CIRCLE/CYLINDER, not NURBS).** An all-NURBS import of an analytic part means you are
+debugging a different solid than the one that failed. If a file stores an analytic part as
+B-splines, `convert_to_elementary` (or `recognize_surface` / `recognize_curve` in
+`crates/geometry/src/convert/`) recovers it, but can overfit slightly different numbers.
+When a STEP fixture will not preserve the failing state at all (in-memory-id-specific bugs),
+escalate to the lossless arena dump (`serializeSolid` / `deserializeSolid` in wasm;
+`arena_io::serialize_solid` / `deserialize_solid` in Rust).
+
+## Writer conformance basics
+
+The STEP writer (`crates/io/src/step/writer.rs`) emits ISO-10303-21 with
+`FILE_SCHEMA(('CONFIG_CONTROL_DESIGN'))`, length unit `SI_UNIT(.MILLI.,.METRE.)`
+(millimetres), angle unit radians. Surface/curve coverage is exhaustive: every
+`FaceSurface` and `EdgeCurve` variant has a real STEP entity (no drops, unlike IGES).
+The writer takes `&[SolidId]` (multi-solid) and errors `InvalidTopology` on an empty slice.
+
+Sanity-check output two ways: (a) re-read it and run the type + volume asserts above
+(pattern `step_output_has_valid_syntax` checks the `ISO-10303-21;` / `HEADER;` / `DATA;` /
+`END-ISO-10303-21;` envelope); (b) open it in an external STEP viewer.
+
+## Adding a format: deltas over CLAUDE.md Recipe 2
+
+Recipe 2 covers the module scaffold, `lib.rs` `pub mod`, and signatures. It omits or gets
+wrong:
+
+- **wasm bindings live in `bindings/io.rs`, not `kernel.rs`.** The whole file is
+  `#![cfg(feature = "io")]` and `io` is a **default** feature; bindings are auto-gated, add
+  no new cfg.
+- **Skip batch dispatch.** `rg -in 'step|import|export'
+  crates/wasm/src/bindings/batch.rs` has no hits; I/O ops are direct `BrepKernel` methods.
+- **Round-trip / golden tests go in `crates/io/tests/`** (crate-level), model on
+  `cross_format.rs`; golden data in `crates/io/tests/data/`.
+- **Mesh reader convention:** expose both `read_<fmt>(data) -> TriangleMesh` and
+  `read_<fmt>_solid(topo, data, tolerance) -> SolidId` (delegates to `import_mesh`).
+
+## Pitfalls: what NOT to conclude
+
+| Observation | Wrong conclusion | Reality |
+|-------------|------------------|---------|
+| Import returned fewer solids than the file has | Reader lost geometry | Only `MANIFOLD_SOLID_BREP` becomes a solid; other reps are dropped silently. Grep the file for its solid rep type. |
+| OBJ/STL import is all planar triangles | Import degraded analytic surfaces | Mesh formats carry no analytic data; a faceted solid is correct output. |
+| STEP surfaces all came in as NURBS | Reader bug | The file likely stored B-splines. Confirm in a viewer, then `convert_to_elementary`. |
+| `UnsupportedEntity` error | The file is corrupt | The reader hit a surface/curve type with no arm. It is a reader gap; the file may be fine. |
+| Fixture volume matches, so the fixture is faithful | Fixture reproduces the bug | If it round-tripped to NURBS you are debugging a different solid. Assert the surface *type*, or use the arena dump. |
+| IGES import produced a shape | IGES import works | The reader only makes fixed unit squares (0.5 half-extent) from entity-108 planes. Use STEP or arena. |
+| Multi-solid order is stable in one run | Order is deterministic | Top-level order comes from HashMap iteration; sort if you depend on it. |
+| Coordinates look wrong scale | Reader has a bug | The reader ignores STEP unit context; a non-mm file imports unscaled. |
+
+## Sibling skills
+
+- **solid-verification**: the measure / validate / watertight / classify bar in depth.
+- **analytic-preservation**: keeping and recovering typed analytic surfaces; the census.
+- **tessellation**: watertightness and periodic-band meshing after import.
+- **testing** and **parity-benchmarking**: capturing faithful fixtures (STEP or arena)
+  from a real tool scenario.
+- **wasm-bindings**: exposing a new format's import/export on `BrepKernel`.
+
+## Reference
+
+STEP entity-to-topology mapping, the exact match arms, and the healing-pass catalog:
+[reference.md](reference.md).

--- a/.claude/skills/io-formats/reference.md
+++ b/.claude/skills/io-formats/reference.md
@@ -1,0 +1,164 @@
+# io-formats reference
+
+Verified against current source. Locate symbols with the given `rg` patterns; line
+numbers rot, symbols do not. Key files: `crates/io/src/lib.rs`,
+`crates/io/src/step/{reader,writer}.rs`, `crates/io/src/iges/{reader,writer}.rs`,
+`crates/io/src/stl/import.rs`, `crates/io/tests/cross_format.rs`,
+`crates/wasm/src/bindings/io.rs`, `crates/operations/src/heal.rs`,
+`crates/heal/src/custom/convert_to_elementary.rs`,
+`crates/geometry/src/convert/recognize_{surface,curve}.rs`,
+`crates/check/src/classify/mod.rs`, `crates/io/src/arena_io.rs`.
+
+## 1. STEP reader anatomy
+
+`rg -n 'pub fn read_step' crates/io/src/step/reader.rs`
+
+Flow: `read_step` parses the `DATA;`..`ENDSEC;` block into a
+`HashMap<u64, StepEntity { entity_type, attrs }>` (split on `;`, no regex), then
+`StepBuilder::build_all_solids` assembles topology.
+
+### Entity to topology mapping
+
+`rg -n 'MANIFOLD_SOLID_BREP|CLOSED_SHELL|ADVANCED_FACE|EDGE_LOOP|ORIENTED_EDGE|EDGE_CURVE' crates/io/src/step/reader.rs`
+
+- `MANIFOLD_SOLID_BREP` -> `Solid` with a single outer shell and no inner shells
+  (`Solid::new(shell_id, Vec::new())`). This is the only entity that becomes a solid.
+  Anything stored as `SHELL_BASED_SURFACE_MODEL`, `GEOMETRIC_SET`, `BREP_WITH_VOIDS`, or a
+  wireframe rep is filtered out with no error (`build_all_solids` filters
+  `entity_type == "MANIFOLD_SOLID_BREP"`).
+- `CLOSED_SHELL` -> `Shell`.
+- `ADVANCED_FACE` -> `build_face`. Reads the `.T.`/`.F.` reversed flag
+  (`Face::new` vs `Face::new_reversed`). `FACE_OUTER_BOUND` gives the outer wire, other
+  bounds give inner wires; if none is flagged outer, the first bound is used as outer.
+- `EDGE_LOOP` -> `Wire`; `ORIENTED_EDGE` (`.T.` = forward) sets edge orientation in the
+  wire.
+- `EDGE_CURVE` -> `build_edge_curve` -> `Edge::new(start_vp, end_vp, curve)` with a 3D
+  curve only. Vertices come from `VERTEX_POINT` / `CARTESIAN_POINT`.
+
+### Surface / curve construction
+
+`rg -n 'fn build_surface|fn build_curve_geometry' crates/io/src/step/reader.rs`
+
+`build_surface` arms: `PLANE` -> `Plane`, `CYLINDRICAL_SURFACE` -> `Cylinder`,
+`CONICAL_SURFACE` -> `Cone` (half_angle in radians), `SPHERICAL_SURFACE` -> `Sphere`,
+`TOROIDAL_SURFACE` -> `Torus`, `B_SPLINE_SURFACE*` -> `Nurbs` (rational detected by
+`attrs.contains("RATIONAL")`). `build_curve_geometry` arms: `LINE` -> `Line`,
+`CIRCLE` -> `Circle`, `ELLIPSE` -> `Ellipse`, `B_SPLINE_CURVE_WITH_KNOTS` -> NURBS.
+
+Both functions end in `_ => Err(IoError::UnsupportedEntity { entity })`. There is no
+skip or substitute path: one unhandled type (for example `SURFACE_OF_REVOLUTION`,
+`SURFACE_OF_LINEAR_EXTRUSION`, an offset surface, or a bounded-curve subtype) fails the
+entire import.
+
+### What the reader does NOT do
+
+- No pcurve / seam-curve reading. STEP `PCURVE` / `SEAM_CURVE` records are ignored;
+  trimming is topological only (vertex endpoints plus edge-loop order). Pcurves are
+  recomputed downstream when an operation needs UV (`crates/algo/src/builder/pcurve_compute.rs`).
+- No unit handling. `GLOBAL_UNIT_ASSIGNED_CONTEXT` / `SI_UNIT` are not parsed; coordinates
+  are taken as authored (assumes mm). A file in inches or metres imports at wrong scale
+  silently.
+- No healing. Parse and build only.
+- Deterministic within a solid (shells/faces/edges follow file order via `parse_list_refs`),
+  but the returned `Vec<SolidId>` order across top-level solids is nondeterministic because
+  brep ids are collected by iterating a `HashMap`.
+
+## 2. IGES limitations
+
+`rg -n 'pub fn read_iges' crates/io/src/iges/reader.rs` and
+`rg -n 'pub fn write_iges' crates/io/src/iges/writer.rs`
+
+- Writer: emits Plane, NURBS surface (entity 128), NURBS curve (126), and lines. Analytic
+  Cylinder/Cone/Sphere/Torus are written only as a placeholder comment (dropped). Circle
+  edges are written as a 32-segment polyline approximation.
+- Reader: reconstructs only entity 108 (planes), building a fixed unit square face
+  (0.5 half-extent, spanning -0.5..+0.5 in u and v) per plane "for visualization."
+  Entities 110/126/128 are not reconstructed.
+- Net: IGES round-trip does not preserve real geometry. Treat it as write-partial /
+  read-stub. Use STEP or the arena format when fidelity matters.
+
+## 3. Mesh import path
+
+`rg -n 'pub fn import_mesh' crates/io/src/stl/import.rs`
+
+All five mesh `*_solid` readers (STL, 3MF, OBJ, PLY, GLB) delegate to `import_mesh(topo,
+&mesh, tolerance) -> SolidId`. It welds vertices by tolerance and auto-flips winding: for a
+closed mesh, outward triangles give positive signed volume (divergence theorem); a negative
+raw signed volume flips the whole mesh. If per-triangle normals are present they take
+precedence, else the signed-volume heuristic applies. Output is a solid of planar-triangle
+faces. This is faithful faceting, never analytic.
+
+## 4. Heal after import
+
+`rg -n 'pub fn heal_solid|pub fn repair_solid|pub fn convert_to_elementary' crates/operations/src/heal.rs`
+
+- `heal_solid` / `repair_solid`: gaps, orientation, degenerate edges, coincident vertices,
+  wire spurs.
+- `convert_to_elementary(topo, solid, tolerance)`: wraps
+  `brepkit_heal::custom::convert_to_elementary::{convert_to_elementary, convert_edges_to_elementary}`.
+  Its doc: the inverse of convert-to-bspline; STEP/IGES imports that came in as NURBS
+  (from CAD systems that export everything as B-splines) are normalized back into analytic
+  forms. Two passes (surfaces then edges), non-transactional (may leave a partially
+  converted state; checkpoint first if you need atomicity). Hyperbola and Parabola are
+  recognized but have no `EdgeCurve` variant, so they stay NURBS.
+- Lower-level recognition (used by `convert_to_elementary`, callable directly):
+  `recognize_surface` / `recognize_curve` in `crates/geometry/src/convert/`
+  (`rg -n 'pub fn recognize_surface' crates/geometry/src/convert/recognize_surface.rs`,
+  same for `recognize_curve.rs`). Tolerance-driven; can reconstruct slightly different
+  parameters than the original (overfit risk).
+- `brepkit_heal::upgrade::unify_same_domain::unify_same_domain(topo, solid, &UnifyOptions)`:
+  merge coplanar / co-cylindrical adjacent faces (wasm `unifyFaces`).
+
+## 5. Fixture faithfulness and the arena escape hatch
+
+Priority order when capturing a fixture from a real failing case:
+
+1. **STEP** if the operands round-trip analytic. Confirm surface *type* survives
+   (section 6). If the part came in as NURBS, the fixture is unfaithful: you would debug a
+   different solid, and `convert_to_elementary` may overfit slightly different numbers.
+2. **Arena binary dump** when STEP goes lossy or the bug is tied to specific in-memory
+   ids. Lossless, no weld, no recognition:
+   `rg -n 'pub fn serialize_solid|pub fn deserialize_solid' crates/io/src/arena_io.rs`;
+   wasm `serializeSolid` / `deserializeSolid`.
+
+## 6. Round-trip / conformance tests
+
+`rg -n 'fn step_roundtrip|fn step_output_has|fn stl_' crates/io/tests/cross_format.rs`
+
+- `step_roundtrip_cylinder_surface_type`: write a cylinder, `read_step`, assert a face
+  `matches!(.., FaceSurface::Cylinder(_))`. The template for "surface type survived."
+- `step_roundtrip_nurbs_edge_survives`, `step_roundtrip_preserves_vertex_positions`,
+  `step_roundtrip_box_volume`, `step_roundtrip_center_of_mass`,
+  `step_roundtrip_multiple_solids`: geometry-value round-trips.
+- `step_output_has_valid_syntax`: checks the `ISO-10303-21;` / `HEADER;` / `DATA;` /
+  `END-ISO-10303-21;` envelope.
+- `stl_import_roundtrip_preserves_aabb`, `stl_roundtrip_preserves_triangle_count`: mesh
+  formats assert AABB / triangle count within tolerance, not surface type.
+- In-crate reader tests: `roundtrip_cylinder_preserves_surface`,
+  `roundtrip_circle_edge_preserved`, `roundtrip_nurbs_*` in
+  `crates/io/src/step/reader.rs` test module.
+
+## 7. Writer output shape
+
+`rg -n 'ISO-10303-21|FILE_SCHEMA|SI_UNIT|fmt_f64' crates/io/src/step/writer.rs`
+
+Header envelope: `ISO-10303-21;` / `HEADER;` /
+`FILE_DESCRIPTION(('brepkit STEP export'), '2;1');` / `FILE_NAME(..)` /
+`FILE_SCHEMA(('CONFIG_CONTROL_DESIGN'));` / `DATA;` .. `ENDSEC;` / `END-ISO-10303-21;`.
+Units: length `SI_UNIT(.MILLI.,.METRE.)`, angle `SI_UNIT($,.RADIAN.)`, plus a solid-angle
+unit. Product structure via `ADVANCED_BREP_SHAPE_REPRESENTATION` +
+`PRODUCT_DEFINITION_SHAPE` + `SHAPE_DEFINITION_REPRESENTATION`. Surface/curve coverage is
+exhaustive (Plane/Cylinder/Cone/Sphere/Torus/Nurbs and Line/Circle/Ellipse/NurbsCurve all
+map to real STEP entities). Floats via `fmt_f64` = `{:.15E}` with a `<1e-15 -> "0."` guard.
+`write_step` takes `&[SolidId]` and errors `InvalidTopology` on an empty slice.
+
+## 8. wasm binding names
+
+`rg -n 'js_name' crates/wasm/src/bindings/io.rs`
+
+Import/export methods on `BrepKernel`: `exportStep`/`importStep`, `exportIges`/`importIges`,
+`exportStl`/`exportStlAscii`/`importStl`, `export3mf`/`import3mf`, `exportObj`/`importObj`,
+`exportGlb`/`importGlb`, `exportPly`, `importIndexedMesh`,
+`serializeSolid`/`deserializeSolid`. The whole file is `#![cfg(feature = "io")]`; `io` is a
+default feature (`crates/wasm/Cargo.toml`). None of these appear in `bindings/batch.rs`, so
+I/O ops are direct methods only, not part of `executeBatch`.

--- a/.claude/skills/layer-boundaries/SKILL.md
+++ b/.claude/skills/layer-boundaries/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: layer-boundaries
+description: Use when adding a workspace dependency between brepkit crates, deciding which crate new code belongs in, adding a variant to EdgeCurve or FaceSurface (or a new analytic surface type), fixing a CI "boundaries" job failure or a VIOLATION from scripts/check-boundaries.sh, or hitting "two different versions of crate brepkit-topology" errors.
+---
+
+# Layer Boundaries
+
+brepkit is a strict layered DAG (L0 math up to L4 wasm/render). This skill covers: keeping the DAG intact, the safe procedure for adding `EdgeCurve`/`FaceSurface` variants, and where new code goes. The dependency table itself lives in CLAUDE.md, "Layer dependency rules". Do not restate it; check against it.
+
+## Quick reference
+
+```bash
+./scripts/check-boundaries.sh          # verify crate deps; exit 0 = "✅ All crate boundaries valid."
+rg -l 'EdgeCurve::' crates/*/src/      # all files matching EdgeCurve variants (~110 files)
+rg -l 'FaceSurface::' crates/*/src/    # all files matching FaceSurface variants (~130 files)
+rg -n '_ =>' crates/io/src/step/writer.rs crates/io/src/iges/writer.rs crates/operations/src/offset_face.rs
+```
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| CI `boundaries` job fails / `VIOLATION: crates/X depends on brepkit-Y` | Cargo dep added against the layer table | Remove the dep; move the code to a layer where the dep is legal, or invert the dependency |
+| `use brepkit_x::...` fails to resolve in crate Y | Y's layer may not depend on x | Same as above; do NOT add the dep to "make it compile" |
+| "two different versions of crate `brepkit-topology`" type errors | A higher-layer crate was added as a dev-dep of topology | Revert; use topology's `test-utils` feature instead (see below) |
+| Hundreds of `non-exhaustive patterns` errors after adding an enum variant | Expected; matches are exhaustive by design | Work through them; this IS the checklist (see procedure below) |
+| New analytic surface pair silently returns "no intersection" | `_ => Ok(None)` fallback in `try_algebraic_intersection` | Add the pair arm deliberately; the compiler will not flag this one (see reference.md, AnalyticSurface) |
+
+## The boundary check
+
+`scripts/check-boundaries.sh` reads only the `[dependencies]` section of each `crates/*/Cargo.toml` and compares against a per-crate allowlist. Dev-dependencies are deliberately exempt. It does not inspect `use` paths; those are enforced transitively because a `use brepkit_x::` without the Cargo dep will not compile.
+
+When it runs: CI only, as the `boundaries` job gated into `ci-pass` (`.github/workflows/ci.yml`). The pre-push hook delegates all validation to CI, so run the script manually before pushing:
+
+```bash
+./scripts/check-boundaries.sh
+```
+
+Expect `✅ All crate boundaries valid.` and exit 0. On failure it prints one `VIOLATION:` line per bad dep and exits 1.
+
+Nuances:
+- The script's allowlist is slightly looser than the CLAUDE.md table: it permits `brepkit-geometry` for `algo`/`blend`, and a direct `brepkit-blend` dep for `wasm` (the table allows blend only transitively, via operations). None of these are used today. Treat the CLAUDE.md table as intent, the script as the floor. Passing the script but violating the table still gets flagged in review.
+- No crate may depend on `brepkit-render`. It is an L4 leaf.
+
+## Adding an EdgeCurve or FaceSurface variant
+
+Full procedure with checkpoints: see [reference.md](reference.md), "Variant-add procedure". Summary:
+
+1. Both enums live in topology: `EdgeCurve` in `crates/topology/src/edge.rs`, `FaceSurface` in `crates/topology/src/face.rs`.
+2. All production match arms are exhaustive (no `_ =>` wildcards). The compiler is the authoritative checklist: add the variant, run `cargo build --workspace`, and fix every flagged site. Do not hand-maintain a file list.
+3. The delegate methods absorb most call sites. They are inherent methods on the enums themselves (not in `math/src/traits.rs`, which holds the `ParametricCurve`/`ParametricSurface` traits for concrete geometry types). Call sites using `EdgeCurve::evaluate_with_endpoints`, `FaceSurface::evaluate`, `as_analytic`, etc. need no change; only the delegate impl gets a new arm.
+4. After the build is green, rescan the three files historically prone to re-introduced wildcards (`rg -n '_ =>'` on them): `io/src/step/writer.rs`, `io/src/iges/writer.rs`, `operations/src/offset_face.rs`. Wildcards inside `#[cfg(test)]` blocks are acceptable; production wildcards are not.
+5. If the new surface is analytic, also extend `AnalyticSurface` in `crates/math/src/analytic_intersection.rs` and check its one compiler-invisible fallback. Details in reference.md.
+
+## The dev-dependency cycle trap
+
+Never add `brepkit-operations` (or any crate above topology) to `[dev-dependencies]` of `brepkit-topology`. Cargo then builds two feature-resolved versions of topology and every `Id<T>` and `Topology` value becomes a "two different versions of crate" type mismatch. The boundary script will NOT catch this: it ignores dev-deps on purpose.
+
+The sanctioned pattern: shape-building test helpers go in `topology/src/test_utils.rs` behind the `test-utils` feature (`#[cfg(feature = "test-utils")]` in `topology/src/lib.rs`). Higher crates enable it in their dev-deps:
+
+```toml
+[dev-dependencies]
+brepkit-topology = { workspace = true, features = ["test-utils"] }
+```
+
+algo, blend, heal, check, offset, operations, and io all already do this. Copy that line, do not invent a new mechanism.
+
+## No tessellation in core (L0 to L2)
+
+Core computation (booleans, classification, intersection, distance, volume, healing) must use exact geometry: analytic formulas and parameter-space algorithms on the B-Rep. Tessellating to triangles and computing on the mesh is a review-rejectable bug in L0-L2, not a style issue. Reasons: meshes lose accuracy, sequential operations explode face counts, and surface type information is destroyed. Production B-Rep kernels, including the reference kernel, never tessellate for computation.
+
+Where tessellation legally lives: `crates/operations/src/tessellate/` (L3, for export and preview) and `crates/render/` (L4, GPU display meshing). If an algorithm seems to need a mesh below L3, the design is wrong; find the analytic or parameter-space formulation, or raise it as a blocker. See the tessellation and analytic-preservation skills.
+
+## Where new code goes
+
+Put code in the lowest layer whose allowed deps suffice, except tessellation and operation orchestration, which never go below L3.
+
+| Kind of change | Location |
+|---|---|
+| Vector/matrix/NURBS/predicate/quadrature primitive | L0 `crates/math/src/` (no workspace deps) |
+| New analytic curve or surface type | L0 `math/src/curves.rs` / `surfaces.rs`, then the variant-add procedure above |
+| Sampling, extrema, analytic-NURBS conversion | L1 `crates/geometry/src/` |
+| B-Rep entity, arena, explorer, adjacency | L1 `crates/topology/src/` |
+| Boolean/classification engine internals | L2 `crates/algo/src/` |
+| Fillet/chamfer engine | L2 `crates/blend/src/` |
+| Healing, validation, properties, distance, solid offset, 2D constraints | L2 `heal` / `check` / `offset` / `sketch` |
+| User-facing modeling op, measure, tessellation | L3 `crates/operations/src/` (CLAUDE.md Recipe 3; see add-operation skill) |
+| New file format | L3 `crates/io/src/<format>/` (CLAUDE.md Recipe 2) |
+| GPU rendering or display meshing | L4 `crates/render/src/` (leaf) |
+| JS-facing API | L4 `crates/wasm/src/bindings/` (CLAUDE.md Recipe 4; see wasm-bindings skill) |
+
+For the exact file within a crate, use the CLAUDE.md Module Map.
+
+## Anti-patterns
+
+- Do NOT add a Cargo dep to silence an unresolved `use`. The unresolved import is the boundary working as intended.
+- Do NOT conclude "the script passed, so the layering is fine". The script is the floor; check the CLAUDE.md table for intent.
+- Do NOT add `_ =>` arms to make a variant-add compile faster. Silencing the compiler discards the checklist and creates silent misbehavior for the new variant.
+- Do NOT move an algorithm up a layer just because a convenient helper lives there. Extract or reimplement the helper at the lower layer instead.
+- Do NOT assume "no compile errors in math" means the analytic intersection work is done: `try_algebraic_intersection` ends in `_ => Ok(None)` and swallows new surface pairs silently.

--- a/.claude/skills/layer-boundaries/reference.md
+++ b/.claude/skills/layer-boundaries/reference.md
@@ -1,0 +1,85 @@
+# Layer Boundaries: Reference
+
+Deep detail for the layer-boundaries skill. All paths and symbols verified against the current tree; when in doubt, re-run the rg commands rather than trusting counts.
+
+## Variant-add procedure (EdgeCurve / FaceSurface)
+
+### Current state
+
+- `EdgeCurve` in `crates/topology/src/edge.rs` (`rg -n 'pub enum EdgeCurve'`). Variants: `Line`, `NurbsCurve(NurbsCurve)`, `Circle(Circle3D)`, `Ellipse(Ellipse3D)`.
+- `FaceSurface` in `crates/topology/src/face.rs` (`rg -n 'pub enum FaceSurface'`). Variants: `Plane { normal, d }`, `Nurbs(NurbsSurface)`, `Cylinder(CylindricalSurface)`, `Cone(ConicalSurface)`, `Sphere(SphericalSurface)`, `Torus(ToroidalSurface)`.
+
+### Delegate methods (where NOT to fan out)
+
+The delegates are inherent methods on the enums, in the same files as the enum definitions. CLAUDE.md's pointer to `math/src/traits.rs` for these delegates is stale: that file holds the `ParametricCurve`/`ParametricSurface` traits and their impls for concrete geometry types, and never mentions `EdgeCurve` or `FaceSurface`.
+
+- `EdgeCurve` delegates (`crates/topology/src/edge.rs`): `evaluate_with_endpoints`, `tangent_with_endpoints`, `domain_with_endpoints`, `type_tag`. Locate: `rg -n 'fn evaluate_with_endpoints' crates/topology/src/edge.rs`.
+- `FaceSurface` delegates (`crates/topology/src/face.rs`): `evaluate`, `normal`, `project_point`, `estimate_radius`, `type_tag`, `is_planar`, `is_analytic`, `as_analytic`. Locate: `rg -n 'fn as_analytic' crates/topology/src/face.rs`.
+
+Every call site that goes through a delegate is done once the delegate impl has the new arm. Only direct `match`/`if let` sites on the enum need per-site work.
+
+### Procedure with checkpoints
+
+1. Define the geometry type first. New analytic curve: `crates/math/src/curves.rs`. New analytic surface: `crates/math/src/surfaces.rs`. Implement the relevant trait from `math/src/traits.rs` (`ParametricCurve` or `ParametricSurface`) so sampling and extrema code can use it.
+   - Checkpoint: `cargo build -p brepkit-math` is green before touching topology.
+2. Add the enum variant in `topology/src/edge.rs` or `topology/src/face.rs` and add its arm to every delegate method in the same file.
+   - Checkpoint: `cargo build -p brepkit-topology` is green.
+3. Enumerate the blast radius (informational; the compiler is the real list):
+   ```bash
+   rg -l 'EdgeCurve::' crates/*/src/    # ~110 files at time of writing
+   rg -l 'FaceSurface::' crates/*/src/  # ~130 files
+   ```
+   Counts drift upward over time; trust the command output, not any recorded number.
+4. `cargo build --workspace` and fix every `non-exhaustive patterns` error. Expect many. Do not add `_ =>` arms to shortcut this; each site needs a real decision (support the variant, or return a typed "unsupported" error).
+   High-traffic direct-match sites, in rough priority order:
+   - `operations/src/tessellate/`, `operations/src/transform.rs`, `operations/src/copy.rs`, `operations/src/section.rs`, `operations/src/boolean/`
+   - EdgeCurve extra: `operations/src/measure/edge_length.rs`, `operations/src/fill_face.rs`
+   - FaceSurface extra: `operations/src/distance.rs`, `operations/src/feature_recognition.rs`, `operations/src/offset_face.rs`
+   - `io/src/step/{reader,writer}.rs`, `io/src/iges/{reader,writer}.rs`
+   - `wasm/src/bindings/{query,batch,tessellate,nurbs}.rs`
+   - Checkpoint: `cargo build --workspace` green, then `cargo clippy --all-targets -- -D warnings`.
+5. Wildcard rescan. Three files have historically re-grown `_ =>` arms:
+   ```bash
+   rg -n '_ =>' crates/io/src/step/writer.rs crates/io/src/iges/writer.rs crates/operations/src/offset_face.rs
+   ```
+   Expected output today: hits only inside `#[cfg(test)]` code in `offset_face.rs` (`_ => panic!("expected planar surface")` style assertions). Any hit on a production path means the new variant is being silently dropped or mis-serialized; replace the wildcard with explicit arms.
+6. Tests: round-trip the new variant through the writers you touched (STEP at minimum), and through `transform`/`copy` (a copied or transformed solid must preserve the variant, not degrade to NURBS; see the analytic-preservation skill).
+7. `./scripts/check-boundaries.sh` if any Cargo.toml changed, then `cargo test --workspace`.
+
+### If the new surface is analytic: AnalyticSurface
+
+`AnalyticSurface<'a>` in `crates/math/src/analytic_intersection.rs` (`rg -n 'pub enum AnalyticSurface'`) holds borrowed refs (`Cylinder(&CylindricalSurface)`, `Cone`, `Sphere`, `Torus`). Adding a variant there fans out to:
+
+- Dispatch sites within `analytic_intersection.rs` itself: `exact_plane_analytic`, `intersect_plane_analytic`, `sample_plane_analytic`, `try_algebraic_intersection`, `project_analytic`, `surface_closures`, and a `matches!` in `is_u_periodic`. The compiler flags most of these. Old docs say "4 match sites"; the real number is larger and grows, so let the build enumerate them.
+- COMPILER-INVISIBLE GOTCHA: `try_algebraic_intersection` does a pairwise `match (a, b)` ending in `_ => Ok(None)`, a legitimate unhandled-pair fallback. A new analytic variant compiles clean there and silently reports "no algebraic intersection" for every pair involving it, so intersections fall back to slower or failing paths. Add the pairs you can solve in closed form deliberately, and record the ones you cannot.
+- Consumers outside math (find with `rg -l 'AnalyticSurface' crates/*/src/`): `topology/src/face.rs` (`as_analytic` delegate), `algo/src/pave_filler/phase_ff.rs`, `offset/src/inter3d.rs`, `wasm/src/bindings/query.rs`, plus tests in `operations/src/boolean/tests.rs`.
+
+## check-boundaries.sh internals
+
+- Extracts only `[dependencies]` per crate: `sed -n '/^\[dependencies\]/,/^\[/p'`, then greps each `brepkit-*` name against the crate's allowlist.
+- `[dev-dependencies]` are exempt by design (integration tests may reach upward). Consequence: the script cannot catch the topology dev-dep cycle trap; that one only shows up as "two different versions of crate" build errors.
+- Output shapes:
+  - Pass: `Checking crate boundary rules...` then `✅ All crate boundaries valid.`, exit 0.
+  - Fail: one `VIOLATION: crates/<crate> depends on <dep> (not allowed)` per offense, then `❌ Boundary check failed.`, exit 1.
+  - `SKIP: crates/<name>/Cargo.toml not found` means a crate was renamed or removed; update the script's `check_deps` calls.
+- Allowlist vs CLAUDE.md table: the script permits `brepkit-geometry` for `algo` and `blend`, and a direct `brepkit-blend` dep for `wasm` (the table allows blend only transitively, via operations; wasm's other deps, including offset and sketch, are allowed by both). None of the extra allowances are used in the actual Cargo.tomls today. If you find yourself needing one, it passes CI, but confirm the layering intent in review first; the CLAUDE.md table is the source of truth for intent.
+- Enforcement points: CI job `boundaries` in `.github/workflows/ci.yml`, gated into `ci-pass`. The `.husky/pre-push` hook runs nothing (it delegates to CI), and `.husky/pre-commit` runs fmt + clippy + taplo + machete only. So a boundary violation surfaces at PR time unless you run the script yourself.
+
+## Symptom-to-cause: boundary and cycle failures
+
+| Symptom | Cause | Action |
+|---|---|---|
+| `error[E0432]: unresolved import brepkit_x` in crate Y | Missing Cargo dep, possibly because the layer forbids it | Check the CLAUDE.md table. If forbidden: move the code down or restructure. If allowed: add the dep and re-run the script |
+| Script prints VIOLATION for a dep you believe is fine | The dep string appears in `[dependencies]` (even transitively via a table entry you edited) | Read the crate's Cargo.toml `[dependencies]` block; the script only sees that section |
+| `expected struct brepkit_topology::Topology, found struct brepkit_topology::Topology` | Two feature-resolved builds of topology, usually from an upward dev-dep on topology | Remove the offending dev-dep; move the helper into `topology/src/test_utils.rs` behind `test-utils` |
+| A crate compiles locally but the `boundaries` CI job fails | You added the dep but never ran the script | `./scripts/check-boundaries.sh` locally, fix, push |
+| Reviewer flags mesh/triangle code in algo, check, math, etc. | Tessellation-based shortcut below L3 | Reformulate analytically; tessellation belongs in `operations/src/tessellate/` or `render/`. Current ground truth: `rg -in 'tessellat' crates/{math,geometry,topology,algo,blend,heal,check,offset,sketch}/src/` matches roughly 15 files, and every hit is a comment or docstring (e.g. "Instead of tessellating a face" in `math/src/quadrature.rs`). Any hit on executable code is a violation. Keep it that way |
+
+## Glossary for newcomers
+
+- B-Rep: boundary representation. Solids as faces/edges/vertices with exact analytic or NURBS geometry, not triangles.
+- GFA: brepkit's general fuse algorithm, the boolean engine (`crates/algo/src/gfa.rs`).
+- PCurve: a 2D curve in a face's UV parameter space representing an edge on that surface.
+- Analytic geometry: exact closed-form types (plane, cylinder, cone, sphere, torus; line, circle, ellipse), as opposed to NURBS approximation.
+- Arena / `Id<T>`: topology entities live in a central arena (`topology/src/arena.rs`) and are referenced by typed handles.
+- Ripple effect: adding an enum variant forces updates at every exhaustive match site; the compiler enumerates them for you.

--- a/.claude/skills/numerical-robustness/SKILL.md
+++ b/.claude/skills/numerical-robustness/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: numerical-robustness
+description: Use when debugging floating-point failures in brepkit: a boolean or heal result flips pass/fail across runs or under tiny (1e-13) input nudges, closed/periodic geometry (circles, tori, seams) produces collapsed AABBs or wrong arcs, intersection points miss chord-discretized seams, near-duplicate vertices fail to merge, or when writing any code that compares floats, hashes coordinates, or iterates edges of closed curves.
+---
+
+# Numerical Robustness in a CAD Kernel
+
+Deep catalog with verified paths, procedures, and case studies: [reference.md](reference.md).
+
+## When to use
+
+- A test passes on some runs and fails on others (same code, same input).
+- A boolean fails, but translating an operand by ~1e-13 makes it pass (or vice versa).
+- A face AABB, winding, or extent computation is wrong on a cylinder, sphere, or torus.
+- An intersection or split "never fires" even though the geometry clearly crosses.
+- Two vertices or edges that should be the same entity stay distinct (free edges, open shells).
+- You are writing code that compares floats, buckets coordinates, or walks a closed curve.
+
+## Symptom-to-cause table
+
+| Symptom | Likely cause | See reference.md |
+|---|---|---|
+| Pass/fail varies across processes, stable within one | HashMap iteration order drives branching | §5 Nondeterminism |
+| Knife-edge sensitivity: 7e-14 nudge passes, 1e-13 fails | Near-duplicates straddle adjacent quantization cells | §2 Quantization buckets |
+| Free edges / open shell after a boolean, mesh fallback | Duplicate-edge merge missed ULP-apart vertices | §2 Quantization buckets |
+| AABB of a curved face collapses to a line or point | Endpoint-only computation on a closed curve (start == end) | §3 Closed geometry |
+| Wrong arc recovered (major vs minor) after copying an edge | Stored vertex order disagrees with curve parameterization | §3 Periodic copy hazard |
+| Intersection against a seam finds zero crossings | Point lies on the true curve, off the stored chords (sagitta gap) | §4 Chord vs analytic |
+| Triangulation self-contradicts or fails to converge | Tolerance comparison used where a sign decision was needed | §1 Exact predicates |
+| Two co-endpoint edges wrongly collapse (or wrongly stay distinct) | Endpoint-pair merge key cannot see curve identity | §2 Merge-key lesson |
+
+## The six rules
+
+1. **Never `==` on floats.** Use `Tolerance::approx_eq` (scale-aware) for coordinates, `approx_eq_abs` for parameter-space values, `parametric()` to convert linear tolerance into parameter space. Defaults: linear 1e-7, angular 1e-12, relative 1e-10 (`crates/math/src/tolerance.rs`). For sign/topology decisions (which side, inside circle, segments cross) tolerance is the wrong tool: use exact predicates in `crates/math/src/predicates.rs` (`orient2d`, `orient3d`, `in_circle`, `point_in_polygon`) or the fast filtered variants in `crates/math/src/filtered.rs`. Details: reference.md §1.
+
+2. **Quantized-coordinate keys are knife-edges.** Any scheme keying on `(coord * scale).round()` fails when two points a few ULPs apart (ULP: unit in the last place, the gap between adjacent f64 values, about 2e-16 relative) land in adjacent cells. The proven fix shape is to weld first with a snap radius larger than the bucket (`weld_coincident_vertices` in `crates/algo/src/builder/builder_solid.rs`, snap = 10x `MERGE_TOL`), not to widen the bucket. Hashes over quantized floats are also order-fragile: build sorted canonical forms (`compute_edge_set_quantized` in `crates/algo/src/builder/same_domain.rs` sorts its pair list). Details: reference.md §2.
+
+3. **Closed curves have start == end.** Any endpoint-only computation (AABB, winding, extent, degeneracy test) silently collapses on a full circle or torus boundary. Always sample along the curve (`compute_face_bbox` in `crates/algo/src/pave_filler/phase_ff.rs` samples 9 points per edge). Degenerate seam edges `Edge::new(v0, v0, EdgeCurve::Line)` exist by construction on full tori (`make_torus` in `crates/operations/src/primitives.rs`). Copying a periodic curve onto a new edge requires vertex order to match the parameterization, or `domain_with_endpoints` recovers the complementary arc: see `reverse_edge_curve` in `crates/operations/src/extrude.rs`. Details: reference.md §3.
+
+4. **Chords are not the curve.** A discretized seam (the sphere equator is stored as line chords) deviates from the true curve by the sagitta `r*(1 - cos(theta/2))` (`crates/math/src/chord.rs`). An intersection point computed against the true curve will not lie on the chords, and every 3D-based layer downstream inherits the gap. Solve such arrangements in UV space where the seam is exact, or against the analytic carrier (`sphere_seam_plane_crossings` in `phase_ff.rs`). Details: reference.md §4.
+
+5. **Nondeterminism signature: stable within a process, varies across processes.** Cause is almost always std `HashMap` iteration order feeding a branch. Fix: sort before branching (`sort_unstable_by_key` on ids, `total_cmp` for float keys). Bisect procedure and in-repo examples: reference.md §5.
+
+6. **Prove the suspect path fires.** Before trusting a diagnosis, add a hit counter or gate the fix behind a flag and confirm the code path executes on the failing input. A plausible static diagnosis once blamed a path that ran zero times. Procedure: reference.md §6.
+
+## Quick procedures
+
+**Confirm cross-process nondeterminism** (checkpoint: expect a mix of `ok` and `FAILED`):
+
+```bash
+for i in $(seq 20); do
+  cargo test -p brepkit-operations --release the_failing_test -- --exact 2>&1 | tail -1
+done
+```
+
+Twenty in-process repeats inside one `cargo test` invocation prove nothing; each fresh process reseeds the HashMap. If all 20 agree, the bug is not seed-driven: look for input-dependent tolerance straddle instead (reference.md §2).
+
+**Probe a bucket-straddle** (checkpoint: expect non-monotonic pass/fail): translate the failing operand by a ladder of tiny offsets (1e-14, 7e-14, 1e-13, 2e-13, 1e-12) and rerun. Pass at 7e-14 and 2e-13 but fail at 1e-13 is the quantization-cell signature.
+
+**Find the relevant sites:**
+
+```bash
+rg -n 'approx_eq' crates/ | head
+rg -n 'pub fn' crates/math/src/predicates.rs crates/math/src/filtered.rs
+rg -n 'quantize_point|MERGE_TOL' crates/algo/src/builder/
+```
+
+**Verify a boolean result geometrically:** use the ray-cast classifier `brepkit_check::classify::classify_point` (`crates/check/src/classify/mod.rs`), never volume alone (tessellated volume once read 1.4% high and nearly masked an un-carved slot) and never the winding classifier on faceted solids. See the solid-verification skill.
+
+## Anti-patterns: what NOT to conclude
+
+- Do NOT conclude "the tolerance is too tight, widen it." Widening a quantization bucket moves the knife-edge; it does not remove it. Weld below the bucket instead (rule 2).
+- Do NOT conclude a test is flaky and retry-loop it. Cross-process variance is a real determinism bug with a known fix shape (rule 5).
+- Do NOT trust a fix because the test went green. A fix once "worked" because a wrong parameter range rejected the bad case for the wrong reason. Confirm the mechanism: the suspect path fired, and toggling the fix flips the outcome (rule 6).
+- Do NOT make a shared merge key "smarter" to resolve one workload. The endpoint-pair edge-merge key is load-bearing: one workload needs co-endpoint chord+arc to collapse, another needs them distinct. Control the geometry you emit (splitter-side midpoint split) instead of discriminating in the key (reference.md §2).
+- Do NOT evaluate curve parameters over an assumed `[0,1]`. `evaluate_with_endpoints` takes the native parameter (radians for circles, knot values for NURBS); get the range from `domain_with_endpoints` (`crates/topology/src/edge.rs`).
+- Do NOT assume "no mesh fallback" means correct. Analytic output can still be geometrically wrong; classify points (solid-verification skill).
+- Do NOT patch a chord-vs-analytic gap one layer at a time. Four consecutive downstream layers hit the same sagitta gap in one case; move the computation to UV or the analytic carrier once (rule 4).
+
+## Related skills
+
+- **boolean-debugging**: GFA pipeline phases, where these failures surface.
+- **solid-verification**: watertightness, classifier choice, volume traps.
+- **debugging-doctrine**: vary one variable, dump literal data, fix at the owning layer.
+- **analytic-preservation**: keeping exact surface types through operations.
+- **testing**: property tests and golden files that catch these regressions.

--- a/.claude/skills/numerical-robustness/reference.md
+++ b/.claude/skills/numerical-robustness/reference.md
@@ -1,0 +1,196 @@
+# Numerical Robustness Reference
+
+Companion catalog to SKILL.md. All paths and symbols verified against the current tree; refresh line positions with the given `rg` patterns, not remembered line numbers.
+
+## §1 Tolerance and exact predicates
+
+### The Tolerance struct
+
+`crates/math/src/tolerance.rs` (find: `rg -n 'pub fn' crates/math/src/tolerance.rs`):
+
+| API | Semantics | Use for |
+|---|---|---|
+| `Tolerance::new()` / `Default` | linear 1e-7, angular 1e-12, relative 1e-10 | the standard tolerance everywhere |
+| `loose()` | 1e-4 / 1e-8 / 1e-6 | visualization only |
+| `tight()` | 1e-10 / 1e-15 / 1e-14 | high-precision internal steps |
+| `approx_eq(a, b)` | `abs(a-b) <= max(linear, relative * max(abs(a), abs(b)))` | coordinates; scale-aware, stays meaningful at large magnitudes |
+| `approx_eq_abs(a, b)` | `abs(a-b) <= linear` | non-coordinate values, e.g. parameters in `[0,1]` where relative scaling is wrong |
+| `parametric(deriv_mag)` | `linear / deriv_mag`, clamped to `[1e-15, 0.1]` | converting linear tolerance into a curve/surface parameter tolerance |
+| `linear_sq()` | squared linear | distance-squared comparisons without sqrt |
+
+Rule (also in CLAUDE.md, Key Patterns): never compare floats with `==`.
+
+Pitfall: `approx_eq` on parameter values silently loosens the comparison when the parameter is large (relative term dominates). Use `approx_eq_abs` for parameters, or `parametric()` when the parameter tolerance should track a derivative magnitude.
+
+### Exact predicates: when tolerance is the wrong tool
+
+Tolerance answers "are these the same within manufacturing precision." Predicates answer "which side" with a guaranteed-correct sign. Any sign or topology decision where an epsilon can produce mutually inconsistent answers must use a predicate:
+
+- Triangle orientation and in-circle tests during constrained Delaunay triangulation.
+- Point-in-polygon and winding.
+- Segment crossing tests.
+
+Tolerating a near-zero determinant in these contexts produces non-convergent or self-contradicting triangulations: point A is left of line BC by one call and right of it by the next.
+
+Where they live:
+
+- `crates/math/src/predicates.rs`: `orient2d`, `orientation2d` (returns the `Orientation` enum), `in_circle`, `winding_number`, `point_in_polygon`, `orient3d`, `orientation3d`, `insphere`, plus simulation-of-simplicity variants `orient2d_sos`, `orient3d_sos` for degeneracy breaking. Backed by the `robust` crate.
+- `crates/math/src/filtered.rs`: `filtered_orient2d`, `filtered_orient3d`, `filtered_in_circle`, `segment_intersection`. Fast float path with automatic fallback to exact arithmetic when the sign is ambiguous (Shewchuk-style adaptive precision); the vast majority of calls resolve in the fast path. Currently no production code calls these: the CDT calls the exact `predicates::{orient2d, in_circle}` and layers its own local fast path on top (`fast_in_circle` in `crates/math/src/cdt/mod.rs`, a float determinant with an error bound that falls back to exact `in_circle`), and mesh booleans (`crates/operations/src/mesh_boolean.rs`) call the exact `predicates::orient3d` directly. Treat `filtered.rs` as the drop-in replacement when a predicate call shows up hot in a profile. Beware name collisions: `cdt/mod.rs`, `polygon_boolean.rs`, and `polygon_offset.rs` each define their own private `segment_intersection_*` helpers that are unrelated to the filtered one.
+
+Decision rule: computing a distance or a merged position, use `Tolerance`. Deciding a branch that must be globally consistent (orientation, containment, crossing), use a predicate.
+
+## §2 Quantization-bucket fragility
+
+### The scheme
+
+Two independent quantizers exist, both named `quantize_point`, both `(coord * scale).round() as i64` triples (find both: `rg -n 'fn quantize_point' crates/algo/src/builder/`):
+
+1. `crates/algo/src/builder/same_domain.rs`: feeds `compute_edge_set_quantized`, the same-domain face-matching edge-set key. Pairs are canonicalized (smaller vertex first) and the list is `sort_unstable()`ed: a sorted canonical form, not an order-dependent hash. Intentionally outer-wire-only (SD candidates share the outer boundary but may differ in holes).
+2. `crates/algo/src/builder/builder_solid.rs`: feeds `merge_duplicate_edges`, keyed on quantized endpoint pairs at `const MERGE_TOL: f64 = 1e-7`.
+
+### The failure mode
+
+The pavefiller can place a vertex a few ULPs short of an exact pre-existing vertex (e.g. -11.999999 vs the exact -12.0). The two points quantize to different cells at `MERGE_TOL`, the duplicate-edge merge never unifies the two faces' partitions, the shared boundary stays open, free edges appear, and the boolean falls back to mesh co-refinement. The in-code comment near the top of `build_solid` in `builder_solid.rs` documents exactly this (find: `rg -n 'different cells at MERGE_TOL' crates/algo/src/builder/builder_solid.rs`).
+
+Empirical signature: a knife-edge, not a smooth threshold. In one diagnosed case, translating the operand by 7e-14 or 2e-13 passed while 1e-13 failed. Non-monotonic pass/fail under tiny nudges = bucket straddle.
+
+### The proven fix shape: weld below the bucket
+
+`weld_coincident_vertices` (`builder_solid.rs`, find: `rg -n 'fn weld_coincident_vertices' crates/algo/src/builder/`) runs before edge splitting and merging with `snap = MERGE_TOL * 10.0`. Vertices within the snap radius are collapsed to one canonical vertex in deterministic vertex-index order, so by the time quantization keys are computed, no near-duplicates exist to straddle cells.
+
+What NOT to do: widen `MERGE_TOL`. That relocates the cell boundaries; some other input will straddle the new ones. The snap radius must be strictly larger than the bucket so every intra-bucket-distance pair is unified before keying.
+
+### Hash-order fragility
+
+A hash accumulated over quantized floats in iteration order changes value when the iteration order changes, even for the identical point set. Always build a sorted canonical form first (collect, canonicalize each element, `sort_unstable`, then compare or hash). `compute_edge_set_quantized` is the in-repo template.
+
+### The merge-key lesson (endpoint-pair keys are load-bearing)
+
+`merge_duplicate_edges` keys edges by quantized endpoint pair only. Two workloads pull in opposite directions:
+
+- One (a rounded-rectangle lip ring) requires a Line chord and a Circle arc with the same endpoints to collapse to one edge, despite deviating by millimeters mid-span.
+- Another (a torus-minus-box lens) requires a Line and a co-endpoint arc to stay distinct, because a real face lies between them.
+
+No local key discriminant (curve type, midpoint sample) separates the cases; the distinction is global (is there face area between the edges?). The surviving fix shape is splitter-side geometry control: give each co-endpoint seam arc a midpoint vertex so no two distinct edges share both endpoints, and the unchanged endpoint-only merge cannot collapse them. In-repo instance: `emit_split_circle_arcs` in `crates/algo/src/pave_filler/phase_ff.rs` divides arc span by `PI * 0.999`, so a diametric semicircle (span exactly pi) gets two sub-arcs and a midpoint vertex. Lesson: when a shared key mis-merges, change what you feed it, not the key.
+
+### SD false-merge guard
+
+Because the edge-set key is outer-wire-only, two sphere bands sharing the same equator polygon once matched falsely. Guards: `distinct_curved_regions` (far-apart interior surface samples mean distinct regions) and, for planar faces, `planar_faces_overlap` (whole-wire containment, conservative by design). Both in `same_domain.rs`.
+
+## §3 Closed and periodic geometry
+
+### Endpoint-only computations collapse on closed curves
+
+`EdgeCurve::domain_with_endpoints` (`crates/topology/src/edge.rs`, find: `rg -n 'CLOSED_EPS' crates/topology/src/edge.rs`): if `(start - end).length() < 1e-9` the edge is treated as the full closed curve; otherwise both endpoints are projected onto the curve and the CCW span from start is taken via `rem_euclid(TAU)`.
+
+Consequence: for a full circle or a closed boundary, start == end, so any computation that looks only at endpoint vertices sees zero extent. Shipped collapses, all fixed by sampling along the curve:
+
+- A face AABB built from endpoint vertices collapsed a cylinder's closed circular edge to a line at the seam, and a full torus boundary to a single point. Current `compute_face_bbox` (`phase_ff.rs`) samples 9 points along every edge curve AND unions a surface-aware box for spheres (`sphere_region_axis` decides hemisphere extent) and full tori (gated by `face_boundary_all_degenerate`). A sphere or torus face bulges beyond its boundary edges, so even a boundary-sampled bbox underestimates; the surface term is required.
+- `face_boundary_all_degenerate` distinguishes a degenerate `Line(v0, v0)` seam (zero sampled extent = full torus) from a closed Circle edge (real sampled loop = trimmed patch). Endpoint inspection alone cannot tell them apart.
+
+Rule: winding, extent, AABB, and degeneracy tests must sample along the curve.
+
+### Degenerate seam edges exist by construction
+
+- `make_torus` (`crates/operations/src/primitives.rs`) builds the full torus as 1 vertex, 2 seam edges `Edge::new(v0, v0, EdgeCurve::Line)`, 1 face, wired as the fundamental polygon a, b, a-inverse, b-inverse (genus 1, V-E+F = 0). Code that assumes every edge has distinct endpoints or nonzero length breaks here.
+- Cylinder and cone seams are real Lines between distinct vertices.
+- `make_sphere` is 2 hemisphere faces joined by a chord-discretized equator: N vertices on the z=0 circle joined by `EdgeCurve::Line` edges. This is the chord seam of §4.
+
+### Periodic-curve copy hazard
+
+Copying a periodic curve (Circle, Ellipse) onto a NEW edge requires the stored start/end vertex order to match the curve's parameterization. If they disagree, `domain_with_endpoints` recovers the complementary sub-arc (the major arc instead of the minor, or vice versa). Forward edges hide the bug because stored order equals wire order; a reversed edge in the wire exposes it.
+
+Fixed site: `reverse_edge_curve` in `crates/operations/src/extrude.rs` flips the circle/ellipse frame (normal and v-axis) so projection negates theta, and for NURBS reverses control points, weights, and mirrors knots. Guard tests: `extrude_half_circle_reversed_edge_volume` and `extrude_half_ellipse_reversed_edge_volume` in `crates/operations/src/extrude/tests.rs`.
+
+Sweep-family exposure varies; check the curve type AND the endpoint pattern:
+
+- `sweep.rs` and `pipe.rs` emit only `EdgeCurve::Line` edges: no hazard.
+- `loft.rs` copies profile Circles onto closed seam edges (`Edge::new(seam_v, seam_v, EdgeCurve::Circle(..))`, find: `rg -n 'seam_v, seam_v' crates/operations/src/loft.rs`). Start == end, so `domain_with_endpoints` takes the full curve and the arc-order ambiguity cannot arise.
+- `revolve.rs` constructs its own Circle and NURBS arc curves. Its closed rings (`Edge::new(vid, vid, ..)`) are safe for the same full-curve reason, but it also creates Circle edges between DISTINCT vertices (find: `rg -n 'v_bot, v_top' crates/operations/src/revolve.rs`). Those are exactly the hazard pattern: stored vertex order must stay consistent with the curve frame. Audit them when touched.
+
+Rule: any edge carrying a periodic curve between distinct vertices needs a vertex-order versus parameterization audit; a closed edge (start == end) does not.
+
+### Native-parameter trap
+
+`evaluate_with_endpoints` (`edge.rs`) takes the curve's NATIVE parameter: radians for Circle/Ellipse, knot values for NURBS. Sampling over an assumed `[0,1]` once made a fix pass for the wrong reason (a wrong range happened to reject the bad cases). Always obtain the range from `domain_with_endpoints(start, end)` first. Related: `NurbsCurve::evaluate` (`crates/math/src/nurbs/curve.rs`) does not clamp; out-of-domain evaluation extrapolates silently, so guard t against the knot domain.
+
+## §4 Chord versus analytic: the sagitta gap
+
+Sagitta: the chord-to-arc midpoint deviation, `r*(1 - cos(theta/2))`. Defined and used in `crates/math/src/chord.rs`, which computes segment counts from a max deflection plus an angular cap (`DEFAULT_ANGULAR_TOL = 0.35`, about 20 degrees).
+
+### The case study (plane x sphere)
+
+The sphere's equator seam is stored as chords (§3). A cutting plane meets the true sphere in an exact circle. That circle bulges outside the inscribed chord polygon by the sagitta (0.05 units in the diagnosed case, far above tolerance), so segment-intersection tests against the chords found zero crossings and the split never fired (`closed_circle_boundary_crossings` in `phase_ff.rs` returned 0).
+
+Fixing crossing detection alone was not enough: the next layer (splitting boundary chords at the crossing point) hit the same gap, because the crossing lies on the true equator, off the chord. Four attempts confirmed: every 3D-based layer downstream fights the chord seam.
+
+Shipped fix: compute crossings against the analytic carrier, not the facets. `sphere_seam_plane_crossings` (`phase_ff.rs`) intersects the cut circle with a Newell-fit seam plane, which is facet-count independent.
+
+### The durable architecture lesson
+
+Do such arrangements in UV space, where the seam is exact: on a sphere the equator is the clean line v = 0, cut arcs are pcurves, and the arrangement is degeneracy-free. When you must stay in 3D, intersect against the analytic curve or surface, never its discretization.
+
+Corroborating in-repo guard for the inverse direction (chord near arc, not crossing it): the `chord_break_on_arc` closure in `crates/algo/src/builder/face_splitter/mod.rs` rejects "phantom breaks" where a chord segment passes near a convex boundary arc; a break registers only if the crossing genuinely lies on the arc within tolerance.
+
+## §5 Nondeterminism
+
+### Signature and cause
+
+Results identical within a process but varying across processes. Cause: std `HashMap` uses a per-process random seed; iteration order differs per process, and if that order feeds any branch (which face is the representative, which intersection is processed first), outputs diverge.
+
+### Fix shape
+
+Sort HashMap-derived iteration before it drives decisions:
+
+- Integer/id keys: `sort_unstable_by_key`. In-repo template: `same_domain.rs`, where the comment "Sort outputs deterministically" precedes `pairs.sort_unstable_by_key(|p| (p.idx_a, p.idx_b))` (find: `rg -n 'Sort outputs deterministically' crates/algo/`).
+- Float keys: `total_cmp`, e.g. `hits.sort_by(|a, b| a.0.total_cmp(&b.0))` in `phase_ff.rs`. Never sort floats with `partial_cmp().unwrap()` (NaN, and the lint denies unwrap anyway).
+
+This class recurs; the git history is rich with instances (search `git log --oneline --grep=deterministic` for the trail, e.g. deterministic GFA iteration, deterministic same-domain merge ordering, deterministic vertex welding, order-independent coincident-face selection).
+
+### Bisect procedure
+
+1. Reproduce across FRESH processes (each reseeds):
+   ```bash
+   for i in $(seq 20); do
+     cargo test -p brepkit-operations --release the_failing_test -- --exact 2>&1 | tail -1
+   done
+   ```
+   Checkpoint: a mix of `ok` and `FAILED` lines confirms process-seed nondeterminism. All-pass or all-fail means the bug is input-shaped, not seed-shaped: go to §2.
+2. Locate candidate HashMaps on the failing code path: `rg -n 'HashMap' <suspect files>`, focusing on `.values()`, `.iter()`, `.keys()`, `.drain()` whose results feed loops with side effects or early returns.
+3. Instrument: `eprintln!` the iteration order per run. Two runs with different orders AND different outcomes pins the site.
+4. Sort at that site, rerun step 1. Checkpoint: 20/20 identical outcomes.
+
+Note `IndexMap` or `BTreeMap` are alternatives when insertion or key order is the natural canonical order, but a one-line sort at the consumption site is the usual minimal fix.
+
+## §6 Prove the suspect path fires
+
+Canonical incident: a plausible static diagnosis blamed a collinear-vertex edge-split helper for handling only Line edges. The proposed arc-handling fix was correct-looking code, but the path fired ZERO times on the failing case; the real cause was elsewhere. Hours saved by a counter, or lost without one.
+
+Procedure before trusting any root-cause claim:
+
+1. Add a hit counter or `eprintln!` at the suspect site (or gate the candidate fix behind an env-var flag).
+2. Run the exact failing input. Checkpoint: the counter is nonzero. If zero, the diagnosis is wrong regardless of how plausible it reads; return to evidence gathering.
+3. Toggle the fix (flag on/off). Checkpoint: the outcome flips with the flag. Green-with-flag-off means something else changed; you have an accidental pass.
+4. Confirm the mechanism, not just the outcome. One shipped fix "worked" because a wrong parameter range rejected phantom breaks for the wrong reason; it was caught in review only because the reviewer traced the parameter semantics.
+
+Supporting tactics (see the debugging-doctrine skill for the full discipline):
+
+- Dump literal data at the boundary between "generated" and "consumed": in one case dumping section edges pre- and post-dedup proved a missing edge was never generated (absent pre-dedup), eliminating the dedup as a suspect in one step.
+- Vary ONE variable at a time (one operand nudge, one flag, one tolerance).
+- Verify geometry with the ray-cast classifier `brepkit_check::classify::classify_point` (`crates/check/src/classify/mod.rs`). Do not use tessellated volume as a correctness oracle (it once read 1.4% high and nearly masked an entirely missing cut), and do not use the winding classifier (`classify_point_winding`) on faceted or non-analytic solids; ray-cast is what the GFA builder itself trusts.
+- Face count is the reliable mesh-fallback tell: an analytic boolean yields roughly 3 to 80 faces with curved types present; a mesh fallback yields hundreds to thousands of planar facets. The approximation census (`cargo run --release --example approx_census -p brepkit-operations`) reports which operations degrade analytic to approximate.
+
+## Glossary
+
+- **GFA**: the general boolean engine in `crates/algo` (entry `gfa.rs`): pavefiller (intersection) plus builder (face splitting and assembly).
+- **Pavefiller**: the intersection orchestrator (`crates/algo/src/pave_filler/`); runs interference phases pairwise by dimension: VV, VE, EE, VF, EF, FF. The FF phase (`phase_ff.rs`) computes face-face section curves and hosts most seam and closed-curve handling.
+- **Pave / PaveBlock**: a split point on an edge, and the sub-segment between paves.
+- **SD (same-domain)**: detection of coincident or overlapping faces from the two operands (`builder/same_domain.rs`) so booleans keep one representative.
+- **Section curve**: the intersection curve between two faces emitted by FF.
+- **Seam edge**: the artificial edge closing a periodic surface: cylinder generatrix line, torus fundamental-polygon `Line(v0, v0)` pair, the sphere's chord equator.
+- **PCurve**: a curve in a surface's UV parameter space; UV-space arrangements dodge 3D chord-vs-analytic gaps.
+- **Mesh fallback**: when the analytic B-Rep boolean fails its validation gate (`crates/operations/src/boolean/mod.rs`), the op reroutes through tessellated co-refinement (`mesh_boolean.rs`).
+- **Free edge**: an edge bounding exactly one face; any free edge means an open, non-watertight shell.
+- **Sagitta**: chord-to-arc midpoint deviation `r*(1 - cos(theta/2))` (`crates/math/src/chord.rs`).
+- **ULP**: unit in the last place, the spacing between adjacent representable floats at a given magnitude; about 2e-16 relative for f64. "A few ULPs apart" means as close as two distinct doubles can get.
+- **Ray-cast vs winding classifier**: the two point-in-solid classifiers in `crates/check/src/classify/`; ray-cast (`classify_point`) is the trustworthy one for faceted or non-analytic solids.

--- a/.claude/skills/parity-benchmarking/SKILL.md
+++ b/.claude/skills/parity-benchmarking/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: parity-benchmarking
+description: Use when proving brepkit matches or beats the reference kernel, running the brepjs wasm head-to-head benchmark, overlaying a local kernel build into the gridfinity tool, re-probing scenario face counts after a GFA or boolean change, capturing faithful fixtures (STEP or arena .bin) from a failing tool scenario, or running local criterion micro-benchmarks. Also use whenever a speedup or parity claim is about to be quoted anywhere.
+---
+
+# Parity benchmarking
+
+Repo rule: never write the competing kernel's name in commits, PRs, code, or skill files. Call it "the reference kernel". The brepjs bench harness and the gridfinity tool already know it by their own internal kernel ids, so you never need to spell it out.
+
+## When to use
+
+- After ANY GFA (General Fuse Algorithm, the analytic boolean engine in `crates/algo`) or boolean-engine PR merges: re-probe face counts (see Probe discipline). This is mandatory, not optional.
+- Before quoting any performance or parity number.
+- When a gridfinity tool scenario fails and you need a Rust-side repro.
+- When asked whether brepkit "wins" on some operation.
+
+## The parity bar
+
+Acceptance, per real gridfinity scenario: triangle-count parity, volume parity, manifold/watertight validity, AND wall-clock at least matching the reference kernel. All four, per case. The end goal is replacing the reference kernel's wasm build in `~/Git/gridfinity-layout-tool`.
+
+Two traps baked into the bar:
+
+1. **Mesh fallback passes correctness while failing everything that matters.** When the analytic boolean result fails the gate in `crates/operations/src/boolean/mod.rs` (find it: `rg -n 'mesh_boolean' crates/operations/src/boolean/mod.rs`), the op reruns as a triangle-mesh boolean. The result is valid, watertight, and often has FEWER triangles than the reference kernel, so triangle and validity checks both mask it. Face count is the tell: analytic results are roughly 3 to 80 faces with curved-surface types present; fallback is hundreds to thousands of faces, all planar.
+2. **Timing is not correctness.** The head-to-head harness times ops but never verifies output equivalence. A 100x speedup usually means an analytic fast path short-circuited work the reference kernel actually did. Verify equal face counts and volumes on both sides before quoting any ratio. `cut(box, cylinder)` is the trustworthy apples-to-apples row.
+
+A hang or multi-hour suite runtime is itself a perf-bar defect, not an environment problem to wait out.
+
+## Quick reference
+
+```bash
+# Fast head-to-head (no npm install, no lockfile churn)
+cd ~/Git/brepkit && wasm-pack build crates/wasm --target nodejs --release --out-dir pkg-node-bench
+# then alias-swap in brepjs, see Procedure 1
+
+# Tool overlay build+copy loop (release build with wasm-opt skipped, direct node_modules only)
+./scripts/parity-loop.sh
+
+# Face count from JS (the fallback tell): getEntityCounts(id)[0]
+# binding: rg -n 'getEntityCounts' crates/wasm/src/bindings/query.rs
+
+# Unified criterion + JS report (slow, batteries included)
+./scripts/bench-compare.sh ~/Git/brepjs
+
+# Analytic-vs-approximation census
+cargo run --release --example approx_census -p brepkit-operations
+```
+
+## Procedure 1: fast head-to-head (wasm vs wasm)
+
+The fair fight is brepkit-wasm vs the reference kernel's wasm build, both driven through brepjs. This recipe needs no `npm install`, so it sidesteps the brepjs lockfile and knip traps entirely.
+
+1. Build: `wasm-pack build crates/wasm --target nodejs --release --out-dir pkg-node-bench` from the brepkit root. Dedicated out-dir so `crates/wasm/pkg` is not clobbered. Rename the emitted `.js` entry to `.cjs` (Node loads the bench as CJS; the published package ships `brepkit_wasm_node.cjs`).
+2. Point brepjs at it: copy `~/Git/brepjs/vitest.bench.config.ts` to a scratch config and change only the `brepkit-wasm` entry in `resolve.alias` to the absolute path of your `pkg-node-bench/*.cjs`. Do not touch `node_modules`.
+3. Run: `cd ~/Git/brepjs && BENCH_KERNELS=<ids> npx vitest run --config <your-config> kernel-comparison`. The `BENCH_KERNELS` syntax (single id, comma list) is documented in `~/Git/brepjs/benchmarks/setup.ts`; the actual kernel ids are defined in `~/Git/brepjs/tests/helpers/kernelInit.ts`. Include `brepkit` plus the reference kernel's wasm id.
+4. Checkpoint: the run takes seconds, not minutes, and regenerates `benchmarks/results/latest.md`. If it hangs for minutes, you included a wrong kernel id (see reference.md, Head-to-head).
+5. Before quoting any ratio, verify equivalence: same face counts (via `getEntityCounts`) and volumes within tolerance on both kernels for each quoted row.
+
+Rules: never set `BENCH_KERNELS=all` or `both`, and never include `manifold` (mesh/CSG kernel, apples to oranges, and it hangs the suite for hours). Single-kernel runs OVERWRITE `latest.md`; `git checkout benchmarks/results/latest.md` after one-offs.
+
+Details, bench-file inventory, and iteration multipliers: see reference.md, "Head-to-head".
+
+## Procedure 2: gridfinity tool overlay (tool-level parity)
+
+Heavier: replaces the tool's installed `brepkit-wasm` in place so the real generators run on your kernel.
+
+1. Get the files: either `npm pack brepkit-wasm@<ver> --pack-destination <tmp>` and use `<tmp>/package/*`, or build locally with `cargo xtask wasm-build` (add `--skip-opt` for iteration speed) and use `crates/wasm/pkg/*`.
+2. Copy the 6 package files into BOTH locations in `~/Git/gridfinity-layout-tool`: `node_modules/brepkit-wasm/` AND `node_modules/.pnpm/brepkit-wasm@<ver>/node_modules/brepkit-wasm/`. pnpm resolves through `.pnpm`; overlaying only the direct path is the classic wasted-probe mistake.
+3. Clear the Vite cache: `rm -rf node_modules/.vite node_modules/.vite-temp` in the tool.
+4. **Verify the overlay took effect before trusting any probe**: `md5sum` the `.wasm` in both locations against your source, or feature-detect a binding that only exists in the new build.
+5. Probe: `BREPJS_KERNEL=brepkit pnpm exec vitest run --config vitest.profile.config.ts <probe>` (set `BREPJS_KERNEL` to the reference kernel's wasm id for the comparison side).
+6. Restore afterward: `pnpm install --force` in the tool.
+
+`scripts/parity-loop.sh` automates the local-build flavor but copies only the direct `node_modules` location; add the `.pnpm` copy yourself when the probe imports resolve through pnpm. Its built-in probe step targets a test file that no longer exists in the tool, so bring your own probe vitest. File list and probe assets: see reference.md, "Tool overlay".
+
+## Probe discipline: re-probe face count after every GFA change
+
+Scorecards go stale silently. A GFA PR once shipped on top of a "locked in" scorecard and had silently broken the stacking-lip fuse for every 2x2-and-larger bin (the tool's DEFAULT config): 78 analytic faces became 190 all-planar mesh-fallback faces. Triangle counts and validity both still passed. It was found only when the probe was rerun.
+
+The rule: after ANY GFA or boolean PR, rerun the scenario matrix and record face counts per scenario and bin size. Face count via `getEntityCounts(solidId)[0]` (returns `[faces, edges, vertices]`; Rust side is `brepkit_topology::explorer::solid_entity_counts`). Do not use a fixed face-count threshold as the fallback detector; check the surface-type mix. All-planar with zero curved surfaces on a shape that should have cylinders is fallback regardless of the number.
+
+Vitest gotcha: the forks pool swallows `console.log`. Write probe results to a file, do not rely on stdout.
+
+## Faithful fixture capture
+
+Never grind on a hand-built repro without proving it matches the real tool geometry first. Diagnosis that flip-flops across debugging passes is itself the signal that your repro is unfaithful.
+
+- **Tier 1, STEP round-trip:** in a tool vitest, build up to the failing op, export the actual operands with `exportSTEP`, write to files, read into a Rust harness via `read_step` in `crates/io/src/step/reader.rs`, run the boolean directly. Checkpoint: confirm the operands round-trip ANALYTIC (cylinder/circle type tags, not NURBS). A lossy fixture produces overfit fixes that do not transfer.
+- **Tier 2, arena serialization:** some failures exist only in the tool's in-memory id layout; STEP renumbers everything and the bug vanishes. Use `serializeSolid`/`deserializeSolid` (`crates/wasm/src/bindings/io.rs`) and `serialize_solid`/`deserialize_solid` (`crates/io/src/arena_io.rs`). Capture `.bin` operands during a tool probe, commit under `crates/io/tests/data/`, replay in a `*_inmem.rs` test. Existing examples: `crates/io/tests/dovetail_cornerclip_intersect_inmem.rs`, `gridfinity_lipfuse_dividers_inmem.rs`.
+
+Capture gotcha and full patterns: see reference.md, "Fixture capture".
+
+## Local micro-benchmarks
+
+- `./scripts/bench-compare.sh ~/Git/brepjs`: unified criterion + JS report into `bench-results/`. It runs `npm install` into brepjs, so it is the slow path; use Procedure 1 for iteration.
+- Criterion benches: `crates/operations/benches/` (`cad_operations.rs` is the main suite; also `boolean_perf.rs`, `boolean_tracking.rs`, `compound_cut_perf.rs`, `fuse_perf.rs`). Run one: `cargo bench -p brepkit-operations --bench cad_operations`.
+- Census: `cargo run --release --example approx_census -p brepkit-operations` shows which ops stayed analytic vs which approximation path fired, with wall-clock and face counts.
+- Flamegraphs: see the profiling skill and CLAUDE.md, "Profiling".
+
+## Anti-patterns
+
+- Do NOT conclude parity from triangle count plus validity. Both pass under mesh fallback. Check face count and surface-type mix.
+- Do NOT quote a speedup from the bench harness alone. Verify output equivalence first.
+- Do NOT trust any scorecard measured before the most recent GFA merge. Re-measure.
+- Do NOT trust a tool probe until you verified the overlay landed in both node_modules locations and the Vite cache was cleared.
+- Do NOT debug from a hand-built repro whose dimensions differ from the real scenario (real bins use values like corner radius 1.485, not round numbers).
+- Do NOT keep debugging an in-memory-only failure through STEP fixtures. Switch to arena serialization.
+
+Symptom-to-cause table and glossary: see [reference.md](reference.md).

--- a/.claude/skills/parity-benchmarking/reference.md
+++ b/.claude/skills/parity-benchmarking/reference.md
@@ -1,0 +1,163 @@
+# parity-benchmarking reference
+
+Naming rule applies here too: the competing kernel is "the reference kernel". Its ids inside the brepjs harness are defined in `~/Git/brepjs/tests/helpers/kernelInit.ts` (`~/Git/brepjs/benchmarks/setup.ts` only documents the `BENCH_KERNELS` syntax); the tool's ids live in its kernel-test helpers. Do not write them into brepkit files.
+
+## Symptom-to-cause table
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| Scenario suddenly has hundreds of all-planar faces | Analytic boolean failed the gate, mesh fallback fired | `getEntityCounts(id)[0]` before/after; surface-type mix; then `rg -n 'mesh_boolean' crates/operations/src/boolean/mod.rs` and instrument the gate |
+| Triangle count and validity pass but perf regressed | Mesh fallback (masked by both headline metrics) | Face count, not triangles |
+| 100x+ speedup in the bench | Analytic fast path short-circuited; the kernels did different work | Compare face counts and volumes of both outputs |
+| Bench suite hangs or runs for hours | Wrong kernel id in `BENCH_KERNELS` (`all`, `both`, or `manifold`) | Rerun with an explicit two-id list |
+| Tool probe shows no change after overlay | Only one of the two node_modules locations was overlaid, or Vite cache stale | `md5sum` both `.wasm` copies; `rm -rf node_modules/.vite node_modules/.vite-temp` |
+| Probe prints nothing | Vitest forks pool swallows `console.log` | Write results to a file from the test |
+| Rust repro of a tool bug does not reproduce | Unfaithful fixture (wrong dimensions, or STEP normalized the failing state) | Verify STEP operands round-trip analytic; if the bug needs the in-memory id layout, switch to arena `.bin` fixtures |
+| Fix works on the fixture but not in the tool | Fixture was lossy (NURBS where the tool had cylinders) | Re-capture and check type tags on read-back |
+| `latest.md` shows only one kernel | A single-kernel run overwrote it | `git checkout benchmarks/results/latest.md` in brepjs |
+| JS monkey-patch on `fuse`/`cut` intercepts nothing | The tool's batch executor bypasses JS-level kernel methods | Capture inside the kernel: instrumented wasm build that serializes operands |
+
+## Head-to-head (brepjs bench harness)
+
+Files in `~/Git/brepjs/benchmarks/`:
+
+- `kernel-comparison.bench.test.ts`: the main comparison suite. Regenerates `benchmarks/results/latest.md` on every run that produced results, including single-kernel runs, which is why one-offs clobber it.
+- `boolean.bench.test.ts`: fuse/cut/intersect through the brepjs top-level API via `benchBoth` from `setup.ts`.
+- `setup.ts`: kernel init; reads `BENCH_KERNELS` (single id, comma list, or `all`/`both`; never use the last two).
+- `harness.ts`: `bench`, `createMultiKernelBench`, `collectResults`, `printResults`, `writeResultsJSON`, `generateReport`. The `benchAndCollect` wrapper is local to `kernel-comparison.bench.test.ts`; the `benchBoth` used by `boolean.bench.test.ts` is exported from `setup.ts`.
+- `results/latest.md`: tracked in git, regenerated per run.
+
+Iteration multipliers inside `kernel-comparison.bench.test.ts` (one measurement wraps a loop): booleans and STEP export x10; translate x1000; rotate, volume, boundingBox, primitives x100; meshing, chamfer, fillet, multi-boolean single-op. Divide accordingly when comparing to criterion numbers.
+
+Config template (`~/Git/brepjs/vitest.bench.config.ts`, verified):
+
+```ts
+resolve: {
+  alias: {
+    '@': resolve(__dirname, 'src'),
+    'brepkit-wasm': resolve(__dirname, 'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'),
+  },
+},
+test: {
+  globals: true,
+  setupFiles: ['./tests/setup.ts'],
+  testTimeout: 120000,
+  pool: 'forks',
+  execArgv: ['--max-old-space-size=6144'],
+  include: ['benchmarks/**/*.bench.test.ts'],
+},
+```
+
+For the fast recipe, copy this and repoint only the `brepkit-wasm` alias at your local `pkg-node-bench` `.cjs`. That is the entire integration: no install, no lockfile change, no type-sync, which avoids two documented brepjs traps (a lockfile-churn dependency problem and knip false-flagging exports on push).
+
+The report baselines its "vs" column to the native reference-kernel id and warns when the subset omits it. That 3-kernel table is for the README-style overview; for parity work the wasm-vs-wasm pair is the fair fight.
+
+Sanity anchors for quoted numbers: `cut(box, cylinder)` makes both kernels do comparable general-boolean work. Rows where brepkit hits an analytic fast path are legitimate wins only after you confirm the outputs are equivalent (face count, volume).
+
+## Tool overlay (gridfinity-layout-tool)
+
+Package file set (copy all 6):
+
+```
+brepkit_wasm_bg.js  brepkit_wasm_bg.wasm  brepkit_wasm.d.ts
+brepkit_wasm.js     brepkit_wasm_node.cjs package.json
+```
+
+Both destinations in `~/Git/gridfinity-layout-tool`:
+
+```
+node_modules/brepkit-wasm/
+node_modules/.pnpm/brepkit-wasm@<ver>/node_modules/brepkit-wasm/
+```
+
+Find the exact `.pnpm` dir with `ls node_modules/.pnpm | grep brepkit-wasm`. There may also be a combined `brepjs@...` entry in `.pnpm`; the one to overlay is the standalone `brepkit-wasm@<ver>` dir, but check where the probe's import actually resolves if in doubt.
+
+Sources:
+
+- Published: `npm pack brepkit-wasm@<ver> --pack-destination <tmp>`, then copy `<tmp>/package/*`.
+- Local: `cargo xtask wasm-build` (flags: `--no-simd`, `--skip-opt`; builds both targets, runs wasm-opt unless skipped, merges into `crates/wasm/pkg/`).
+
+`scripts/parity-loop.sh` = xtask release build with wasm-opt skipped (`--skip-opt` skips only the wasm-opt post-pass; the compile is still `--release`, so timings are near-representative), copy to the DIRECT location only, then a `vitest run ... topologyParity` step. That probe file has been removed from the tool, so the filter matches nothing and the script today only builds and overlays; write your own probe vitest (consistent with "do not expect ready-made probe files" below). The script also echoes the name of a JSON cache of the reference kernel's topology results at the tool root; delete that cache to re-measure the reference side.
+
+Overlay verification (do this before every probe batch):
+
+```bash
+md5sum crates/wasm/pkg/brepkit_wasm_bg.wasm \
+  ~/Git/gridfinity-layout-tool/node_modules/brepkit-wasm/brepkit_wasm_bg.wasm \
+  ~/Git/gridfinity-layout-tool/node_modules/.pnpm/brepkit-wasm@*/node_modules/brepkit-wasm/brepkit_wasm_bg.wasm
+```
+
+All three hashes must match. The documented failure mode is several probes wasted on a half-applied overlay.
+
+Probe assets in the tool (`src/features/generation/worker/generators/__kernel-tests__/`): `testCases.ts` (the canonical kernel parity matrix, roughly a dozen cases), `meshAssertions.ts`, `scenarioRunner.ts`, `scenarioTypes.ts`, `kernelInit.ts`/`dualKernelInit.ts`. Beyond that, the repo has ~80 `*.scenario.*.test.ts` files: a wide pre-validated oracle. Kernel selection per run: `BREPJS_KERNEL=<id> pnpm exec vitest run --config vitest.profile.config.ts <pattern>`.
+
+Ad-hoc probes (per-scenario face-count sweeps, perf sweeps) are write-your-own: a small vitest that runs the generator per scenario and dumps `getEntityCounts` results to a file. Do not expect ready-made probe files in the tool repo.
+
+Restore: `pnpm install --force` in the tool when done.
+
+## Face-count probe details
+
+Binding (`crates/wasm/src/bindings/query.rs`, `rg -n 'getEntityCounts'`):
+
+```rust
+#[wasm_bindgen(js_name = "getEntityCounts")]
+pub fn get_entity_counts(&self, solid: u32) -> Result<Vec<u32>, JsError>
+```
+
+Returns `[faces, edges, vertices]` via `brepkit_topology::explorer::solid_entity_counts`. Tool-side JS shape: `getRawBrepkitKernel().getEntityCounts(getSolidId(solid))[0]` (helpers in the tool's `__kernel-tests__/dualKernelInit.ts`). For the surface-type mix, the same raw kernel exposes `getSolidFaces(solidId)` and `getSurfaceType(faceId)`; count planar vs curved.
+
+Reading the number:
+
+- Healthy analytic result: order of 3 to 80 faces, curved surface types present where the inputs had them.
+- Mesh fallback: hundreds to thousands of faces, all planar. A fixed threshold once missed a 436-face all-planar fallback, so classify by surface-type mix (planar vs cylinder/cone/sphere/torus counts), not by a cutoff.
+- Rust side, the only reliable post-hoc tell that the gate rejected the analytic result is the face count and type mix of the RESULT; the gate itself lives in `crates/operations/src/boolean/mod.rs` (`rg -n 'mesh_boolean'`).
+
+Record per scenario AND per bin size. The shipped-regression case broke only 2x2-and-larger bins; a 1x1-only probe would have shown green.
+
+## Fixture capture details
+
+Fixture-tier APIs and test templates: see the testing skill. Parity-specific notes:
+
+- Tier 1 (STEP): in a tool vitest, construct the case up to (not including) the failing op, export both operands with `k.unwrap(k.exportSTEP(operand))`, replay in a Rust harness via `read_step`, call the boolean directly. Checkpoint before debugging: the read-back faces/edges must carry analytic type tags (Cylinder, Circle) where the tool had them; NURBS-ified operands mean a lossy fixture and a fix that will not transfer.
+- Tier 2 (arena `.bin`): some failures depend on the exact in-memory edge/vertex id layout; STEP renumbers into a clean layout and the repro vanishes, and repeated debugging passes then overturn each other. That instability is the signal to switch tiers. Templates: `crates/io/tests/dovetail_cornerclip_intersect_inmem.rs`, `gridfinity_lipfuse_dividers_inmem.rs`, `scoop_fix_inmem.rs`, `gridfinity_wallcut_seq_inmem.rs`.
+- Capture gotcha: the tool's batch executor bypasses JS-level kernel methods, so monkey-patching `fuse`/`cut` in JS intercepts zero booleans. Capture requires an instrumented wasm build that serializes operands inside the kernel, run through the tool overlay. That occupies the tool checkout; coordinate if another agent owns it.
+
+Repro fidelity: before grinding on any repro, diff its dimensions against the real scenario (real gridfinity bins use values like corner radius 1.485; a round-number stand-in once cost ~10 debugging passes).
+
+## Micro-benchmark details
+
+`scripts/bench-compare.sh <path-to-brepjs>`, five steps:
+
+1. `cargo bench -p brepkit-operations` (criterion) into `bench-results/criterion.log`.
+2. `wasm-pack build crates/wasm --target nodejs --release --out-dir crates/wasm/pkg`.
+3. `npm install` of the built package into brepjs with `--no-save` (this is why it is the slow path; it also touches node_modules state).
+4. `BENCH_OUTPUT_JSON=1 npx vitest run benchmarks/kernel-comparison.bench.test.ts --config vitest.bench.config.ts --reporter=verbose`, JSON extracted between `--- BENCHMARK RESULTS JSON ---` sentinels.
+5. `npx tsx scripts/bench-report.ts --criterion-dir target/criterion --js-json <file> --output-dir bench-results` producing `bench-results/report.md` and `comparison.json`.
+
+Criterion benches in `crates/operations/benches/`:
+
+- `cad_operations.rs`: primitives x100, fuse/cut/intersect x10, sphere meshing, chamfer, fillet, multi-boolean model, gridfinity 1x1 bin, 3x3 baseplate, 64-cut 8x8 grid, tessellation cases. The names inside the file are the `--bench` filter strings for flamegraphs.
+- `boolean_perf.rs`, `boolean_tracking.rs`, `compound_cut_perf.rs`, `fuse_perf.rs`: targeted boolean perf suites.
+
+Census: `crates/operations/examples/approx_census.rs` (`boolean_matrix()` plus per-op sections). Run `cargo run --release --example approx_census -p brepkit-operations`. Output rows show, per operation, whether it stayed exact-analytic or which approximation fallback fired, with wall-clock and face count. This is the standing scoreboard for the analytic-preservation goal (see the analytic-preservation skill).
+
+Flamegraphs: `cargo flamegraph --profile profiling --bench cad_operations -p brepkit-operations -o /tmp/flamegraph.svg -- --bench "<filter>"` (see the profiling skill).
+
+## Glossary
+
+- **GFA**: brepkit's General Fuse Algorithm, the analytic boolean engine (`crates/algo/src/gfa.rs`): intersect all faces (PaveFiller), split, classify, reassemble.
+- **PaveFiller**: GFA phase 1 (`crates/algo/src/pave_filler/`), pairwise interference phases VV/VE/EE/VF/EF/FF; edges split at intersection points ("paves").
+- **FF phase**: face-face intersection (`pave_filler/phase_ff.rs`), producer of section curves; historically the richest bug vein.
+- **SD / same-domain**: detection of coincident/overlapping faces between operands (`detect_same_domain`), merged rather than intersected. Coincident-contact bugs usually live in the classifier, not SD; rule SD out by instrumenting it first (see the boolean-debugging skill).
+- **Mesh fallback**: rerun of a failed analytic boolean as triangle-mesh co-refinement. Correct and watertight, but slow and it destroys analytic surfaces.
+- **Analytic face**: exact surface (Plane/Cylinder/Cone/Sphere/Torus) rather than NURBS or mesh facets.
+- **Entity counts**: `getEntityCounts(solid)` returning `[faces, edges, vertices]`; faces is the fallback tell.
+- **Overlay**: in-place replacement of the tool's installed `brepkit-wasm` files (both pnpm locations) to test an unpublished kernel.
+- **Faithful fixture**: captured actual tool operands (STEP or arena `.bin`) replayed in a Rust test, as opposed to a hand-built repro.
+- **Arena serialization**: binary dump of the exact in-memory topology arena, preserving failing states that STEP normalizes away.
+- **Scorecard**: per-scenario brepkit-vs-reference table (time, faces, triangles, validity). Stale the moment any GFA PR merges; never cite one without re-measuring.
+- **Census**: the `approx_census` example output, exact-analytic vs approximation per operation.
+
+## Sibling skills
+
+boolean-debugging (GFA failure triage), solid-verification (validity checks), analytic-preservation (keeping surfaces exact), tessellation (triangle counts), profiling (flamegraphs), release-flow (publishing brepkit-wasm and the brepjs sync), wasm-bindings (adding probe bindings), testing, debugging-doctrine.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: pr-workflow
+description: Use when committing, pushing, opening, reviewing, or merging a pull request in brepkit, or when a git hook fails, a push hangs, commitlint flags a message, a PR sits waiting on AI review, or parallel work needs a worktree. Covers hooks, conventional commits, the AI-review merge gate, the sandbox HTTPS push, and release-please.
+---
+
+# PR Workflow
+
+End-to-end change flow for this repo: branch, commit, push, PR, AI review gate, squash-merge, release. Main is protected; every change lands as a squash-merged PR. There is no human approval gate: the AI review check is the gate.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Branch | `git checkout -b <type>/<kebab-description>` (e.g. `feat/render-lod`, `fix/ci-crates-io-flake`) |
+| Local gate before push | `cargo nextest run -p <touched-crate>` and, if any `Cargo.toml` changed, `./scripts/check-boundaries.sh` |
+| Compliance grep | See "Banned-name compliance" below |
+| Push (sandbox) | `git push "https://x-access-token:$(gh auth token)@github.com/andymai/brepkit.git" <branch>` |
+| Verify remote head | `gh pr view <N> --json headRefOid` (never `git rev-parse origin/<branch>`) |
+| Review-gate poll | `gh pr checks <N>` until the `Greptile Review` check is completed |
+| Read findings | `gh api repos/andymai/brepkit/pulls/<N>/comments` and `gh pr view <N> --comments` |
+| Merge | `gh pr merge <N> --squash --auto` (only after findings are addressed) |
+| Post-merge | `git checkout main && git pull --ff-only` |
+| Worktree | `git worktree add .worktrees/<branch-name> <branch>` |
+
+## Hooks: what actually runs
+
+Hooks live in `.husky/`. Read the hook files themselves when in doubt; the "Git Conventions" section of CLAUDE.md describes an older pre-push behavior and the hook file is authoritative.
+
+- `pre-commit`: fmt, clippy, taplo, and cargo-machete run in parallel. No tests. Expect `✅ Pre-commit checks passed.` If it fails, fix and re-commit. Caveat: the hook silently skips taplo and cargo-machete when the binaries are not installed (`command -v` guards in `.husky/pre-commit`), so a passing hook does not prove TOML formatting or unused-dep cleanliness. Install both with `cargo install taplo-cli cargo-machete`.
+- `commit-msg`: runs commitlint (`@commitlint/config-conventional`, `commitlint.config.js`) but always exits 0: its not-installed fallback also swallows real lint failures, so violations print `✖` lines without blocking the commit. Treat any `✖` output as a hard failure and `git commit --amend` the message. Shape: `type(scope): subject`, e.g. `feat(render): screen-space adaptive LOD`. Nothing in CI lints messages either, and release-please parses the squash-commit title (the PR title), so a malformed title silently skips the version bump.
+- `pre-push`: prints one info line and exits 0. Validation is deliberately delegated to CI (`.github/workflows/ci.yml`). Do not re-add local test runs to this hook, and do not treat its emptiness as a reason to skip local testing: run touched-crate tests yourself before pushing.
+
+Hard rules:
+- Never `--no-verify`, never `HUSKY=0`, never edit a hook to get past it. If a hook fails on pre-existing breakage you did not cause, stop and report; do not bypass.
+- CI is the real gate: fmt, clippy, test (nextest workspace + doc tests), coverage, MSRV, wasm, boundaries, deny, audit, docs, machete, taplo, all fanned into one required check named `CI Pass`. Job catalog: see [reference.md](reference.md), "CI jobs".
+
+## Procedure: land a change
+
+1. **Branch** off `main` as `<type>/<kebab-description>`. Never commit to `main` directly.
+2. **Develop and test locally.** `cargo nextest run -p <crate>` for touched crates; `./scripts/check-boundaries.sh` if you touched any `Cargo.toml` (this check only runs in CI, catch it early).
+3. **Commit.** Conventional message. Never commit plan/spec working documents: if `git status` shows untracked planning docs (ad-hoc `*-plan.md` or `*-spec.md` working documents), leave them untracked.
+4. **Compliance grep** (below). Expect zero output.
+5. **Push.** Plain `git push` hangs: `origin` is SSH and SSH is blocked in this sandbox, and a global `insteadOf` rewrite converts bare `https://github.com/...` URLs back to SSH. Use the token-embedded URL from the quick reference. Checkpoint: `gh pr view <N> --json headRefOid` matches `git rev-parse HEAD`. Local `origin/<branch>` refs do not update after explicit-URL pushes, so never trust them.
+6. **Create the PR** with `gh pr create`. Do NOT set auto-merge yet.
+7. **Review gate** (next section).
+8. **After merge:** `git checkout main && git pull --ff-only`. The remote branch is deleted automatically.
+
+## The review gate
+
+Branch protection requires only `CI Pass`. The AI review check (`Greptile Review`) is NOT required by branch protection, so the PR can show mergeable while unread findings sit on it. Policy, not GitHub, enforces the gate:
+
+1. After `gh pr create`, work on the next independent task. Reviewers (Greptile, Copilot, cubic) comment within roughly 5 to 7 minutes.
+2. Poll until the review check completes:
+   ```bash
+   gh pr view <N> --json statusCheckRollup \
+     --jq '.statusCheckRollup[] | select(.name=="Greptile Review") | .status'
+   ```
+   Expect `COMPLETED`. A background watcher may poll for this, but it must hand control back for the next step, never merge on its own.
+3. Read every inline finding: `gh api repos/andymai/brepkit/pulls/<N>/comments`. Fix P0/P1 findings (push a follow-up commit, which restarts CI). Reply to lower-severity findings with a reasoned response.
+4. Only then: `gh pr merge <N> --squash --auto`. Auto-merge fires once `CI Pass` is green.
+5. This applies to every PR including high-risk core changes (GFA boolean engine, public WASM API). No human review step exists; review-check completion plus addressed findings is the whole gate.
+
+Anti-patterns:
+- Do NOT merge because CI is green or `mergeStateStatus` is `CLEAN`. That state says nothing about review findings (see PRs #828/#830 in history, fixed in #832).
+- Do NOT set `--auto` at PR-creation time.
+- Do NOT conclude "no findings" from an empty `gh pr view --comments`; inline review comments live on the pulls comments API, check both.
+
+## Banned-name compliance
+
+The names of the reference kernel (the incumbent C++ CAD kernel) must not appear in changed files, commit messages, or PR titles/bodies. Run before pushing:
+
+```bash
+# pattern split so this file itself stays clean
+banned='oc''ct|open''cascade'
+git diff main... --name-only | xargs -r rg -n -i "$banned"
+git log main.. --format='%s%n%b' | rg -n -i "$banned"
+```
+
+Pass condition: no output (rg exits 1). Grandfathered files that legitimately contain the names: `README.md`, `CHANGELOG.md`, `crates/wasm/CHANGELOG.md`, `scripts/bench-compare.sh`, `scripts/bench-report.ts`, `scripts/parity-loop.sh`. Do not add new occurrences anywhere, and do not "clean up" the grandfathered ones. Reading the reference kernel's source locally to study an approach is fine; naming it in committed text is not. For benchmark instructions, point at the brepjs harness scripts by path instead (see the parity-benchmarking skill).
+
+## Worktrees
+
+Parallel work lives inside the repo under `.worktrees/` (gitignored):
+
+```bash
+git worktree add .worktrees/<branch-name> <branch>
+```
+
+Ignore the older `../feat-branch` sibling-directory form in CLAUDE.md; in-repo `.worktrees/` is the rule. Each worktree pushes and PRs independently with the same procedure above.
+
+## Release flow
+
+release-please (`.github/workflows/publish.yml`) maintains a pending `chore(main): release X.Y.Z` PR. Merging a `feat`/`fix`/`perf` PR updates it; merging the release PR itself tags, creates the GitHub release, and publishes the wasm package to npm. `docs`/`chore` commits and changes under excluded paths (`.github`, `scripts`, `benches`, `examples`, and similar) do not bump the version. Cross-repo consumption by brepjs: see the release-flow skill. Details and manual escape hatch: [reference.md](reference.md), "Release-please".
+
+## CI failures you did not cause
+
+`Cargo.lock` is gitignored, so deny, audit, and MSRV re-resolve dependencies on every CI run; a new advisory or dep release can fail an unrelated PR with zero diff. Never widen `deny.toml` to get green. Triage order, the MSRV and wasm-bindgen pins, and scheduled workflows: see [reference.md](reference.md), "CI failures you did not cause".
+
+## Symptoms
+
+Symptom-to-cause table (push hangs, commitlint rejects, review check missing, release PR not updating): see [reference.md](reference.md), "Symptom table".

--- a/.claude/skills/pr-workflow/reference.md
+++ b/.claude/skills/pr-workflow/reference.md
@@ -1,0 +1,145 @@
+# pr-workflow reference
+
+Deep catalog behind SKILL.md. Everything here was verified against the repo; when it disagrees with prose elsewhere (including CLAUDE.md's "Git Conventions"), the workflow files (`.husky/*`, `.github/workflows/*.yml`) are authoritative.
+
+## CI jobs (`.github/workflows/ci.yml`)
+
+All jobs except `wasm-size` fan into `ci-pass` (display name `CI Pass`), the only check required by branch protection.
+
+| Job | Display name | What it runs |
+|-----|--------------|--------------|
+| `fmt` | Format | `cargo fmt --all -- --check` |
+| `clippy` | Clippy | `cargo clippy --all-targets --all-features -- -D warnings` |
+| `test` | Test | `cargo nextest run --workspace`, doc tests, complexity guards |
+| `coverage` | Coverage | llvm-cov coverage report |
+| `msrv` | MSRV (1.88) | build on the minimum supported Rust |
+| `wasm` | WASM Build & Validate | `cargo xtask wasm-build --skip-opt` (wasm-pack build + validation for `wasm32-unknown-unknown`) |
+| `wasm-size` | WASM Size Report | PR-only size delta comment (informational, not gated by `ci-pass`) |
+| `boundaries` | Layer Boundaries | `./scripts/check-boundaries.sh` |
+| `deny` | Cargo Deny | license/advisory/ban checks |
+| `audit` | Security Audit | `cargo audit` |
+| `docs` | Rustdoc | doc build with warnings denied |
+| `machete` | Unused Dependencies | `cargo machete` |
+| `taplo` | TOML Format | `taplo fmt --check` |
+
+Local pre-commit covers only fmt, clippy, taplo, machete, and the last two only when the binaries are installed (the hook skips them silently otherwise). Everything else (tests, boundaries, deny, docs) first runs in CI unless you run it yourself. Before pushing, run at minimum the tests for touched crates and, on any `Cargo.toml` change, `./scripts/check-boundaries.sh`.
+
+## Repo merge settings (verified via `gh api repos/andymai/brepkit`)
+
+- `allow_squash_merge: true`; merge commits and rebase merges disabled.
+- `allow_auto_merge: true`; `delete_branch_on_merge: true`.
+- Branch protection on `main`: linear history, no force pushes, required check = `CI Pass` only, `required_approving_review_count: 0`.
+- Squash commit titles on `main` look like `type(scope): subject (#N)`.
+
+## AI reviewers
+
+| Actor | Surface |
+|-------|---------|
+| `greptile-apps` | Inline findings with P0/P1/P2 severity; posts the `Greptile Review` status check (not branch-protection required) |
+| `copilot-pull-request-reviewer` | Inline review comments |
+| `cubic-dev-ai` | Review plus a `cubic · AI code reviewer` check |
+
+Reading findings:
+
+```bash
+gh api repos/andymai/brepkit/pulls/<N>/comments   # inline (diff-anchored) comments
+gh pr view <N> --comments                          # issue-level comments
+```
+
+Triage: P0/P1 findings get a fix commit before auto-merge is set. P2 and style findings get a short reply (agree-and-fix, or explain why not). A finding being wrong is fine; ignoring it silently is not.
+
+## Sandbox push details
+
+- `origin` is `git@github.com:andymai/brepkit.git`; SSH to github.com:22 is blocked, so plain `git push` hangs until timeout.
+- Global rewrite trap: `git config --get-regexp 'url\..*insteadof'` shows `url.git@github.com:.insteadof https://github.com/`. This silently converts even an explicit `git push https://github.com/...` back to SSH. The token-embedded URL avoids the rewrite because it does not match the prefix:
+
+```bash
+git push "https://x-access-token:$(gh auth token)@github.com/andymai/brepkit.git" <branch> \
+  2>&1 | sed 's/x-access-token:[^@]*@/x-access-token:***@/g'
+```
+
+- Explicit-URL pushes never update local `origin/<branch>` tracking refs. Verify what the remote actually has:
+
+```bash
+gh pr view <N> --json headRefOid --jq .headRefOid
+gh api repos/andymai/brepkit/commits/<branch> --jq .sha
+```
+
+Do not conclude "push failed" or "remote is behind" from `git rev-parse origin/<branch>`; that ref is stale by construction here.
+
+- All `gh` operations (create, view, merge, api) go over HTTPS with the CLI token and work normally.
+
+## Release-please (`.github/workflows/publish.yml`)
+
+- Runs on every push to `main` using `googleapis/release-please-action` v5 with a bot app token.
+- Config: `release-please-config.json`; current version manifest: `.release-please-manifest.json`. Single package rooted at `.`, component `brepkit-wasm`; the version is also bumped in `crates/wasm/Cargo.toml`.
+- Flow: merging a `feat`/`fix`/`perf` PR creates or updates the pending release PR (`chore(main): release X.Y.Z`, head branch `release-please--branches--main--components--brepkit-wasm`). Merging that release PR creates the tag and GitHub release and publishes to npm.
+- Version-neutral changes: `docs` and `chore` commits are changelog-hidden; changes only under excluded paths (`.github`, `book`, `scripts`, `benches`, `bench-results`, `examples`, `bindings`) do not bump.
+- Manual escape hatch: `workflow_dispatch` on the Publish workflow with a `publish_version` input skips release-please.
+- Cross-repo: brepjs (`~/Git/brepjs`) consumes the published wasm package; see the release-flow skill for the two-repo runbook.
+
+## CI failures you did not cause
+
+Supply-chain and toolchain jobs can fail on a PR that never touched dependencies. Root cause: `Cargo.lock` is gitignored (see `.gitignore`), so every CI run resolves dependencies fresh. The `audit` job even runs `cargo generate-lockfile` explicitly. A new advisory or a new dep release changes the verdict with zero diff on your branch.
+
+### cargo-deny / audit / OSV advisories
+
+The `deny` job runs cargo-deny-action against `deny.toml`; the `audit` job runs rustsec/audit-check on a freshly generated lockfile. Both gate PRs through `CI Pass`. OSV lives in its own workflow (`.github/workflows/osv-scan.yml`): on PRs it is report-only and does not gate; pushes to `main` and the Monday 06:00 UTC schedule fail closed.
+
+Policy: do NOT widen the `deny.toml` license allowlist and do NOT add blanket ignore entries to get green. Current state to preserve: `licenses.allow` has eight permissive entries, the four non-obvious ones (CC0-1.0, ISC, BSD-2-Clause, BSD-3-Clause) carrying a provenance comment that names the dependency tree pulling them in, and there is no `[advisories] ignore` list at all (`[advisories]` sets only `unmaintained` and `yanked`).
+
+Triage order when an advisory lands on your PR:
+
+1. Check whether a patched version exists (`cargo audit` output or the advisory page names it). Semver-compatible patches are picked up automatically by the fresh resolution, so a persistent failure usually means the fix is in a new major or minor. Raise the version requirement in the relevant `Cargo.toml` in a separate commit, not mixed into your feature diff.
+2. If no patched version exists, add a narrowly scoped `[advisories] ignore` entry to `deny.toml`: the specific advisory id, a comment explaining why it does not apply or cannot be fixed yet, and a concrete re-check trigger (e.g. "remove when <crate> X.Y ships"). State the ignore and its rationale in the PR body.
+3. If unsure whether the advisory is exploitable or how to scope it, stop and report per the blocked-state rule. Silencing a security check is never a way to unblock a PR.
+
+### MSRV job
+
+Workspace `Cargo.toml` declares `rust-version = "1.88"`; the CI job `MSRV (1.88)` runs `cargo check --workspace --all-features` on toolchain 1.88.0. Because resolution is fresh, a dependency releasing a version that needs newer Rust breaks this job on unrelated PRs. The errors are confusing: syntax, edition, or feature errors deep inside the dependency, never the word MSRV. Fix: constrain that dependency in `Cargo.toml` to the last version that builds on 1.88. Do not bump `rust-version` casually; it is a public contract, and raising it is its own PR with its own justification.
+
+### wasm-bindgen pin
+
+The workspace `Cargo.toml` pins `wasm-bindgen = "=0.2.125"` and says why in an inline comment: the crate version must match the wasm-bindgen-cli tooling. The coupling is enforced in `xtask/src/wasm.rs` via the `WASM_BINDGEN_VERSION` constant; `cargo xtask wasm-build` bails when a locally installed wasm-bindgen-cli differs. The two locations must move together, and the xtask constant has lagged the Cargo.toml pin before, so verify both:
+
+```bash
+rg -n 'wasm-bindgen' Cargo.toml xtask/src/wasm.rs
+```
+
+Bumping wasm-bindgen is its own change with its own PR. Never bump it as a drive-by to fix an unrelated failure, and never let a general `cargo update`-style version bump move it silently.
+
+### Scheduled workflows
+
+- `.github/workflows/mutants.yml` (Mutation Testing): Sundays 02:00 UTC plus manual dispatch. Runs cargo-mutants on `brepkit-math` and `brepkit-algo` and uploads a report artifact. It never runs on PRs and never gates them; a red scheduled run is a signal to improve tests, not a merge blocker.
+- `.github/workflows/osv-scan.yml`: Mondays 06:00 UTC plus main pushes, fail-closed there; report-only on PRs (see above).
+- `benchmark.yml` runs on pushes and PRs, not on a schedule, and is not part of `CI Pass`.
+
+## Symptom table
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| `git push` hangs, no output | SSH origin plus blocked port 22; or the `insteadOf` rewrite converted your HTTPS URL | Use the token-embedded HTTPS URL above |
+| `origin/<branch>` does not match what you pushed | Explicit-URL pushes never update tracking refs | Verify with `gh pr view <N> --json headRefOid` |
+| commitlint prints `✖ found N problems` yet the commit succeeded | The commit-msg hook swallows commitlint failures and exits 0 by design of its fallback | Treat as a rejection: `git commit --amend` to `type(scope): subject` form |
+| pre-commit fails on clippy warnings you did not write | Pre-existing breakage on the branch base | Stop and report; never `--no-verify` |
+| `⚠️ commitlint not available` warning on commit | `node_modules` missing, but only if no `✖` lines print above it; the same warning also follows a real lint failure (see the `✖` row) because the hook's fallback fires on any nonzero commitlint exit | If `✖` lines precede it, fix the message; otherwise `npm install` at repo root. Either way the commit went through unchecked, re-verify the message manually |
+| PR shows mergeable but you have not read reviews | `Greptile Review` is not branch-protection required | Wait for the check to complete, read findings, only then `--auto` |
+| `Greptile Review` check absent minutes after PR creation | Reviewers take roughly 5 to 7 minutes to post | Keep polling `gh pr checks <N>`; do other work meanwhile |
+| CI `boundaries` job fails | A crate dependency violates the layer rules | Run `./scripts/check-boundaries.sh` locally; see the layer-boundaries skill |
+| CI `taplo` or `machete` fails but pre-commit passed | Tool not installed locally; the hook skips it silently | `cargo install taplo-cli cargo-machete`, fix, re-commit |
+| Compliance grep hits in a file you touched | You introduced a banned reference-kernel name, or you touched a grandfathered file | Remove new occurrences; leave grandfathered ones as-is |
+| Release PR did not update after merge | Commit type was `docs`/`chore`, or all changes fell under excluded paths | Expected; only `feat`/`fix`/`perf` in versioned paths bump |
+| `deny` or `audit` fails on a PR that never touched deps | `Cargo.lock` is gitignored; CI resolved a newly-advisoried or newly-released dep | Follow the triage order in "CI failures you did not cause"; never blanket-ignore |
+| MSRV job fails with syntax or feature errors inside a dependency | A dep released a version requiring Rust newer than 1.88 | Constrain that dep in `Cargo.toml`; do not bump `rust-version` |
+| `cargo xtask wasm-build` bails with a wasm-bindgen-cli version mismatch | Local CLI differs from the pin; the crate pin and `xtask/src/wasm.rs` constant must match | Install the pinned CLI version; bump the pin only as its own PR |
+| Push rejected on `main` | Branch protection; direct pushes to main are not allowed | Branch and open a PR |
+
+## Anti-patterns (what NOT to conclude)
+
+- "CI is green so the PR is done": review findings do not block CI. The gate is the review check completing plus findings addressed.
+- "The pre-push hook printed one line and passed, so the change is validated": the hook intentionally runs nothing. Validation is CI plus the local tests you ran yourself.
+- "CLAUDE.md says pre-push runs tests and cargo-deny": stale. The hook file delegates to CI; do not re-add local suites to it and do not cite the stale description.
+- "High-risk change, better wait for a human": no human gate exists. Address findings, then auto-merge.
+- "gh pr view showed no comments, so there are no findings": inline findings live on `pulls/<N>/comments` (the API), check both surfaces.
+- "The plan doc helps reviewers, commit it": working plans and specs never get committed.
+- "The commit went through, so the message passed commitlint": the commit-msg hook never blocks. Check the hook output for `✖` lines and amend if any appeared.

--- a/.claude/skills/profiling/SKILL.md
+++ b/.claude/skills/profiling/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: profiling
+description: Use when investigating or fixing performance in brepkit: a benchmark got slower, an operation (boolean, fuse, tessellation) is unexpectedly slow or hangs, a criterion bench times out or shows wild variance, or a PR needs before/after perf numbers. Covers flamegraphs, the criterion bench suite, cross-kernel comparison, and the perf bug classes this codebase has actually had.
+---
+
+# Profiling and Performance Debugging
+
+## The bar
+
+brepkit must beat the reference kernel on performance, not merely pass tests. Perf regressions are release blockers. CI runs `boolean_tracking` on a shared runner and only comments on regressions over 200% (`.github/workflows/benchmark.yml`, `fail-on-alert: false`), so the automated gate is looser than the real bar. You are the gate: any PR touching a hot path pastes before/after criterion numbers in its body. Cross-kernel claims require `./scripts/bench-compare.sh ~/Git/brepjs` output, not native-only numbers (see the parity-benchmarking skill).
+
+## Quick reference
+
+```bash
+cargo bench-fast                                          # kernel-comparison suite (cad_operations, ~2 min)
+cargo bench-full                                          # all 5 bench files
+cargo bench -p brepkit-operations --bench boolean_perf -- "N=64"   # isolate one bench by substring
+cargo flamegraph --profile profiling --bench cad_operations -p brepkit-operations \
+  -o /tmp/flamegraph.svg -- --bench "<filter>"            # flamegraph a specific criterion bench
+cargo run --profile profiling --example profile_boolean -- honeycomb   # per-phase boolean timing
+cargo run --profile profiling --example tess_profile      # tessellation drill-down (64-hole plate)
+./scripts/bench-compare.sh ~/Git/brepjs                   # native + wasm vs the reference kernel
+```
+
+The `[profile.profiling]` block in the workspace `Cargo.toml` is release optimization plus debug symbols with `lto = false`: fast rebuilds, full symbol names in flamegraphs. Always profile with it, never with plain `release` (LTO mangles frames) or `dev` (measures nothing real).
+
+Bench files (`crates/operations/benches/`), one line each:
+
+| Bench | Covers |
+|---|---|
+| `cad_operations.rs` | Head-to-head suite (`fuse(box,box) x10`, `mesh sphere (tol=0.01)`, `tessellate 64-hole plate`, ...); paired with `brepjs/benchmarks/kernel-comparison.bench.test.ts` via the `NAME_MAP` table in `scripts/bench-report.ts`, so a new head-to-head bench must be added to that table or it will not appear in the comparison report |
+| `boolean_perf.rs` | Boolean scaling: `sequential_cylinder_cuts/N={4,16,64}` and `single_boolean_at_face_count` |
+| `boolean_tracking.rs` | Small fast suite CI tracks for trend (`boolean/cut_cylinder_through_box`, `boolean/perforated_cut_36`) |
+| `compound_cut_perf.rs` | `compound_cut` vs sequential cuts: cylinder grids and honeycomb grids |
+| `fuse_perf.rs` | `fuse_all` tree-reduce vs sequential left-fold (`fuse_balanced` has `balanced_N=` and `sequential_N=`; `fuse_touching` has only `balanced_N=`) |
+
+## Method: the perf loop
+
+1. **Baseline.** `cargo bench -p brepkit-operations --bench <file> -- "<filter>"`. Expect a line like `sequential_cylinder_cuts/N=64  time: [x.xx s x.xx s x.xx s]`. Save it verbatim. Criterion stores history in `target/criterion/`, so later runs print change-% automatically.
+2. **Isolate.** Narrow the filter to one benchmark ID. If the bench seems to hang or shows wild run-to-run variance, do not fight criterion: write a plain timed loop that runs the op N times on fresh `Topology` instances and prints per-iteration wall clock. Huge iteration spread is itself the diagnosis (see bug class B).
+3. **Flamegraph that exact workload.** Use the quick-reference command with the same filter, or for boolean work use `--example profile_boolean -- <scenario>` (scenarios: `honeycomb`, `cylinders`, `fuse`, `large-honeycomb`, `scale`, `xl`, `tess`; the example header documents them). Open the SVG in a browser and look for wide frames. Checkpoint: if the widest frames are in `mesh_boolean` on analytic inputs, stop, that is the bug (class D).
+4. **Fix.** Vary one variable at a time. Match the symptom to a known class first (table below) before inventing a new theory.
+5. **Re-run the same bench with the same filter.** Criterion prints the delta against the stored baseline. Checkpoint: expect `change: [-XX% ...] Performance has improved`. If the number moved less than the flamegraph suggested, the wide frame was not on the measured path; re-check the filter.
+6. **PR body.** Paste both criterion lines verbatim. For scaling fixes, also add a deterministic complexity-guard test so the win cannot regress on noisy runners; pattern: `scaling_perforated_cut_is_subquadratic` in `crates/operations/src/boolean/tests.rs`. Historical absolute times are machine-specific; never write them into tests as thresholds, assert growth ratios instead.
+
+## Known perf bug classes
+
+| Symptom | Likely cause | Fix shape | Detail |
+|---|---|---|---|
+| N-tool boolean scales worse than linear; each cut/fuse slower than the last | Pairwise accumulation: `acc = fuse(acc, next)` pays growing cost every step in GFA (the general-fuse boolean engine in `crates/algo`), O(N²) total | Batch it: `compound_ops::fuse_all` (bbox-partition + disjoint merge + tree-reduce) or `boolean::compound_cut`; `boolean()` already fast-paths provably disjoint Fuse | reference.md, class A |
+| Same op varies 100x+ between identical runs; criterion "hangs"; results differ across runs | HashMap iteration order feeding downstream branching; the random seed sometimes samples a pathological path | Sort (and dedup) any collection derived from HashMap iteration before it drives decisions | reference.md, class B |
+| Preview/mesh path slow; triangle counts explode | Deflection too fine for the use; re-tessellating at export tolerance | Coarse deflection for preview; drill down with `tess_profile` | reference.md, class C |
+| Flamegraph dominated by `mesh_boolean` on analytic inputs | B-Rep path bailed via error-variant fallthrough into the mesh fallback | Fix the error handling, not the algorithm; the fallthrough is the bug | reference.md, class D |
+
+## Anti-patterns: what NOT to conclude
+
+- A hung or 100x-variance bench does NOT mean "the algorithm is slow". Rule out nondeterminism (class B) first with the fresh-Topology timed loop.
+- A green CI benchmark run does NOT mean no regression. The alert threshold is 200% and it only comments. Compare criterion output yourself.
+- Native criterion wins do NOT prove "beats the reference kernel". Only `bench-compare.sh` output does; wasm behaves differently.
+- Do NOT profile with `--release` (LTO destroys symbols) or trust `dev`-profile timings at all.
+- Do NOT "fix" a scaling problem by making each pairwise call faster. If cost grows with accumulator size, the fix is batching or disjointness detection, not micro-optimization.
+- Do NOT paste historical numbers from old PRs as expected timings. Re-measure on the current machine and commit.
+- Do NOT speed up tessellation by loosening deflection inside core geometry or booleans. Mesh approximation in core paths is a fidelity bug (see the tessellation and analytic-preservation skills).
+
+## Deep detail
+
+- [reference.md](reference.md): full command catalog, bug classes A-D with verified symbols and rg patterns, `bench-compare.sh` pipeline, profiling-example internals, glossary.
+- Sibling skills: parity-benchmarking (cross-kernel harness), tessellation (deflection semantics), boolean-debugging (when the slow path is also wrong), debugging-doctrine (bisection discipline), pr-workflow (getting the numbers merged).

--- a/.claude/skills/profiling/reference.md
+++ b/.claude/skills/profiling/reference.md
@@ -1,0 +1,148 @@
+# Profiling reference
+
+Everything here is verified against the current tree. Symbols move; re-find them with the rg patterns given, not line numbers.
+
+## Tooling catalog
+
+### The profiling profile
+
+Workspace `Cargo.toml`:
+
+```toml
+[profile.profiling]
+debug = true
+inherits = "release"
+lto = false
+opt-level = 3
+```
+
+Release-speed code, debug symbols, no LTO. Plain `release` has `lto = true` and `codegen-units = 1`: slow to rebuild and flamegraph frames get inlined/mangled beyond use.
+
+### Flamegraphs
+
+`cargo-flamegraph` is installed. Two targets:
+
+```bash
+cargo flamegraph --profile profiling --bench <bench_file> -p brepkit-operations \
+  -o /tmp/flamegraph.svg -- --bench "<filter>"
+
+cargo flamegraph --profile profiling --example profile_boolean -o /tmp/flame.svg -- honeycomb
+```
+
+The trailing `-- --bench "<filter>"` is criterion syntax: `--bench` switches the harness to bench mode, the string is a substring filter selecting benchmark IDs. Output is an SVG; open in a browser, click frames to zoom. Wide frame = time spent (inclusive). Read bottom-up from `main` to find the hot subsystem, then top-down inside it.
+
+### Criterion benches
+
+All five files in `crates/operations/benches/`, each `harness = false` in `crates/operations/Cargo.toml`.
+
+- `cad_operations.rs`: the head-to-head suite: `makeBox(10,20,30) x100`, `fuse(box,box) x10`, `cut(box,cyl) x10`, `intersect(box,sphere) x10`, `mesh box (tol=0.1)`, `mesh sphere (tol=0.01)`, `tessellate 64-hole plate`, `boolean 64 cuts (8x8 grid)`, `gridfinity 1x1 bin (box+shell+chamfer)`, and more. Native and JS numbers line up via the hand-maintained `NAME_MAP` table in `scripts/bench-report.ts` (rg: `NAME_MAP`), which pairs each criterion name with its counterpart in `brepjs/benchmarks/kernel-comparison.bench.test.ts`. The names do not match literally: criterion names carry an ` xN` repetition suffix (`fuse(box,box) x10`), the JS names do not (`fuse(box,box)`, `translate ×1000`). Any new head-to-head benchmark must be added to `NAME_MAP` or it will be silently missing from `bench-results/report.md`.
+- `boolean_perf.rs`: scaling behavior. Group `sequential_cylinder_cuts` with IDs `N=4`, `N=16`, `N=64`; group `single_boolean_at_face_count` for cost vs target complexity. This is where O(N²) regressions show first.
+- `boolean_tracking.rs`: the small fast suite CI runs for trend tracking (group `boolean`; IDs include `cut_cylinder_through_box`, `perforated_cut_36`). Keep it under a minute; it runs on every push to main.
+- `compound_cut_perf.rs`: `compound_cut` vs sequential `boolean(Cut)`. Groups `compound_cut_cylinders` (grids of 4/16/36/64) and `compound_cut_honeycomb` (hex grids, IDs like `compound_rings=2_N=19`).
+- `fuse_perf.rs`: `fuse_all` vs sequential left-fold. Group `fuse_balanced` has both `balanced_N={n}` and `sequential_N={n}` (N in 4/9/16/25); group `fuse_touching` has only `balanced_N={n}` (N in 4/9/16).
+
+Cargo aliases (`.cargo/config.toml`):
+
+```bash
+cargo bench-fast   # bench -p brepkit-operations --bench cad_operations
+cargo bench-full   # bench -p brepkit-operations
+```
+
+Output shape per benchmark:
+
+```
+sequential_cylinder_cuts/N=64
+                        time:   [1.021 s 1.0324 s 1.0442 s]
+                        change: [-2.1% +0.3% +2.8%] (p = 0.81 > 0.05)
+```
+
+The `change:` line appears once `target/criterion/` holds a prior run. That directory is your baseline mechanism: run before the fix, run after, criterion computes the delta.
+
+### CI benchmark tracking
+
+`.github/workflows/benchmark.yml` runs `cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher` and feeds github-action-benchmark with `alert-threshold: '200%'`, `comment-on-alert: true`, `fail-on-alert: false`. Shared runners are noisy, so it comments instead of failing. Consequence: a merged PR can regress perf 1.9x with zero CI signal. The deterministic guard that does hard-fail is the complexity test `scaling_perforated_cut_is_subquadratic` (rg: `fn scaling_` in `crates/operations/src/boolean/tests.rs`), which asserts a growth ratio, not wall clock. Add tests in that style for any scaling fix.
+
+### Profiling examples (`crates/operations/examples/`)
+
+- `profile_boolean.rs`: per-phase timing harness. Scenarios (from its header): `honeycomb`, `cylinders`, `fuse`, `large-honeycomb`, `scale` (scaling study), `xl` (200+ tool stress), `tess` (tessellation focus).
+
+  ```bash
+  cargo run --profile profiling --example profile_boolean -- <scenario>
+  ```
+
+  This is the preferred flamegraph payload for boolean work: it runs one workload continuously instead of criterion's sample loop, so the SVG is cleaner.
+- `tess_profile.rs`: builds the 64-hole plate (100x100x10 box minus an 8x8 grid of r=2 cylinders), prints per-face surface-type/edge/inner-wire breakdown and arena sizes, then times `tessellate_solid(&topo, result, 0.1)` three times with vertex/triangle counts. Use it to see which surface types and face counts drive triangle counts before touching tessellation code.
+- `debug_boolean.rs` and `approx_census.rs` also live there; the latter is analytic-degradation auditing, not perf.
+
+### Cross-kernel comparison
+
+```bash
+./scripts/bench-compare.sh ~/Git/brepjs
+```
+
+Pipeline: (1) full native criterion run, log to `bench-results/criterion.log`; (2) `wasm-pack build crates/wasm --target nodejs --release`; (3) install the built package into brepjs with `--no-save`; (4) run `benchmarks/kernel-comparison.bench.test.ts` under vitest with `BENCH_OUTPUT_JSON=1`; (5) `npx tsx scripts/bench-report.ts` produces `bench-results/report.md` and `comparison.json`. That report is the only valid evidence for "faster than the reference kernel" claims. See the parity-benchmarking skill for interpreting it and for a lighter one-off head-to-head (wasm-pack build plus a vitest `resolve.alias` swap in brepjs, which avoids the npm install step).
+
+## Bug classes in depth
+
+### Class A: pairwise N-way accumulation is quadratic
+
+Symptom: `for tool in tools { acc = boolean(acc, tool) }` where each iteration is slower than the last. Cause: the accumulator's face count grows every step, and every pairwise boolean pays full GFA arena/assemble cost proportional to it. Total cost O(N²) even when each individual call is optimal.
+
+Fix shape, in order of preference:
+
+1. Skip booleans entirely when operands are provably disjoint. `boolean()` already does this for Fuse: `solids_provably_disjoint` + `merge_disjoint_solids` in `crates/operations/src/boolean/mod.rs` (rg: `solids_provably_disjoint`). Two soundness traps if you extend it: disjoint requires a strictly positive gap (`b.min - a.max > margin`; touching is NOT disjoint, coincident faces need real boolean handling), and the accumulator can span many components, so test per-component AABBs, not one global box.
+2. Batch entry points: `pub fn fuse_all(topo, compound)` in `crates/operations/src/compound_ops.rs` (bbox-partitions into overlapping groups, merges disjoint groups without booleans, tree-reduces within groups) and `pub fn compound_cut` in `crates/operations/src/boolean/mod.rs`. Both are exposed to wasm; `fuseAll` lives in `crates/wasm/src/bindings/booleans.rs`.
+3. Balanced tree-reduce as a floor: fusing pairs of similar size keeps intermediate face counts logarithmically bounded. `fuse_perf.rs` measures exactly this against the left-fold.
+
+Historically this class produced two-to-three orders of magnitude wins. Verify a fix with `fuse_perf` or `compound_cut_perf` (the `sequential_` vs `balanced_`/`compound_` IDs are the before/after built in), then guard it with a growth-ratio test.
+
+### Class B: HashMap iteration order feeding downstream branching
+
+Symptom: the identical operation on identical input varies enormously (100x to 500x observed historically) across process runs, or a criterion bench appears to hang. It is not a hang: `HashMap`'s per-process random seed changes iteration order, and when downstream logic branches on that order, some orderings steer the pipeline into a pathological path. Criterion's sampling then repeatedly draws the slow branch. The same mechanism also produces nondeterministic results, so this class is both a perf bug and a correctness bug.
+
+Diagnostic recipe:
+
+```rust
+for i in 0..10 {
+    let mut topo = Topology::new();
+    let start = std::time::Instant::now();
+    run_the_op(&mut topo);
+    println!("iter {i}: {:?}", start.elapsed());
+}
+```
+
+Fresh `Topology` each iteration (arena state must not carry over). Fixed code shows all iterations within roughly 2x of each other; a 10x+ spread confirms the class. Note this loop shares one process, so one seed; run the binary a few times if the spread hides.
+
+Fix shape: sort, and usually dedup, any collection derived from HashMap iteration before it drives decisions. Live examples of the pattern: `neighbors.sort_unstable_by_key(|id| id.index())` in `crates/topology/src/adjacency.rs`; `nonmanifold.sort_by_key(|(eid, _)| eid.index())` and `neighbors.sort_unstable()` in `crates/operations/src/boolean/assembly.rs`. Sorting by arena index is the house convention.
+
+Hunting for new instances: HashMaps still exist across the GFA pipeline, so treat any unsorted `.values()`, `.keys()`, `.iter()`, or `for (k, v) in map` whose output feeds ordering-sensitive logic as a suspect:
+
+```bash
+rg -n '\.values\(\)|\.keys\(\)|HashMap' crates/algo/src/builder crates/algo/src/pave_filler
+```
+
+Do not assume any specific file is currently buggy; several determinism fixes have landed (git history around #681, #683, #901, #907 if you want the archaeology). The pattern, not the file list, is durable.
+
+### Class C: tessellation deflection dominates preview cost
+
+`tessellate_solid(topo, solid, deflection)` in `crates/operations/src/tessellate/solid.rs` (rg: `pub fn tessellate_solid`); variants `tessellate_solid_with_tolerance`, `tessellate_solid_grouped_with_tolerance`, `tessellate_solid_for_boolean` live in the same file. Deflection is max chord deviation: on curved surfaces triangle count grows superlinearly as it shrinks. The bench suite encodes the sensitivity: `mesh box (tol=0.1)` is nearly free, `mesh sphere (tol=0.01)` is not, and `tessellate 64-hole plate` adds boolean-heavy topology.
+
+Fix shape: preview paths use coarse deflection and cache the mesh; never re-tessellate at export tolerance for an interactive path. Drill down with `tess_profile` to see whether triangles come from many faces (topology problem, maybe a boolean left fragments) or few finely-meshed curved faces (deflection problem). Hard boundary: deflection is a rendering/export knob only. Introducing tessellation into core geometry or boolean classification to "speed things up" is forbidden; see the tessellation and analytic-preservation skills.
+
+### Class D: error-variant fallthrough into a silent slow path
+
+The largest single perf win in this codebase's history was not an algorithmic change. An intermediate Cut returned an unexpected `Err` variant, the multi-region handling matched only the expected variant, and the operation fell through to the mesh-boolean fallback (`crates/operations/src/mesh_boolean.rs`), which is orders of magnitude slower and lossy. The fix widened a match arm.
+
+Lesson: a perf cliff can hide entirely inside error-handling plumbing. The flamegraph signature is unmistakable: a subsystem that should not be running (mesh boolean on analytic inputs) dominating the graph. When you see it, find the fallback's entry condition and trace why the primary path bailed; do not optimize the fallback. This overlaps with the boolean-debugging skill: the same fallthrough that costs time also degrades analytic geometry to mesh.
+
+## Glossary
+
+- **GFA**: the general-fuse-style boolean engine in `crates/algo` (`gfa.rs`): intersect everything, split faces, classify, reassemble. Every pairwise boolean pays its arena/assemble overhead.
+- **PaveFiller**: GFA's intersection orchestrator (`crates/algo/src/pave_filler/`); runs interference phases pairwise by entity type.
+- **FF phase**: face-face intersection (`pave_filler/phase_ff.rs`), typically the hottest GFA phase; produces section curves.
+- **SD (same-domain)**: detection and merging of coincident overlapping faces from the two operands (`crates/algo/src/builder/same_domain.rs`); a classic source of order-sensitivity.
+- **Mesh fallback**: `crates/operations/src/mesh_boolean.rs`, tessellation-based co-refinement used when the B-Rep path fails. Slow and lossy; appearing in a flamegraph on analytic inputs is itself a bug.
+- **Deflection**: max chord deviation for tessellation, the third argument to `tessellate_solid`. Smaller means superlinearly more triangles on curved faces.
+- **Arena / Topology**: the arena allocator owning all B-Rep entities (`crates/topology`). Booleans against a growing accumulator solid slow down as its face count grows.
+- **Criterion baseline**: history in `target/criterion/` that makes re-runs print change-%; the before/after mechanism.
+- **The reference kernel**: the incumbent C++ CAD kernel brepkit replaces. The perf bar is beating it, measured through `bench-compare.sh`.

--- a/.claude/skills/release-flow/SKILL.md
+++ b/.claude/skills/release-flow/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: release-flow
+description: Shipping a brepkit change all the way into brepjs. Use when a feature PR has merged and the change must reach npm and the brepjs adapter, when bumping the brepkit-wasm pin in brepjs, when running or debugging the type sync (sync:brepkit-types, tsc failures on Brepkit* types), when a dep-bump branch conflicts with a release-please commit, or when a push fails or hangs in this sandbox.
+---
+
+# release-flow: brepkit merge to brepjs activation
+
+## When to use
+
+A brepkit change is not "shipped" when its PR merges. It is shipped when brepjs
+installs the new kernel version, the type sync regenerates cleanly, and the
+adapter can call the new method. This skill covers that 4-hop chain and the
+trap at each hop. For getting the feature PR itself merged, see the
+`pr-workflow` skill. For benchmark comparisons after a release, see
+`parity-benchmarking`. To test an unreleased kernel build inside brepjs
+without waiting for any of this chain, see the `wasm-bindings` skill.
+
+## Quick reference: the 4-hop chain
+
+Each hop is gated on the previous one. Never skip a gate.
+
+| Hop | Action | Gate before next hop |
+|-----|--------|---------------------|
+| 1 | Feature PR squash-merges to brepkit main | Merge lands on main |
+| 2 | release-please opens `chore(main): release X.Y.Z` PR; it auto-merges, tags `vX.Y.Z`, and the release event triggers the publish workflow | GitHub release exists |
+| 3 | Publish workflow builds wasm and runs `npm publish` | `npm view brepkit-wasm versions --json` lists X.Y.Z AND your commit is an ancestor of the tag |
+| 4 | In brepjs: bump the devDependency pin, `npm install`, `npm run sync:brepkit-types` | tsc and knip pass, diff drops no method signatures |
+
+Key commands:
+
+```bash
+npm view brepkit-wasm versions --json
+cd ~/Git/brepkit && git fetch --tags
+git merge-base --is-ancestor <feature-sha> vX.Y.Z && echo in-release
+cd ~/Git/brepjs && npm install && npm run sync:brepkit-types
+```
+
+## Procedure
+
+### Hop 1 to 2: brepkit release
+
+1. After the feature PR merges, the push to main runs
+   `.github/workflows/publish.yml`. Its `release-please` job opens or updates
+   the release PR, and its `auto-merge` job enables squash auto-merge on that
+   PR. You do not merge it by hand; it lands when checks pass.
+2. Checkpoint: `gh pr list --search 'chore(main): release'` shows the PR, then
+   it disappears and `gh release list` shows the new version. If the release
+   PR is stuck, check its CI, not the workflow.
+3. The tag is plain `vX.Y.Z` (no package prefix; see
+   `release-please-config.json`, `include-component-in-tag: false`).
+
+### Hop 3: poll npm, do not trust the tag
+
+The GitHub tag and release appear minutes before npm has the version, because
+the publish job is still building wasm. Gate on both of these:
+
+```bash
+npm view brepkit-wasm versions --json          # array must end with "X.Y.Z"
+git merge-base --is-ancestor <feature-sha> vX.Y.Z && echo in-release
+```
+
+The second check matters when releases are frequent: your commit may have
+missed the cut and be waiting for the NEXT release. Do not bump brepjs to a
+version that does not contain your change.
+
+If the release exists but npm never gets the version, the publish job failed;
+`workflow_dispatch` on publish.yml with a `publish_version` input is the
+manual escape hatch.
+
+### Hop 4: brepjs dependency bump and type sync
+
+In `~/Git/brepjs` (use a worktree if the checkout is busy):
+
+1. Edit `package.json`: set the **devDependencies** entry
+   `"brepkit-wasm": "X.Y.Z"` (exact pin). Leave the **peerDependencies**
+   range alone; it already covers `^2.0.0`. The pin is what brepjs CI tests
+   against; the range is what consumers may bring.
+2. `npm install`. Then verify the lockfile kept the three `@emnapi` entries
+   (see Pitfalls below).
+3. `npm run sync:brepkit-types`. This regenerates
+   `src/kernel/brepkit/brepkitWasmTypes.ts` from the installed
+   `node_modules/brepkit-wasm/brepkit_wasm.d.ts`. That file is generated;
+   never hand-edit it.
+4. Checkpoint: `npm run validate && npm run knip`; pass means both exit 0.
+   `validate` (`scripts/validate-change.sh`) runs typecheck, lint, boundary
+   check, format check, and tests. knip is a separate gate not covered by
+   `validate`; do not skip it. If tsc fails on an undefined
+   `Js*` or `Brepkit*` type, you hit the type-sync trap: see
+   [reference.md](reference.md), "Type-sync internals".
+5. Checkpoint: the diff of `brepkitWasmTypes.ts` may legitimately shrink
+   (comment compaction), but it must drop zero real method signatures:
+
+   ```bash
+   git diff src/kernel/brepkit/brepkitWasmTypes.ts | grep '^-' | grep -E '\w+\(' 
+   ```
+
+   Every removed line here must reappear as a `+` line or be a comment.
+
+## Pitfalls: symptom to cause
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Tag `vX.Y.Z` exists but `npm view` lacks X.Y.Z | Publish job still running or failed | Wait and re-poll; if failed, `workflow_dispatch` publish |
+| tsc: cannot find name `JsFoo` after sync | New return type has no `mapReturnType` case and no emitted interface block | reference.md, "Type-sync internals": both edits are required |
+| New method missing from generated types | Method not listed in `METHOD_SECTIONS` in `scripts/sync-brepkit-types.ts` | Add it to the right section |
+| Dep-bump PR: "merge commit cannot be cleanly created" | release-please bumped package.json/lock on brepjs main right after a merge | reference.md, "Lockfile rebase": rebase, take main's lock, `npm install`, never hand-merge |
+| `gh pr view` says CONFLICTING right after force-push | GitHub computes mergeability async; the value is stale | Re-query after a few seconds before acting |
+| knip flags a src export as unused, blocks push | knip cannot trace usage from `tests/` | `@testOnly` JSDoc tag on the export; `knip.config.ts` already has `tags: ['-testOnly']` |
+| CI `npm ci` fails: `Missing: @emnapi/core ... from lock file` | Old npm (< 11.11) dropped the three `@emnapi` lock entries | reference.md, "@emnapi lockfile" |
+| `git push` hangs or times out | SSH port 22 blocked, and a global insteadOf rewrite converts even explicit https URLs back to SSH | reference.md, "Pushing over HTTPS": token-embedded URL |
+| `git rev-parse origin/<branch>` disagrees with GitHub | Explicit-URL pushes do not update remote-tracking refs | Confirm head via `gh pr view <n> --json headRefOid` |
+
+## Anti-patterns: what NOT to conclude
+
+- Tag exists, so npm has it: false, poll npm.
+- Tag exists, so my commit is in it: false, check ancestry.
+- Types now declare the method, so the adapter's `typeof` guard is dead code:
+  false. Consumers bring any kernel in the peer range, which is wider than
+  the pin. Keep the guard (see reference.md, "Adapter feature-detection").
+- Lockfile conflict, so resolve hunks by hand: never. Take main's lockfile
+  and regenerate with `npm install`.
+- Peer range needs bumping with the pin: no, only the devDependency pin moves
+  per release.
+- `brepkitWasmTypes.ts` needs a small fix, so edit it directly: no, it is
+  regenerated; fix the sync script and re-run.
+
+## Before any push, in either repo
+
+Grep changed files, commit messages, and the PR body for the banned
+reference-kernel names. See reference.md, "Reference-kernel hygiene" for the
+exact commands (the pattern is split there so these skill files pass their
+own check).

--- a/.claude/skills/release-flow/reference.md
+++ b/.claude/skills/release-flow/reference.md
@@ -1,0 +1,236 @@
+# release-flow reference
+
+Deep detail for the hops in SKILL.md. Paths are absolute; brepjs lives at
+`~/Git/brepjs`.
+
+## Publish workflow anatomy (brepkit)
+
+File: `~/Git/brepkit/.github/workflows/publish.yml` ("Release & Publish").
+
+- `release-please` job: runs on push to main, opens or updates the
+  `chore(main): release X.Y.Z` PR, exposes a `release_created` output.
+- `auto-merge` job: runs `gh pr merge <release-pr> --auto --squash`. The
+  release PR merges itself once checks pass. Do not merge it manually unless
+  auto-merge visibly failed.
+- `publish` job: triggers on the GitHub `release` event, on the
+  `release_created` output, or on `workflow_dispatch` with a
+  `publish_version` input (the manual escape hatch). It builds the wasm
+  package for both targets:
+
+  ```bash
+  wasm-pack build crates/wasm --target bundler --release --out-dir pkg
+  wasm-pack build crates/wasm --target nodejs --release --out-dir pkg-node
+  ```
+
+  merges them into one package, verifies `package.json` version equals the
+  tag, and runs `npm publish --provenance`. Publish is idempotent: it skips
+  if the version is already on npm, so a re-run is safe.
+- Versioning config: `release-please-config.json` sets
+  `"component": "brepkit-wasm"` but `"include-component-in-tag": false`, so
+  tags are plain `vX.Y.Z`. It also bumps `crates/wasm/Cargo.toml` via
+  `extra-files`.
+
+## Type-sync internals (brepjs)
+
+Script: `~/Git/brepjs/scripts/sync-brepkit-types.ts`, run via
+`npm run sync:brepkit-types`.
+
+What it does:
+
+1. Parses the `BrepKernel` class body out of
+   `node_modules/brepkit-wasm/brepkit_wasm.d.ts` with a regex (the regex
+   cannot handle nested-paren parameter types; a method like that will parse
+   wrong, check the output).
+2. Emits `src/kernel/brepkit/brepkitWasmTypes.ts`. The header records
+   `Synced against brepkit-wasm@<version>`. The file is AUTO-GENERATED;
+   hand edits are clobbered on the next sync.
+3. Only methods listed in `const METHOD_SECTIONS: Section[]` appear in the
+   output, grouped by category label. Find it:
+   `rg -n 'const METHOD_SECTIONS' scripts/sync-brepkit-types.ts`.
+4. Methods not referenced from the adapter layer
+   (`src/kernel/brepkit/*.ts`, excluding the generated file) are tagged
+   `/** @unwired */`.
+
+### The new-return-type trap
+
+`function mapReturnType(rt, methodName)` maps known wasm return types to
+local interface names: `JsMesh` to `BrepkitMesh`, `JsEdgeLines` to
+`BrepkitEdgeLines`, `JsGroupedMesh` to `BrepkitGroupedMesh`. A return type of
+`any` maps to `ANY_RETURN_OVERRIDES[methodName] ?? 'string'` (example
+override: `getEdgeNurbsData: 'string | null'`).
+
+An unmapped `JsFoo` passes through verbatim into the generated file, where no
+`BrepkitFoo` interface exists, so tsc fails. Adding the method to
+`METHOD_SECTIONS` alone is NOT enough. A new `Js*` return type requires BOTH:
+
+1. A case in `mapReturnType` returning `'BrepkitFoo'`.
+2. A hardcoded interface block emitted by the script. The existing ones are
+   pushed as lines, e.g. `lines.push('export interface BrepkitMesh {')`.
+   Find them: `rg -n "export interface Brepkit" scripts/sync-brepkit-types.ts`.
+   Add a matching block for the new type, mirroring the fields of the Rust
+   struct in `crates/wasm/src/shapes.rs` or `types.rs`.
+
+Then re-run the sync and re-check tsc.
+
+Notes:
+
+- wasm-bindgen `Vec<f32>` / `Vec<u32>` getters return owned copies (the JS
+  glue slices and frees the Rust buffer), so the interface fields are plain
+  `Float32Array` / `Uint32Array` and no defensive copy is needed JS-side.
+- Interim state before a dep bump lands: a hand-added OPTIONAL forward
+  declaration for the new method lets the adapter's `typeof` guard typecheck
+  against the old kernel; the next sync replaces it canonically.
+
+### Verifying the sync diff
+
+The regenerated file may shrink for legitimate reasons (JSDoc and formatting
+compaction). What it must never do is silently drop a method. Check:
+
+```bash
+git diff src/kernel/brepkit/brepkitWasmTypes.ts | grep '^-' | grep -E '\w+\('
+```
+
+Eyeball each hit: it must either reappear as an added line or be a comment.
+A genuinely dropped signature means a method fell out of `METHOD_SECTIONS`
+or the upstream `.d.ts` regressed; stop and find out which.
+
+## Lockfile rebase (the release-please collision)
+
+brepjs also uses release-please. Right after any brepjs PR merges, the bot
+pushes a commit to main bumping `package.json` version, `package-lock.json`,
+and `CHANGELOG.md`. A dep-bump branch that also touches package.json and the
+lock then fails to merge ("merge commit cannot be cleanly created").
+
+Resolution, always the same shape:
+
+```bash
+git fetch origin
+git rebase origin/main
+git checkout --ours package-lock.json
+npm install
+git add package-lock.json
+git rebase --continue
+expected=$(gh pr view <n> --json headRefOid -q .headRefOid)
+git push --force-with-lease=<branch>:"$expected" \
+  "https://x-access-token:$(gh auth token)@github.com/andymai/brepjs.git" <branch>
+```
+
+Notes:
+
+- The lease MUST carry an explicit expected value. Explicit-URL pushes never
+  update remote-tracking refs (see "Pushing over HTTPS"), so a bare
+  `--force-with-lease` has no expected value to check against and is always
+  rejected with `! [rejected] ... (stale info)`. Take the expected old head
+  from `gh pr view` immediately before the push, as above.
+- In a REBASE, `--ours` is the side you are rebasing ONTO, i.e. main. That
+  is intentional: discard your branch's lockfile, then let `npm install`
+  regenerate it against the merged `package.json`.
+- `package.json` usually auto-merges cleanly (the version field and your dep
+  line are far apart); only the lockfile truly conflicts.
+- Never resolve lockfile hunks by hand. The file is generated; hand-merged
+  lockfiles are how CI gets `npm ci` integrity failures.
+- After the force-push, GitHub's mergeable state is computed asynchronously.
+  `gh pr view <n> --json mergeable,mergeStateStatus` returning `CONFLICTING`
+  or `DIRTY` immediately after the push is usually stale. Re-query after a
+  few seconds; it flips to `MERGEABLE` or `BLOCKED` (blocked = waiting on
+  checks, which is fine).
+
+## brepjs push gates
+
+### knip and @testOnly
+
+knip (the unused-export linter, a pre-push gate) cannot trace usage from
+`tests/` (separate tsconfig and import alias), so a src export exercised only
+by tests gets flagged as unused and blocks the push. The sanctioned escape
+hatch, already wired in `~/Git/brepjs/knip.config.ts` via
+`tags: ['-testOnly']`:
+
+```ts
+/** @testOnly Exercised by tests/vectorOperations.test.ts. */
+export function myHelper() { ... }
+```
+
+Live examples: `src/utils/vec2d.ts`, `src/measurement/measureCache.ts`,
+`src/core/kernelBoundary.ts`. Do not delete the export or inline it into the
+test to appease knip; tag it.
+
+### @emnapi lockfile entries
+
+`brepkit-wasm` has three transitive optional deps whose top-level lockfile
+entries npm older than 11.11 silently dropped on `npm install`, making CI's
+`npm ci` fail with `Missing: @emnapi/core@... from lock file`. Current local
+npm is past 11.11, so plain `npm install` is safe. Keep the verification
+step regardless, after any install that touches the lock:
+
+```bash
+grep -c '"node_modules/@emnapi/core"' package-lock.json
+grep -c '"node_modules/@emnapi/runtime"' package-lock.json
+grep -c '"node_modules/@emnapi/wasi-threads"' package-lock.json
+```
+
+Each must print `1`. If any prints `0` you are on an old npm; upgrade npm
+rather than hand-editing the lock.
+
+### Adapter feature-detection
+
+The adapter layer (`src/kernel/brepkit/*Ops.ts`) guards newer kernel methods
+and keeps a fallback path:
+
+```ts
+if (typeof bk.tessellateSolidGroupedBinary === 'function') { ... }
+```
+
+Live guard sites: `meshOps.ts` (`tessellateSolidGroupedBinary`),
+`modifierOps.ts` (`chamferAsymmetric`, `offsetWire2DWithJoin`),
+`ioOps.ts` (`fromBREP`), `repairOps.ts` (`validateSolidDetails`).
+
+Keep the guard even after the re-synced types declare the method as present.
+The devDependency pin is exact, but consumers satisfy the wide
+peerDependencies range (`^0.10.1 || ^1.0.0 || ^2.0.0`) and may run an older
+kernel where the method does not exist. eslint does not flag the guard as
+redundant; leave it.
+
+## Reference-kernel hygiene
+
+The name of the C++ kernel brepkit replaces is banned from commits, PR
+titles and bodies, and code in both repos. Call it "the reference kernel".
+The brepkit-side compliance grep and the grandfathered file list (README,
+the two changelogs, three bench scripts) live in the pr-workflow skill.
+In brepjs, package and adapter identifiers that contain the name are
+legitimate code; the ban targets prose, commit messages, and PR text.
+
+For brepjs, the pattern below is assembled from split shell strings so this
+file passes its own check; the shell concatenates them into the real pattern.
+
+```bash
+pat="$(printf 'o%s|open%s' 'cct' 'cascade')"
+git diff main --name-only --diff-filter=d | xargs -r rg -in "$pat" --
+git log main.. --format='%B' | rg -in "$pat"
+gh pr view <n> --json title,body -q '.title + .body' | rg -in "$pat"
+```
+
+Run all three before every push and before merging, in BOTH repos. Expected
+output: nothing (rg exits nonzero on no match, which is the pass state).
+Any hit in prose must be rewritten before pushing. A hit that is a literal
+package identifier in brepjs code, or inside a brepkit grandfathered file,
+is acceptable.
+
+## Pushing over HTTPS (SSH blocked)
+
+Both repos' `origin` is an SSH URL, port 22 is blocked, and a global
+`insteadOf` rewrite converts even explicit `https://github.com/...` URLs
+back to SSH. Full mechanics: see the pr-workflow skill, "Sandbox push
+details". The same token-embedded form works for brepjs:
+
+```bash
+git push "https://x-access-token:$(gh auth token)@github.com/andymai/brepjs.git" <branch> \
+  2>&1 | sed 's/x-access-token:[^@]*@/x-access-token:***@/g'
+```
+
+Consequences:
+
+- Explicit-URL pushes do NOT update `origin/<branch>` remote-tracking refs.
+  Never trust `git rev-parse origin/<branch>` for the remote head; use
+  `gh pr view <n> --json headRefOid` or
+  `gh api repos/andymai/<repo>/commits/<branch>`.
+- `gh` itself (pr create, view, merge, api) talks HTTPS and is unaffected.

--- a/.claude/skills/render-verify/SKILL.md
+++ b/.claude/skills/render-verify/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: render-verify
+description: Use when working with brepkit-render (offscreen GPU render, face-id buffer, interactive viewer, compute mesher, screen-space LOD) or when visually verifying a solid in this sandbox, including capturing a live viewer window headlessly, writing image-based render tests, or deciding between render checks and mesh watertightness checks.
+---
+
+# render-verify: GPU rendering and visual verification
+
+## When to use
+
+- You changed geometry, tessellation, booleans, or the render crate and need to SEE the result.
+- You need an automated image assertion (test that a render is non-blank, silhouette shape, seam holes).
+- You need to verify interactive behavior (orbit, zoom LOD, click-to-pick) in the live viewer.
+- You are tempted to conclude "renders fine, so the mesh is correct" (do not; see anti-patterns).
+
+For mesh manifoldness itself see the `tessellation` and `solid-verification` skills. For why analytic surface types survive operations, see `analytic-preservation`.
+
+## Quick reference
+
+| Goal | Tool | How |
+|---|---|---|
+| Automated image assertion | `render_solid_offscreen` | headless, no window; assert on `id_buffer` |
+| Compute-mesher / LOD assertion | `render_cylinder_compute_offscreen`, `render_cylinder_compute_screen_lod` | same, cylinder faces only |
+| Eyeball a solid | offscreen render, save PNG, Read it | fastest, no window needed |
+| Interactive behavior (pick, orbit, live LOD) | viewer example + X11 capture recipe | see Procedure B |
+| Watertightness | `is_watertight`, `boundary_edge_count`, `non_manifold_edge_count` in `crates/operations/src/tessellate/mesh_ops.rs` | NOT a render question |
+
+```bash
+cargo test -p brepkit-render                                    # offscreen render tests
+cargo run -p brepkit-render --example viewer --features window  # live viewer (needs display)
+```
+
+Crate map, full API signatures, LOD math, and the environment fact sheet: [reference.md](reference.md).
+
+## Procedure A: offscreen verification (default path)
+
+1. Gate on an adapter. `brepkit_render::probe_adapter()` returns `Some("Vulkan / NVIDIA ... (DiscreteGpu)")` style strings, or a software fallback (lavapipe) when no real GPU exists, or `None`. Tests must early-return on `None`, never fail. Copy the `let Some(_) = probe_adapter() else { return; }` pattern from `crates/render/tests/offscreen_render.rs`.
+2. Build the scene, render:
+   ```rust
+   let out = render_solid_offscreen(&topo, solid, &camera, &RenderOpts::new(800, 600))?;
+   out.color.save("/path/render.png")?;
+   ```
+3. Checkpoint: Read the PNG. Expect a shaded solid on a dark gray background (default `[0.11, 0.12, 0.14, 1.0]`) with dark edge lines. All-background image: see reference.md, symptom table.
+4. Assert on the face-id buffer, not color bytes. `out.face_id_at(x, y)` returns `None` for background or out-of-bounds; the stored `id_buffer` value is `FaceId.index() + 1`, `0` means background. Test helpers to copy from `crates/render/tests/`: `non_background_pixels`, `id_silhouette_bbox`, `horizontal_profile`, `interior_holes`.
+
+## Procedure B: live viewer verification (proven sandbox recipe)
+
+This sandbox has a real GPU and a live display `:0`. These steps are environment facts proven here, not brepkit code behavior.
+
+1. Launch, forcing X11. winit 0.30 prefers Wayland when `WAYLAND_DISPLAY` is set and a native Wayland window is not capturable here (`grim` is absent, `WINIT_UNIX_BACKEND` is ignored by winit 0.30). Run via the Bash tool with `run_in_background: true` (foreground `sleep` is blocked in the agent shell, so never `sleep && capture` in one command):
+   ```bash
+   env -u WAYLAND_DISPLAY DISPLAY=:0 cargo run -p brepkit-render --example viewer --features window
+   ```
+2. Checkpoint: find the window (poll across tool calls until it appears; first launch includes compile time):
+   ```bash
+   DISPLAY=:0 xwininfo -root -tree | grep -i 'brepkit viewer'
+   ```
+   Expect a line like `0x1c00007 "brepkit viewer ...": ... 1024x768+...`. No match after the build finished: see reference.md, symptom table.
+3. Capture with ImageMagick and Read the PNG. Use the window id from step 2, and write into your session scratchpad directory if the system prompt lists one (`${TMPDIR:-/tmp}` works as a fallback):
+   ```bash
+   DISPLAY=:0 import -window 0x1c00007 "${TMPDIR:-/tmp}/viewer.png"
+   ```
+4. Kill it by binary path, never by a word that appears in your own command line (`pkill -f` matches your own cmdline and self-kills with exit 144):
+   ```bash
+   pkill -f 'target/debug/examples/viewer'
+   ```
+
+Viewer controls: left-drag orbit, right-drag or shift+left-drag pan, scroll zoom, plain left click picks a face (tint via the id buffer, click again to clear).
+
+## The architectural bet
+
+brepkit preserves exact analytic surfaces (plane, cylinder, cone, sphere, torus) through operations. The render bet: ship the surface parameters to the GPU and evaluate the mesh there in a compute pass at a view-dependent LOD, instead of CPU-tessellating and uploading triangles. WebGPU has no tessellation or mesh shaders, hence the compute pass. This is why analytic preservation matters to rendering: a face degraded to NURBS cannot take this path. Currently shipped for cylinder faces only; module doc of `crates/render/src/compute_mesh.rs` is the source of truth.
+
+## Anti-patterns: what NOT to conclude
+
+- "It renders correctly, so the mesh is watertight." False. The rasterizer hides hairline gaps; a mesh with boundary edges can look perfect. Use `mesh_ops` counters.
+- "The mesh is watertight, so the render is correct." False. Watertight meshes can render with bad normals or wrong face ids. Check the image and `id_buffer` too.
+- "No adapter in CI means the render code is broken." No. Gate on `probe_adapter()` and skip.
+- "The compute mesher renders wrong, so tessellation is broken." They are separate paths: `render_solid_offscreen` uses CPU tessellation; the compute path is `render_cylinder_compute_*` only.
+- "The viewer would prove this" when an offscreen render answers the question. Offscreen first; the window is only for interaction and live LOD.
+- Do not document or rely on cone/sphere/torus compute meshing, quadric ray-casting, or a wasm render path. Roadmap, not shipped.
+- Do not assert on color bytes when the id buffer answers the question; shading changes with lighting defaults, ids do not.
+- Do not compare render performance against other kernels here; that lives in the `parity-benchmarking` skill via the brepjs harness.

--- a/.claude/skills/render-verify/reference.md
+++ b/.claude/skills/render-verify/reference.md
@@ -1,0 +1,112 @@
+# render-verify reference
+
+Deep catalog for `brepkit-render`. Everything here was verified against the repo; when in doubt, re-check with the `rg` patterns given. Line numbers are deliberately absent.
+
+## 1. Crate map
+
+`crates/render/` is an L4 leaf crate. Allowed deps: `brepkit-math`, `brepkit-topology`, `brepkit-operations`. `scripts/check-boundaries.sh` also rejects any crate that depends on render (see the `layer-boundaries` skill). Stack: wgpu + pollster; winit only behind the optional `window` feature (`window = ["dep:winit", "dep:log"]` in `crates/render/Cargo.toml`; the `viewer` example declares `required-features = ["window"]`).
+
+| File | Provides |
+|---|---|
+| `src/lib.rs` | `render_solid_offscreen`, `RenderOpts`, `RenderOutput`, `DEFAULT_DEFLECTION`, re-exports |
+| `src/pipeline.rs` | `probe_adapter`, `acquire_device`, `GpuContext`, `Pipelines`, `GeometryBuffers`, `encode_scene`, texture formats |
+| `src/mesh.rs` | `RenderMesh::build`: CPU tessellation to GPU buffers, face-id per vertex, RTC positions |
+| `src/camera.rs` | `Camera`, `view_proj_rtc(cam, center)` (folds the f64 model center into the view matrix) |
+| `src/viewer.rs` | `view_solid`, `ViewOpts` (feature `window` only) |
+| `src/compute_mesh.rs` | GPU compute mesher: `CylinderDescriptor`, `extract_cylinder_descriptor`, `TessFactor`, `screen_space_tess_factor`, `render_cylinder_compute_offscreen`, `render_cylinder_compute_screen_lod`, `DEFAULT_TARGET_PX` |
+| `shaders/mesh.wgsl`, `shaders/edge.wgsl` | Draw passes (shaded mesh + id target, edge overlay) |
+| `shaders/quadric_mesh.wgsl` | Compute mesher: `cs_vertices` / `cs_indices` entry points, `@workgroup_size(8, 8, 1)` |
+| `examples/viewer.rs` | Demo scene: 40x40x20 box fused with an r=10 h=35 cylinder via `boolean(.., BooleanOp::Fuse, ..)` |
+| `tests/offscreen_render.rs` | Offscreen smoke + size-validation tests, image-assertion helpers |
+| `tests/compute_mesh_render.rs` | Compute mesher vs CPU silhouette, seam, off-origin tests |
+| `tests/compute_mesh_lod.rs` | Screen-space LOD behavior tests |
+
+## 2. Offscreen API
+
+```rust
+pub fn render_solid_offscreen(
+    topo: &Topology, solid: SolidId, cam: &Camera, opts: &RenderOpts,
+) -> Result<RenderOutput, RenderError>
+```
+
+- `RenderOpts::new(w, h)` defaults: `edges: true`, `background: [0.11, 0.12, 0.14, 1.0]` (linear RGBA), `ambient: 0.25`, `deflection: DEFAULT_DEFLECTION` (0.05). Zero or oversized dimensions are rejected (tests `invalid_size_is_rejected`, `oversized_render_is_rejected`).
+- `RenderOutput { color: image::RgbaImage, id_buffer: Vec<u32>, width, height }`. `id_buffer` is row-major, `0` = background, else `FaceId.index() + 1`. `face_id_at(x, y) -> Option<u32>` returns the same encoding, `None` for background or out-of-bounds.
+- Formats (`src/pipeline.rs`): color `Rgba8UnormSrgb` (`COLOR_FORMAT_OFFSCREEN`), depth `Depth32Float` (`DEPTH_FORMAT`), id `R32Uint` (`ID_FORMAT`).
+- Mesh path: `RenderMesh::build` calls `brepkit_operations::tessellate::tessellate_solid_grouped_with_tolerance` (grouped mesh with `face_offsets`, one range per face plus a sentinel) and `sample_solid_edges` for the edge overlay. Positions are uploaded as f32 relative to the model's f64 AABB center (RTC); `view_proj_rtc` folds the center into the matrix so far-from-origin models stay precise.
+
+### Adapter gating
+
+`probe_adapter() -> Option<String>` returns `"{backend:?} / {name} ({device_type:?})"`. Device acquisition tries a real GPU first, then a software fallback (Mesa lavapipe via Vulkan), so offscreen tests pass on machines without hardware GPUs. Every render test starts with:
+
+```rust
+let Some(_) = probe_adapter() else {
+    return;
+};
+```
+
+### Image-assertion helpers (copy from tests, not exported)
+
+Defined in `crates/render/tests/*.rs`:
+
+- `non_background_pixels(&out, bg)`: count of color pixels differing from the background.
+- `id_silhouette_bbox(&out)`: bounding box of nonzero `id_buffer` pixels, `None` if blank.
+- `horizontal_profile(&out)`: per-row `(min_x, max_x)` of the id silhouette; compare profiles between two renders to assert silhouette equivalence (used to compare compute mesh vs CPU mesh).
+- `interior_holes(&out)`: background pixels strictly inside the silhouette; the seam-watertightness image check asserts this is 0.
+
+Prefer id-buffer assertions over color assertions: ids are invariant to lighting and shading defaults.
+
+## 3. Compute mesher (M2) and screen-space LOD (M2.1)
+
+Scope: cylinder lateral faces only, full `0..2π` angular range. `extract_cylinder_descriptor(topo, face)` errors with `RenderError::Operations` if the face is not `FaceSurface::Cylinder`; the axial trim `v0..v1` comes from projecting the outer-wire vertices onto the axis. Cone, sphere, torus, quadric ray-casting, and a wasm render path are roadmap, not shipped.
+
+- `TessFactor::new(n_u, n_v)` clamps `n_u` to `[3, 16384]`, `n_v` to `[1, 16384]` (`MAX_TESS = 16_384`).
+- The WGSL writes a flat `array<u32>` at `WORDS_PER_VERT = 7` (pos 3 + normal 3 + face_id 1, the 28-byte draw `Vertex` stride) so one buffer binds as STORAGE for the compute pass and VERTEX for the draw pass, reusing `shaders/mesh.wgsl` unchanged.
+- Entry points: `render_cylinder_compute_offscreen(desc, tess, face_id, cam, opts)` and `render_cylinder_compute_screen_lod(desc, face_id, cam, opts, target_px)` (the latter derives `n_u` per view; `DEFAULT_TARGET_PX = 0.5` px).
+
+LOD math (`screen_space_tess_factor`): projected pixel radius `r_px = r * (H/2) / (d * tan(fov_y/2))` where `d` is view-space depth (`view_dir . (center - eye)`). Chord error bound `r_px * (1 - cos(pi/n_u)) <= target_px` gives `n_u = ceil(pi / acos(1 - clamp(target_px / r_px, 0, 2)))`. Edge cases: camera engulfed (`r_px` infinite) or a non-finite/non-positive `target_px` budget yields `MAX_TESS` (a budget that cannot bound anything falls back to max detail); behind camera or NaN `r_px` yields the minimum (3); fov is clamped into `(0, pi)`. `n_v = 1` because a cylinder's lateral face is ruled.
+
+Verify silhouette smoothness scaling with the pattern in `tests/compute_mesh_lod.rs`: render at two distances, assert the closer render used more angular subdivisions and a smoother `horizontal_profile`.
+
+## 4. Viewer
+
+```rust
+pub fn view_solid(topo: &Topology, solid: SolidId, opts: &ViewOpts) -> Result<(), RenderError>
+```
+
+Blocks until the window closes. `ViewOpts::new(title)`, default 1024x768. Needs a surface, so it cannot run headlessly; anything assertable belongs in the offscreen path. Face picking reads the same `R32Uint` id target under the cursor and maps back to a kernel `FaceId`.
+
+Run: `cargo run -p brepkit-render --example viewer --features window`.
+
+## 5. Sandbox environment fact sheet (proven here, not code)
+
+- `DISPLAY=:0` is a live X display visible on the user's desktop; `WAYLAND_DISPLAY` is also set. The machine has a discrete NVIDIA GPU (`nvidia-smi` works).
+- winit 0.30 prefers Wayland when `WAYLAND_DISPLAY` is set; `WINIT_UNIX_BACKEND` is ignored (removed in winit 0.30). A native Wayland window cannot be captured here (`grim` is absent). Fix: `env -u WAYLAND_DISPLAY DISPLAY=:0 <cmd>` forces X11/XWayland, which is both visible and capturable.
+- Capture tools present: `import` and `xwininfo` (ImageMagick / X11 utils). Absent: `grim`.
+- Foreground `sleep` is blocked in the agent shell (dies with exit 144, even inside a backgrounded compound command). Run the viewer with the Bash tool's `run_in_background`, then poll for the window in later tool calls.
+- `pkill -f <pattern>` matches your own command line; if the pattern appears in your own invocation you kill yourself (exit 144). Match the binary path (`pkill -f 'target/debug/examples/viewer'`), never a bare word like `viewer` from a command containing it.
+
+## 6. Symptom-to-cause table
+
+| Symptom | Likely cause | Check |
+|---|---|---|
+| Test skipped / `probe_adapter()` is `None` | No GPU and no lavapipe in this environment | expected in bare CI; not a code bug |
+| Offscreen image is all background | Camera not looking at the solid, or solid empty/degenerate | print the solid AABB; check `id_silhouette_bbox` is `None`; verify the solid with the `solid-verification` skill |
+| Render OK but `face_id_at` gives unexpected ids | Off-by-one: buffer stores `FaceId.index() + 1` | subtract 1 before comparing to `FaceId.index()` |
+| Pixel gaps along a cylinder seam in compute renders | Seam vertices not bitwise-identical at u=0 and u=2pi | `interior_holes` > 0; see `compute_mesh_seam_is_watertight` in `tests/compute_mesh_render.rs` |
+| Compute render differs from CPU render | Compare silhouettes, not pixels: shading may differ legitimately | `horizontal_profile` diff, pattern in `compute_mesh_matches_cpu_silhouette` |
+| `extract_cylinder_descriptor` errors | Face is not `FaceSurface::Cylinder` (may have degraded to NURBS upstream) | inspect the face surface type; see the `analytic-preservation` skill |
+| Far-from-origin model shimmers or distorts | RTC path bypassed (raw f32 absolute positions) | positions must be center-relative; `view_proj_rtc` in `src/camera.rs` |
+| Viewer window never appears in `xwininfo` | Still compiling; or it opened as native Wayland | wait for the build; re-launch with `env -u WAYLAND_DISPLAY` |
+| `import` captures a black or wrong image | Wrong window id, or window unmapped | re-run `xwininfo -root -tree`, grep for `brepkit viewer` |
+| Viewer process refuses to die | Self-matching `pkill` killed your shell instead | kill by `target/debug/examples/viewer` path |
+| Render looks perfect but downstream consumers see holes | Rendering does not prove watertightness | `is_watertight` / `boundary_edge_count` in `crates/operations/src/tessellate/mesh_ops.rs` |
+
+## 7. Glossary
+
+- **face-id buffer**: per-pixel `R32Uint` target storing `FaceId.index() + 1` (0 = background); maps pixels back to kernel topology for picking and tests.
+- **RTC**: render-relative-to-center; f32 vertices relative to the f64 AABB center, center folded into the view matrix on CPU.
+- **quadric**: second-degree surface (cylinder, cone, sphere; torus grouped loosely); the compute mesher evaluates these parametrically on GPU.
+- **deflection**: linear chord tolerance for CPU tessellation; smaller = finer; render default 0.05.
+- **seam**: the u=0 / u=2pi closure line of a periodic surface; both sides must emit identical vertices or pixels leak.
+- **lavapipe**: Mesa's software Vulkan implementation; the adapter fallback that lets offscreen tests run without hardware.
+- **watertight / 2-manifold**: every mesh edge shared by exactly two triangles; orthogonal to "renders correctly".

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: roadmap
+description: Use at the start of an autonomous or unsupervised session to pick what to work on, when deciding whether a geometry case is worth chasing, when a task looks like something a past session already tried, or before claiming a case is closed. The sanctioned work-selection doctrine: what is open and ready, what is terminal, the chase filters, and the acceptance bar.
+---
+
+# Roadmap: choosing what to work on
+
+This is the sanctioned work-selection doctrine for autonomous sessions. It says what
+is open and ready, what is TERMINAL (do not re-attempt without new tooling), which
+work to chase and which to skip, and the bar a case must clear to be called closed.
+
+## This is a LIVING document: maintenance is mandatory
+
+When a session **closes, defers, or discovers** a work item, it MUST update this skill
+in the same PR. A stale roadmap is worse than none: past sessions burned large budgets
+rediscovering dead ends this file was supposed to name. Keep every entry to ONE line
+with a pointer (a test path, a git-history PR number, a memory-free source file) that
+carries the detail. Never duplicate the detailed truth here; point at the repro.
+
+The `#[ignore]` inventory below is the load-bearing artifact. Before quoting any
+"deferred" claim, regenerate and reconcile it:
+
+```bash
+rg -n -A2 '#\[ignore' crates/    # filter the 3 doc-comment false hits by hand
+```
+
+## When to use
+
+- Starting a session with no assigned task and needing to pick high-value work.
+- A task resembles something that may already be tried, closed, or proven impossible.
+- Deciding whether an analytic-recovery or parity case is worth the budget.
+- Before writing "this case is closed" anywhere.
+
+## The north star
+
+Replace the incumbent kernel in the gridfinity layout tool (`~/Git/gridfinity-layout-tool`)
+at full parity, across all its generator scenarios: 100% triangle correctness, volume
+correctness, manifold correctness, AND generation performance at least as good. Parity
+first, then beating it, is the acceptance bar. See `parity-benchmarking` for the harness.
+
+Campaign history, one paragraph: gridfinity bin parity reached (10/11 kernel-suite
+cases, PRs through #938); the four primitive-boolean mesh-fallbacks eliminated and made
+exact analytic that now beat the reference kernel 2.9-9.5x head to head (box-sphere
+intersect #1006, sphere-cyl cut #1005, perpendicular cyl-union #1008, torus-box #1010,
+all on the keystone surface-aware-AABB fix #1003); revolve made exact-analytic (#1012);
+GPU render milestones shipped (offscreen #1013, interactive viewer #1016, compute-mesher
+#1017, screen-space adaptive LOD #1021).
+
+## The priority filters (rules with reasons)
+
+1. **Chase operations that RE-CREATE an existing analytic surface type. Do NOT chase
+   ops that INVENT a blend or approximation surface.** A boolean or revolve result face
+   is a trimmed patch of an *input* surface, so it is always closable with the right
+   split. Fillet and chamfer walls, general sweep and loft side faces, and offsets of
+   NURBS input introduce a NEW surface with no closed form; they are fundamentally
+   approximate. See `analytic-preservation`.
+2. **Solve the NARROW case (coaxial, perpendicular, equal-radius), not the general
+   problem.** Every primitive-boolean win was gated to one specific configuration and
+   defers to the generic marcher otherwise. Sessions that reached for a general solver
+   burned budget and shipped nothing.
+3. **Prefer work with a stable primitive repro over work that needs tooling first.**
+   The four primitive-boolean cases (stable repros in
+   `crates/operations/examples/approx_census.rs`) were picked over the tooling-blocked
+   scoop case for exactly this reason.
+4. **After ANY GFA or boolean change, re-probe scenario face counts before claiming
+   anything.** Scorecards rot silently; a stale one once hid a regression through a
+   whole release. This is mandatory, not optional (see `parity-benchmarking`).
+
+## TERMINAL cases: do not re-attempt without the named missing primitive
+
+Several past sessions burned large budgets rediscovering these. Each needs a component
+that does not exist yet; without it, stop.
+
+- **Equal-radius perpendicular cylinder-union RENDER.** The exact seam is a
+  self-touching figure-eight (a genuine non-manifold singularity, odd Euler). The
+  shipped artifact (#1008: analytic B-Rep whose marched-NURBS seam dodges the touch,
+  plus exact closed-form volume) STANDS. Needs a face-split-at-pinch primitive on a
+  periodic wall, or a periodic-aware crossing-holes mesher. There is no
+  `exact_cylinder_cylinder` symbol; do not go looking for one.
+- **Plane-by-sphere splitting across the chord-discretized equator.** The general
+  capability behind box-sphere; a section circle's crossings miss a polygon-approximated
+  equator by the sagitta. Box-sphere was closed (#1006) with a case-specific seam-plane
+  fit (`rg -n 'seam_plane' crates/`). The general fix is a UV-space arrangement
+  splitter, a dedicated multi-day component not yet built. The boundary-plane
+  crossing technique is proven and reusable.
+- **Gridfinity scoop fuse (3x3 scoop+label+lip).** Root: a lip-foot cone must be split
+  with a coordinated staircase cone-split plus bracket-cap re-trim sharing the new edge;
+  every one-sided attempt regresses. Many sequential autonomous passes exhausted.
+  Parity is already MET via a correct-but-slow mesh fallback (this is perf-only). Note:
+  STEP-faithful in-memory repros now EXIST (`crates/io/tests/scoop*_inmem.rs`); the old
+  "needs serialization tooling first" framing is stale. The real blocker is the
+  coordinated split.
+- **Snap-clip deepened-notch case.** A later cut deepening an earlier opening strands
+  the old floor edge. The 2D polygon-union primitive it needs now EXISTS
+  (`crates/math/src/polygon_boolean.rs::polygon_union`). What remains is sound
+  deepened-notch detection that does not false-positive on near-coincident faces.
+- **A universal smarter merge-key for duplicate edges. PROVEN UNBUILDABLE.** The
+  gridfinity lip corner (chord + arc, same endpoints) MUST merge; the torus-box in-tube
+  lens (line + co-endpoint arc) MUST stay distinct. No merge-key discriminant separates
+  them; the distinction is global. Sanctioned pattern: splitter-side midpoint splits,
+  per case, so no two edges share both endpoints, and leave
+  `merge_duplicate_edges` (in `crates/algo/src/builder/builder_solid.rs`) alone. Control
+  the geometry you emit; do not make the shared merge smarter.
+
+## DEFERRED but ready: open items with a repro
+
+Regenerate the inventory (command above) and reconcile before trusting this table.
+Current genuine `#[ignore]` items worth work:
+
+| Item (repro) | Layer | Symptom / first probe |
+|---|---|---|
+| `dovetail_corner_clip_intersect_is_watertight` (`crates/io/tests/dovetail_cornerclip_intersect_inmem.rs`) | algo/GFA | Coincident-wall + analytic-corner Intersect drops the boundary; tool mesh-falls-back to a slab. The sibling non-ignored test reaches free<=1 raw, so the residual is the last corner-cap sub-face. Probe: `cargo test -p brepkit-io --test dovetail_cornerclip_intersect_inmem -- --ignored --nocapture`. |
+| `fuse_shelled_box_with_socket_loft` (`crates/operations/src/boolean/tests.rs`) | operations/loft + algo | Non-manifold edge at shelled-box + socket-loft fuse. Root: `loft` builds `EdgeCurve::Line` ring edges (`crates/operations/src/loft.rs`, `rg -n 'EdgeCurve::Line' crates/operations/src/loft.rs`) so an octagonal frustum cannot annihilate an arc-cornered cap. Gated on a curve-preserving loft. Probe: run it `-- --ignored`. |
+| Fillet closed-rim free-edges (latent, no ready repro) | blend | `split_edge_at` in `crates/blend/src/trimmer.rs` rebuilds only the trimmed face's wire, never the neighbor cap face, leaving boundary edges. The d5 repro was reworked to dodge it and now passes. See `fillet-blend`. |
+| Revolve follow-ups (no ignored test) | operations/revolve | Pointed-cone apex merge, annulus/washer-cap merge, partial-turn torus. All stay analytic+exact, merely over-segmented. Probe: `cargo run --release --example approx_census -p brepkit-operations` (`revolve_matrix`). |
+
+The remaining `#[ignore]` entries are diagnostics or slow perf cases, not open bugs:
+the `profile_intersect.rs` box-sphere probes are stale leftovers (box-sphere shipped
+analytic in #1006), `staircase_fuse_with_cylinders` is a ~2 min perf run, and the two
+`#696` dovetail entries plus `diverge_first_cut` are print-only diagnostics.
+
+CLOSED, do not re-open as deferred: honeycomb wall-pattern cut (#925/#928,
+`crates/io/tests/gridfinity_honeycomb_cut_inmem.rs` passes), reversed-edge periodic-copy
+top-face (#932, `extrude_half_*_reversed_edge_volume` pass), multi-arc hemisphere gap
+(#1006).
+
+## Subsystem trap notes (crates without their own skill)
+
+- **heal `fix_duplicate_faces` IS implemented** (solid-scoped, `crates/heal/src/fix/solid.rs`,
+  returns `Status::DONE2`), not a no-op stub. It compares only centroid, normal, and
+  edge count, so it can miss true-but-differently-wound duplicates; do not rely on it
+  for subtle cases. Verify current state before quoting either way.
+- **heal, offset, and sketch have no distilled campaign knowledge.** They follow the
+  same `debugging-doctrine`, but no skill covers their internals. Treat any diagnosis
+  there as first-of-kind and write findings down (a test comment or a new note).
+- **The v1 fillet deprecations are entangled with the public wasm API.**
+  `operations/src/fillet/mod.rs::fillet` and `fillet/rolling_ball.rs::fillet_rolling_ball`
+  are `#[deprecated]` yet still reached through the wasm `fillet` binding, via
+  `wasm/src/helpers.rs::try_fillet` (it tries `fillet_rolling_ball` and `fillet` in its
+  engine-preference chain). Migrating them changes public behavior; that is a product
+  decision, not safe cleanup. The offset v1 path was already dropped in #850.
+  `offsetSolid` now routes through the non-deprecated `offset_v2::offset_solid_v2`. See
+  `fillet-blend` and `wasm-bindings`.
+
+## Acceptance bar for a geometry campaign case
+
+Every box before "closed":
+
+- [ ] **Exact analytic result** where the inputs are analytic (typed faces, single to
+      low-tens face count, not hundreds).
+- [ ] **Watertight** tessellation (zero boundary edges).
+- [ ] **Manifold** B-Rep (every edge used by exactly two faces, Euler balanced).
+- [ ] **Full workspace suites green, INCLUDING** `cargo test -p brepkit-wasm --lib gridfinity`
+      (running only algo/io/operations has shipped a gridfinity regression before).
+- [ ] **Regression fixture shipped** with the fix (STEP or arena `.bin`; see `testing`).
+- [ ] **Census clean or improved:** the row flips FALLBACK to analytic
+      (`cargo run --release --example approx_census -p brepkit-operations`).
+- [ ] **Head-to-head timing at least parity** (the brepjs wasm bench; see
+      `parity-benchmarking`).
+- [ ] **Release published** when user-facing (see `release-flow`).
+
+## Anti-patterns
+
+- Do NOT re-attempt a TERMINAL case hoping this time is different; it needs the named
+  missing primitive, not another pass.
+- Do NOT reach for the general solver when the narrow case is what parity needs.
+- Do NOT call a case closed on an "exact analytic" census row alone; the census does not
+  check correctness (see `analytic-preservation`).
+- Do NOT quote a "deferred" or face-count claim without regenerating the inventory and
+  re-probing scenarios; both rot silently.
+- Do NOT close, defer, or discover an item and leave this skill unchanged.
+
+## Related skills
+
+`analytic-preservation` (the chase filters in depth), `parity-benchmarking` (the
+scenario re-probe and head-to-head), `debugging-doctrine` (before any multi-pass dig),
+`solid-verification` (the acceptance oracles), `testing` (fixtures and ready-repros),
+`fillet-blend` (the blend traps), `release-flow` (shipping a user-facing close).

--- a/.claude/skills/solid-verification/SKILL.md
+++ b/.claude/skills/solid-verification/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: solid-verification
+description: Ground-truth verification of any B-Rep result in brepkit. Use when checking whether a solid is watertight, manifold, correctly classified, or has the right volume; when signing off a boolean, offset, fillet, or other geometry change; when a volume looks wrong or disagrees across deflections; or when deciding whether a "passing" check actually proves the geometry is correct.
+---
+
+# Solid Verification
+
+## When to use
+
+You produced or modified a solid (boolean result, primitive, sweep, import, healed shape) and need to answer: is this geometry actually correct? This skill gives the verification ladder, what each rung proves and does not prove, and the traps that have produced wrong sign-offs before. For debugging a failing boolean itself, see the boolean-debugging skill. For mesh quality questions, see the tessellation skill.
+
+## The verification ladder (cheapest to strongest)
+
+Run rungs in order. Each rung's "does NOT prove" column is the point. Full API detail per rung: [reference.md](reference.md), section "Ladder detail".
+
+| Rung | Question | API (Rust) | Expect | A pass does NOT prove |
+|---|---|---|---|---|
+| 1. Census | Right face count and surface types? | `explorer::solid_entity_counts`, `FaceSurface::type_tag()` over `explorer::solid_faces`; `cargo run --release --example approx_census -p brepkit-operations` | Tens of faces, quadric types present for curved solids | Geometry is correct. An "exact analytic" result can still have an uncarved feature |
+| 2. Validation | Topologically sane? | `brepkit_operations::validate::validate_solid` (loop-aware Euler) or `brepkit_check::validate::validate_solid` (report with `CheckId`s) | 0 errors | The shape matches intent. A closed manifold of the WRONG shape passes |
+| 3. Free edges | B-Rep closed and manifold? | Errors from `validate_solid` ("boundary edge(s)", "non-manifold"), or `heal::analysis::free_bounds::find_free_bounds` for the loops | 0 free, 0 non-manifold | Faces were classified correctly by the boolean |
+| 4. Mesh watertight | Tessellation closed? | `tessellate_solid` then `mesh_ops::boundary_edge_count` and `non_manifold_edge_count` | Both 0 | The B-Rep is closed (the tessellator can stitch over small B-Rep gaps) |
+| 5. Classification | Is material where intended? | `brepkit_check::classify::classify_point` (ray-cast) at intent-encoding probe points | Inside carved features: `Outside`. Inside kept material: `Inside` | Anything between probes. A thin missing sliver escapes sparse probes |
+| 6. Volume/area | Quantity right? | `measure::solid_volume(topo, solid, deflection)` at two deflections, vs closed form when one exists | Agreement within ~1e-4 relative; converges as deflection refines | The feature was carved. Volume can read plausible while a cut never happened |
+
+## Procedure: verifying a boolean result
+
+1. Count faces and census the surface types (rung 1). Checkpoint: a clean analytic boolean of primitives has roughly 3 to 80 faces with cylinder/sphere/cone/torus types surviving. Hundreds to thousands of all-plane faces means the mesh fallback fired: the result is a co-refined triangle soup, not analytic B-Rep. Triangle counts and validity checks BOTH mask this; face census is the only reliable tell. If the fallback fired, stop and see the boolean-debugging skill.
+2. Validate (rungs 2 and 3). Checkpoint: `brepkit_operations::validate::validate_solid` returns an empty issue list, or only issues you can explain. Free edges must be 0. Note the check-crate `SolidEulerCharacteristic` check demands V-E+F == 2 exactly and will warn on any solid with a through-hole; the operations-crate validator applies the genus and inner-loop correction, so prefer it for boolean results. For assembled compounds that legitimately do not share edges, use `validate_solid_relaxed`.
+3. Mesh watertightness (rung 4). `is_watertight(&mesh)` from `operations/src/tessellate/mesh_ops.rs`, or the two counts separately. Checkpoint: both 0 at the deflection you ship with.
+4. Ray-cast spot checks (rung 5). Pick probes AT the feature being verified: pocket centers, wall midpoints, points just inside and just outside each cut face. Use `brepkit_check::classify::classify_point` with `ClassifyOptions::default()`. NEVER the winding classifier here (see below).
+5. Volume convergence (rung 6). Compute `solid_volume` at two deflections FINER than `bbox_diagonal * 5e-5` (coarser requests are clamped to that value and will trivially "agree"). Checkpoint: agreement within ~1e-4 relative, and match against a closed form if one exists. If volume moves as deflection refines, especially upward, the geometry is bad: inscribed meshes of good geometry converge to the truth from below.
+
+## Volume traps
+
+Details and the full path list: [reference.md](reference.md), section "Volume paths".
+
+- `solid_volume` clamps the tessellation deflection: `volume_tessellation_deflection` in `crates/operations/src/measure/volume.rs` returns `requested.min((bbox_diag * 5e-5).max(1e-9))`. It refines coarse preview deflections but never coarsens a fine request. Consequence: callers passing preview-tuned deflections still get accurate volume, and two coarse requests are not an independent convergence test.
+- There are three tiers of volume path inside `solid_volume`: analytic (`try_analytic_solid_volume` for pure sphere/cylinder/cone/torus, plus `analytic_faces_solid_volume` and `analytic_revolution_solid_volume` behind narrow structural guards), direct per-face (`solid_volume_from_faces`, `volume_from_direct_face_tessellation`), and whole-solid tessellation with signed tetrahedra. Which path fired matters when a volume looks wrong.
+- The check-crate `brepkit_check::properties::solid_volume` (naive Gauss sum over all faces via `face_integrator::integrate_face`) is NOT a safe exact path for general or boolean solids. It gets trimmed periodic faces and orientation issues wrong; the engine itself only uses it behind narrow guards. Recorded example (PR #959 investigation): a half-disc prism integrated 54.08 against a true 39.27. Do not reach for it as an independent oracle.
+- Never sign off a boolean on volume alone. Recorded precedent (PR #997): a seam-collapse bug produced a result whose slot was never carved, the census said "exact analytic", and the volume read plausible (about 1.4% high, diverging further with refinement). Ray-cast classification inside the supposed cut is the ground truth.
+
+## Point classification: which classifier
+
+- Rust ground truth: `brepkit_check::classify::classify_point` (analytic ray casting, majority vote over fixed ray directions, perturbed recovery rays). Returns `Inside | Outside | OnBoundary`.
+- The winding-number variants `classify_point_winding` and `classify_point_robust` return confidently WRONG answers (Outside for interior points) on faceted, stepped, boolean-result, and NURBS-heavy solids, and `robust` never falls back because the winding value is not near 0.5. This has caused multiple wrong diagnoses. Rule: winding only for clean analytic primitives, ray-cast for everything you are actually verifying.
+- Caveat: all check-crate classifiers walk `outer_shell()` faces only. A probe inside a cavity bounded by an inner shell is not tested against the cavity faces.
+- JS side: the `classifyPoint` binding routes to the operations-crate tessellation-based ray caster with a fixed deflection of 0.1. Fine for spot checks; in Rust prefer the check-crate analytic version.
+
+## Watertightness: two distinct questions
+
+- B-Rep watertight: every edge maps to exactly 2 faces. Check via `validate_solid` errors, or get the actual open loops from `find_free_bounds`.
+- Mesh watertight: `boundary_edge_count(&mesh) == 0 && non_manifold_edge_count(&mesh) == 0`.
+- They can disagree in both directions: the tessellator can stitch a closed mesh over a leaky B-Rep, and a closed B-Rep can tessellate with per-face seam boundary edges. Check both when it matters; `solid_volume` itself gates some paths on a watertight mesh and falls through rather than return a leaky volume.
+
+## Verification bar for shipping a geometry change
+
+1. Suite green: `cargo test --workspace`, `cargo clippy --all-targets -- -D warnings`, `./scripts/check-boundaries.sh` (see CLAUDE.md, Commands).
+2. Census unchanged or improved: `cargo run --release --example approx_census -p brepkit-operations`. No new approximation probes fire; face counts stay analytic-sized. Re-run this after every boolean-engine change; prior results go stale.
+3. Watertight both ways: B-Rep free edges 0 and non-manifold 0; mesh boundary edges 0.
+4. Ray-cast spot checks with `brepkit_check::classify::classify_point` at points that encode the intent of the change.
+5. Volume agreement within tolerance at two deflections finer than the clamp, plus closed-form match where available. Divergence under refinement means bad geometry.
+
+## Anti-patterns: what NOT to conclude
+
+- "Volume matches, so the cut happened." No. Verify with classification probes inside the cut.
+- "The mesh is watertight, so the B-Rep is closed." No. Check free edges separately.
+- "Validation passed, so the boolean is correct." No. Validation is topological; it cannot see a wrong-but-closed face selection.
+- "Winding says Outside, so the point is outside." Not on faceted or NURBS solids. Re-check with the ray-cast classifier before theorizing.
+- "Triangle count looks normal, so no mesh fallback." Triangle count masks the fallback. Only the face census tells.
+- "V-E+F != 2, so the solid is broken." Not if it has a through-hole or inner loops; use the operations-crate Euler check.
+- "Two volumes at 0.1 and 0.01 deflection agree, so it converged." Both were likely clamped to the same effective deflection. Use requests finer than `bbox_diag * 5e-5`.
+- "I walked `outer_shell()` and saw all the faces." Hollow solids have inner shells; use `explorer::solid_faces` (see CLAUDE.md, Walking faces in a solid).
+
+## Related skills
+
+boolean-debugging (when a rung fails on a boolean result), tessellation (mesh quality and deflection), analytic-preservation (keeping results analytic), parity-benchmarking (comparing against the reference kernel via the brepjs harness), testing (where verification assertions belong).

--- a/.claude/skills/solid-verification/reference.md
+++ b/.claude/skills/solid-verification/reference.md
@@ -1,0 +1,122 @@
+# solid-verification: reference
+
+Symbol catalog for the verification ladder. All paths and symbols verified against the current tree; if something does not resolve, re-locate it with the given `rg` pattern rather than trusting a line number.
+
+## Ladder detail
+
+### Rung 1: entity counts and surface census
+
+- `brepkit_topology::explorer::solid_entity_counts(topo, solid) -> (faces, edges, vertices)`. Locate: `rg -n 'pub fn solid_entity_counts' crates/topology/src/explorer.rs`.
+- `brepkit_topology::explorer::solid_faces(topo, solid) -> Result<Vec<FaceId>, _>` flattens outer plus inner shells. Always use this over walking `outer_shell()` (see CLAUDE.md, Walking faces in a solid).
+- Surface census: iterate `solid_faces`, call `FaceSurface::type_tag()` (an inherent method on the enum in `crates/topology/src/face.rs`). Edge equivalent: `EdgeCurve::type_tag()` in `crates/topology/src/edge.rs`.
+- Approximation census tool: `cargo run --release --example approx_census -p brepkit-operations` (source: `crates/operations/examples/approx_census.rs`). It installs a logger capturing `brepkit_approx`-target debug probes and reports, per operation, whether the result stayed analytic or which approximation path fired. Probe sites: `rg -n 'brepkit_approx' crates/operations/src/`.
+- Mesh-fallback tell: a clean analytic boolean of primitives yields roughly 3 to 80 faces with quadric surface types present. A mesh fallback yields hundreds to thousands of faces, all `plane`. Face count and census are the ONLY reliable tell; triangle count and validity both look normal after a fallback.
+- WASM: `getEntityCounts(solid) -> [f, e, v]`, `getSurfaceType(face)`, `getEdgeCurveType(edge)` in `crates/wasm/src/bindings/query.rs`.
+- Does not prove: representation quality is not correctness. An all-analytic, no-probe result can still be missing a carved feature (recorded precedent: PR #997).
+
+### Rung 2: validation reports (two validators, do not conflate)
+
+**(a) operations-crate validator, prefer for boolean results.** `crates/operations/src/validate.rs`:
+- `validate_solid(topo, solid)` returns the full issue list.
+- `validate_solid_with_options(topo, solid, &ValidationOptions { tolerance_scale })` (scale clamped internally to [0.1, 1000]). The bare-scale form `validateSolidWithOptions(solid, tolerance_scale)` is the WASM binding only.
+- `validate_solid_relaxed(topo, solid)` skips Euler, boundary-edge, non-manifold, and shell-connectivity checks for assembled geometry that legitimately does not share edges.
+- `euler_characteristic(topo, solid) -> i64`.
+- Its Euler check is loop-aware: V-E+F = 2(1-g) + L with L the count of inner wire loops; it errors only when the implied genus is negative or non-integral. Its edge checks come from `explorer::edge_to_face_map`: 0 faces per edge is an orphan (Error), 1 is a boundary edge ("shell is not closed", Error), 3 or more is non-manifold (Error).
+
+**(b) check-crate validator, richer per-check report.** `brepkit_check::validate::validate_solid(topo, solid, &ValidateOptions::default()) -> ValidationReport` in `crates/check/src/validate/mod.rs`. Options: `ValidateOptions { tolerance_scale, disabled_checks: HashSet<CheckId> }`. Report API: `is_valid()`, `error_count()`, `warning_count()`. `CheckId` variants (in `crates/check/src/validate/checks.rs`): `VertexOnCurve`, `VertexOnSurface`, `EdgeNoCurve3D`, `EdgeSameParameter`, `EdgeRangeValid`, `EdgeDegenerate`, `WireEmpty`, `WireNotConnected`, `WireClosure3D`, `WireRedundantEdge`, `WireSelfIntersection`, `FaceNoSurface`, `FaceOrientationConsistency`, `ShellEmpty`, `ShellConnected`, `ShellClosed`, `ShellOrientationConsistent`, `SolidEulerCharacteristic`, `SolidDuplicateFaces`. Severities: Info, Warning, Error.
+- Caveat: its `check_euler` (`crates/check/src/validate/solid.rs`) requires V-E+F == 2 exactly (Warning). It does not correct for genus or inner loops, so a legitimate solid with a through-hole warns here. Disable via `disabled_checks` or use validator (a).
+- WASM: `validateSolid(solid) -> u32` error count (routes to the operations validator, count only), `validateSolidRelaxed`, `validateSolidWithOptions(solid, tolerance_scale)` in `crates/wasm/src/bindings/measure.rs`.
+- Does not prove: all checks are topological or local-geometric. None compares against intent. A watertight, manifold, Euler-consistent solid can be the wrong shape.
+
+### Rung 3: free edges and Euler (B-Rep watertightness)
+
+- Programmatic: validator (a) errors quoted above; or check-crate `ShellClosed` ("shell has {n} free (boundary) edges", `crates/check/src/validate/shell.rs`).
+- To get the actual open loops for inspection: `brepkit_heal::analysis::free_bounds::find_free_bounds(topo, shell_id) -> Result<Vec<Vec<EdgeId>>, _>`. Per shell: for hollow solids run it on the outer shell and every inner shell.
+- Raw map: `explorer::edge_to_face_map(topo, solid)`; expect every edge to map to exactly 2 faces.
+- JS: `edgeToFaceMap(solid)` binding in `crates/wasm/src/bindings/query.rs`; count 1-face entries.
+- Does not prove: closed and manifold does not mean correctly classified. A boolean can keep the wrong face set and still assemble a perfectly closed manifold. Note a spur (a face fan sharing one edge 3+ ways) does surface here as non-manifold.
+
+### Rung 4: mesh watertightness
+
+- `brepkit_operations::tessellate::tessellate_solid(topo, solid, deflection) -> Result<TriangleMesh, _>` (`crates/operations/src/tessellate/solid.rs`).
+- From `crates/operations/src/tessellate/mesh_ops.rs`:
+  - `boundary_edge_count(&mesh)`: directed half-edges without an opposite. Expect 0.
+  - `non_manifold_edge_count(&mesh)`: undirected edges referenced by 3+ triangles. Expect 0.
+  - `is_watertight(&mesh)`: both zero.
+- Test-suite idiom: see `tessellate_solid_box_watertight` in `crates/operations/src/tessellate/tests.rs`.
+- Does not prove: mesh closure does not prove B-Rep closure (the tessellator stitches shared boundary vertices and can close over small B-Rep defects). And a watertight mesh of the wrong solid is still wrong.
+
+### Rung 5: point classification
+
+**check crate (`crates/check/src/classify/mod.rs`), recommended in Rust:**
+- `classify_point(topo, solid, point, &ClassifyOptions::default()) -> Result<PointClassification, _>`. Analytic ray casting against face surfaces (`crates/check/src/classify/ray_surface.rs`) with UV boundary containment, three fixed irrational ray directions, majority vote with early exit, up to `max_recovery_attempts` perturbed recovery rays. `ClassifyOptions { tolerance: 1e-6, max_recovery_attempts: 10 }`. Returns `Inside | Outside | OnBoundary`. This matches what the boolean builder itself uses (`crates/algo/src/classifier/ray_cast.rs`).
+- `classify_point_winding`: generalized winding number, threshold 0.5.
+- `classify_point_robust`: winding first, ray-cast fallback only when winding lands in (0.4, 0.6).
+- The trap: on faceted, stepped, boolean-result, or NURBS-heavy solids, winding lands confidently in the wrong bucket, so `robust` never falls back and both return Outside for interior points. This cost multiple debugging sessions chasing a wrong theory. Rule: ray-cast `classify_point` for anything you are verifying.
+- Code caveat: all three walk `solid.outer_shell()` faces only. Points inside a cavity bounded by an inner shell are not tested against the cavity faces.
+
+**operations crate (`crates/operations/src/classify.rs`), tessellation-based:**
+- Same-named `classify_point(topo, solid, point, deflection, tolerance)`: ray casting against tessellated faces, so deflection-dependent.
+- The WASM `classifyPoint` binding routes here with a hardcoded deflection of 0.1 (`crates/wasm/src/bindings/measure.rs`), returning `"inside" | "outside" | "boundary"`. `classifyPointWinding` and `classifyPointRobust` bindings live in `crates/wasm/src/bindings/operations.rs`; the same winding caveat applies.
+
+Probe selection: sample the intent, not the space. Centers of every carved pocket (expect Outside), midpoints of every kept wall (expect Inside), pairs just inside and just outside each cut face. Sparse random probes miss thin slivers.
+
+### Rung 6: volume and area
+
+- `brepkit_operations::measure::solid_volume(topo, solid, deflection) -> Result<f64, _>` (`crates/operations/src/measure/volume.rs`).
+- `solid_surface_area(topo, solid, deflection)` (`crates/operations/src/measure/area.rs`): sums per-face areas, analytic formulas where the surface type allows, tessellation fallback otherwise.
+- WASM: `volume(solid, deflection)` in `crates/wasm/src/bindings/measure.rs`. The deflection clamp lives in the kernel, so preview-tuned caller deflections still produce accurate volumes.
+
+## Volume paths
+
+`solid_volume` tries these in order (read the function body in `crates/operations/src/measure/volume.rs`; locate with `rg -n 'pub fn solid_volume' crates/operations/src/measure/volume.rs`):
+
+| # | Path | Symbol | Fires when |
+|---|---|---|---|
+| 1 | Closed form | `try_analytic_solid_volume` | Pure primitive: sphere, cylinder, cone/frustum, torus. Not box (all-planar solids fall through and are exact via tessellation). Bails on any NURBS face or any face with inner wires |
+| 2 | Guarded Gauss | `analytic_faces_solid_volume` | All-analytic solid matching narrow structural guards (e.g. bored sphere with constant-v outer wire); uses `brepkit_check::properties::face_integrator::integrate_face` per face |
+| 3 | Revolution | `analytic_revolution_solid_volume` | Fully analytic surface-of-revolution solid: one shared axis, concentric circular caps, no NURBS, no inner wires. Deliberately narrow so it never fires on boolean results with arc-bounded planar caps |
+| 4-5 | Gated mesh | shape guards + `signed_volume_from_mesh` | Specific boolean shapes (scalloped-sphere collar, torus notch band), gated on `mesh_boundary_edge_count == 0`; falls through rather than return a leaky volume |
+| 6 | Direct faces | `solid_volume_from_faces` | All-planar-triangular solids (mesh imports) |
+| 7 | Per-face tess | `volume_from_direct_face_tessellation` | Faces with inner wires or reversed non-planar faces |
+| 8 | Whole-solid tess | `tessellate_solid` + `signed_volume_from_mesh`, fallback `volume_from_per_face_tessellation` | Everything else. Signed tetrahedra: abs(sum of v0 dot (v1 cross v2)) / 6 |
+
+Mental model: an analytic tier (1-3), a direct/per-face tier (6-7), a tessellation tier (4-5, 8).
+
+### The deflection clamp
+
+`volume_tessellation_deflection(topo, solid, requested)` computes the bbox diagonal and returns `requested.min((diag * 5e-5).max(1e-9))`. It refines coarse requests, never coarsens fine ones. The motivation (see the code comments nearby): inscribed meshes under-count curved faces by roughly 1-2% at preview deflections.
+
+Convergence-test consequence: two coarse requests (say 0.1 and 0.01) may both clamp to the same effective deflection and trivially agree. To genuinely test convergence, request deflections finer than `bbox_diag * 5e-5`, or scale requests off the bbox.
+
+### Why the check-crate Gauss integrator is not a general oracle
+
+`brepkit_check::properties::solid_volume` (`crates/check/src/properties/mod.rs`, default `gauss_order: 5`) sums `face_integrator::integrate_face` over all faces with no structural guards. It mishandles trimmed periodic faces (a half-cylinder lateral integrates as the full period) and is sensitive to face orientation errors that the tessellation path's abs() tolerates. Recorded findings from the PR #959 investigation: half-disc prism 54.08 vs true 39.27; wrong results on box-sphere booleans. The engine only trusts `integrate_face` behind the narrow guards of paths 2 and 3. Known latent issue feeding this: `wire_polygon` in `crates/check/src/util.rs` samples closed circle/ellipse/NURBS edges but reduces a NON-closed arc edge to its endpoint vertex, so open arcs become chords and corrupt `check::properties` area/volume for arc-bounded planar faces.
+
+### Divergence heuristics (recorded findings, not code facts)
+
+- Good geometry: inscribed-mesh volume converges to the truth from below as deflection refines.
+- Volume that moves as deflection refines, especially upward, signals broken geometry (self-intersection, collapsed seam, doubled faces). The PR #997 seam-collapse result read about 1.4% high and got worse with refinement.
+- Volume can be plausible while the intended cut never happened. Volume never signs off a boolean alone; pair with rung 5 probes inside the supposed cut.
+
+## Quick command crib
+
+```bash
+cargo run --release --example approx_census -p brepkit-operations
+rg -n 'pub fn solid_volume' crates/operations/src/measure/volume.rs
+rg -n 'pub fn classify_point' crates/check/src/classify/mod.rs crates/operations/src/classify.rs
+rg -n 'pub fn (is_watertight|boundary_edge_count|non_manifold_edge_count)' crates/operations/src/tessellate/mesh_ops.rs
+rg -n 'pub fn validate_solid' crates/operations/src/validate.rs crates/check/src/validate/mod.rs
+```
+
+For head-to-head numeric comparison against the reference kernel, use the brepjs harness (see the parity-benchmarking skill); do the comparison at the JS binding layer, not by re-deriving expected values by hand.
+
+## Glossary
+
+- **GFA**: brepkit's boolean engine (`crates/algo`): pave-filler intersection phases plus a builder that splits faces, classifies pieces, and assembles the result.
+- **Mesh fallback**: when the analytic boolean fails, meshes are co-refined instead; detected by face count and census, not triangle count.
+- **Census**: the `approx_census` example; per-operation analytic-vs-approximation report driven by `brepkit_approx` log probes.
+- **Deflection**: max chord deviation for tessellation; smaller is finer.
+- **Free (boundary) edge**: a B-Rep edge referenced by exactly one face, meaning an open shell. Mesh analogue: a half-edge with no opposite.
+- **Inscribed-mesh undercount**: tessellation vertices lie on curved surfaces, so mesh volume of good geometry converges from below; upward drift under refinement means broken geometry.
+- **Inner shells**: cavity shells of a hollow solid; anything walking only `outer_shell()` silently skips them.

--- a/.claude/skills/tessellation/SKILL.md
+++ b/.claude/skills/tessellation/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: tessellation
+description: Use when meshing B-Rep faces or debugging tessellation output in crates/operations/src/tessellate/. Triggers: mesh cracks at shared face boundaries, boundary_edge_count > 0, non-manifold edges, a hole on a sphere/torus skinned over (mesh area too large), flipped triangle normals, adding or changing a face mesher, or choosing between CDT and a structured band mesher on a periodic surface (cylinder, cone, sphere, torus).
+---
+
+# Tessellation: watertight meshing of B-Rep faces
+
+## When to use
+
+You are producing or debugging a `TriangleMesh` from a solid: cracks between faces, `boundary_edge_count(mesh) > 0`, wrong mesh area or volume, flipped normals, or you are adding a mesher path. All CPU meshing lives in `crates/operations/src/tessellate/`. For verifying the overall solid (volume, Euler, validity) see the **solid-verification** skill; for booleans producing bad faces to mesh, see **boolean-debugging**; for keeping faces analytic in the first place, see **analytic-preservation**.
+
+## Quick reference
+
+```rust
+use brepkit_operations::tessellate::{
+    tessellate_solid, is_watertight, boundary_edge_count, non_manifold_edge_count,
+};
+
+let mesh = tessellate_solid(&topo, solid, 0.1)?;
+assert_eq!(boundary_edge_count(&mesh), 0);
+assert!(is_watertight(&mesh));
+```
+
+`is_watertight` == boundary edges 0 AND non-manifold edges 0. Defined in `crates/operations/src/tessellate/mesh_ops.rs`, re-exported from `tessellate/mod.rs`. `TriangleMesh { positions, normals, indices }` is in `tessellate/mod.rs`. Deflection is the max chord sag; the default angular tolerance is `brepkit_math::chord::DEFAULT_ANGULAR_TOL`.
+
+Locate the meshers and the dispatch:
+
+```bash
+rg -n 'pub\(super\) fn tessellate_' crates/operations/src/tessellate/nonplanar.rs
+rg -n 'handled_notch|handled_band|tessellate_revolution_band_shared' crates/operations/src/tessellate/solid.rs
+```
+
+Expected mesher set (verify, do not assume): `tessellate_revolution_band_shared`, `tessellate_torus_notch_band`, `tessellate_latitude_band_shared`, `tessellate_nonplanar_cdt`, `tessellate_nonplanar_snap`. Full inventory and dispatch order: see [reference.md](reference.md), section "Mesher inventory".
+
+## Core doctrine: shared vertices by construction
+
+Independently triangulated adjacent faces crack at their shared boundary. `tessellate_solid` samples every edge exactly once into a shared pool (`edge_global_indices`); every face's boundary triangles must reference those shared global ids. Two ways a face can fail this:
+
+1. **The snap path** (`tessellate_nonplanar_snap`) meshes the face independently and reconciles rim vertices to the pool by 1e-6 proximity. When independent rim sampling and shared-edge sampling diverge by one segment (a radius/deflection dependent off-by-one), rim vertices land at different angles, miss the snap, and become near-coincident duplicates: a crack. This is issue #696 (drilled magnet hole); the rationale is in the doc comment of `tessellate_revolution_band_shared` in `nonplanar.rs`.
+2. **Free CDT on a periodic wall.** Unwrapping u to a flat strip and welding u=0 to u=2pi still leaves the wall CDT free to disagree with a separately triangulated cap disc exactly at the cap-rim/seam corner. CDT cannot weld to a mesh it did not build. Same crack class as #696.
+
+**Rule: periodic-wall bands get STRUCTURED meshers that consume the shared rim vertex ids directly.** Each structured mesher is deliberately narrow, checks its exact shape, and returns `Ok(false)` to defer to the fallback chain otherwise. When adding one, copy that contract: never guess, always defer.
+
+CDT (`tessellate_nonplanar_cdt`) is correct for faces whose UV boundary is a genuine simple polygon: non-periodic patches, partial-revolution faces, faces with inner wires that do not wrap the seam.
+
+## Verify a change (procedure)
+
+1. Build the shape, tessellate at two deflections (e.g. 0.1 and 0.5). Sampling-density bugs are deflection dependent; one value can pass by luck.
+2. Check `boundary_edge_count(&mesh) == 0` and `non_manifold_edge_count(&mesh) == 0` at both. A small stable nonzero count (say 8) localized at seam/rim corners means a shared-vertex violation, not "almost done tuning". See [reference.md](reference.md), "Reading a nonzero boundary count".
+3. Check orientation via signed volume: integrate the mesh (divergence theorem, as `measure/volume.rs` does) and compare against the analytic volume. Sign flip = global winding wrong; magnitude too large = a hole skinned over; too small = a face missing or inverted run.
+4. All tessellation tests live in `crates/operations/src/tessellate/tests.rs` (included via `mod tests;` in `tessellate/mod.rs`); add one there that asserts bd=0 for your exact shape class.
+
+## Symptom to cause
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| Cracks at a hole rim or cap boundary | Snap path proximity miss (off-by-one rim sampling) | Did dispatch fall through to `tessellate_nonplanar_snap`? Instrument `solid.rs` dispatch |
+| Mesh area/volume too LARGE on a bored sphere/torus | Constant-v band degenerated in UV, CDT skinned the hole | Should have hit `tessellate_latitude_band_shared`; check its early-return conditions |
+| Stable small nonzero boundary count at seam corners | CDT wall vs separately meshed cap disagreement | Needs a structured shared-vertex mesher, not CDT tuning |
+| Zero-extent face, empty triangulation on a closed edge | Endpoint-derived range on a closed edge (start == end) | `edge_sampling.rs` `is_closed()` handling; sample along the curve |
+| Scattered flipped triangles inside one face, thin slivers | Per-triangle normal flipping on stitch triangles | Orient the whole run once: `orient_triangle_run` in `nonplanar.rs` |
+| Whole face wound inward | Run-level flip decision wrong (degenerate largest triangle) | `orient_triangle_run` normal comparison at the centroid |
+| Non-manifold edges after boolean | Upstream face topology (figure-eight wires), not the mesher | See **boolean-debugging**; also `crates/heal/src/upgrade/split_self_intersecting_wires.rs` |
+
+## Degenerate-UV traps
+
+- **Constant-v bands give CDT nothing to bound.** A sphere/torus band between two constant-v full-revolution loops projects each boundary to a zero-area back-and-forth segment in UV; CDT then fills the removed cap. The dispatch comment in `solid.rs` (search `degenerates in UV`) documents this. Structured band meshers exist because of it.
+- **Closed edges: start == end.** Any quantity derived from a closed edge's endpoints (param range, winding, extent) collapses to zero. `circle_param_range` and `sample_edge` in `edge_sampling.rs` special-case `edge.is_closed()` to return the full period. Rule: whenever an edge can be closed, sample points along the curve; never derive from endpoints. The boolean engine learned the same lesson (`face_boundary_all_degenerate` in `crates/algo/src/pave_filler/phase_ff.rs` samples along curves).
+
+## Triangle orientation: orient runs, not triangles
+
+Structured meshers emit a coherently wound run, then make ONE flip decision for the whole run via `orient_triangle_run` (`nonplanar.rs`): take the largest-area triangle (most reliable normal), compare its geometric normal to the surface outward normal at its centroid, flip the entire run if they disagree. Per-triangle flipping is unstable on the thin stitch triangles that bridge unevenly sampled rings; it flips neighbors inconsistently and breaks the 2-manifold. If you write a new stitching routine, emit raw, then orient the run.
+
+## Known-terminal case: crossing seam holes
+
+A full-revolution periodic wall carrying two hole loops that CROSS each other (figure-eight, pinching at two points; the equal-radius perpendicular cylinder-union wall) is not triangulable by any current path. Two crossing hole loops are invalid hole topology for flat CDT, and the wall is periodic so flat-strip CDT cracks at the seam. Do not grind this blind. Bounded fixes only; details and what a real fix requires are in [reference.md](reference.md), "Crossing seam holes". Note `split_self_intersecting_wires.rs` in heal is a wire-topology cleanup and is NOT the missing geometric face split.
+
+## GPU path: keep faces analytic
+
+CPU tessellation is not the only consumer of surface parameters. `crates/render/src/compute_mesh.rs` meshes cylinders on the GPU from packed analytic descriptors at screen-space LOD (`CylinderDescriptor`, `screen_space_tess_factor`). Cylinder only at time of writing; verify with `rg -n 'Descriptor' crates/render/src/compute_mesh.rs` before claiming more. Any operation that degrades an analytic face to NURBS or mesh kills this path for that face. See the **analytic-preservation** skill; audit degradations with `cargo run --release --example approx_census -p brepkit-operations`.
+
+## Anti-patterns
+
+- Do NOT conclude "CDT just needs denser sampling" when boundary edges sit at seam or rim corners. That is a structural shared-vertex problem; density changes move the cracks, they do not close them.
+- Do NOT snap vertices by proximity as a fix. Snapping is the disease (#696), not the cure.
+- Do NOT widen a structured mesher's acceptance heuristically. If the shape check is not exact, return `Ok(false)` and let the chain fall through; a wrong structured mesh is worse than a snap-path crack.
+- Do NOT fix winding per-triangle. Orient the run.
+- Do NOT derive anything from a closed edge's endpoints.
+- Do NOT tessellate inside L0-L2 crates to work around a hard face. Tessellation lives in operations (L3); core stays analytic (see CLAUDE.md, layer rules).
+- Do NOT treat one passing deflection value as proof; sampling off-by-ones are deflection dependent.

--- a/.claude/skills/tessellation/reference.md
+++ b/.claude/skills/tessellation/reference.md
@@ -1,0 +1,144 @@
+# Tessellation reference
+
+Deep catalog backing SKILL.md. All symbols verified against main; re-verify with the rg patterns given (line numbers rot, symbols mostly do not).
+
+## Mesher inventory
+
+All in `crates/operations/src/tessellate/nonplanar.rs`. Find current set:
+
+```bash
+rg -n 'pub\(super\) fn tessellate_' crates/operations/src/tessellate/nonplanar.rs
+```
+
+| Mesher | Handles | Contract |
+|---|---|---|
+| `tessellate_revolution_band_shared` | Cylinder/Cone lateral face: a simple two-rim full-revolution band. No inner wires, exactly two closed rim-circle edges, everything else seam lines, matching shared-vertex counts on the two rims. | Reuses shared rim vertex ids from `edge_global_indices`; watertight by construction. Returns `Ok(false)` for anything else. |
+| `tessellate_torus_notch_band` | Torus minus box notch: a kept toroidal patch wrapping the tube angle v fully, bounded by two v-wrapping seam-arc loops at the ends of a ring-angle (u) span; swept along u. | Boundary loops use shared wall vertices. Returns `Ok(false)` for any other torus face. |
+| `tessellate_latitude_band_shared` | Sphere/Torus band between two full-revolution boundaries, exactly one inner wire. Two modes: constant-v latitude band (bored sphere), and a varying-v scalloped collar (box-intersect-sphere: scalloped floor plus latitude-cap ceiling). | Boundary rows reuse shared rim global ids; interior rows are fresh surface-evaluated points. Collar helpers: `collect_var_v_ring`, `build_collar_row`, `emit_aligned_quad_strip`, `stitch_rings`. Returns `Ok(false)` otherwise. |
+| `tessellate_nonplanar_cdt` | Everything with a genuine simple UV boundary polygon: partial-revolution patches, NURBS faces, non-degenerate holed faces. | UV-space constrained Delaunay. Fallible; caller checks error or empty output. |
+| `tessellate_nonplanar_snap` | Last resort. Meshes the face independently, snaps boundary vertices to the shared pool by 1e-6 proximity. | Crack-prone (issue #696). Never prefer it; it exists so nothing returns an empty mesh. |
+
+Planar faces take a separate path (`crates/operations/src/tessellate/planar.rs`); this file covers nonplanar only.
+
+## Dispatch chain
+
+In `tessellate_face_with_shared_edges` in `crates/operations/src/tessellate/solid.rs` (find it with `rg -n 'fn tessellate_face_with_shared_edges' crates/operations/src/tessellate/solid.rs`):
+
+```bash
+rg -n 'handled_notch|handled_band|is_standard_rect|tessellate_revolution_band_shared' crates/operations/src/tessellate/solid.rs
+```
+
+- **Cylinder/Cone, "standard rect" outer wire** (at most 4 edges, all `EdgeCurve::Line` or `EdgeCurve::Circle`): try `tessellate_revolution_band_shared`; on `Ok(false)` fall to snap.
+- **Cylinder/Cone, non-standard wire**: CDT; on error or zero triangles emitted, truncate the partial output back to the saved lengths and fall to snap.
+- **Sphere/Torus**: `tessellate_torus_notch_band` first (torus only), then `tessellate_latitude_band_shared`, then CDT, then snap. Same truncate-on-failure discipline.
+
+The truncation bookkeeping matters: CDT may have appended positions/normals/indices before failing. Any new fallible mesher slotted into the chain must save `positions.len()`, `normals.len()`, `indices.len()` (and `point_to_global` size where used) and truncate on failure, or the merged mesh gets orphan vertices and partial fans.
+
+## Shared edge pool
+
+`tessellate_solid` samples every edge once into `edge_global_indices: DetHashMap<usize, Vec<u32>>` mapping edge index to the ordered global vertex ids along that edge. Adjacent faces stitch because both reference the same ids. A structured mesher's job is to build its boundary rows FROM these ids, not from its own re-sampling of the same circle. If your mesher evaluates the surface to place a boundary vertex that an edge already owns, you have reinvented the snap path.
+
+Entry points (`crates/operations/src/tessellate/solid.rs`):
+
+```rust
+pub fn tessellate_solid(topo, solid, deflection) -> Result<TriangleMesh, OperationsError>
+pub fn tessellate_solid_with_tolerance(topo, solid, deflection, angular_tol) -> ...
+pub fn tessellate_solid_for_boolean(...)   // keeps the circle curvature floor for co-refinement
+pub fn tessellate_solid_grouped_with_tolerance(...)  // per-face groups, for render/face-id buffers
+```
+
+## Watertightness API
+
+`crates/operations/src/tessellate/mesh_ops.rs`, re-exported at `brepkit_operations::tessellate`:
+
+```rust
+pub fn is_watertight(mesh: &TriangleMesh) -> bool
+pub fn boundary_edge_count(mesh: &TriangleMesh) -> usize
+pub fn non_manifold_edge_count(mesh: &TriangleMesh) -> usize
+```
+
+- `boundary_edge_count`: directed half-edges (a,b) lacking an opposite (b,a).
+- `non_manifold_edge_count`: undirected edges referenced by 3 or more triangles. Edges used exactly once are NOT counted here; they are boundary edges, counted separately by `boundary_edge_count`. Always assert both.
+- `is_watertight`: both counts zero.
+
+### Reading a nonzero boundary count
+
+- **Large and scattered**: a face failed to mesh (empty output swallowed) or a whole face's boundary missed the pool. Diff the per-face grouped output.
+- **Small and stable across deflections, localized at cap-rim/seam corners**: structural. Two meshers disagree about vertices at a corner where a periodic seam meets a rim. Only shared-vertex-by-construction closes it; parameter tuning relocates it.
+- **Exactly proportional to a ring's segment count**: an entire rim failed to weld (off-by-one segment count between rim and pool). Check who sampled that circle and with what count.
+
+### Orientation check
+
+No single-call API. Pair watertightness with signed volume: the divergence-theorem integral over the mesh (see how `crates/operations/src/measure/volume.rs` consumes tessellation) must match the analytic volume in sign and magnitude. Sign wrong: global winding flipped. Magnitude high: a hole skinned over. Magnitude low: a face missing or an inverted run canceling volume.
+
+## Closed-edge sampling detail
+
+`crates/operations/src/tessellate/edge_sampling.rs`:
+
+```bash
+rg -n 'is_closed' crates/operations/src/tessellate/edge_sampling.rs
+```
+
+`circle_param_range` returns the full `(0, TAU)` range when `edge.is_closed()`; `sample_edge` does the equivalent for closed Ellipse edges. Without this, start == end makes the param range zero and the edge contributes one point.
+
+The parallel lesson boolean-side: `crates/algo/src/pave_filler/phase_ff.rs` (`sphere_region_axis`, `face_boundary_all_degenerate`) samples several points along each boundary curve instead of trusting endpoints, because a degenerate seam `Line(v0, v0)` has zero endpoint extent yet spans the full period, and a closed Circle is a real loop. Anywhere an edge can be closed or degenerate: sample along the curve.
+
+## orient_triangle_run mechanics
+
+`fn orient_triangle_run` in `nonplanar.rs`. Contract: the run appended from `idx_start` onward is already wound coherently by construction; the function only decides whether that single orientation needs a global flip. It scans for the largest-area triangle (best-conditioned normal), projects its centroid to (u,v), compares the triangle's geometric normal against the surface outward normal there, and if they disagree swaps indices t+1/t+2 for every triangle in the run.
+
+Why not per-triangle: thin stitch triangles bridging a clustered ring to an evenly sampled ring have near-degenerate normals; per-triangle correction flips neighbors inconsistently and produces a non-manifold fan. `emit_aligned_quad_strip` deliberately emits raw with no winding correction for exactly this reason; the caller orients the whole strip afterwards.
+
+If a whole face comes out inverted, suspect the flip decision itself: the largest triangle can still be a sliver on pathological faces, or the centroid projection can land across a seam. Check the (u,v) the centroid projects to.
+
+## Crossing seam holes (known-terminal, do not grind)
+
+The shape: a full-revolution periodic wall (u = 0 identified with u = 2pi) whose two hole loops cross each other, meeting in a figure-eight that pinches at two points. Canonical producer: the union of two equal-radius perpendicular cylinders (Steinmetz configuration); the lateral wall of either cylinder carries both intersection loops and they cross.
+
+Why every current path fails:
+
+1. Two crossing hole loops are invalid hole topology for any flat CDT-with-holes; the loops are not disjoint simple polygons.
+2. The wall is periodic, so flat-strip CDT (unwrap u, weld the strip edges) still cracks at the seam corners against separately meshed caps (the doctrine failure from SKILL.md).
+3. The torus-notch arc trick does not transfer: that band is bounded, non-periodic in the swept direction, and its loops do not cross.
+4. Chasing exact intersection curves makes topology worse near the pinch, not better: as the loops approach the true crossing the mesh becomes genuinely non-manifold at the pinch points.
+
+What a real fix requires (bounded scope, neither exists today):
+
+- A **face-split-at-pinch primitive**: split a face at a boundary self-intersection vertex into simple-loop lobe faces on a periodic wall. This is a geometric/topological operation on the B-Rep, upstream of tessellation.
+- Or a **periodic-seam-aware holed-band tessellator** that natively resolves two crossing loops on the unrolled periodic domain.
+
+Do not confuse with `crates/heal/src/upgrade/split_self_intersecting_wires.rs`: that splits figure-eight WIRES (same-vertex-twice pinch artifacts from the mesh-fallback assembler) into simple sub-cycles. It rearranges wire topology only, creates or removes no edges, leaves outer wires alone, and does not perform the geometric face split above.
+
+Practical stance: the analytic B-Rep and exact volume for such shapes can be correct while render meshing stays deferred (see git history around PR #1008). If asked to "just make it render", scope the ask to one of the two bounded fixes or decline.
+
+## GPU compute mesher (brepkit-render)
+
+`crates/render/src/compute_mesh.rs`. Cylinder only at time of writing; verify current coverage:
+
+```bash
+rg -n 'Descriptor|pub fn render_' crates/render/src/compute_mesh.rs
+```
+
+Key symbols:
+
+- `CylinderDescriptor`: packed analytic surface params (axis frame, radius, axial range) uploaded to the GPU. Extracted from a `FaceSurface::Cylinder` face by `extract_cylinder_descriptor` (errors on non-cylindrical or degenerate-axial faces).
+- `TessFactor` and `screen_space_tess_factor`: per-frame `n_u` from projected pixel radius using the chord-error bound `r * (1 - cos(pi / n_u)) <= target_px`; `n_v = 1` because a cylinder lateral face is ruled.
+- `render_cylinder_compute_offscreen` and `render_cylinder_compute_screen_lod`: end-to-end paths; the WGSL kernel writes vertices at the render pipeline's vertex stride so one buffer binds as STORAGE then VERTEX.
+
+Doctrine consequence: the GPU path consumes analytic surface PARAMETERS, not triangles. A face degraded to NURBS or mesh by an upstream operation is invisible to this path forever. When choosing between an analytic-preserving and an approximating implementation of an operation, the GPU mesher is a second consumer arguing for analytic (see the **analytic-preservation** skill). Audit current degradation points:
+
+```bash
+cargo run --release --example approx_census -p brepkit-operations
+```
+
+For verifying rendered output on the live display, see the **render-verify** skill.
+
+## Glossary
+
+- **Seam**: the u = 0 identified with u = 2pi closure line on a periodic surface; in UV the surface is a rectangle whose left and right edges are the same 3D line.
+- **Band**: a face on a periodic surface bounded by two full-revolution loops (rims). Latitude band: boundaries at constant v. Notch band: boundaries wrapping v, swept in u.
+- **Shared edge pool**: `edge_global_indices`, the once-per-edge sampled vertex ids that all faces must reference on their boundaries.
+- **Snap path**: legacy fallback that meshes a face independently and welds by proximity; crack-prone.
+- **bd=0**: `boundary_edge_count(mesh) == 0`, the primary watertightness regression signal.
+- **Deflection**: max chord deviation (sag) driving sampling density, paired with an angular tolerance (`DEFAULT_ANGULAR_TOL` in `brepkit_math::chord`).
+- **Mesh fallback**: when a boolean's analytic result fails its gates, the operation re-runs as a tessellate-then-co-refine mesh boolean; output is hundreds of planar faces. Face count is the tell (a handful analytic vs hundreds planar). See **boolean-debugging**.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: testing
+description: Use when writing, placing, running, or updating tests in brepkit; when a bug fix needs a regression fixture; when deciding whether a repro is faithful to the real failing geometry; when a golden file mismatches; or when ending a session with unverified work (verify-or-revert). Covers unit, proptest, golden, integration, wasm contract, bench, and ignored ready-repro tests.
+---
+
+# Testing in brepkit
+
+## When to use
+
+- Adding tests for a new operation or a bug fix, and choosing where they go.
+- A test fails with "Golden file mismatch" or "Golden file not found".
+- You fixed a boolean bug and need the fixture that proves it.
+- You built a repro and are about to spend hours debugging on it.
+- End of session and the fix is not verified.
+
+Deep catalog, fixture-capture procedures, and glossary: see [reference.md](reference.md).
+
+## Quick reference
+
+```bash
+cargo test --workspace                                        # everything
+cargo test -p brepkit-operations                              # one crate
+cargo test -p brepkit-operations --test regress_hexwall_cuts  # one integration file
+cargo test -p brepkit-operations some_test_name_substring     # filter by name
+cargo test -p brepkit-wasm                                    # wasm contract tests (run native)
+cargo test -p brepkit-io --test dovetail_cornerclip_intersect_inmem -- --ignored   # a ready-repro
+UPDATE_GOLDEN=1 cargo test --workspace golden                 # regenerate golden files
+cargo bench -p brepkit-operations --bench cad_operations      # criterion bench
+rg -n '#\[ignore' crates -g '*.rs'                            # list all ignored repros/diagnostics
+```
+
+Expected shape: `cargo test` prints per-target `test result: ok. N passed; 0 failed; K ignored`. Ignored counts are normal, they are known-open repros and diagnostics, not rot.
+
+## Where a test goes (decision table)
+
+| You are testing | Put it | Example to copy |
+|---|---|---|
+| One module's logic | `#[cfg(test)] mod tests` in that file, with the clippy allow header | `crates/operations/src/boolean/tests.rs` |
+| A workflow across modules in one crate | `crates/<crate>/tests/<name>.rs` | `crates/operations/tests/regress_hexwall_cuts.rs` |
+| An invariant over an input range | proptest, in either location above | `crates/operations/tests/proptest_operations.rs` |
+| Exact output bytes/text stability | golden test + file in `tests/golden/data/` | `crates/operations/tests/golden_regression.rs` |
+| A JS-facing binding | wasm contract test via `execute_batch` | `crates/wasm/src/bindings/gridfinity_tests.rs` |
+| A bug fixed via STEP or `.bin` fixture | `crates/io/tests/` (needs the io readers, io is L3) | `crates/io/tests/lipfuse_fixture.rs` |
+| Performance | criterion bench in `crates/operations/benches/` | `cad_operations.rs` |
+| A bug you could NOT fix this session | `#[ignore = "open: ..."]` ready-repro, kept compiling | `crates/io/tests/dovetail_cornerclip_intersect_inmem.rs` |
+
+Every test module or file starts with the allow header, because workspace lints deny `unwrap_used` and `panic`:
+
+```rust
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+```
+
+Note: root `tests/integration/` holds only a README of patterns. Runnable integration tests live in each crate's `tests/` dir. Root `tests/golden/` holds only the `.golden` data files; the test code is `crates/operations/tests/golden_regression.rs`.
+
+## Regression-fixture doctrine
+
+Every bug fix ships a fixture that fails before the fix and passes after. Run it against the pre-fix tree at least once to confirm it actually fails. Three tiers, escalate only when the lower tier cannot reproduce:
+
+1. **Minimal native primitive repro** (preferred). Rebuild the failing scenario from primitives in a crate test. Copy the shape of `regress_hexwall_cuts.rs`.
+2. **STEP fixture captured from the real failing tool geometry**, when the geometry does not reconstruct exactly from a native rebuild. Files in `crates/io/tests/data/*.step`, loaded via `brepkit_io::step::reader::read_step`. Faithfulness check: the operands must round-trip as analytic surfaces (Cylinder/Cone/Plane, not NURBS). A NURBS round-trip means the fixture is unfaithful, do not use it.
+3. **Arena `.bin` fixture**, when STEP round-trip renumbers ids or re-derives vertices and the bug disappears. Captured tool-side via the `serializeSolid` wasm binding, loaded via `brepkit_io::arena_io::deserialize_solid`. Tests named `*_inmem.rs` in `crates/io/tests/` are this tier.
+
+Assert on measurements (volume against an exact analytic value, edge-use counts for watertightness, face counts for analytic-vs-mesh-fallback), not on internal topology layout. See `tests/integration/README.md` and reference.md section "What to assert".
+
+## Faithful-repro-first
+
+Before grinding on a repro, verify it matches the REAL failing geometry: same dimensions, same layout, same failure signature (same face-count explosion, same free-edge pattern). A proxy repro that diverges from the real case burns many debugging passes and its fixes do not transfer. Known failure mode: a proxy with a rounded corner radius that straddles a numeric boundary the real geometry never crosses produced an entire false root-cause theory.
+
+Checkpoint: run the repro, confirm it fails the same way the real case does, THEN debug. If a STEP round-trip cleans the failure away, escalate to a tier-3 `.bin` fixture instead of debugging the cleaned version.
+
+## Verify-or-revert
+
+Work that cannot be verified by the end of the session is reverted to a clean tree. An unverified "fix" is worse than no fix: it corrupts the next investigator's baseline. The reverted session's deliverables are:
+
+1. Findings written down (PR description, issue, or investigation notes in the ready-repro's doc comment).
+2. An `#[ignore = "open: ..."]` ready-repro test that compiles, whose assertions encode the acceptance target for the eventual fix. `dovetail_cornerclip_intersect_inmem.rs` is the template: its assertions check watertight, analytic, and compact, exactly what the fix must produce.
+
+Verification is empirical, not plausible: vary one variable, dump literal data, and check cut geometry with the ray-cast classifier (`brepkit_check::classify::classify_point`), never with volume alone (tessellated volume can mask an un-carved cut). See the solid-verification and debugging-doctrine skills.
+
+When a fix ships for a previously ignored repro, remove the `#[ignore]` in the same PR so it becomes a permanent regression test.
+
+## Golden-file update procedure
+
+1. A golden test fails with `Golden file mismatch: <name>` and a diff.
+2. Decide: is the output change intentional (better tessellation, new field) or a regression? Read the diff; do not skip this step.
+3. If intentional: `UPDATE_GOLDEN=1 cargo test --workspace golden`, then inspect `git diff tests/golden/data/` and commit the data change with the code change.
+4. If not intentional: it is a regression, do not regenerate.
+
+Missing file panics with "Run with UPDATE_GOLDEN=1 to create it." New golden files follow `{shape}_{operation}.golden` and stay small.
+
+## Anti-patterns
+
+- Do not conclude a boolean fix works because volume looks right. Tessellation-based volume can read high and mask failures. Use `classify_point` probes and edge-use counts.
+- Do not conclude a result is analytic because it is valid and manifold. Face count is the reliable tell: analytic results have a handful of faces, mesh fallback has hundreds to thousands of all-planar facets.
+- Do not delete or skip an `#[ignore]` test because it fails when run with `--ignored`. It is supposed to fail, that is its job.
+- Do not call wasm binding methods directly in tests. `JsError` cannot be constructed on non-wasm targets; go through `execute_batch` (see CLAUDE.md, Recipe 4).
+- Do not hand-edit `.proptest-regressions` files. proptest writes failing seeds there automatically; commit them, they are regression tests.
+- Do not leave a half-verified fix in the tree "for the next session". Revert and write the ready-repro instead.
+- Do not skip git hooks to get a red tree pushed. Pre-commit and pre-push gates are the contract.
+
+## Sibling skills
+
+boolean-debugging (root-causing the failures these fixtures capture), solid-verification (the measurement oracles), debugging-doctrine (vary-one-variable, diagnosis instability), parity-benchmarking (scoring against the reference kernel via the brepjs harness), add-operation and wasm-bindings (where new-feature tests slot in), pr-workflow (review gates before merge).

--- a/.claude/skills/testing/reference.md
+++ b/.claude/skills/testing/reference.md
@@ -1,0 +1,183 @@
+# Testing reference
+
+Deep catalog for the testing skill. Everything here is verified against the current tree; when line numbers would rot, symbols and rg patterns are given instead.
+
+## 1. Test taxonomy, with live examples
+
+### 1a. Module unit tests
+
+`#[cfg(test)] mod tests` inside the source file. Workspace lints deny `unwrap_used` and `panic`, so every test module opens with a module-level allow. Real headers in the tree:
+
+- `crates/operations/src/boolean/tests.rs`: `#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::print_stderr, clippy::cast_precision_loss, clippy::cast_possible_wrap)]`
+- `crates/operations/src/tessellate/tests.rs`: `#![allow(clippy::unwrap_used, deprecated)]`
+- Standalone test files use the same pattern, e.g. `crates/operations/tests/regress_hexwall_cuts.rs`.
+
+Find them: `rg -n '#!\[allow\(clippy::unwrap_used' crates -g '*.rs'`
+
+Large modules split tests into a sibling file (`boolean/tests.rs`, `tessellate/tests.rs`, `fillet/tests.rs`) wired in via `mod tests;` under `#[cfg(test)]`.
+
+### 1b. proptest property tests
+
+Invariants over generated inputs. Examples:
+
+- `crates/operations/tests/proptest_operations.rs`: `prop_boolean_volume_conservation` asserts V(A) + V(B) = V(A union B) + V(A intersect B), inside `proptest! { #![proptest_config(ProptestConfig::with_cases(20))] ... }`. Keep case counts low for expensive CAD ops.
+- `crates/operations/tests/coincident_proptest.rs`: coincident-contact boolean fuzzing.
+- Heavy use inside `crates/math/src/` modules. Find all: `rg -l 'proptest!' crates --type rust`
+
+Failing seeds auto-persist to `.proptest-regressions` files next to the test (e.g. `crates/operations/tests/proptest_operations.proptest-regressions`) and under `crates/math/proptest-regressions/`. Commit them; each seed is a permanent regression case replayed on every run. Never hand-edit or delete them to make a run green.
+
+### 1c. Golden-file tests
+
+- Data: `tests/golden/data/*.golden` at workspace root (e.g. `box_10x20x30.golden`, `boolean_box_minus_cylinder.golden`, `tessellation_sphere.golden`). Docs: `tests/golden/README.md`.
+- Test code: `crates/operations/tests/golden_regression.rs`. Helper `golden_path()` joins `CARGO_MANIFEST_DIR/../../tests/golden/data`; `assert_golden()` regenerates when `UPDATE_GOLDEN=1` is set, otherwise diffs trimmed strings.
+- `rg -n 'UPDATE_GOLDEN' crates -g '*.rs'` hits only that file.
+- Naming: `{shape}_{operation}.golden`. Keep files small; golden tests are for output stability, not for exhaustive geometry checks.
+
+### 1d. Integration tests (per-crate `tests/` dirs)
+
+Root `tests/integration/` contains only a README describing the patterns. Runnable tests:
+
+- `crates/operations/tests/`: the main suite. Boolean edge cases and invariants (`boolean_edge_cases.rs`, `boolean_invariants.rs`, `boolean_stress.rs`), coincident and coaxial families (`coincident_planes.rs`, `coaxial_cylinders.rs`, `coaxial_cones.rs`, `coaxial_torus.rs`, `concentric_spheres.rs`), regressions (`regress_hexwall_cuts.rs`), tessellation (`tessellate_watertight.rs`), and the parity corpus.
+- Parity corpus: `parity_boolean_planar.rs`, `parity_boolean_curved.rs`, `parity_boolean_empty.rs` share `parity_support/mod.rs`, which defines `struct Case` and `run_corpus(cases: &[Case])`. Oracles are exact closed-form values, never face counts: `enum Oracle` in `parity_support/mod.rs` has `Volume(f64)` (the most common), `Area(f64)`, and `Empty` (the result must be empty). Add new boolean scenarios as `Case` entries here when they have a closed-form expected value.
+- `crates/io/tests/`: fixture-based regressions (section 2).
+- Others: `crates/math/tests/ssi_robustness.rs`, `crates/offset/tests/integration.rs`, `crates/render/tests/` (offscreen render and compute-mesh tests).
+
+Doctrine from `tests/integration/README.md`: measure, do not inspect topology. Verify with `volume()` / `bounding_box()`; tolerances around 1e-6 for direct computation, 1e-3 for I/O round-trips. Test the workflow, not the internals.
+
+### 1e. Criterion benches
+
+All in `crates/operations/benches/`: `cad_operations.rs`, `boolean_perf.rs`, `boolean_tracking.rs`, `compound_cut_perf.rs`, `fuse_perf.rs`. Bench targets are declared in `crates/operations/Cargo.toml`. Run one:
+
+```bash
+cargo bench -p brepkit-operations --bench boolean_perf
+```
+
+For profiling a bench, see CLAUDE.md, Profiling, and the profiling skill. For cross-kernel comparison against the reference kernel, use the brepjs harness (see the parity-benchmarking skill).
+
+### 1f. WASM contract tests via `execute_batch`
+
+`crates/wasm/src/bindings/gridfinity_tests.rs` is the template (`mod gridfinity_tests` under `#[cfg(test)]` in `bindings/mod.rs`). Pattern:
+
+```rust
+let mut k = BrepKernel::new();
+let result = k.execute_batch(
+    r#"[{"op": "makeBox", "args": {"width": 10.0, "height": 5.0, "depth": 10.0}},
+        {"op": "volume", "args": {"solid": 0}}]"#,
+);
+```
+
+then parse the JSON with the file's local helpers (`parse_batch`, `assert_ok`, `assert_no_crash`, `ok_f64`, `ok_bbox`). `execute_batch` is defined in `crates/wasm/src/bindings/batch.rs`.
+
+Why this shape: `JsError` cannot be constructed on non-wasm targets, so binding methods cannot be called directly in native tests. `execute_batch` takes and returns strings, so `cargo test -p brepkit-wasm` runs these on the host. See CLAUDE.md, Recipe 4.
+
+Handle gotcha, documented in the file header: solid handles in a batch are arena indices, not batch result indices. The header lists which ops create new solids (`makeBox`, `fuse`, `cut`, `extrude`, ...) versus which return the same handle or a float (`transform`, `volume`, `boundingBox`, ...). Count created solids to compute the handle for a later op.
+
+### 1g. Ignored ready-repro tests
+
+An `#[ignore = "..."]` test that reproduces a known-open bug, kept compiling, with the ignore string naming the open condition. The next session starts from a runnable repro instead of re-deriving one. Live examples:
+
+- `crates/io/tests/dovetail_cornerclip_intersect_inmem.rs`, test `dovetail_corner_clip_intersect_is_watertight`. Ignore string starts "open: coincident-wall + analytic-corner intersect drops the boundary". Its assertions encode the acceptance target: watertight, analytic, compact face count.
+- `crates/operations/src/boolean/tests.rs`, test `fuse_shelled_box_with_socket_loft`. Ignore string: "known bug: non-manifold edge at shelled-box + socket fuse boundary".
+
+Two neighboring variants that also use `#[ignore]` but are NOT ready-repros:
+
+- Diagnostic tools: explicit-only harnesses that print internal state and are expected to fail or never pass, e.g. `crates/operations/tests/perf_64cut_determinism.rs` (nondeterminism bisect tool) and `crates/operations/tests/profile_intersect.rs` (topology-inspection probes). Their ignore strings start with "diagnostic".
+- Slow tests: e.g. `staircase_fuse_with_cylinders` in `boolean/tests.rs`, ignore string starting "slow (~2 min)".
+
+Convention for the ignore string prefix: `open:` for a bug awaiting a fix, `known bug:` acceptable too, `diagnostic` for tools, `slow` for runtime. Always include enough context that a reader with no history understands what is broken.
+
+Find all: `rg -n '#\[ignore' crates -g '*.rs'`
+
+Lifecycle: bug found, ready-repro written and ignored, fix ships, `#[ignore]` removed in the fix PR, test becomes a permanent regression guard.
+
+## 2. Fixture tiers in detail
+
+### Tier 1: native primitive repro
+
+Rebuild the failing scenario from primitives and operations inside a crate test. `crates/operations/tests/regress_hexwall_cuts.rs` is the template: hollow thin-walled box, sequence of hex-prism cuts, each cut asserted to remove exactly the analytic prism volume. The historical failure it guards: later cuts silently no-opped while returning Ok, which is why per-step volume deltas are asserted, not just the final value.
+
+### Tier 2: STEP fixture from real tool geometry
+
+When the failing geometry cannot be reconstructed exactly from a native rebuild (e.g. a tapered multi-section loft), capture the tool's literal operands as STEP and commit them. Template: `crates/io/tests/lipfuse_fixture.rs` with `crates/io/tests/data/lipfuse_*.step` (also `wallcut_*.step`, `scoop_*.step`, `multicavity_*.step`). Load with `brepkit_io::step::reader::read_step`.
+
+The lipfuse header states the doctrine: the fixtures are the tool's literal operands, exported via STEP, round-tripping as exact cylinders, cones, and planes. Faithfulness gate: after import, confirm the surfaces are analytic types, not NURBS approximations. If STEP degraded them, the fixture no longer exercises the analytic code path where the bug lives.
+
+These tests live in `crates/io/tests/` because they need the io readers, and io (L3) sits above operations. Do not add io as a dependency of operations tests.
+
+### Tier 3: arena `.bin` fixture
+
+Some bugs exist only in a specific in-memory id/vertex layout. A STEP round-trip renumbers entities and re-derives vertices, which can erase the bug. For those, serialize the arena directly:
+
+- Capture tool-side: the `serializeSolid` wasm binding in `crates/wasm/src/bindings/io.rs` returns bytes.
+- Commit as `crates/io/tests/data/<name>.bin`.
+- Load in the test with `brepkit_io::arena_io::deserialize_solid` (module `crates/io/src/arena_io.rs`).
+- Name the test file `*_inmem.rs`. Existing examples: `dovetail_cornerclip_intersect_inmem.rs`, `gridfinity_wallcut_seq_inmem.rs`, `scoop_fix_inmem.rs`, and others in `crates/io/tests/`.
+
+Decision rule: try tier 1. If the repro passes while the real tool fails, capture tier 2. If the STEP round-trip also passes while the in-memory case fails, capture tier 3. Never debug on a repro from a lower tier that does not reproduce.
+
+## 3. What to assert
+
+| Property | How | Do NOT use |
+|---|---|---|
+| Cut/fuse actually happened | `brepkit_check::classify::classify_point` probes at points that must be inside/outside | volume alone (tessellated volume can read high over an un-carved cut) |
+| Correct volume | `brepkit_operations::measure` volume vs a closed-form analytic value, tolerance ~1e-6 | comparing against a previously recorded float with no derivation |
+| Watertight / manifold | count edge uses via quantized endpoint pairs, every edge used exactly twice (see the `edge_use` / `edge_health` helpers in the io fixture tests) | "it tessellates without error" |
+| Result stayed analytic | face count: analytic results have a handful of faces, mesh fallback produces hundreds to thousands of all-planar facets | triangle count or validity, both mask the fallback |
+| In/out classification on non-analytic solids | ray-cast classifier `classify_point` | winding-number classifier (`classify_point_winding`), wrong for non-analytic solids |
+
+Boolean gate context: `boolean()` in `crates/operations/src/boolean/mod.rs` validates the analytic GFA result and falls back to `mesh_boolean_fallback` (same file, `rg -n 'fn mesh_boolean_fallback'`) when validation fails. A silent fallback is itself a regression for analytic scenarios; assert face counts to catch it.
+
+## 4. Commands with expected output shapes
+
+```bash
+cargo test --workspace
+# per test target: "test result: ok. N passed; 0 failed; K ignored; ..."
+
+cargo test -p brepkit-operations --test parity_boolean_curved
+# runs one integration-test binary
+
+cargo test -p brepkit-io --test dovetail_cornerclip_intersect_inmem -- --ignored
+# runs the ready-repro; EXPECTED TO FAIL while the bug is open
+
+cargo test --release -p brepkit-operations --test perf_64cut_determinism -- --ignored --nocapture
+# diagnostic tool; its own file header documents this exact invocation
+
+UPDATE_GOLDEN=1 cargo test --workspace golden
+# rewrites tests/golden/data/*.golden; inspect git diff before committing
+
+cargo bench -p brepkit-operations --bench cad_operations
+# criterion output with per-benchmark timing and change-vs-baseline
+
+cargo run --release --example approx_census -p brepkit-operations
+# enumerates ops that degrade analytic to approximation/mesh; rerun after a fix to confirm a flip
+
+cargo clippy --all-targets -- -D warnings
+# test code compiles under the strict lints; missing allow headers fail here
+
+./scripts/check-boundaries.sh
+# layer-dependency gate; CI runs it in the boundaries job
+```
+
+Failure shapes worth recognizing:
+
+- `Golden file mismatch: <name>` plus a diff: output changed; decide intentional vs regression before regenerating.
+- `Golden file not found: ... Run with UPDATE_GOLDEN=1 to create it.`: new golden test, generate the file.
+- A proptest failure prints the minimal failing input and writes a seed to the `.proptest-regressions` file; commit that file.
+- `test result: ok` but a scenario silently fell back to mesh: no test failure at all unless a face-count assertion exists. This is why fixtures assert face counts.
+
+Hooks (see `.husky/pre-commit` and `.husky/pre-push` for the authoritative contents): pre-commit runs fast checks only, fmt + clippy + taplo + cargo-machete in parallel, and runs no tests. Pre-push runs nothing locally; all validation (nextest, deny, boundaries, and more) is delegated to CI in `.github/workflows/ci.yml`, gated by the `ci-pass` job. Nothing on the local path runs the test suite for you: run tests manually before pushing. Never bypass the hooks.
+
+## 5. Glossary
+
+- **GFA**: brepkit's general boolean engine (`crates/algo`), a pave-filler plus builder pipeline that intersects, splits, classifies, and reassembles faces.
+- **PaveFiller**: GFA phase 1, computes interferences between entity pairs and splits edges at paves (intersection points). Phases VV/VE/EE/VF/EF/FF; FF (face-face) creates intersection sections and hosts most curved-boolean bugs.
+- **Section**: an intersection curve segment between two faces, produced in FF, later stitched into face-splitting wires.
+- **Same-domain (SD)**: detection that two operand faces lie on the same surface (coincident contact), so they merge instead of splitting each other.
+- **Mesh fallback**: when the analytic GFA result fails validation, `boolean()` falls back to a triangle-mesh co-refinement boolean. Correct but slow and non-analytic; the telltale is exploding face count.
+- **Analytic vs NURBS**: analytic means exact Plane/Cylinder/Cone/Sphere/Torus surfaces and Line/Circle/Ellipse curves. The quality bar is preserving these through operations instead of degrading to fitted NURBS or mesh. See the analytic-preservation skill.
+- **Watertight / manifold**: every edge shared by exactly two faces. Free edges (used once) or over-shared edges (three or more) mean a broken shell.
+- **Ray-cast classifier**: `brepkit_check::classify::classify_point`, the trustworthy in/out oracle. The winding classifier is unreliable on non-analytic solids.
+- **Approx census**: `crates/operations/examples/approx_census.rs`, enumerates operations that still degrade analytic input.
+- **Parity corpus**: the `parity_boolean_*.rs` tests scoring booleans against exact analytic volume oracles, built to match and beat the reference kernel.
+- **Reference kernel**: the mature C++ CAD kernel brepkit benchmarks against via the brepjs harness (see the parity-benchmarking skill).
+- **Ready-repro**: an `#[ignore]`d, compiling test that reproduces a known-open bug and whose assertions encode the fix's acceptance target.

--- a/.claude/skills/wasm-bindings/SKILL.md
+++ b/.claude/skills/wasm-bindings/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: wasm-bindings
+description: Use when adding or changing methods on BrepKernel in crates/wasm, wiring ops into executeBatch, writing tests for bindings, building the wasm package (wasm-pack or cargo xtask wasm-build), testing a local kernel build inside brepjs or another JS consumer, or debugging wasm-only failures such as tests that will not compile with JsError, panics that abort the wasm instance, "recursive use of an object" errors, or a JS app silently loading a stale wasm build. Also use when the CI "WASM Binary Size" PR comment shows growth or a change adds a dependency to the wasm graph.
+---
+
+# wasm-bindings
+
+The WASM layer exports one class, `BrepKernel` (`crates/wasm/src/kernel.rs`). JS holds opaque `u32` handles (arena indices into the kernel's `Topology`, NOT batch result indices). Bindings live in `crates/wasm/src/bindings/<domain>.rs`, one `#[wasm_bindgen] impl BrepKernel` block per module (wasm-bindgen supports multiple impl blocks across files; non-exported helpers go in a separate plain `impl BrepKernel` block).
+
+## Quick reference
+
+| Task | Command | Expect |
+|---|---|---|
+| Type-check for wasm target | `cargo build -p brepkit-wasm --target wasm32-unknown-unknown` | Clean build; catches target-specific errors |
+| Run contract tests | `cargo test -p brepkit-wasm` | Native target; see "Contract tests" below |
+| Build for node/vitest | `wasm-pack build crates/wasm --target nodejs --release` | `crates/wasm/pkg/` with CJS entry `brepkit_wasm.js` |
+| Full release package | `cargo xtask wasm-build` | Dual-target merge + wasm-opt; entry `brepkit_wasm_node.cjs`. See [reference.md](reference.md) section 1 |
+| Smoke-test the package | `node scripts/test-wasm-smoke.mjs` | `ok - ...` lines, ends `All smoke tests passed`. Only works after xtask build (needs `brepkit_wasm_node.cjs`) |
+
+Never `wasm-pack build --target web` for node consumption: the web target's init uses `fetch()` and fails under node. The bundler ESM entry also fails under vitest.
+
+## Procedure: add a binding
+
+CLAUDE.md Recipe 4 covers the skeleton (js_name, `validate_positive`/`validate_finite`, `?` via the blanket `From<E> for JsError`). What it omits or gets stale:
+
+1. Pick or create `crates/wasm/src/bindings/<domain>.rs`. Do not add bindings to `kernel.rs` (it holds the struct, constructor, and private helpers only, despite Recipe 1's stale wording).
+2. Reads go through `self.topo` / `self.topo()`; writes MUST go through `self.topo_mut()` (it is `Rc::make_mut` copy-on-write shared with checkpoints; rg: `fn topo_mut` in `kernel.rs`).
+3. Resolve incoming handles with `resolve_solid` / `resolve_face` / etc. from `crates/wasm/src/handles.rs`; convert results back with `*_id_to_u32`.
+4. **Batch dispatch**: there are no `batch_*` companion functions (Recipe 4's wording is stale; the only `batch_*` names are test helpers). To add an op to `executeBatch`, add a match arm in `fn dispatch_op` in `crates/wasm/src/bindings/batch.rs`. Parse args with `get_f64` / `get_u32` from `crates/wasm/src/helpers.rs`, map errors with `.map_err(|e| e.to_string())`, return `Ok(serde_json::json!(...))`. Copy the `"makeBox"` arm as the template. Note: `tessellateSolid` is deliberately not in the dispatcher.
+5. **Panic safety** for panic-prone ops (booleans, fillets): wrap the body in `std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| ...))` and build the error with `panic_message` (`crates/wasm/src/helpers.rs`, rg: `fn panic_message`). Reason: a panic crossing the WASM FFI boundary aborts the entire wasm instance. Live examples: `fillet` in `bindings/operations.rs`, `compound_cut` in `bindings/booleans.rs` (that one also checks and sets `self.poisoned`; subsequent guarded calls refuse with "Kernel poisoned after panic"). Do NOT use the `#[wasm_binding]` attribute from `crates/wasm-macros`: the macro is fully written but unwired (not a dependency of `brepkit-wasm`, zero usages). The manual pattern is the live one.
+6. Checkpoint: `cargo build -p brepkit-wasm --target wasm32-unknown-unknown` compiles, then write a contract test (below), then `cargo test -p brepkit-wasm`.
+
+## Contract tests: why execute_batch, not method calls
+
+`JsError::new` panics on non-wasm targets. Any `#[wasm_bindgen]` method returning `Result<_, JsError>` or `JsValue` cannot be exercised on the error path (or at all, for `JsValue`) under native `cargo test`. Three patterns that work, all in-tree:
+
+1. **Batch contract test** (default): `let mut k = BrepKernel::new(); let r = k.execute_batch(r#"[{"op":"makeBox","args":{"width":10.0,"height":10.0,"depth":10.0}}]"#);` then parse `r` with `serde_json` and assert on `{"ok": ...}` / `{"error": "..."}` entries. Examples: `mod batch_tests` in `kernel.rs`, tests in `bindings/booleans.rs`, `bindings/gridfinity_tests.rs`.
+2. **`pub(crate)` `_impl` functions returning `WasmError`** for logic that must be unit-testable natively (rg: `fn from_brep_impl` in `kernel.rs`).
+3. **Error paths through `resolve_*`** (return `WasmError`, safe natively). See the comment in `bindings/query/tests.rs`.
+
+Batch semantics to assert against: errors do not stop later ops in the array; invalid JSON returns `[{"error": "invalid JSON: ..."}]`.
+
+## Symptom-to-cause
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Test compiles-fails or panics with a JsError construction | Calling a `JsError`/`JsValue` method under native `cargo test` | Rewrite as an `execute_batch` contract test or `_impl` fn |
+| JS reports "recursive use of an object detected which would lead to unsafe aliasing" | Observed symptom: a panic inside wasm on an earlier call, often `std::time::Instant::now()` (panics on wasm32, no monotonic clock). The re-entrancy error surfaces on the next call, masking the real cause | Find bare `Instant::now()` reachable from wasm (`operations` and below). Use the cfg-gated `timer_now` / `timer_elapsed_ms` pattern (rg: `fn timer_now` in `crates/operations/src/boolean/mod.rs`) |
+| Wasm instance dead after one bad op | Uncaught panic crossed the FFI boundary | Wrap the op in `catch_unwind` + `panic_message` (step 5 above) |
+| `cargo xtask wasm-build` bails: wasm-bindgen-cli version mismatch demanding 0.2.121 | Stale `WASM_BINDGEN_VERSION` constant in `xtask/src/wasm.rs`; workspace `Cargo.toml` pins `wasm-bindgen = "=0.2.125"` | Update the constant to match the workspace pin, or uninstall the local cli and let wasm-pack fetch its own |
+| `node scripts/test-wasm-smoke.mjs` cannot find `brepkit_wasm_node.cjs` | Plain wasm-pack build names the entry `brepkit_wasm.js`; only the xtask merge produces the `.cjs` | Run `cargo xtask wasm-build` first, or point your consumer at `brepkit_wasm.js` directly |
+| JS consumer still runs old kernel behavior after overlaying a local build | pnpm `.pnpm` store copy not overlaid, or stale Vite dep-optimizer cache | See [reference.md](reference.md) section 2: copy into BOTH node_modules locations, `rm -rf node_modules/.vite*`, verify with md5 or a new binding key |
+
+## Testing a local kernel in a JS consumer
+
+Cheap path first: brepjs already aliases `'brepkit-wasm'` in `~/Git/brepjs/vitest.config.ts` (also `vitest.bench.config.ts`, `vitest.stress.config.ts`). Build `wasm-pack build crates/wasm --target nodejs --release`, then temporarily point that alias at `~/Git/brepkit/crates/wasm/pkg/brepkit_wasm.js`. No npm install, no lockfile churn. Full overlay recipe for pnpm+Vite apps: [reference.md](reference.md) section 2.
+
+## Anti-patterns
+
+- Do not conclude "the binding is broken" from a native test that fails constructing `JsError`; that is the test pattern, not the binding.
+- Do not conclude "re-entrancy bug" from the "recursive use of an object" error; look for an earlier panic first.
+- Do not trust that a JS consumer picked up your local build; verify (md5 the `.wasm`, or probe a binding that only exists in the new build).
+- Do not add timing code with bare `std::time::Instant` anywhere reachable from `brepkit-wasm`.
+- Do not follow CLAUDE.md Recipe 4's "add a `batch_*` companion fn" literally; add a `dispatch_op` match arm.
+- Do not reach for the `#[wasm_binding]` macro; it is unwired.
+
+## Binary size
+
+Small wasm size is a headline competitive property of this kernel (several times smaller than the reference kernel's wasm). The `wasm-size` CI job only posts a PR comment ("WASM Binary Size") and never fails, so read that comment as a review item on every wasm-touching PR. Rule: an unexplained increase above roughly 1% needs a justification sentence in the PR body; a new dependency in the wasm graph always does. Measurement details and the twiggy diagnosis recipe: [reference.md](reference.md) section 6.
+
+## Related skills
+
+`add-operation` (the L3 operation a binding usually wraps), `testing` (workspace test conventions), `release-flow` (publishing the package), `parity-benchmarking` (running the brepjs bench harness against a local build), `layer-boundaries` (what `wasm/src` may import).

--- a/.claude/skills/wasm-bindings/reference.md
+++ b/.claude/skills/wasm-bindings/reference.md
@@ -1,0 +1,153 @@
+# wasm-bindings reference
+
+Deep detail backing SKILL.md. Everything here is verified against the repo; re-verify with the given rg patterns if a symbol has moved.
+
+## 1. cargo xtask wasm-build (the release-grade package)
+
+`xtask` is aliased in `.cargo/config.toml` (`xtask = "run --manifest-path xtask/Cargo.toml --"`) and is intentionally not a workspace member. Source: `xtask/src/main.rs`, `xtask/src/wasm.rs`.
+
+`cargo xtask wasm-build [--no-simd] [--skip-opt]` runs five steps:
+
+1. `check_tools`: requires `wasm-pack`. If a local `wasm-bindgen-cli` is installed it must equal the pinned `WASM_BINDGEN_VERSION` constant in `xtask/src/wasm.rs`. Known gotcha: that constant is `0.2.121` while the workspace `Cargo.toml` pins `wasm-bindgen = "=0.2.125"`, so a correctly matched local cli fails the check. Fix the constant or uninstall the cli (wasm-pack fetches its own). `wasm-opt` is optional; missing means a warning and a skipped step.
+2. `build_both_targets`: two wasm-pack builds from `crates/wasm` with `RUSTFLAGS="-Dwarnings"` (plus `-C target-feature=+simd128` unless `--no-simd`): `--target bundler --out-dir pkg` and `--target nodejs --out-dir pkg-node`.
+3. `run_wasm_opt`: `wasm-opt -O3` in place on `pkg/brepkit_wasm_bg.wasm`, prints before/after KB.
+4. `merge_packages`: copies `pkg-node/brepkit_wasm.js` into `pkg/` as `brepkit_wasm_node.cjs` (renamed to `.cjs` because the bundler package.json has `"type": "module"`), patches `pkg/package.json` (`name: brepkit-wasm`, `main: brepkit_wasm_node.cjs`, `module: brepkit_wasm.js`, an `exports` map with node/import/default conditions, `files`), then deletes `pkg-node/`.
+5. `validate_output`: checks the required files exist, `.wasm` size in a 500 KB to 20 MB window, the `.d.ts` contains `export class BrepKernel` with at least `MIN_METHOD_COUNT` methods, and package.json fields.
+
+Output lands in `crates/wasm/pkg/`, git-ignored by wasm-pack's own generated `crates/wasm/pkg/.gitignore`.
+
+`cargo xtask wasm-publish [--dry-run]` runs the same pipeline, then `node scripts/test-wasm-smoke.mjs`, then `npm publish --provenance --access public`. It requires a `TAG_NAME` env var matching the `package.json` version.
+
+### Which build for which purpose
+
+| Purpose | Build | Entry file |
+|---|---|---|
+| Node / vitest, quick iteration | `wasm-pack build crates/wasm --target nodejs --release` | `crates/wasm/pkg/brepkit_wasm.js` (CJS despite the name) |
+| Published package, smoke test, overlay into a real app | `cargo xtask wasm-build` | `crates/wasm/pkg/brepkit_wasm_node.cjs` (node) + `brepkit_wasm.js` (bundler ESM) |
+| Browsers via a bundler | the same xtask package; the bundler resolves the `import` condition | `brepkit_wasm.js` |
+
+Never `--target web` for node: its init path uses `fetch()`. The bundler ESM entry also fails under vitest because Vite resolves the `import` exports condition to an entry that uses the unsupported WASM ESM integration proposal (see the comment in `~/Git/brepjs/vitest.config.ts`). Node and vitest must get the CJS entry.
+
+## 2. Running a local kernel build inside a JS consumer
+
+### Cheap path: vitest resolve.alias (preferred, no npm install)
+
+brepjs maps `'brepkit-wasm'` to `resolve(__dirname, 'node_modules/brepkit-wasm/brepkit_wasm_node.cjs')` in `vitest.config.ts`, `vitest.bench.config.ts`, and `vitest.stress.config.ts`. To test a local kernel:
+
+```bash
+wasm-pack build crates/wasm --target nodejs --release
+```
+
+Then temporarily change the alias target to `~/Git/brepkit/crates/wasm/pkg/brepkit_wasm.js` (plain nodejs build; only the xtask merge renames the entry to `.cjs`). Run the tests or bench, then revert the alias. This sidesteps npm install and the lockfile and lint-config churn that comes with it.
+
+### Full overlay: pnpm + Vite consumers (e.g. gridfinity-layout-tool)
+
+pnpm resolves through its `.pnpm` store, so `node_modules/brepkit-wasm/` is a link-like copy of `node_modules/.pnpm/brepkit-wasm@<ver>/node_modules/brepkit-wasm/`. Overlaying only one location silently loads the old build; Vite's dep-optimizer cache adds a second layer of staleness. The full recipe (copy into BOTH node_modules locations, `rm -rf node_modules/.vite*`, md5-verify all copies, restore with `pnpm install --force`) is owned by the parity-benchmarking skill, Procedure 2. Get the package contents from `crates/wasm/pkg/` after `cargo xtask wasm-build`, or unpack `npm pack brepkit-wasm@<ver>`. Alternative overlay check: probe for a binding key that only exists in the new build (`typeof kernel.myNewMethod === 'function'`).
+
+## 3. dispatch_op anatomy
+
+`executeBatch` (`pub fn execute_batch(&mut self, json: &str) -> String`, rg: `js_name = "executeBatch"` in `crates/wasm/src/bindings/batch.rs`) takes a JSON array of `{"op": "...", "args": {...}}` and returns a JSON array of `{"ok": <value>}` / `{"error": "<msg>"}`. One boundary crossing for N ops. An error entry does not stop later ops; invalid input JSON returns `[{"error": "invalid JSON: ..."}]`.
+
+Adding an op is a match arm in `fn dispatch_op(&mut self, op: &str, args: &serde_json::Value) -> Result<serde_json::Value, String>`:
+
+```rust
+"makeBox" => {
+    let w = get_f64(args, "width")?;
+    let h = get_f64(args, "height")?;
+    let d = get_f64(args, "depth")?;
+    let solid = brepkit_operations::primitives::make_box(self.topo_mut(), w, h, d)
+        .map_err(|e| e.to_string())?;
+    Ok(serde_json::json!(solid_id_to_u32(solid)))
+}
+```
+
+Arg helpers `get_f64` / `get_u32` live in `crates/wasm/src/helpers.rs` and return `Result<_, String>` so `?` composes directly. Optional args: `get_u32(args, "segments").unwrap_or(16)`.
+
+Handles in batch args are arena indices returned by earlier calls (batched or not), NOT positions in the batch result array. The header of `bindings/gridfinity_tests.rs` states this and its tests show the pattern.
+
+`tessellateSolid` is not in the dispatcher (stated in the `bindings/gridfinity_tests.rs` header); call it as a direct method. Its tessellation reproducer tests therefore live in `crates/operations/src/tessellate/` instead of the wasm contract tests.
+
+## 4. Panic safety, verbatim pattern
+
+Two live variants, both hand-rolled with `panic_message` from `crates/wasm/src/helpers.rs`:
+
+- Non-poisoning (fillet): `bindings/operations.rs`, rg: `catch_unwind` in that file. Wraps the body, converts a panic payload into a `JsError` via `panic_message(&panic_info, "Fillet")`, kernel stays usable.
+- Poisoning (`compoundCut`): `bindings/booleans.rs`, in its own impl block. Checks `self.poisoned` first and refuses with "Kernel poisoned after panic. Create a new BrepKernel instance."; on a caught panic sets `self.poisoned = true` because the topology may be half-mutated.
+
+Choose poisoning when the op mutates `self.topo` before the panic-prone phase; choose non-poisoning when the mutation is atomic-ish or recoverable. Either way the point is the same: an uncaught panic across the FFI boundary aborts the whole wasm instance, taking every handle with it.
+
+`crates/wasm-macros/src/lib.rs` contains a complete `#[wasm_binding]` attribute macro (js_name plus a `recoverable` mode with snapshot restore) but it is unwired: `brepkit-wasm-macros` is not in `crates/wasm/Cargo.toml` and `rg -n 'wasm_binding' crates/wasm/src` finds nothing. Treat it as a possible future consolidation, not the recipe.
+
+## 5. scripts/test-wasm-smoke.mjs
+
+Loads `crates/wasm/pkg/brepkit_wasm_node.cjs` via `createRequire` (CJS from ESM), then asserts in order:
+
+1. `new BrepKernel()` constructs.
+2. `makeBox(10, 20, 30)` returns a number handle.
+3. `volume(box, 0.1)` is within 1e-6 of 6000.
+4. `tessellateSolid` returns non-empty positions and indices, both multiples of 3.
+5. `exportStl` if present; feature-detected, skipped when the `io` cargo feature is off (`io` is a default feature per `crates/wasm/Cargo.toml`).
+
+Output shape: `ok - ...` per check, final line `All smoke tests passed`. Run it after every `cargo xtask wasm-build` (the build prints a reminder); `cargo xtask wasm-publish` runs it automatically. It will not work after a plain wasm-pack build because that names the entry `brepkit_wasm.js`, not `brepkit_wasm_node.cjs`.
+
+## 6. Binary size: budget and diagnosis
+
+Small wasm size is a headline competitive property of this kernel. The shipped `.wasm` is several times smaller than the reference kernel's. Nothing in CI enforces it, so erosion is silent unless someone reads the size comment.
+
+### What CI measures
+
+The `wasm-size` job ("WASM Size Report") in `.github/workflows/ci.yml` runs on PRs only. It builds `cargo build -p brepkit-wasm --target wasm32-unknown-unknown --release` for both the PR head and the base branch, stats `target/wasm32-unknown-unknown/release/brepkit_wasm.wasm`, and posts or updates one PR comment titled "WASM Binary Size" with a main/PR/delta table. It is informational only: it has no failure path, and growth above 50 KB just adds a "Please verify this is expected" line to the comment. The only hard gate anywhere is the coarse `validate_output` window in `xtask/src/wasm.rs` (`MIN_WASM_SIZE` 500 KB, `MAX_WASM_SIZE` 20 MB). Treat the size comment as a review item on every PR that touches `crates/wasm` or anything in its dependency tree.
+
+The CI number is the un-optimized cargo build. The shipped artifact goes through `cargo xtask wasm-build`, which runs `wasm-opt -O3` on `pkg/brepkit_wasm_bg.wasm` and prints before and after KB. The two deltas usually track each other; confirm a suspicious delta on the wasm-opt output before acting on it.
+
+### Budget rule
+
+- An unexplained size increase above roughly 1% of the base size needs a justification sentence in the PR body.
+- Adding any new dependency to the wasm dependency tree always needs one, even if the measured delta is small.
+
+### Diagnosis recipe
+
+1. Reproduce the CI measurement on both branches (main via a worktree or stash):
+
+```bash
+cargo build -p brepkit-wasm --target wasm32-unknown-unknown --release
+stat -c %s target/wasm32-unknown-unknown/release/brepkit_wasm.wasm
+```
+
+2. Confirm on the shipped path: `cargo xtask wasm-build`, read the wasm-opt before/after line, or stat `crates/wasm/pkg/brepkit_wasm_bg.wasm`.
+3. Attribute the growth with twiggy. Check availability first (`command -v twiggy`; `cargo install twiggy` if missing):
+
+```bash
+twiggy top -n 30 target/wasm32-unknown-unknown/release/brepkit_wasm.wasm
+twiggy diff base.wasm pr.wasm
+twiggy monos target/wasm32-unknown-unknown/release/brepkit_wasm.wasm
+```
+
+Without twiggy, optimize both files with `wasm-opt -O3` and compare the optimized sizes. Growth that survives `-O3` is real code or data, not padding.
+4. Check the dependency graph for a new crate and diff against main:
+
+```bash
+cargo tree -p brepkit-wasm --target wasm32-unknown-unknown -e normal
+```
+
+### Usual suspects
+
+- A new crate pulled into the wasm graph, often transitively. The `cargo tree` diff finds it.
+- Format and panic string bloat: `format!` in error paths, derived `Debug` on large types, long message literals. Shows up in twiggy as `core::fmt` frames and data-segment growth.
+- Code that should be feature-gated. `crates/wasm/Cargo.toml` defines `default = ["io"]` and `io = ["dep:brepkit-io"]`; a heavy optional capability should follow that pattern instead of landing unconditionally.
+- Monomorphization bloat from a generic instantiated with many types. `twiggy monos` lists it.
+
+The release profile is already size-conscious (`codegen-units = 1`, `lto = true` in the root `Cargo.toml` `[profile.release]`). Attribute the growth before reaching for profile tweaks.
+
+## 7. Glossary
+
+- **BrepKernel**: the single WASM-exported modeling context; owns all topology; JS holds only opaque `u32` handles.
+- **Handle**: a `u32` arena index into the kernel's `Topology`, resolved via `resolve_*` in `crates/wasm/src/handles.rs`. Not a batch result index.
+- **executeBatch / dispatch_op**: the one-boundary-crossing JSON batch API and its string-keyed dispatcher in `bindings/batch.rs`.
+- **Contract test**: a native `cargo test` exercising bindings via `execute_batch` JSON or `_impl` fns, because `JsError`/`JsValue` panic when constructed off-wasm.
+- **Poisoned kernel**: `poisoned: bool` set after a caught panic in a non-recoverable op; guarded calls then refuse.
+- **bundler vs nodejs target**: wasm-pack output flavors. ESM for bundlers (uses the WASM ESM integration proposal, unsupported in node) vs CJS for node. The published package merges both.
+- **Dual-target merge**: the xtask step producing `brepkit_wasm_node.cjs` and the patched `exports` map.
+- **Overlay**: hand-copying a local build over an installed `brepkit-wasm` in a consumer's node_modules (both direct and `.pnpm` copies) plus clearing the `.vite` cache.
+- **tsify**: derive crate generating TypeScript types for the typed result structs in `crates/wasm/src/types.rs`.
+- **io feature**: default cargo feature gating `bindings/io.rs` (STEP, STL, and the other formats).


### PR DESCRIPTION
## What

Eighteen skills under `.claude/skills/`, each capturing the method and traps for one recurring class of work, so engineers and smaller models can debug, extend, validate, benchmark, and ship this kernel without prior project context. `README.md` indexes them with a suggested reading order and a glossary.

**Doctrine and verification:** `debugging-doctrine`, `solid-verification`, `numerical-robustness`, `testing`.
**Engine internals:** `boolean-debugging`, `analytic-preservation`, `tessellation`, `fillet-blend`.
**Building:** `layer-boundaries`, `add-operation`, `wasm-bindings`, `render-verify`, `io-formats`.
**Shipping:** `pr-workflow`, `profiling`, `parity-benchmarking`, `release-flow`.
**Work selection:** `roadmap`, a living index of open, deferred, and terminal cases with the chase filters and the acceptance bar.

## How it was built

Each skill went through research, authoring, adversarial verification, and fix stages, then cross-skill consistency and coverage passes. Every file path, symbol, and command was checked against the current tree. Several beliefs carried in from earlier work were found stale and corrected in place (tooling that now exists, a heal function that is implemented rather than a stub, a deprecation already removed).

## Scope

Documentation only. No source, test, or build changes. The `roadmap` skill declares a maintenance contract: sessions that close, defer, or discover a work item update it in the same PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the brepkit engineering skill library under `.claude/skills` with 18 task-focused guides and references so contributors can debug, extend, verify, benchmark, and ship the kernel. Docs-only; includes an indexed `README.md` and a maintenance rule for the `roadmap` skill.

- **New Features**
  - Eighteen skill guides across doctrine/verification, engine internals, building, shipping, and work selection, each with `SKILL.md` + `reference.md` verified against current symbols, paths, and commands.
  - `README.md` index with suggested reading order and glossary.
  - `roadmap` adds a maintenance contract: sessions that close/defer/discover work must update it in the same PR.

<sup>Written for commit 3f6b64818afdb31a27b07edef926fc63b9ba623b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

