### PR TITLE
fix(operations): recognize spline-encoded profile edges before extruding walls

### DIFF
--- a/crates/operations/src/extrude.rs
+++ b/crates/operations/src/extrude.rs
@@ -597,6 +597,98 @@ fn ruled_nurbs_surface(
     .map_err(crate::OperationsError::Math)
 }
 
+/// Recognize spline-encoded profile edges back to their analytic form,
+/// in place.
+///
+/// 2D drawing pipelines ship corner-treated profiles as B-splines: a chamfer
+/// segment and the corner-trimmed remainders of straight runs arrive as
+/// degree-N NURBS even though they are exact lines, and fillet arcs can
+/// arrive as rational splines. Extruding those emits ruled-NURBS side walls
+/// for geometry that is exactly planar/cylindrical, and every downstream
+/// boolean against the prism degrades (the snap-clip relief cut fell to a
+/// mesh fallback purely because its clip walls were spline-encoded). The
+/// caps' wires and the wall builder all read the same edges, so rewriting
+/// the curve in place fixes every consumer at once.
+fn normalize_profile_wire_curves(
+    topo: &mut Topology,
+    wire_id: WireId,
+    tol: f64,
+) -> Result<(), crate::OperationsError> {
+    let edge_ids: Vec<brepkit_topology::edge::EdgeId> = topo
+        .wire(wire_id)?
+        .edges()
+        .iter()
+        .map(brepkit_topology::wire::OrientedEdge::edge)
+        .collect();
+    for eid in edge_ids {
+        let edge = topo.edge(eid)?;
+        let EdgeCurve::NurbsCurve(nc) = edge.curve() else {
+            continue;
+        };
+        let s3 = topo.vertex(edge.start())?.point();
+        let e3 = topo.vertex(edge.end())?.point();
+        let (d0, d1) = nc.domain();
+        let a3 = nc.evaluate(d0);
+        let b3 = nc.evaluate(d1);
+        let mid3 = nc.evaluate(f64::midpoint(d0, d1));
+        // Only convert when the spline's own endpoints coincide with the edge
+        // vertices (either order) — anything else is a malformed profile this
+        // pass must not reinterpret.
+        let fwd = (a3 - s3).length() <= tol && (b3 - e3).length() <= tol;
+        let rev = (a3 - e3).length() <= tol && (b3 - s3).length() <= tol;
+        if !fwd && !rev {
+            continue;
+        }
+        let new_curve = match brepkit_geometry::convert::recognize_curve(nc, tol * 100.0) {
+            brepkit_geometry::convert::RecognizedCurve::Line { .. } if (s3 - e3).length() > tol => {
+                Some(EdgeCurve::Line)
+            }
+            brepkit_geometry::convert::RecognizedCurve::Circle {
+                center,
+                normal,
+                radius,
+            } => {
+                // Edges store arcs in the CCW convention: the span from the
+                // START vertex to the END vertex runs counter-clockwise about
+                // the curve normal. Pick the normal sign that puts the spline's
+                // own midpoint on the CCW span from the start VERTEX (using the
+                // curve-ordered endpoints, which lie exactly on the curve), or
+                // an open arc would flip to its complement.
+                let is_closed = (s3 - e3).length() <= tol;
+                let n = if is_closed {
+                    normal
+                } else {
+                    let (from, to) = if fwd { (a3, b3) } else { (b3, a3) };
+                    let u = from - center;
+                    let v = to - center;
+                    let m = mid3 - center;
+                    let ang = |w: Vec3| -> f64 {
+                        u.cross(w)
+                            .dot(normal)
+                            .atan2(u.dot(w))
+                            .rem_euclid(std::f64::consts::TAU)
+                    };
+                    let span = ang(v);
+                    let mid_a = ang(m);
+                    if span > 1e-12 && mid_a <= span {
+                        normal
+                    } else {
+                        -normal
+                    }
+                };
+                brepkit_math::curves::Circle3D::new(center, n, radius)
+                    .ok()
+                    .map(EdgeCurve::Circle)
+            }
+            _ => None,
+        };
+        if let Some(c) = new_curve {
+            topo.edge_mut(eid)?.set_curve(c);
+        }
+    }
+    Ok(())
+}
+
 /// Extrude a planar face along a direction to produce a solid.
 ///
 /// The extrusion creates a prism-like solid from the face. A reversed copy of
