### PR TITLE
docs(roadmap): post-#1054 baseplate re-probe baseline

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -143,6 +143,26 @@ kernel-specific), groupedScoop + splitBin manifold PASS, combinedFeatures 3/11
 dovetailKey 1/2 (all three: watertight-STL asserts — re-probe after the lip-corner fix
 lands, they may share it), dovetail suite timeout >25min (cornerclip row above).
 
+Baseplate re-probe on published 2.124.12 (2026-07-08, post-#1054): partial movement,
+no closures — snapClip 0/4 (nm 14 unchanged, key 16→12, 0.6mm-nozzle 11→**1**, clip
+volume 46.78 vs 46.6±0.05), fit-offset 0/2 (loose bnd 184→144, at-floor 144
+unchanged), dovetailKey 1/2 (bnd=108 unchanged). The #1054 fixture was the CORNER
+tile (one rounded corner); the residuals live in the other tile/connector configs —
+next step is a fresh operand capture of one failing case (dovetailKey bnd=108 or the
+nm=1 nozzle case) on ≥2.124.12. The full dovetail suite: **>25-min timeout →
+355s total** (mesh-fallback slab gone in-tool; most tiles now 0.3–1.5s), 2/9 pass;
+the A1-canonical corner tile fell ~597 nm → **nm=3 at 468ms**. Residual family:
+bnd=108 (5×4 middle-column, inverted, AND dovetailKey — one shared root), bnd=144
+(4×4 interior ×2 — interior tiles have NO rounded corners, so this is the
+fully-coincident-walls intersect variant), bnd=5 (5×4.5 fractional edge tile, also
+still slow at 265s), nm=6 (magnet variant, 82s), nm=3 (corner tile). combinedFeatures re-read (2026-07-08, 900s runs):
+"handle holes" + "funnel cutout" PASS at engine level in 62–87s (the tool's per-test
+60s timeout masks them — PERF item); the real defect is "handles + label (back
+skip)": a swallowed panic poisons the wasm borrow flag ("recursive use of an
+object" from a later `getSolidFaces` inside brepjs translate) — generator
+catch-and-continue sites (`wallPatternCompound.ts` etc.) hide the panic text; dig
+with a node-level panic hook.
+
 The remaining `#[ignore]` entries are diagnostics or slow perf cases, not open bugs:
 the `profile_intersect.rs` box-sphere probes are stale leftovers (box-sphere shipped
 analytic in #1006), `staircase_fuse_with_cylinders` is a ~2 min perf run, and the two


### PR DESCRIPTION
Living-doc update after #1054 released as 2.124.12 and the baseplate suites were re-probed tool-side.

**Headline**: the dovetail scenario suite went from a >25-minute timeout to **355s total** — the corner-rounding intersect no longer mesh-falls-back, so connector fuses stopped consuming the 6116-facet slab. The A1-canonical corner tile dropped from ~597 non-manifold STL edges (11 min/tile) to nm=3 at 468ms.

Records the residual failure families for the next fix cycles:
- bnd=108: 5×4 middle-column + inverted + dovetailKey (one shared root)
- bnd=144: 4×4 interior tiles — no rounded corners, i.e. the fully-coincident-walls intersect variant
- bnd=5 + 265s: 5×4.5 fractional edge tile; nm=6 magnet variant; nm=3 corner tile
- snapClip: partial movement (nozzle case nm 11→1), clip-solid nm is a separate (fillet-family) root
- combinedFeatures honeycomb+handles: 'handle holes'/'funnel cutout' PASS at engine level in 62–87s (masked by the 60s per-test timeout — perf item); the real defect is the 'handles + label (back skip)' swallowed panic that poisons the wasm borrow flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the roadmap with the post-#1054 re-probe baseline on 2.124.12. Notes the dovetail suite speedup (>25 min → 355s), the A1 corner tile improvement (~597 non‑manifold edges → 3 at 468ms), the remaining failure families (bnd=108/144/5; nm=6/3), and a swallowed‑panic defect in combinedFeatures that’s hidden by the 60s test timeout.

<sup>Written for commit 907f8bf6d774737d5240bd5ada0f36faeb1e9f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

