### PR TITLE
docs(skills): roadmap — correct funnel campaign scope after tool re-probe

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -768,6 +768,17 @@ existing `split_arc_edges_at_collinear_vertices` propagates the cut to the share
 rim — no two-site coordination; NOT a merge-key change). Synthetic pocket-notch repro
 `crates/io/examples/replay_synthbox.rs` now posBad=0 on ALL cases. Distinct from the
 snapClip deepened-notch pave-bypass root above.
+**SCOPE CORRECTION (2026-07-18 tool re-probe, 2.126.17 overlay):** "CLOSED" = the ENGINE
+sub-class (cylinder-pocket-notch / disc-chord), foil-safe (27/0) and NO tool regression
+(export-integrity: 33 real fails = same known deferred families; published solid-cutouts
+6=6; the other 180 fails are the task-#14 poison cascade). **BUT the TOOL's own
+`combined features › 2×2 honeycomb walls + funnel cutout` scenario is NOT fixed — still a
+533s bisect-hang + fail.** Its root is the SEPARATE honeycomb-cut coincident-wall
+assembler hang ([[honeycomb-wall-cut-coincident]] pcut0) + the funnel-cutout, not this
+cylinder-arrangement bug. The synthetic proxy fixed a real class but was NOT validated
+against the real honeycomb+funnel operands first (the roadmap's own warning). This campaign
+did NOT move tool parity; the headline failing families (scoop #11, screw base #12, solid
+cutouts #13, honeycomb-cut) remain open.
 
 combinedFeatures re-read (2026-07-10, 2.124.13-based overlay, full 11-case suite):
 all 6 structural cases PASS including "handles + label (back skip)" (7167 tris,


### PR DESCRIPTION
The 2.126.17 tool re-probe shows the cylinder-disc arrangement campaign (#1109/#1112/#1114) closed an **engine sub-class** (cylinder-pocket-notch / disc-chord) — foil-safe (27/0) and **no tool regression** (export-integrity: 33 real fails = same known deferred families; published solid-cutouts 6=6; the other 180 fails are the pre-existing kernel-poison cascade).

**But the tool's own `combined features › 2×2 honeycomb walls + funnel cutout` scenario is NOT fixed** — still a 533s bisect-hang + fail. Its root is the separate honeycomb-cut coincident-wall assembler hang + the funnel-cutout, not this cylinder-arrangement bug. The synthetic proxy fixed a real class but wasn't validated against the real honeycomb+funnel operands first (the roadmap's own warning).

Docs-only; records the scope correction so the roadmap isn't overclaiming tool-parity impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the roadmap docs to correct scope: the cylinder–disc arrangement campaign closed only the engine sub-class (foil-safe, no regression), while the tool’s "2×2 honeycomb walls + funnel cutout" case still fails due to a separate honeycomb coincident-wall assembler issue. Clarifies that tool parity did not move and key failing families (scoop #11, screw base #12, solid cutouts #13, honeycomb-cut) remain open.

<sup>Written for commit 08368a4bd58628cc13d34c3a710b4210f0e093f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