@@ -638,6 +730,11 @@ pub fn extrude(
     let mut input_surface = face_data.surface().clone();
     let input_wire_id = face_data.outer_wire();
     let inner_wire_ids: Vec<WireId> = face_data.inner_wires().to_vec();
+
+    normalize_profile_wire_curves(topo, input_wire_id, tol.linear)?;
+    for &iw in &inner_wire_ids {
+        normalize_profile_wire_curves(topo, iw, tol.linear)?;
+    }
 
     let offset = Vec3::new(
         direction.x() * distance,

--- a/crates/operations/src/extrude/tests.rs
+++ b/crates/operations/src/extrude/tests.rs
@@ -1317,3 +1317,97 @@ fn extrude_half_ellipse_reversed_edge_volume() {
         "reversed-edge half-ellipse volume {vol:.4} != {expected:.4}"
     );
 }
+
+#[test]
+fn extrude_spline_encoded_profile_recovers_analytic_walls() {
+    // A chamfered-rectangle profile whose edges arrive as B-splines (the 2D
+    // drawing pipeline ships corner-treated profiles this way): four straight
+    // runs and one chamfer segment as degree-1 NURBS, one fillet corner as a
+    // rational-quadratic arc. Every side wall must come out Plane/Cylinder.
+    use brepkit_geometry::convert::{circle_to_nurbs, line_to_nurbs};
+    use brepkit_topology::edge::Edge;
+    use brepkit_topology::face::Face;
+    use brepkit_topology::vertex::Vertex;
+    use brepkit_topology::wire::Wire;
+
+    let mut topo = Topology::new();
+    let tol = Tolerance::new().linear;
+    // Rectangle [0,10]x[0,6] with a 2mm chamfer at (10,6) and an r=2 fillet
+    // arc at (0,6).
+    let pts = [
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(10.0, 0.0, 0.0),
+        Point3::new(10.0, 4.0, 0.0), // chamfer start
+        Point3::new(8.0, 6.0, 0.0),  // chamfer end
+        Point3::new(2.0, 6.0, 0.0),  // fillet start
+        Point3::new(0.0, 4.0, 0.0),  // fillet end
+    ];
+    let vids: Vec<_> = pts
+        .iter()
+        .map(|&p| topo.add_vertex(Vertex::new(p, tol)))
+        .collect();
+    let nurbs_line = |a: Point3, b: Point3| EdgeCurve::NurbsCurve(line_to_nurbs(a, b).unwrap());
+    let fillet_circle = brepkit_math::curves::Circle3D::new(
+        Point3::new(2.0, 4.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+        2.0,
+    )
+    .unwrap();
+    // CCW arc from (2,6) to (0,4) — parameters via projection, because
+    // Circle3D picks its own reference axis.
+    let t0 = fillet_circle.project(pts[4]);
+    let mut t1 = fillet_circle.project(pts[5]);
+    if t1 < t0 {
+        t1 += std::f64::consts::TAU;
+    }
+    let fillet_arc = EdgeCurve::NurbsCurve(circle_to_nurbs(&fillet_circle, t0, t1).unwrap());
+    let curves = [
+        nurbs_line(pts[0], pts[1]),
+        nurbs_line(pts[1], pts[2]),
+        nurbs_line(pts[2], pts[3]), // chamfer
+        nurbs_line(pts[3], pts[4]),
+        fillet_arc,
+        nurbs_line(pts[5], pts[0]),
+    ];
+    let mut oes = Vec::new();
+    for (i, c) in curves.into_iter().enumerate() {
+        let a = vids[i];
+        let b = vids[(i + 1) % vids.len()];
+        let e = topo.add_edge(Edge::new(a, b, c));
+        oes.push(OrientedEdge::new(e, true));
+    }
+    let wid = topo.add_wire(Wire::new(oes, true).unwrap());
+    let face = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+    let mut nurbs_walls = 0usize;
+    let mut cylinders = 0usize;
+    for fid in brepkit_topology::explorer::solid_faces(&topo, solid).unwrap() {
+        match topo.face(fid).unwrap().surface() {
+            FaceSurface::Nurbs(_) => nurbs_walls += 1,
+            FaceSurface::Cylinder(_) => cylinders += 1,
+            _ => {}
+        }
+    }
+    assert_eq!(
+        nurbs_walls, 0,
+        "spline-encoded straight/arc profile edges must extrude as analytic walls"
+    );
+    assert_eq!(
+        cylinders, 1,
+        "the fillet arc must extrude as a true cylinder"
+    );
+    // Exact area: 10*6 - chamfer triangle (2*2/2) - fillet corner (4 - pi) = 58 - (4 - pi).
+    let expected = (60.0 - 2.0 - (4.0 - std::f64::consts::PI)) * 3.0;
+    let vol = crate::measure::solid_volume(&topo, solid, 0.001).unwrap();
+    assert!(
+        (vol - expected).abs() / expected < 1e-4,
+        "analytic prism volume {vol:.9} != exact {expected:.9}"
+    );
+}


### PR DESCRIPTION
## Summary

The snap-clip connector key (snapClip suite, bnd=326 export failure) traced to the extrude source: 2D drawing pipelines ship corner-treated profiles as B-splines (chamfer segments and corner-trimmed straight runs arrive as degree-N NURBS; fillet arcs as rational splines), and extrude emitted ruled-NURBS side walls for geometry that is exactly planar/cylindrical. Every downstream boolean against the prism degraded — the clip's four socket-relief cuts fell to a mesh fallback purely because the walls were spline-encoded.

Fix: normalize the profile wires' curves in place at extrude entry, mirroring the loft profile-recognition from the analytic-socket work — NURBS→Line and NURBS→Circle (oriented so the CCW start→end span covers the spline's own midpoint; conversion skipped unless the spline's endpoints coincide with the edge vertices).

## Verification

- New unit fixture: spline-encoded chamfered/filleted profile extrudes with zero NURBS walls, one true cylinder, and exact volume.
- Captured tool chain (snap-clip key): clip prism 4 cyl + 18 plane (was 8 NURBS walls); all four socket-relief cuts analytic and watertight (F=98, E=350 vs the fallback's E=3029); the connector-key scenario passes tool-side on an overlay build.
- Full suites: operations 971, io 207, wasm 229 — all green; workspace clippy clean.