### PR TITLE
docs(skills): roadmap — snapClip bed-flat volume pin resolved

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -256,8 +256,15 @@ snapClip family — THREE roots CLOSED 2026-07-16 (#1080, #1082, #1085); deepene
   cache — captured operands are fallback-poisoned, never replay them directly),
   the by-edge-id acceptance gate is BLIND to position-duplicate leaks (poison
   propagates silently — evaluate a position-quantized gate), and the bed-flat
-  clip volume 46.701 vs 46.6±0.05 pin (genuine deviation, the reference kernel
-  passes — per-op dual-kernel volume diff).
+  clip volume 46.701 vs 46.6±0.05 pin — RESOLVED, NOT a brepkit defect: the
+  per-stage dual-kernel diff localized the whole delta to the relief cut, whose
+  cutter (buildSingleCellSocket) brepkit represents as EXACT ANALYTIC (native
+  census F=34 {plane:18,cylinder:8,cone:8}, zero NURBS — the #1045
+  loft-recognition) while the reference keeps a NURBS loft that bulges ~0.062mm³
+  and over-removes 0.146mm³ from the clip corners. brepkit's 46.701 is the MORE
+  accurate value; the pin is calibrated to the reference's loft approximation
+  (the "snapshot pins are kernel-specific" class). Resolution is tool-side pin
+  recalibration, not a brepkit change.
 
 Fit-offset groove-mouth sliver family — CLOSED (2026-07-16, PR #1078, fixture
 `crates/io/tests/fitoffset_groove_mouth_inmem.rs`): each groove cutter's mouth
@@ -570,8 +577,15 @@ snapClip family — THREE roots CLOSED 2026-07-16 (#1080, #1082, #1085); deepene
   cache — captured operands are fallback-poisoned, never replay them directly),
   the by-edge-id acceptance gate is BLIND to position-duplicate leaks (poison
   propagates silently — evaluate a position-quantized gate), and the bed-flat
-  clip volume 46.701 vs 46.6±0.05 pin (genuine deviation, the reference kernel
-  passes — per-op dual-kernel volume diff).
+  clip volume 46.701 vs 46.6±0.05 pin — RESOLVED, NOT a brepkit defect: the
+  per-stage dual-kernel diff localized the whole delta to the relief cut, whose
+  cutter (buildSingleCellSocket) brepkit represents as EXACT ANALYTIC (native
+  census F=34 {plane:18,cylinder:8,cone:8}, zero NURBS — the #1045
+  loft-recognition) while the reference keeps a NURBS loft that bulges ~0.062mm³
+  and over-removes 0.146mm³ from the clip corners. brepkit's 46.701 is the MORE
+  accurate value; the pin is calibrated to the reference's loft approximation
+  (the "snapshot pins are kernel-specific" class). Resolution is tool-side pin
+  recalibration, not a brepkit change.
 
 Fit-offset groove-mouth sliver family — CLOSED (2026-07-16, PR #1078, fixture
 `crates/io/tests/fitoffset_groove_mouth_inmem.rs`): each groove cutter's mouth


### PR DESCRIPTION
## Summary

Resolves the long-standing snapClip bed-flat clip volume question (46.701 brepkit vs the 46.6±0.05 test pin) — **it is not a brepkit defect; brepkit is the more accurate kernel.**

A per-stage dual-kernel volume diff of `buildSnapClip` localized the entire delta to the relief cut:

| stage | brepkit | reference | delta |
|---|---|---|---|
| base extrude (chamfered/filleted profile) | 52.5508 | 52.5502 | +0.0006 (negligible) |
| lofted relief foot | 7518.3376 | 7518.4000 | reference +0.062 larger |
| relief removed | 5.8498 | 5.9960 | reference over-removes 0.146 |
| final clip | 46.7011 | 46.5543 | — |

The relief cutter is `buildSingleCellSocket` (a lofted gridfinity socket foot). A native face census of brepkit's foot shows **F=34, {plane:18, cylinder:8, cone:8}, zero NURBS** — brepkit represents it as *exact analytic* geometry (the #1045 loft-recognition). The reference kernel keeps it as a NURBS loft that bulges ~0.062mm³ outward; used as a relief cutter, that bulging wall removes 0.146mm³ more from the clip's top-bridge corners. The cutters' total volumes are identical to 0.001% — the whole difference is the local loft-surface approximation in the corner-overlap sliver.

So brepkit's 46.701 is the more accurate value, and the 46.6±0.05 pin is calibrated to the reference's NURBS-loft approximation — the roadmap's "snapshot pins are kernel-specific" class. The resolution is tool-side pin recalibration, not a brepkit change.

This also **corrects a prior roadmap claim** ("genuine deviation, the reference kernel passes") that saw the reference pass the pin but never checked which kernel is more correct.

Docs-only; no code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the roadmap docs to resolve the snapClip bed-flat clip volume pin issue: a per-stage dual-kernel diff shows the delta comes from the relief cut, where `brepkit`’s analytic loft is more accurate than the reference’s NURBS; the fix is tool-side pin recalibration, not a `brepkit` change. Also corrects the earlier claim that this was a genuine deviation that the reference kernel passed.

<sup>Written for commit 293ee607c67acb60b879a306b8b25eabdcbef214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

