### PR TITLE
fix(deps): upgrade quick-xml to 0.41 for RUSTSEC-2026-0194/0195

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,14 @@
+# cargo-audit configuration. Mirrors the advisory ignores in deny.toml, because
+# cargo-audit does not read deny.toml.
+#
+# RUSTSEC-2026-0194 / -0195 are denial-of-service advisories against quick-xml
+# on untrusted XML input. The only path that parses untrusted input, the 3MF
+# reader in brepkit-io, is on the patched quick-xml >= 0.41.0. The residual
+# quick-xml 0.39.4 in the lock enters solely through wayland-scanner (a
+# build-time proc-macro under winit, behind brepkit-render's `window` feature),
+# which generates code from vendored, trusted Wayland protocol XML at compile
+# time and never touches runtime input. wayland-scanner pins quick-xml ^0.39, so
+# this copy cannot advance until that upstream chain updates. Re-check and drop
+# these entries when winit/wayland-scanner move off quick-xml 0.39.
+[advisories]
+ignore = ["RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ proptest = "1"
 criterion = {version = "0.8", features = ["html_reports"]}
 
 # IO formats
-quick-xml = "0.40"
+quick-xml = "0.41"
 zip = {version = "8", default-features = false, features = ["deflate"]}
 
 # Workspace crates

--- a/deny.toml
+++ b/deny.toml
@@ -11,8 +11,8 @@ yanked = "warn"
 # this copy cannot advance until that upstream chain updates. Re-check and drop
 # these entries when winit/wayland-scanner move off quick-xml 0.39.
 ignore = [
-  { id = "RUSTSEC-2026-0194", reason = "only reachable via wayland-scanner build-time codegen on trusted protocol XML; the untrusted-input 3MF path is patched to quick-xml >= 0.41" },
-  { id = "RUSTSEC-2026-0195", reason = "only reachable via wayland-scanner build-time codegen on trusted protocol XML; the untrusted-input 3MF path is patched to quick-xml >= 0.41" },
+  {id = "RUSTSEC-2026-0194", reason = "only reachable via wayland-scanner build-time codegen on trusted protocol XML; the untrusted-input 3MF path is patched to quick-xml >= 0.41"},
+  {id = "RUSTSEC-2026-0195", reason = "only reachable via wayland-scanner build-time codegen on trusted protocol XML; the untrusted-input 3MF path is patched to quick-xml >= 0.41"},
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,19 @@
 [advisories]
 unmaintained = "workspace"
 yanked = "warn"
+# RUSTSEC-2026-0194 / -0195 are denial-of-service advisories against quick-xml
+# on untrusted XML input. The only path that parses untrusted input, the 3MF
+# reader in brepkit-io, is on the patched quick-xml >= 0.41.0. The residual
+# quick-xml 0.39.4 in the lock enters solely through wayland-scanner (a
+# build-time proc-macro under winit, behind brepkit-render's `window` feature),
+# which generates code from vendored, trusted Wayland protocol XML at compile
+# time and never touches runtime input. wayland-scanner pins quick-xml ^0.39, so
+# this copy cannot advance until that upstream chain updates. Re-check and drop
+# these entries when winit/wayland-scanner move off quick-xml 0.39.
+ignore = [
+  { id = "RUSTSEC-2026-0194", reason = "only reachable via wayland-scanner build-time codegen on trusted protocol XML; the untrusted-input 3MF path is patched to quick-xml >= 0.41" },
+  { id = "RUSTSEC-2026-0195", reason = "only reachable via wayland-scanner build-time codegen on trusted protocol XML; the untrusted-input 3MF path is patched to quick-xml >= 0.41" },
+]
 
 [licenses]
 # CC0-1.0 (hexf-parse) and ISC (libloading) enter via the wgpu/naga dependency


### PR DESCRIPTION
## Why

Two DoS advisories landed against `quick-xml` on untrusted XML input, failing Cargo Deny and Security Audit on `main` and on every open PR:

- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194): quadratic time checking a start tag for duplicate attribute names.
- [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195): unbounded namespace-declaration allocation in `NsReader`.

Both are fixed in `quick-xml >= 0.41.0`.

## What

- Bump the direct dependency `quick-xml` from `0.40` to `0.41` (root `Cargo.toml`). The only path that parses untrusted input is the 3MF reader in `brepkit-io`; it and the 3MF writer build and pass unchanged against 0.41.
- Scope a documented advisory ignore in `deny.toml` for the residual `quick-xml 0.39.4`, which enters only through `wayland-scanner` (a build-time proc-macro under `winit`, behind `brepkit-render`'s `window` feature). It generates code from vendored, trusted Wayland protocol XML at compile time and never touches runtime input, and it is pinned to `^0.39` upstream so it cannot advance yet. The ignore carries a re-check trigger for when the `winit` chain moves off `quick-xml 0.39`.

## Verification

- `cargo build -p brepkit-io` and `cargo test -p brepkit-io` pass against 0.41.
- `cargo deny --all-features check` reports `advisories ok, bans ok, licenses ok, sources ok` locally (all-features reproduces the CI action's graph breadth, which includes the window/wayland path).

## Note

Unblocks the repo's security checks, which are currently red on `main` independent of any single PR (including the docs-only #1023).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `quick-xml` to 0.41 to patch `RUSTSEC-2026-0194`/`0195` DoS issues and restore passing security checks. 3MF parsing/writing in `brepkit-io` builds and tests unchanged.

- **Dependencies**
  - Add scoped `deny.toml` ignores for `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` on the residual `quick-xml 0.39.4` via `wayland-scanner` under `winit` (`brepkit-render` `window` feature); build-time codegen only. Taplo-formatted and includes a re-check note for when the chain updates.
  - Mirror the same ignores in `.cargo/audit.toml` so the Security Audit job (`cargo-audit`) also passes.

<sup>Written for commit 89f7898476290ef41e39ba6e224917f903418381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

