### PR TITLE
fix(algo): split marched-NURBS boundary edges at neighbor partition anchors

### DIFF
--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -55,7 +55,10 @@ pub(super) fn split_boundary_edges_at_3d_points(
         for &(t, pt) in &splits {
             // Circle splits carry the exact on-curve foot; re-evaluating via
             // `evaluate_edge_at_t` would re-apply the CCW-span convention
-            // that iso-v rim splits deliberately bypass.
+            // that iso-v rim splits deliberately bypass. NURBS splits carry
+            // the CANDIDATE point itself (validated within `tol` of the
+            // curve): it is the neighbouring face's anchor, and adopting it
+            // verbatim gives both faces the identical split vertex.
             let split_3d = if matches!(
                 edge.curve_3d,
                 EdgeCurve::Circle(_) | EdgeCurve::NurbsCurve(_)

--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -34,7 +34,13 @@ pub(super) fn split_boundary_edges_at_3d_points(
             EdgeCurve::Ellipse(ellipse) => {
                 find_splits_on_ellipse(ellipse, &edge, split_pts_3d, tol)
             }
-            _ => find_splits_on_line(&edge, split_pts_3d, tol),
+            // A marched-NURBS boundary edge (a plane×cone conic minted by an
+            // earlier boolean) must split where a neighbouring face's
+            // partition anchors on it — the chord-based line fallback rejects
+            // on-curve points by the sagitta, leaving the shared edge whole on
+            // one face and split on the other (cross-face desync).
+            EdgeCurve::NurbsCurve(_) => find_splits_on_nurbs_section(&edge, split_pts_3d, tol),
+            EdgeCurve::Line => find_splits_on_line(&edge, split_pts_3d, tol),
         };
 
         if splits.is_empty() {
@@ -50,7 +56,10 @@ pub(super) fn split_boundary_edges_at_3d_points(
             // Circle splits carry the exact on-curve foot; re-evaluating via
             // `evaluate_edge_at_t` would re-apply the CCW-span convention
             // that iso-v rim splits deliberately bypass.
-            let split_3d = if matches!(edge.curve_3d, EdgeCurve::Circle(_)) {
+            let split_3d = if matches!(
+                edge.curve_3d,
+                EdgeCurve::Circle(_) | EdgeCurve::NurbsCurve(_)
+            ) {
                 pt
             } else {
                 evaluate_edge_at_t(&edge.curve_3d, edge.start_3d, edge.end_3d, t)

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -2722,6 +2722,9 @@ pub fn split_face_2d(
     }
 
     let mut split_pts_3d: Vec<Point3> = sections.iter().flat_map(|s| [s.start, s.end]).collect();
+    if !is_plane && let Some(reg) = split_registry.as_deref_mut() {
+        split_pts_3d.extend(reg.values().flatten().copied());
+    }
 
     // For periodic faces, align closed boundary edge UV with seam edge UV.
     // The same 3D vertex projects to u=0 (from circle unwrapping) and u=seam

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -367,11 +367,7 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
             None, // PlaneFrame built internally by face_splitter
             info.as_ref(),
             edge_images,
-            if is_plane_face {
-                Some(&mut section_split_registry)
-            } else {
-                None
-            },
+            Some(&mut section_split_registry),
         );
 
         log::debug!(


### PR DESCRIPTION
## Summary

Follow-up to #1092, next increment on the snapClip deepened-notch chain. A marched-NURBS boundary edge (a plane×cone conic minted by an earlier boolean) is shared between a plane face and a curved face. The plane side splits its copy face-locally where its section web anchors on it, but `split_boundary_edges_at_3d_points` had **no NurbsCurve arm** — the chord-based line fallback rejects on-curve points by the sagitta — so the curved side kept the edge whole and the two partitions desynchronized: unpaired result edges, analytic-gate rejection, mesh fallback.

## Changes

- The boundary splitter routes NURBS edges through the existing sampled point-on-curve matcher (`find_splits_on_nurbs_section`: nearest-sample pre-locate + ternary refine, weld band) and uses the refined on-curve foot as the split vertex, mirroring the Circle arm.
- Curved faces feed the #1092 section split registry into their boundary split candidates, so anchors registered by plane neighbours reach the shared edges. Candidates not on an edge are inert by construction.

An earlier attempt at this arm (pre-#1092) regressed the groove-mouth chain; on top of #1092's refined arrangement (on-line validation, endpoint guards, sagitta cover) the groove landscape produces no NURBS boundary splits at all and stays green.

## Testing

- snapClip deepened-notch raw repro: unpaired/over-shared edges **22 → 10**.
- Full calibrated foil battery green: groove-mouth, both A1-corner fixtures, honeycomb pcut, wall-cutout, junction-disc, snap-slot, cornerclip, divider-lip, fit-offset nub chain, dblcorner nub, d4 canary 27/27.
- io / operations / algo suites green; clippy -D warnings + fmt clean; pre-push full-test hook passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desynced splits on marched NURBS boundary edges shared by plane and curved faces. NURBS edges now split at neighbor anchors, keeping shared edges in sync and avoiding analytic rejection and mesh fallback.

- **Bug Fixes**
  - Route NURBS boundary edges through the sampled point-on-curve matcher and use the neighbor anchor point as the split vertex (adopted verbatim).
  - Provide the section split registry to all faces so curved-face boundary candidates receive plane-side anchors.
  - Result: snapClip deepened-notch unpaired/over-shared edges reduced from 22 to 10; full test suites green.

<sup>Written for commit 71fdc9858a5383feafed05f225f33251201aeb23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

