### PR TITLE
fix(topology): trim NURBS edge domains to validated forward endpoint sub-spans

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -358,26 +358,31 @@ nozzle nm 1→15, clip volume 46.78→46.70 vs 46.6±0.05). Dovetail residuals:
   keyed, NURBS boundary arm) broke the groove/a1corner calibrated chains
   which DEPEND on downstream reconciliation of asymmetric splits.** Repro:
   cache replay_scplate.rs (RAWN=n) + capture-snapclip-plate-fresh.
-- **NURBS endpoint-trimmed convention DOES NOT EXIST — OPEN (discovered
-  2026-07-17, the deepened-notch dig's terminal root):**
-  `EdgeCurve::domain_with_endpoints` for `NurbsCurve` returns the FULL knot
-  domain, ignoring the endpoints (topology/src/edge.rs ~line 95) — while
-  Circle/Ellipse project endpoints to the true sub-span. Every NURBS
-  sub-span consumer silently evaluates the WHOLE curve: piece pcurves carry
-  the parent's UV endpoints, and the wire builder conflates near-coincident
-  structures (the snapClip deepened-notch cone: twin rims 0.01 apart merged
-  into one loop → duplicate regions → the residual unpaired edges after
-  #1094). A narrow fix (endpoint projection in
-  `pcurve_compute::evaluate_edge_at_t`, math nurbs projection) confirmed
-  the diagnosis but immediately broke the curved-lens interior machinery
-  ("no contained interior for curved-lens wall") — consumers are calibrated
-  on the full-domain behavior. The fix needs a DEDICATED pass: implement
-  the convention (globally in `domain_with_endpoints` or path-by-path
-  starting at pcurve_compute + the curved-lens interior search), then the
-  regression ladder: the deepened-notch raw repro (cached
-  replay_scplate.rs, RAWN=1 — expect the cone conflation to resolve),
-  curved-lens fixtures, full foil battery, workspace, tool matrix. Dig
-  provenance: memory project_snapclip-plate-bore.md.
+- **NURBS endpoint-trimmed convention — FORWARD SPANS SHIPPED; reversed
+  spans remain OPEN behind a named arrangement defect (2026-07-17, the
+  deepened-notch dig's terminal root):** `EdgeCurve::domain_with_endpoints`
+  for `NurbsCurve` historically returned the FULL knot domain, ignoring the
+  endpoints — every NURBS sub-span consumer silently evaluated the WHOLE
+  curve (piece pcurves carried the parent's UV endpoints; the wire builder
+  conflated near-coincident structures — the snapClip deepened-notch cone's
+  twin rims). SHIPPED (topology/src/edge.rs, unit tests in the same file):
+  whole-edge endpoints (either orientation) and closed edges keep the full
+  span; a validated FORWARD interior sub-span (both projections on-curve
+  within the 1e-5 weld band, span > 1e-6·domain) returns the projected
+  trimmed `[t₀, t₁]`. On the RAWN=1 raw repro this cleaned one of the two
+  mirrored junction signatures (the use=3 triple + micro-edge chain at
+  y=−39.4). RESIDUAL: the mirrored twin needs REVERSED sub-spans (SCDOM
+  instrumentation showed on-curve reversed pairs at 1e-14), but accepting
+  them (returning `t₀ > t₁`, even gated to open curves) makes the
+  arrangement mint a DEGENERATE single-edge closed loop (endpoint gap ~4e-9
+  — a phantom point-hole at the micro-junction, below vertex-merge reach)
+  as an inner wire on the cone wall, which trips the curved-lens
+  no-contained-interior abort (wall Id(1137) in the repro). Next step is
+  the arrangement/wire-builder side: collapse or reject degenerate
+  (sub-weld-extent) closed loops before they become inner wires, then
+  re-attempt reversed acceptance. Repro: cached replay_scplate.rs, RAWN=1,
+  capture capture-snapclip-plate-fresh. Dig provenance: memory
+  project_snapclip-plate-bore.md.
 - **Mesh-boolean fallback emits OPEN meshes that get CONSUMED — OPEN
   (discovered 2026-07-16):** on the dblcorner nub operands the co-refinement
   fallback produced bnd=5/6 output (warn-logged, then used anyway, poisoning

--- a/crates/topology/src/edge.rs
+++ b/crates/topology/src/edge.rs
@@ -337,6 +337,19 @@ mod tests {
         EdgeCurve::NurbsCurve(brepkit_math::nurbs::fitting::interpolate(&pts, 3).unwrap())
     }
 
+    fn assert_full_domain(got: (f64, f64), d0: f64, d1: f64) {
+        assert!(
+            (got.0 - d0).abs() < f64::EPSILON,
+            "t0={} expected {d0}",
+            got.0
+        );
+        assert!(
+            (got.1 - d1).abs() < f64::EPSILON,
+            "t1={} expected {d1}",
+            got.1
+        );
+    }
+
     #[test]
     fn nurbs_domain_whole_edge_keeps_full_span_both_orientations() {
         let curve = open_nurbs();
@@ -346,8 +359,8 @@ mod tests {
         let (d0, d1) = brepkit_math::traits::ParametricCurve::domain(n);
         let p0 = brepkit_math::traits::ParametricCurve::evaluate(n, d0);
         let p1 = brepkit_math::traits::ParametricCurve::evaluate(n, d1);
-        assert_eq!(curve.domain_with_endpoints(p0, p1), (d0, d1));
-        assert_eq!(curve.domain_with_endpoints(p1, p0), (d0, d1));
+        assert_full_domain(curve.domain_with_endpoints(p0, p1), d0, d1);
+        assert_full_domain(curve.domain_with_endpoints(p1, p0), d0, d1);
     }
 
     #[test]
@@ -383,7 +396,7 @@ mod tests {
         let tb = d0 + 0.7 * (d1 - d0);
         let pa = brepkit_math::traits::ParametricCurve::evaluate(n, ta);
         let pb = brepkit_math::traits::ParametricCurve::evaluate(n, tb);
-        assert_eq!(curve.domain_with_endpoints(pb, pa), (d0, d1));
+        assert_full_domain(curve.domain_with_endpoints(pb, pa), d0, d1);
     }
 
     #[test]
@@ -398,6 +411,6 @@ mod tests {
         let off = Vec3::new(0.0, 0.0, 1.0) * 0.5;
         let pa = brepkit_math::traits::ParametricCurve::evaluate(n, ta) + off;
         let pb = brepkit_math::traits::ParametricCurve::evaluate(n, tb) + off;
-        assert_eq!(curve.domain_with_endpoints(pa, pb), (d0, d1));
+        assert_full_domain(curve.domain_with_endpoints(pa, pb), d0, d1);
     }
 }

--- a/crates/topology/src/edge.rs
+++ b/crates/topology/src/edge.rs
@@ -59,17 +59,27 @@ impl EdgeCurve {
 
     /// Parameter domain of this curve.
     ///
-    /// `Line` uses `[0, 1]`. NURBS uses its knot span. Closed Circle and
-    /// Ellipse edges (`start ≈ end`) use the full `[0, 2π]` domain. Open
-    /// arcs project both endpoints onto the curve and return the CCW
-    /// angular range `[a₀, a₁]` with `a₁ > a₀`, so sampling the domain
-    /// traces exactly the trimmed arc rather than the full curve.
+    /// `Line` uses `[0, 1]`. Closed Circle and Ellipse edges (`start ≈ end`)
+    /// use the full `[0, 2π]` domain. Open arcs project both endpoints onto
+    /// the curve and return the CCW angular range `[a₀, a₁]` with `a₁ > a₀`,
+    /// so sampling the domain traces exactly the trimmed arc rather than the
+    /// full curve. NURBS edges whose endpoints sit at the curve's natural
+    /// ends (either orientation), or whose endpoint projections fail to
+    /// validate as a forward interior sub-span, use the full knot span; a
+    /// validated open sub-span returns the projected `[t₀, t₁]` so the edge
+    /// samples only its own piece of a shared curve.
     #[must_use]
     pub fn domain_with_endpoints(&self, start: Point3, end: Point3) -> (f64, f64) {
         const TAU: f64 = std::f64::consts::TAU;
         // Below this chord the endpoints are considered coincident and the
         // edge is treated as a closed (full) curve.
         const CLOSED_EPS: f64 = 1e-9;
+        // NURBS whole-edge match band: split vertices on marched/fit curves sit
+        // up to the fit error (~1e-6) off the exact curve, well above vertex
+        // tolerance.
+        const END_EPS: f64 = 1e-6;
+        // NURBS sub-span on-curve band (the weld scale).
+        const WELD_EPS: f64 = 1e-5;
         match self {
             Self::Line => (0.0, 1.0),
             Self::Circle(c) => {
@@ -92,7 +102,37 @@ impl EdgeCurve {
                     (a0, a0 + delta)
                 }
             }
-            Self::NurbsCurve(n) => ParametricCurve::domain(n),
+            Self::NurbsCurve(n) => {
+                let (d0, d1) = ParametricCurve::domain(n);
+                if (start - end).length() < CLOSED_EPS {
+                    return (d0, d1);
+                }
+                let p0 = ParametricCurve::evaluate(n, d0);
+                let p1 = ParametricCurve::evaluate(n, d1);
+                if ((p0 - start).length() < END_EPS && (p1 - end).length() < END_EPS)
+                    || ((p0 - end).length() < END_EPS && (p1 - start).length() < END_EPS)
+                {
+                    return (d0, d1);
+                }
+                let proj = |p| brepkit_math::nurbs::projection::project_point_to_curve(n, p, 1e-9);
+                if let (Ok(pa), Ok(pb)) = (proj(start), proj(end)) {
+                    // Accept only a forward, non-degenerate, on-curve span.
+                    // Everything else — reversed pairs (on a closed curve these
+                    // are usually seam-crossing forward sub-arcs, where
+                    // interpolating backward would trace the complement arc;
+                    // downstream arrangement consumers also mint degenerate
+                    // sliver loops from reversed spans), degenerate spans,
+                    // off-curve endpoints — keeps the historical full-domain
+                    // behaviour.
+                    if pa.distance < WELD_EPS
+                        && pb.distance < WELD_EPS
+                        && pb.parameter - pa.parameter > 1e-6 * (d1 - d0)
+                    {
+                        return (pa.parameter, pb.parameter);
+                    }
+                }
+                (d0, d1)
+            }
         }
     }
 
@@ -284,5 +324,80 @@ mod tests {
         let (v0, v1) = make_test_vertices();
         let edge = Edge::new(v0, v1, EdgeCurve::Line);
         assert!((edge.effective_tolerance(1e-7) - 1e-7).abs() < f64::EPSILON);
+    }
+
+    fn open_nurbs() -> EdgeCurve {
+        let pts = [
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 1.0, 0.0),
+            Point3::new(2.0, 1.5, 0.0),
+            Point3::new(3.0, 1.0, 0.0),
+            Point3::new(4.0, 0.0, 0.0),
+        ];
+        EdgeCurve::NurbsCurve(brepkit_math::nurbs::fitting::interpolate(&pts, 3).unwrap())
+    }
+
+    #[test]
+    fn nurbs_domain_whole_edge_keeps_full_span_both_orientations() {
+        let curve = open_nurbs();
+        let EdgeCurve::NurbsCurve(n) = &curve else {
+            unreachable!()
+        };
+        let (d0, d1) = brepkit_math::traits::ParametricCurve::domain(n);
+        let p0 = brepkit_math::traits::ParametricCurve::evaluate(n, d0);
+        let p1 = brepkit_math::traits::ParametricCurve::evaluate(n, d1);
+        assert_eq!(curve.domain_with_endpoints(p0, p1), (d0, d1));
+        assert_eq!(curve.domain_with_endpoints(p1, p0), (d0, d1));
+    }
+
+    #[test]
+    fn nurbs_domain_forward_sub_span_is_trimmed() {
+        let curve = open_nurbs();
+        let EdgeCurve::NurbsCurve(n) = &curve else {
+            unreachable!()
+        };
+        let (d0, d1) = brepkit_math::traits::ParametricCurve::domain(n);
+        let ta = d0 + 0.25 * (d1 - d0);
+        let tb = d0 + 0.7 * (d1 - d0);
+        let pa = brepkit_math::traits::ParametricCurve::evaluate(n, ta);
+        let pb = brepkit_math::traits::ParametricCurve::evaluate(n, tb);
+        let (t0, t1) = curve.domain_with_endpoints(pa, pb);
+        assert!((t0 - ta).abs() < 1e-6, "t0={t0} expected {ta}");
+        assert!((t1 - tb).abs() < 1e-6, "t1={t1} expected {tb}");
+        // The trimmed domain evaluates back to the endpoints, so a consumer
+        // sampling it traces only the edge's own piece of the shared curve.
+        let s = curve.evaluate_with_endpoints(t0, pa, pb);
+        let e = curve.evaluate_with_endpoints(t1, pa, pb);
+        assert!((s - pa).length() < 1e-6);
+        assert!((e - pb).length() < 1e-6);
+    }
+
+    #[test]
+    fn nurbs_domain_reversed_sub_span_falls_back_to_full_domain() {
+        let curve = open_nurbs();
+        let EdgeCurve::NurbsCurve(n) = &curve else {
+            unreachable!()
+        };
+        let (d0, d1) = brepkit_math::traits::ParametricCurve::domain(n);
+        let ta = d0 + 0.25 * (d1 - d0);
+        let tb = d0 + 0.7 * (d1 - d0);
+        let pa = brepkit_math::traits::ParametricCurve::evaluate(n, ta);
+        let pb = brepkit_math::traits::ParametricCurve::evaluate(n, tb);
+        assert_eq!(curve.domain_with_endpoints(pb, pa), (d0, d1));
+    }
+
+    #[test]
+    fn nurbs_domain_off_curve_endpoints_fall_back_to_full_domain() {
+        let curve = open_nurbs();
+        let EdgeCurve::NurbsCurve(n) = &curve else {
+            unreachable!()
+        };
+        let (d0, d1) = brepkit_math::traits::ParametricCurve::domain(n);
+        let ta = d0 + 0.25 * (d1 - d0);
+        let tb = d0 + 0.7 * (d1 - d0);
+        let off = Vec3::new(0.0, 0.0, 1.0) * 0.5;
+        let pa = brepkit_math::traits::ParametricCurve::evaluate(n, ta) + off;
+        let pb = brepkit_math::traits::ParametricCurve::evaluate(n, tb) + off;
+        assert_eq!(curve.domain_with_endpoints(pa, pb), (d0, d1));
     }
 }


### PR DESCRIPTION
## Summary

`EdgeCurve::domain_with_endpoints` for `NurbsCurve` historically ignored its endpoints and returned the full knot span — unlike Circle/Ellipse, which project endpoints to the true sub-arc. Every consumer of a NURBS sub-span edge (piece pcurves, boundary sampling, wire polygons) therefore silently evaluated the WHOLE shared curve. On the snapClip deepened-notch raw repro this conflated twin cone rims 0.01 apart into one loop, leaving unpaired micro-edges at the junction.

## The convention (validation-gated; every ambiguous case keeps the historical full domain)

- **Closed edges** (endpoint chord < 1e-9): full knot span, unchanged.
- **Whole-curve edges** (endpoints match the natural curve ends within 1e-6, either orientation): full knot span, unchanged — also the cheap fast path (two curve evaluations, no projection).
- **Forward interior sub-span**: both endpoint projections on-curve within the 1e-5 weld band (split vertices on marched sections sit up to ~1e-5 off the fitted curve) AND span > 1e-6 of the domain → returns the projected trimmed `[t₀, t₁]`.
- **Everything else** (reversed pairs, degenerate spans, off-curve endpoints, failed projections): full-domain fallback, byte-for-byte the old behaviour.

Reversed sub-spans are deliberately NOT accepted yet: accepting them exposes a downstream arrangement defect (a degenerate single-edge closed loop with a 4e-9 endpoint gap minted at the junction, which pattern-matches the curved-lens hole signature and aborts the analytic split). That residual is precisely documented in the roadmap row updated in this PR, with the repro recipe.

## Verification

- New unit tests in `edge.rs`: whole-edge both orientations, forward sub-span trims and evaluates back to its endpoints, reversed sub-span falls back, off-curve endpoints fall back.
- Deepened-notch raw repro (arena-captured operands): one of the two mirrored junction signatures fully resolves (the use=3 triple + micro-edge chain); posBad signature documented in the roadmap.
- d4 canary green (`cargo test -p brepkit-wasm --lib gridfinity`), full workspace green in release (all crates, 0 failures).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim NURBS edge domains to validated forward endpoint sub-spans so edges only sample their own piece of a shared curve. This prevents whole-curve evaluation that merged nearby rims in the deepened‑notch repro.

- **Bug Fixes**
  - `EdgeCurve::domain_with_endpoints` for `NurbsCurve` now projects endpoints and, if both lie on-curve within 1e-5 and form a forward span >1e-6 of the domain, returns the trimmed `[t0, t1]`.
  - Closed edges and whole-curve matches (endpoints at natural ends within 1e-6, either orientation) keep the full knot span.
  - Reversed or invalid spans fall back to the full domain to avoid a downstream degenerate-loop defect; forward case resolves one mirrored junction in the deepened‑notch repro.
  - Tests cover whole-edge, forward trim, reversed fallback, and off-curve fallback; fallback domain comparisons now use approximate assertions to avoid float flakiness. Roadmap updated to track the reversed-span follow-up.

<sup>Written for commit fad5a65143c7b052dabd46b83044eec7632415f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

