### PR TITLE
docs(algo): reattach the self-cross gate doc comment to its function

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -893,21 +893,6 @@ fn attach_whole_holes(sub_faces: &mut [SplitSubFace], holes: &[Vec<OrientedPCurv
     }
 }
 
-/// True when any wire loop revisits a UV vertex — the signature of a
-/// self-crossing trace from the angular wire builder, which the arrangement
-/// decomposition can replace with simple (non-self-intersecting) regions even
-/// when it produces FEWER loops. A simple closed loop visits each vertex once;
-/// a figure-eight or out-and-back revisits one.
-///
-/// Detection is vertex-topological: it tests only the edges' endpoints
-/// (`start_uv`). That is exactly the failure mode this gate targets — the
-/// angular builder over-splits by walking out-and-back through a shared UV
-/// vertex (see `remove_pendant_sections`), so the bad trace always reuses a
-/// vertex. It deliberately does NOT detect a self-crossing that occurs only
-/// along an edge's interior (e.g. an arc whose curved path crosses another
-/// edge's chord in UV between their endpoints, with no shared vertex). No
-/// wire-builder trace produces such a crossing here, so testing arc interiors
-/// would add cost without changing any outcome.
 /// True when any traced loop's sampled UV polygon is area-degenerate — the
 /// classifier's sliver guard would silently drop it, so the loops path
 /// under-represents the face even though the loop COUNT looks fine. The
@@ -929,6 +914,21 @@ fn wire_loops_have_degenerate_area(loops: &[Vec<OrientedPCurveEdge>], tol: f64) 
     })
 }
 
+/// True when any wire loop revisits a UV vertex — the signature of a
+/// self-crossing trace from the angular wire builder, which the arrangement
+/// decomposition can replace with simple (non-self-intersecting) regions even
+/// when it produces FEWER loops. A simple closed loop visits each vertex once;
+/// a figure-eight or out-and-back revisits one.
+///
+/// Detection is vertex-topological: it tests only the edges' endpoints
+/// (`start_uv`). That is exactly the failure mode this gate targets — the
+/// angular builder over-splits by walking out-and-back through a shared UV
+/// vertex (see `remove_pendant_sections`), so the bad trace always reuses a
+/// vertex. It deliberately does NOT detect a self-crossing that occurs only
+/// along an edge's interior (e.g. an arc whose curved path crosses another
+/// edge's chord in UV between their endpoints, with no shared vertex). No
+/// wire-builder trace produces such a crossing here, so testing arc interiors
+/// would add cost without changing any outcome.
 fn wire_loops_self_cross(loops: &[Vec<OrientedPCurveEdge>], tol: f64) -> bool {
     let qscale = 1.0 / tol.max(1e-12);
     let qkey = |p: brepkit_math::vec::Point2| -> (i64, i64) {


### PR DESCRIPTION
Follow-up to #1082 (automerge outran Copilot's finding): the new `wire_loops_have_degenerate_area` was inserted between `wire_loops_self_cross`'s doc comment and the function, misattaching the rustdoc. Reorders the comments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reattached the doc comment for the self-cross gate to `wire_loops_self_cross`. Fixes a misattached rustdoc caused by inserting `wire_loops_have_degenerate_area`, ensuring the correct function is documented.

<sup>Written for commit 7cb4a956ffd746c8efa9f382616b32eb62d44523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

