### PR TITLE
fix(algo): split co-endpoint lens arc in disc-chord split (funnel watertight)

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -749,20 +749,25 @@ nozzle nm 1→15, clip volume 46.78→46.70 vs 46.6±0.05). Dovetail residuals:
   must be watertight or rejected. Repro: the dblcorner fixture operands with
   the analytic path disabled, or any pre-fix build.
 
-Funnel/honeycomb cylinder-disc arrangement campaign — PART (2) CLOSED (#1109);
-(1)+(3) OPEN (2026-07-17, memory `project_cylinder-arrangement-rescue.md`):
-curved/periodic faces have NO arrangement rescue (the plane path's rescues are all
-`is_plane`-gated), so a box cut crossing a cylindrical pocket at PARTIAL overlap
-figure-eights the greedy wire builder. Three sub-gaps, all "closed/arc-bounded face
-cut by sections, greedy drops/mistraces": (2) PLANE disc (closed-circle boundary) cut
-by chords — **CLOSED #1109** (`try_split_disk_by_chords` in
-`face_splitter/special_cases.rs` + single-crossing bail relaxation in
-`fill_images_faces.rs::clip_line_to_face_boundary`; 6 committed unit tests); (3) PLANE
-wall + single-arc crossing — OPEN; (1) CYLINDER-wall arc-DCEL (partial-band figure-eight)
-— implemented + foil-safe but REVERTED, re-apply LAST (its correctness EXPOSES the
-dropped 2+3 plane faces). Scratch repros `crates/io/examples/replay_{synthbox,diskcut}.rs`.
-All three landed = funnel watertight. Distinct from the snapClip deepened-notch
-pave-bypass root above.
+Funnel/honeycomb cylinder-disc arrangement campaign — CLOSED (2026-07-17, memory
+`project_cylinder-arrangement-rescue.md`): curved/periodic faces had NO arrangement
+rescue (the plane path's rescues are all `is_plane`-gated), so a box cut crossing a
+cylindrical pocket at PARTIAL overlap figure-eighted the greedy wire builder. Fixed as
+three sub-gaps, all "closed/arc-bounded face cut by sections, greedy drops/mistraces":
+(2) PLANE disc (closed-circle boundary) cut by chords — #1109 (`try_split_disk_by_chords`
+in `face_splitter/special_cases.rs` + single-crossing bail relaxation in
+`fill_images_faces.rs::clip_line_to_face_boundary`); (3) PLANE wall + single-arc crossing
+— SUBSUMED by #1109's single-crossing relaxation (tool walls are hole-free planes cut by
+one generator; proven by single-variable isolation, no separate work); (1) CYLINDER-wall
+rectilinear-UV arrangement (`split_cylinder_band_by_arrangement` in `face_splitter/mod.rs`,
+purely additive, gated `u_periodic && !v_periodic && Cylinder && greedy-broken`) — #1112.
+Final residual (floor lens's co-endpoint rim-arc + tool-chord collapsing in
+`merge_duplicate_edges` — the merge-key UNBUILDABLE class) closed by the SANCTIONED
+splitter-side midpoint split of the minor lens arc (`try_split_disk_by_chords`; the
+existing `split_arc_edges_at_collinear_vertices` propagates the cut to the shared cylinder
+rim — no two-site coordination; NOT a merge-key change). Synthetic pocket-notch repro
+`crates/io/examples/replay_synthbox.rs` now posBad=0 on ALL cases. Distinct from the
+snapClip deepened-notch pave-bypass root above.
 
 combinedFeatures re-read (2026-07-10, 2.124.13-based overlay, full 11-case suite):
 all 6 structural cases PASS including "handles + label (back skip)" (7167 tris,

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -2436,7 +2436,7 @@ pub(super) fn try_split_disk_by_chords(
 ) -> Option<Vec<SplitSubFace>> {
     use brepkit_math::curves::Circle3D;
     use brepkit_math::curves2d::{Curve2D, Line2D};
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::f64::consts::{PI, TAU};
 
     use crate::builder::classify_2d::{sample_interior_point, signed_area_2d};
@@ -2660,8 +2660,7 @@ pub(super) fn try_split_disk_by_chords(
     // (< π): a crescent lens is always minor, while a semicircle/major-arc
     // partition (a diameter cut's half-discs, a corner bite's major remnant) is
     // a calibrated shape that carries its own interior vertices — left untouched.
-    let mut chord_pairs: std::collections::HashSet<((i64, i64), (i64, i64))> =
-        std::collections::HashSet::new();
+    let mut chord_pairs: HashSet<((i64, i64), (i64, i64))> = HashSet::new();
     for s in &subs {
         if matches!(s.kind, Kind::Line) {
             chord_pairs.insert(if s.a <= s.b { (s.a, s.b) } else { (s.b, s.a) });
@@ -2688,8 +2687,16 @@ pub(super) fn try_split_disk_by_chords(
         if hi - lo < PI - 1e-6 && chord_pairs.contains(&pair) {
             let mid = 0.5 * (lo + hi);
             let mid_pt = Point2::new(cu.x() + r * mid.cos(), cu.y() + r * mid.sin());
+            let before = vpos.len();
             let km = reg(mid_pt, &mut vpos);
-            if km != k_lo && km != k_hi {
+            // Split only when the midpoint is a genuinely NEW on-circle vertex.
+            // `reg` returns an EXISTING key on a quantization collision (e.g. a
+            // chord-interior crossing sharing mid_pt's cell); that vertex is not
+            // on this arc, so reusing it would break the `Arc { lo, hi }`
+            // invariant (endpoint `a` at angle `lo`, `b` at `hi`) and miscompute
+            // DCEL tangents. Defer to the whole arc in that rare case — the lens
+            // stays a bigon (safe, never miswound), not degenerate geometry.
+            if vpos.len() > before {
                 subs.push(Sub {
                     a: k_lo,
                     b: km,

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -2646,6 +2646,28 @@ pub(super) fn try_split_disk_by_chords(
     if nodes.len() < 2 {
         return None;
     }
+
+    // A minor-arc gap whose two endpoints are ALSO joined directly by a chord
+    // (Line sub) forms a co-endpoint lens (a thin crescent: arc + chord sharing
+    // both vertices). `merge_duplicate_edges` keys edges by endpoint pair alone,
+    // so it would collapse the arc and chord into one edge and degenerate the
+    // lens face (and, where the arc is a shared rim, fold in the adjacent face's
+    // copies too). Splitting the arc at its angular midpoint adds an interior
+    // on-circle vertex that breaks the shared-endpoint collision;
+    // `split_arc_edges_at_collinear_vertices` then propagates the identical cut
+    // to the coincident rim arc on the neighbouring (e.g. cylinder-wall) face,
+    // keeping the shared rim consistent on both sides. Restricted to minor arcs
+    // (< π): a crescent lens is always minor, while a semicircle/major-arc
+    // partition (a diameter cut's half-discs, a corner bite's major remnant) is
+    // a calibrated shape that carries its own interior vertices — left untouched.
+    let mut chord_pairs: std::collections::HashSet<((i64, i64), (i64, i64))> =
+        std::collections::HashSet::new();
+    for s in &subs {
+        if matches!(s.kind, Kind::Line) {
+            chord_pairs.insert(if s.a <= s.b { (s.a, s.b) } else { (s.b, s.a) });
+        }
+    }
+
     let node_count = nodes.len();
     for idx in 0..node_count {
         let (k_lo, lo) = nodes[idx];
@@ -2657,6 +2679,29 @@ pub(super) fn try_split_disk_by_chords(
         };
         if hi - lo < 1e-9 {
             continue;
+        }
+        let pair = if k_lo <= k_hi {
+            (k_lo, k_hi)
+        } else {
+            (k_hi, k_lo)
+        };
+        if hi - lo < PI - 1e-6 && chord_pairs.contains(&pair) {
+            let mid = 0.5 * (lo + hi);
+            let mid_pt = Point2::new(cu.x() + r * mid.cos(), cu.y() + r * mid.sin());
+            let km = reg(mid_pt, &mut vpos);
+            if km != k_lo && km != k_hi {
+                subs.push(Sub {
+                    a: k_lo,
+                    b: km,
+                    kind: Kind::Arc { lo, hi: mid },
+                });
+                subs.push(Sub {
+                    a: km,
+                    b: k_hi,
+                    kind: Kind::Arc { lo: mid, hi },
+                });
+                continue;
+            }
         }
         subs.push(Sub {
             a: k_lo,
@@ -3402,6 +3447,94 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn disk_lens_arc_is_split_to_break_coendpoint_collision() {
+        use crate::ds::Rank;
+        // r=8 disc on z=0, bitten by a single chord y=6 spanning the circle at
+        // (-√28, 6) and (√28, 6). The thin crescent above y=6 is a LENS: its
+        // ~83° minor rim arc and the straight chord share BOTH endpoints. Left
+        // whole, `merge_duplicate_edges` (endpoint-pair keyed) would collapse
+        // the arc into the chord and degenerate the lens. The splitter must
+        // therefore emit the crescent's arc split at its midpoint (an interior
+        // on-circle vertex), so the arc no longer shares both endpoints with the
+        // chord — while the complementary major-arc region keeps its single arc.
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 8.0).unwrap();
+        let surface = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+        let boundary = vec![arc_edge(&circle, 0.0, TAU, true)];
+        let x = 28.0_f64.sqrt();
+        let sections = vec![section_chord(
+            Point3::new(-x, 6.0, 0.0),
+            Point3::new(x, 6.0, 0.0),
+        )];
+
+        let regions = super::try_split_disk_by_chords(
+            &surface,
+            &boundary,
+            &sections,
+            Rank::A,
+            false,
+            dummy_face_id(),
+            &disk_test_frame(),
+            1e-7,
+        )
+        .expect("disc + chord must split into crescent + major remnant");
+        assert_eq!(regions.len(), 2);
+
+        // The crescent (minor-arc lens) must be the arc-split region: two arc
+        // sub-edges + one chord, all endpoints distinct. The major remnant keeps
+        // its single (major) arc + chord.
+        let arc_counts: Vec<usize> = regions
+            .iter()
+            .map(|r| {
+                r.outer_wire
+                    .iter()
+                    .filter(|e| matches!(e.curve_3d, EdgeCurve::Circle(_)))
+                    .count()
+            })
+            .collect();
+        assert!(
+            arc_counts.contains(&2),
+            "the lens crescent's minor arc is split into two, got {arc_counts:?}"
+        );
+        assert!(
+            arc_counts.contains(&1),
+            "the major remnant keeps one arc, got {arc_counts:?}"
+        );
+
+        // In the two-arc lens no arc shares both endpoints with the chord: every
+        // edge in that region has a distinct endpoint pair.
+        let lens = regions
+            .iter()
+            .find(|r| {
+                r.outer_wire
+                    .iter()
+                    .filter(|e| matches!(e.curve_3d, EdgeCurve::Circle(_)))
+                    .count()
+                    == 2
+            })
+            .expect("lens region present");
+        let q = |p: Point3| -> (i64, i64, i64) {
+            (
+                (p.x() * 1e5).round() as i64,
+                (p.y() * 1e5).round() as i64,
+                (p.z() * 1e5).round() as i64,
+            )
+        };
+        let mut pairs = std::collections::HashSet::new();
+        for e in &lens.outer_wire {
+            let (a, b) = (q(e.start_3d), q(e.end_3d));
+            let key = if a <= b { (a, b) } else { (b, a) };
+            assert!(
+                pairs.insert(key),
+                "no two lens edges may share both endpoints"
+            );
         }
     }
 


### PR DESCRIPTION
Closes the cylinder/disc arrangement-rescue campaign (#1109, #1112) — the funnel/honeycomb boolean is now watertight.

## Problem

After #1112, the synthetic pocket-notch repro reached posBad=0 on every case **except** `top-inside` (posBad=1). Root: the pocket-floor crescent left by a box-corner cut is a **co-endpoint lens** — a minor rim **arc** and the tool-cut **chord** share both endpoints. `merge_duplicate_edges` keys edges by endpoint pair alone, so it collapsed the arc into the chord and degenerated the lens face.

(The complementary `x>16` lens is fine only because its arc happens to pass through the cylinder seam vertex, which an existing reconciliation splits — the `y>16` arc has no interior vertex, so it collapses.)

## Fix — the sanctioned splitter-side split (not a merge-key change)

A smarter `merge_duplicate_edges` key is **proven unbuildable** (the gridfinity lip corner chord+arc MUST merge; the torus-box lens line+arc MUST stay distinct). So the fix is splitter-side: in `try_split_disk_by_chords`, when a **minor** arc (< π) has both endpoints also joined by a chord (the co-endpoint lens condition), split it at its angular midpoint. The new on-circle vertex breaks the shared-endpoint collision, and the **existing** `split_arc_edges_at_collinear_vertices` reconciliation propagates the identical cut to the coincident cylinder-wall rim arc (position-based, symmetric) — **no two-site coordination**. Restricted to minor arcs so diameter half-discs and major-arc partitions keep their calibrated behavior.

## Verification

`replay_synthbox` — **posBad=0 on every case** (`top-inside` 1→0; base/clear-corner/past-pocket stay 0):

- `cargo test -p brepkit-wasm --lib gridfinity` → **27/0**
- `cargo test -p brepkit-algo` → **166/0** (+1 regression test)
- `cargo test -p brepkit-io` → **214/0**
- `cargo test -p brepkit-operations` → **972/0**
- clippy `-D warnings` clean; fmt clean

Also records the campaign close in the roadmap skill.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split minor co-endpoint lens arcs in the disk-by-chords splitter to prevent arc+chord collapsing; now guarded to avoid quantization collisions. The funnel/honeycomb boolean is watertight, fixing the pocket-floor crescent in the top-inside case and completing the cylinder/disc arrangement work (#1109, #1112).

- **Bug Fixes**
  - In `try_split_disk_by_chords`, when a minor rim arc (< π) shares endpoints with a chord, split the arc at its angular midpoint and insert an on-circle vertex — only if the midpoint creates a new vertex (skip on quantization alias).
  - Propagate the cut to coincident rim arcs via `split_arc_edges_at_collinear_vertices`; no merge-key changes.
  - Preserve diameter half-discs and major-arc partitions.
  - Add a regression test and update docs; `replay_synthbox` now reports posBad=0 for all cases.

<sup>Written for commit c5b40455b5082fe1a684ad3730658db09126a89b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

