### PR TITLE
docs(skills): roadmap — funnel/disc arrangement campaign (part 2 via #1109)

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -749,6 +749,21 @@ nozzle nm 1→15, clip volume 46.78→46.70 vs 46.6±0.05). Dovetail residuals:
   must be watertight or rejected. Repro: the dblcorner fixture operands with
   the analytic path disabled, or any pre-fix build.
 
+Funnel/honeycomb cylinder-disc arrangement campaign — PART (2) CLOSED (#1109);
+(1)+(3) OPEN (2026-07-17, memory `project_cylinder-arrangement-rescue.md`):
+curved/periodic faces have NO arrangement rescue (the plane path's rescues are all
+`is_plane`-gated), so a box cut crossing a cylindrical pocket at PARTIAL overlap
+figure-eights the greedy wire builder. Three sub-gaps, all "closed/arc-bounded face
+cut by sections, greedy drops/mistraces": (2) PLANE disc (closed-circle boundary) cut
+by chords — **CLOSED #1109** (`try_split_disk_by_chords` in
+`face_splitter/special_cases.rs` + single-crossing bail relaxation in
+`fill_images_faces.rs::clip_line_to_face_boundary`; 6 committed unit tests); (3) PLANE
+wall + single-arc crossing — OPEN; (1) CYLINDER-wall arc-DCEL (partial-band figure-eight)
+— implemented + foil-safe but REVERTED, re-apply LAST (its correctness EXPOSES the
+dropped 2+3 plane faces). Scratch repros `crates/io/examples/replay_{synthbox,diskcut}.rs`.
+All three landed = funnel watertight. Distinct from the snapClip deepened-notch
+pave-bypass root above.
+
 combinedFeatures re-read (2026-07-10, 2.124.13-based overlay, full 11-case suite):
 all 6 structural cases PASS including "handles + label (back skip)" (7167 tris,
 106s) and "handle holes" (86s) — the 2026-07-08 swallowed-panic/borrow-poisoning


### PR DESCRIPTION
Records the funnel/honeycomb cylinder-disc arrangement campaign in the living roadmap (mandatory maintenance per the roadmap doctrine — #1109 shipped part 2 without it).

**The campaign**: curved/periodic faces have no arrangement rescue (the plane path's rescues are all `is_plane`-gated), so a box cut crossing a cylindrical pocket at partial overlap figure-eights the greedy wire builder. Three sub-gaps:
- **(2)** plane disc (closed-circle boundary) cut by chords — **CLOSED in #1109**
- **(3)** plane wall + single-arc crossing — OPEN
- **(1)** cylinder-wall arc-DCEL — foil-safe, re-apply LAST (its correctness exposes the dropped plane faces)

Detail lives in memory `project_cylinder-arrangement-rescue.md`; scratch repros are `crates/io/examples/replay_{synthbox,diskcut}.rs`.

Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the roadmap to document the funnel/honeycomb cylinder-disc arrangement campaign, marking part (2) (plane disc cut by chords) as closed in #1109 and tracking parts (1) and (3) as open. Adds pointers to `project_cylinder-arrangement-rescue.md` and `crates/io/examples/replay_{synthbox,diskcut}.rs`; clarifies that all three fixes are required for a watertight funnel.

<sup>Written for commit 98af5202a1c6c076e1b17ca1efc7f2212ef044a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

