### PR TITLE
docs(algo): align section-clip and internal-loop doc comments with the multi-interval behavior

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -219,6 +219,31 @@ suite reaches 9/9. DURABLE: stored `start_uv`/pcurves on hole wires can be
 fitted in a FOREIGN frame — any consumer building polygons from them must
 re-derive via frame.project(3D) (same class as the pcurve-convention lesson).
 
+snapClip family — THREE roots CLOSED 2026-07-16 (#1080, #1082, #1085); deepened-notch remains:
+- Connector key (#1080, fixture `extrude_spline_encoded_profile_recovers_analytic_walls`):
+  2D drawings ship corner-treated profiles as B-splines; extrude emitted ruled-NURBS
+  walls for exact plane/cylinder geometry and every boolean against the prism fell
+  back. Profile-wire curve recognition at extrude entry (the loft pattern).
+- Completed 4-way socket-junction disc (#1082, fixture `socket_junction_disc_inmem`):
+  the junction circle's 2-arc traced loop samples area-degenerate, the sliver guard
+  dropped it silently, and the arrangement was declined on equal loop COUNT; the
+  arrangement gate now also fires on any area-degenerate traced loop. Full 20-pocket
+  snapClip plate chain analytic (F=595 vs F=6923/bnd=930).
+- Snap-slot hole cuts (#1085, fixture `snapclip_slot_cut_inmem`): four stacked
+  section-machinery gaps — outermost-pair clip vs INWARD-bulging bite arcs
+  (midpoint-classified multi-interval clip, HOLE-FREE faces only: holed faces'
+  sections feed the weave, calibrated on whole pieces), multi-window sections kept
+  one window, plane×band Lines never clipped to the band v-window (exact affine-v
+  trim; mixed pairs get ONLY that trim — the plane-polygon clip on banded pairs
+  broke seam-anchored cylinder bands), and marched-fit endpoints ~1e-6 off exact
+  chain partners (weld at 100·tol). FOIL SET GREW: cylinder-slot + groove-mouth +
+  junction-disc are now mandatory alongside d4/pcut3/divider for ANY section/clip
+  change — three wrong gate choices were each caught by a different foil.
+- REMAINING: hole-1+ deepened-notch/coplanar-margin family (0.01 offsets between
+  successive slot cutters → micro-edges + near-coincident conic pairs; the
+  deepened-notch TERMINAL row's missing piece), 0.6mm-nozzle nm, bed-flat clip
+  volume 46.701 vs 46.6±0.05 pin (run the reference kernel side-by-side first).
+
 Fit-offset groove-mouth sliver family — CLOSED (2026-07-16, PR #1078, fixture
 `crates/io/tests/fitoffset_groove_mouth_inmem.rs`): each groove cutter's mouth
 clips the adjacent socket-pocket rim corners, leaving zero-width top-face

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -3782,9 +3782,10 @@ pub fn interior_point_3d(sub_face: &SplitSubFace, frame: Option<&PlaneFrame>) ->
     Point3::new(sum.x() / n, sum.y() / n, sum.z() / n)
 }
 
-/// Detect all-Line section edges forming closed loops strictly inside a
-/// plane face's boundary (nested coplanar footprints), and dedup repeated
-/// segments. Both the coplanar-contact pass and adjacent-face plane-plane
+/// Detect section edges (lines, open arcs, and open NURBS conics) forming
+/// closed loops strictly inside a plane face's boundary (nested coplanar
+/// footprints, or a box wall's socket-profile silhouette), and dedup
+/// repeated segments. Both the coplanar-contact pass and adjacent-face plane-plane
 /// intersections can emit the same footprint segment, so identical
 /// segments (by unordered quantized endpoints) collapse to one.
 ///

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2182,7 +2182,8 @@ fn arc_segment_crossings(
 ///
 /// Collects the outer wire vertices as line segments, then finds where
 /// the section line enters and exits the polygon. Returns the trimmed
-/// `(start, end)` or `None` if the line doesn't cross the face.
+/// Every in-face `(start, end)` interval of the line (a section can cross a
+/// face in multiple material windows), or `None` when nothing lies inside.
 #[allow(clippy::too_many_lines)]
 fn clip_line_to_face_boundary(
     topo: &Topology,
@@ -2329,8 +2330,9 @@ fn clip_line_to_face_boundary(
     // section then extends into the bite (air on this face), the splitter
     // weaves a wrong region, and the cut falls to a mesh fallback (the
     // snap-slot hole cuts). Classify each candidate sub-interval's midpoint
-    // against the arc-true boundary polygon and keep the longest interval that
-    // is actually inside the face.
+    // against the arc-true boundary polygon and keep EVERY interval that is
+    // actually inside the face (a section can cross the face in multiple
+    // material windows).
     let plane_frame = match face.surface() {
         FaceSurface::Plane { normal, .. } => {
             let pts: Vec<Point3> = boundary_segments.iter().map(|&(s, _)| s).collect();


### PR DESCRIPTION
Follow-up to #1085 (automerge outran Copilot's three stale-doc findings): the clip now returns every in-face interval and the internal-loop detector accepts open arcs/NURBS — the doc comments still described the old single-interval/all-Line behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns code doc comments with current behavior: section clipping returns every in-face interval, and internal-loop detection accepts lines, open arcs, and open NURBS conics with dedup. Also updates the skills roadmap to mark snapClip’s three roots closed (#1080/#1082/#1085) and note the remaining deepened‑notch work.

<sup>Written for commit 34ceff783db6e568fcbed779ed319b484a38d832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

