### PR TITLE
fix(tessellate): keep self-intersecting planar caps watertight via fan fallback

### DIFF
--- a/crates/operations/src/tessellate/planar.rs
+++ b/crates/operations/src/tessellate/planar.rs
@@ -775,12 +775,14 @@ pub(super) fn cdt_triangulate_simple(positions: &[Point3], normal: Vec3) -> Vec<
     }
 
     let mut indices = Vec::with_capacity(cdt_triangles.len() * 3);
+    let mut mapped = 0usize;
     for &(v0, v1, v2) in &cdt_triangles {
         if let (Some(&i0), Some(&i1), Some(&i2)) = (
             cdt_to_input.get(&v0),
             cdt_to_input.get(&v1),
             cdt_to_input.get(&v2),
         ) {
+            mapped += 1;
             #[allow(clippy::cast_possible_truncation)]
             {
                 indices.push(i0 as u32);
@@ -790,7 +792,17 @@ pub(super) fn cdt_triangulate_simple(positions: &[Point3], normal: Vec3) -> Vec<
         }
     }
 
-    if indices.is_empty() {
+    // A boundary constraint can only cross another constraint when the polygon
+    // self-intersects (booleans occasionally emit a planar face whose outer
+    // wire pinches through zero width — two boundary arcs that overlap by a few
+    // hundred microns). CDT recovers crossing constraints by inserting a Steiner
+    // vertex at the crossing; triangles touching it have no input-vertex mapping
+    // and would be dropped here, leaving a hole. The Steiner vertex also splits
+    // the shared boundary edges, which cracks against the neighbouring faces.
+    // Fall back to a fan, which uses only the original boundary vertices and is
+    // manifold by construction (each boundary edge used once, each diagonal
+    // twice) regardless of the self-overlap.
+    if mapped < cdt_triangles.len() || indices.is_empty() {
         return fan_triangulate(n);
     }
 

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -2057,3 +2057,197 @@ fn grouped_tessellation_triangles_lie_on_their_face() {
         faces.len()
     );
 }
+
+/// Build a closed prism solid whose top/bottom caps are the given planar
+/// polygon (shared boundary edges with the side walls). Used to exercise
+/// watertight meshing of a self-intersecting (pinched) planar cap.
+fn build_prism(
+    topo: &mut Topology,
+    poly2d: &[(f64, f64)],
+    z0: f64,
+    z1: f64,
+) -> brepkit_topology::solid::SolidId {
+    use brepkit_topology::shell::Shell;
+    use brepkit_topology::solid::Solid;
+    let n = poly2d.len();
+    let tol = 1e-7;
+    let top_v: Vec<_> = poly2d
+        .iter()
+        .map(|&(x, y)| topo.add_vertex(Vertex::new(Point3::new(x, y, z1), tol)))
+        .collect();
+    let bot_v: Vec<_> = poly2d
+        .iter()
+        .map(|&(x, y)| topo.add_vertex(Vertex::new(Point3::new(x, y, z0), tol)))
+        .collect();
+    let top_e: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(top_v[i], top_v[(i + 1) % n], EdgeCurve::Line)))
+        .collect();
+    let bot_e: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(bot_v[i], bot_v[(i + 1) % n], EdgeCurve::Line)))
+        .collect();
+    let vert_e: Vec<_> = (0..n)
+        .map(|i| topo.add_edge(Edge::new(bot_v[i], top_v[i], EdgeCurve::Line)))
+        .collect();
+
+    let top_wire = topo.add_wire(
+        Wire::new(
+            top_e.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+            true,
+        )
+        .unwrap(),
+    );
+    let bot_wire = topo.add_wire(
+        Wire::new(
+            bot_e.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+            true,
+        )
+        .unwrap(),
+    );
+    let top_face = topo.add_face(Face::new(
+        top_wire,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: z1,
+        },
+    ));
+    let bot_face = topo.add_face(Face::new(
+        bot_wire,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, -1.0),
+            d: -z0,
+        },
+    ));
+
+    let mut faces = vec![top_face, bot_face];
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let (xi, yi) = poly2d[i];
+        let (xj, yj) = poly2d[j];
+        let (dx, dy) = (xj - xi, yj - yi);
+        // Horizontal normal perpendicular to the wall (dir x z-axis).
+        let nrm = Vec3::new(dy, -dx, 0.0);
+        let len = (nrm.x() * nrm.x() + nrm.y() * nrm.y()).sqrt().max(1e-12);
+        let normal = Vec3::new(nrm.x() / len, nrm.y() / len, 0.0);
+        let d = normal.x() * xi + normal.y() * yi;
+        let quad = Wire::new(
+            vec![
+                OrientedEdge::new(bot_e[i], true),
+                OrientedEdge::new(vert_e[j], true),
+                OrientedEdge::new(top_e[i], false),
+                OrientedEdge::new(vert_e[i], false),
+            ],
+            true,
+        )
+        .unwrap();
+        let quad_wire = topo.add_wire(quad);
+        faces.push(topo.add_face(Face::new(
+            quad_wire,
+            vec![],
+            FaceSurface::Plane { normal, d },
+        )));
+    }
+
+    let shell = topo.add_shell(Shell::new(faces).unwrap());
+    topo.add_solid(Solid::new(shell, vec![]))
+}
+
+/// Regression: a boolean occasionally emits a planar face whose outer wire
+/// pinches through zero width — two boundary arcs overlap by a few hundred
+/// microns, so the projected boundary polygon self-intersects. CDT recovers the
+/// crossing constraints with Steiner vertices; dropping their triangles left a
+/// hole in the ledge (nonzero boundary edges). These two polygons are the exact
+/// self-intersecting ledge boundaries captured from the gridfinity "2x2 with
+/// stadium slot" cut at deflection 0.1 (28 pts) and 0.05 (34 pts). The prism
+/// meshing must stay watertight at both.
+#[test]
+#[allow(clippy::unreadable_literal)]
+fn pinched_ledge_prism_is_watertight() {
+    // defl 0.1 capture (28 pts).
+    let poly_28: Vec<(f64, f64)> = vec![
+        (-34.56, -40.55),
+        (-16.54, -40.550000000000004),
+        (-15.738116168931496, -40.49608307905734),
+        (-14.950668099841263, -40.3353029453993),
+        (-14.191831677633331, -40.070554012967634),
+        (-13.475267711451144, -39.7066023743365),
+        (-12.813876008545115, -39.25000000003244),
+        (-15.240000000000073, -39.25000000000008),
+        (-35.8599999999999, -39.25000000000011),
+        (-38.0, -39.25000000000011),
+        (-38.38627124296872, -39.18882064536907),
+        (-38.73473156536566, -39.011271242968796),
+        (-39.01127124296875, -38.73473156536567),
+        (-39.188820645369, -38.386271242968725),
+        (-39.25000000000001, -38.0),
+        (-39.25000000000001, -35.85999999999999),
+        (-39.250000000000014, -33.240000000000016),
+        (-39.250000000000014, -30.813876008504252),
+        (-39.706602374315146, -31.475267711415285),
+        (-40.07055401295537, -32.19183167760453),
+        (-40.335302945393764, -32.950668099821144),
+        (-40.49608307905595, -33.73811616892115),
+        (-40.55, -34.54),
+        (-40.55, -34.56),
+        (-40.256828532607976, -36.411011796305935),
+        (-39.40601179630594, -38.080833661231914),
+        (-38.08083366123192, -39.40601179630594),
+        (-36.411011796305935, -40.256828532607976),
+    ];
+    // defl 0.05 capture (34 pts).
+    let poly_34: Vec<(f64, f64)> = vec![
+        (-34.56, -40.55),
+        (-16.54, -40.550000000000004),
+        (-15.966381445824009, -40.52247111140214),
+        (-15.398035372875258, -40.4401374805693),
+        (-14.8401857997605, -40.30375588658364),
+        (-14.297960265295309, -40.114579896626324),
+        (-13.776342698138523, -39.87434834366997),
+        (-13.280127606436032, -39.58526934379438),
+        (-12.813876008545115, -39.25000000003244),
+        (-15.240000000000073, -39.25000000000008),
+        (-35.8599999999999, -39.25000000000011),
+        (-38.0, -39.25000000000011),
+        (-38.38627124296872, -39.18882064536907),
+        (-38.73473156536566, -39.011271242968796),
+        (-39.01127124296875, -38.73473156536567),
+        (-39.188820645369, -38.386271242968725),
+        (-39.25000000000001, -38.0),
+        (-39.25000000000001, -35.85999999999999),
+        (-39.250000000000014, -33.240000000000016),
+        (-39.250000000000014, -30.813876008504252),
+        (-39.58526934377004, -31.280127606398516),
+        (-39.87434834365278, -31.776342698105463),
+        (-40.11457989661517, -32.29796026526766),
+        (-40.30375588657729, -32.84018579973906),
+        (-40.440137480566456, -33.398035372860626),
+        (-40.52247111140143, -33.96638144581659),
+        (-40.55, -34.54),
+        (-40.55, -34.56),
+        (-40.399818193969125, -35.892900394398325),
+        (-39.9568035187355, -37.15896359731418),
+        (-39.243170579983506, -38.294703913133816),
+        (-38.294703913133816, -39.2431705799835),
+        (-37.15896359731418, -39.9568035187355),
+        (-35.892900394398325, -40.399818193969125),
+    ];
+
+    for (label, poly) in [("28pt/defl0.1", &poly_28), ("34pt/defl0.05", &poly_34)] {
+        let mut topo = Topology::new();
+        let solid = build_prism(&mut topo, poly, 0.0, 4.0);
+        for defl in [0.1, 0.05] {
+            let mesh = tessellate_solid(&topo, solid, defl).unwrap();
+            assert_eq!(
+                boundary_edge_count(&mesh),
+                0,
+                "{label} defl={defl}: pinched ledge left boundary edges (crack)"
+            );
+            assert_eq!(
+                non_manifold_edge_count(&mesh),
+                0,
+                "{label} defl={defl}: pinched ledge produced non-manifold edges"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the gridfinity "2×2 solid with slot (stadium) cutout" export producing a non-watertight STL (8 boundary edges) — the first of the solid-cutouts parity failures. Root-caused with a faithful native repro (operands captured from the real tool cut site).

## Root cause
**Tessellation defect, not a boolean bug.** `boolean(Cut, bin, stadium)` yields a watertight, fully-analytic B-Rep (F=60, euler=2, nm=0, bd=0). Boundary edges appear only when tessellating at fine deflection (0 @ defl=0.5 → 8 @ 0.05 — the count-grows-with-refinement signature).

The offending face is the bin's top ledge plane: a weaving, simply-connected planar annulus. At one corner the inner socket-foot cone rim (circle r=1.25) and the bin's outer rounded corner (circle r≈5.99) **genuinely intersect** — the inner rim bulges ~0.11mm *past* the outer arc, so the ledge pinches through zero to negative width. The projected boundary polygon is therefore self-intersecting.

`cdt_triangulate_simple` on such a polygon: CDT recovers the crossing constraints with a Steiner vertex, then the input-index mapping **silently drops** every triangle touching it → the pinch sliver is left untriangulated → single-use mesh edges → cracks.

## Fix
Detect that CDT introduced Steiner vertices (`mapped < cdt_triangles.len()`) and fall back to `fan_triangulate`, which uses only the original boundary vertices and is manifold by construction regardless of the self-overlap. Steiner vertices arise *only* for self-intersecting boundaries, so normal planar faces are unaffected. Minimal (+13/-1 in planar.rs); no L0–L2 code touched.

## Verification
- Faithful repro: boundary_edges **8 → 0** at defl 0.1/0.05/0.01; cut B-Rep unchanged (nm=0 bd=0).
- `brepkit-operations --lib tessellate` **72/0** (incl. new `pinched_ledge_prism_is_watertight`); `brepkit-operations --lib` **766/0**; `brepkit-wasm --lib gridfinity` **27/0** (canary); `brepkit-io` green; clippy `-D warnings` clean.

## Follow-up (not in scope)
The same Steiner-drop pattern exists in the holed CDT paths (`run_planar_cdt`, `tessellate_planar_shared_with_holes`) — no current repro self-intersects an *inner* wire, so untouched. Noted in the roadmap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tessellation cracks in self-intersecting planar caps by falling back to a fan when CDT inserts Steiner vertices, keeping caps watertight. The gridfinity “2×2 solid with stadium slot” now exports a watertight mesh.

- **Bug Fixes**
  - In `cdt_triangulate_simple`, detect Steiner insertion (`mapped < cdt_triangles.len()`) and fall back to `fan_triangulate`; also fall back if CDT maps no triangles. Only applies to self-intersecting boundaries; normal faces are unchanged.
  - Adds `pinched_ledge_prism_is_watertight` regression with captured polygons; asserts 0 boundary and non‑manifold edges at deflections 0.1 and 0.05.

<sup>Written for commit 77f44b1d8a50c9c430348e48d370fc697bcb6193. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

