### PR TITLE
fix(algo): salvage closed-circle cap sections in the planar face splitter

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -3175,43 +3175,57 @@ pub fn split_face_2d(
     // point with an open arc section, and their "circle" is the corner cylinder
     // tangent to the face outline). Only genuine caps are peeled off; everything
     // else stays in `sections` and reaches the impl unchanged.
-    let wire_pts = collect_wire_points(topo, face.outer_wire());
+    // The FRAME must be built from the same points (and thus the same
+    // convention) the impl uses, so the sub-face UVs and the projected circle
+    // centres agree. The containment POLYGON, by contrast, must follow wire
+    // TRAVERSAL order — `collect_wire_points` takes every edge's stored
+    // `start()` and ignores the oriented-edge flag, so a wire carrying reversed
+    // edges would come back scrambled and the containment test meaningless.
+    let frame_pts = collect_wire_points(topo, face.outer_wire());
     let owned_frame;
     let cap_frame = if let Some(f) = frame {
         f
     } else {
         let normal = extract_plane_normal(&surface);
-        owned_frame = PlaneFrame::from_plane_face(normal, &wire_pts);
+        owned_frame = PlaneFrame::from_plane_face(normal, &frame_pts);
         &owned_frame
     };
-    let outer_poly: Vec<Point2> = wire_pts.iter().map(|&p| cap_frame.project(p)).collect();
+    let outer_poly: Vec<Point2> = collect_wire_points_oriented(topo, face.outer_wire())
+        .iter()
+        .map(|&p| cap_frame.project(p))
+        .collect();
 
-    let is_cap_circle = |s: &SectionEdge| -> bool {
-        if (s.start - s.end).length() >= tol.linear {
-            return false; // not a closed loop
-        }
-        let EdgeCurve::Circle(circle) = &s.curve_3d else {
-            return false;
+    // One pass: partition into cap circles (keeping each centre so the carve
+    // step never re-derives it) and everything else.
+    let mut cap_sections: Vec<SectionEdge> = Vec::new();
+    let mut cap_centers: Vec<Point3> = Vec::new();
+    let mut rest_sections: Vec<SectionEdge> = Vec::new();
+    for s in sections {
+        let cap_center = if (s.start - s.end).length() < tol.linear
+            && outer_poly.len() >= 3
+            && let EdgeCurve::Circle(circle) = &s.curve_3d
+        {
+            let center_uv = cap_frame.project(circle.center());
+            (super::classify_2d::point_in_polygon_2d(center_uv, &outer_poly)
+                && super::classify_2d::distance_to_polygon_boundary(center_uv, &outer_poly)
+                    > circle.radius() * CAP_INTERIORITY_MARGIN)
+                .then(|| circle.center())
+        } else {
+            None
         };
-        if outer_poly.len() < 3 {
-            return false;
+        match cap_center {
+            Some(c) => {
+                cap_sections.push(s.clone());
+                cap_centers.push(c);
+            }
+            None => rest_sections.push(s.clone()),
         }
-        let center_uv = cap_frame.project(circle.center());
-        // Strictly interior: the whole circle clears the face boundary, so its
-        // centre sits inside the outline by more than its radius. A corner
-        // cylinder's section circle is tangent to (its centre exactly a radius
-        // from) the outline, so this rejects it.
-        super::classify_2d::point_in_polygon_2d(center_uv, &outer_poly)
-            && super::classify_2d::distance_to_polygon_boundary(center_uv, &outer_poly)
-                > circle.radius() * 1.05
-    };
+    }
 
-    let cap_count = sections.iter().filter(|s| is_cap_circle(s)).count();
     // Engage only where the impl would silently drop cap circles: at least one
     // genuine cap circle AND not the single-closed fast path (exactly one
     // section, that one circle) which the impl already handles correctly.
-    let engage = cap_count > 0 && !(cap_count == 1 && sections.len() == 1);
-    if !engage {
+    if cap_sections.is_empty() || (cap_sections.len() == 1 && sections.len() == 1) {
         return split_face_2d_impl(
             topo,
             face_id,
@@ -3224,17 +3238,6 @@ pub fn split_face_2d(
             split_registry,
         );
     }
-
-    let cap_sections: Vec<SectionEdge> = sections
-        .iter()
-        .filter(|s| is_cap_circle(s))
-        .cloned()
-        .collect();
-    let rest_sections: Vec<SectionEdge> = sections
-        .iter()
-        .filter(|s| !is_cap_circle(s))
-        .cloned()
-        .collect();
 
     // Split by the open (non-cap) sections through the normal path — identical
     // to today's output for those, since the cap circles were being dropped
@@ -3251,7 +3254,49 @@ pub fn split_face_2d(
         split_registry,
     );
 
-    distribute_cap_circles(topo, face_id, base, &cap_sections, rank, frame)
+    distribute_cap_circles(
+        topo,
+        face_id,
+        base,
+        &cap_sections,
+        &cap_centers,
+        rank,
+        frame,
+    )
+}
+
+/// Slack on the cap-circle interiority test. A genuine drilled-hole rim clears
+/// the face outline by its full radius, while a corner cylinder's section circle
+/// is exactly tangent (centre one radius out); the 5% margin keeps float noise
+/// on such a tangent circle from reading as interior.
+const CAP_INTERIORITY_MARGIN: f64 = 1.05;
+
+/// Wire points in TRAVERSAL order, honouring each oriented edge's direction.
+///
+/// [`collect_wire_points`] pushes every edge's stored `start()` and ignores the
+/// orientation flag, so a wire carrying reversed edges comes back scrambled.
+/// Containment tests need the traversal-ordered outline, so they use this.
+fn collect_wire_points_oriented(
+    topo: &Topology,
+    wire_id: brepkit_topology::wire::WireId,
+) -> Vec<Point3> {
+    let Ok(wire) = topo.wire(wire_id) else {
+        return Vec::new();
+    };
+    let mut pts = Vec::new();
+    for oe in wire.edges() {
+        if let Ok(edge) = topo.edge(oe.edge()) {
+            let vid = if oe.is_forward() {
+                edge.start()
+            } else {
+                edge.end()
+            };
+            if let Ok(v) = topo.vertex(vid) {
+                pts.push(v.point());
+            }
+        }
+    }
+    pts
 }
 
 /// Carve closed cap circles (see [`split_face_2d`]) into the base sub-faces.
@@ -3267,6 +3312,7 @@ fn distribute_cap_circles(
     face_id: FaceId,
     base: Vec<SplitSubFace>,
     cap_sections: &[SectionEdge],
+    cap_centers: &[Point3],
     rank: Rank,
     frame: Option<&PlaneFrame>,
 ) -> Vec<SplitSubFace> {
@@ -3289,18 +3335,7 @@ fn distribute_cap_circles(
         &owned_frame
     };
 
-    let centers_uv: Vec<Point2> = cap_sections
-        .iter()
-        .map(|s| {
-            let c3d = match &s.curve_3d {
-                EdgeCurve::Circle(c) => c.center(),
-                // Ellipse fallback: a point on the loop still lands inside the
-                // (much larger) containing region, which is all assignment needs.
-                _ => s.start,
-            };
-            frame.project(c3d)
-        })
-        .collect();
+    let centers_uv: Vec<Point2> = cap_centers.iter().map(|&c| frame.project(c)).collect();
 
     let mut assigned = vec![false; cap_sections.len()];
     let mut result: Vec<SplitSubFace> = Vec::with_capacity(base.len() + cap_sections.len());

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -3097,6 +3097,23 @@ fn clip_sections_to_outer_region(
 /// If there are no section edges, returns a single sub-face covering
 /// the entire face (pass-through).
 ///
+/// Wraps [`split_face_2d_impl`] to salvage closed-circle *cap* sections on
+/// plane faces. The impl's planar arrangement decomposition
+/// ([`arrangement_regions_from_inputs`]) drops any input whose UV chord is
+/// zero-length, and a closed circle section has `start == end` — so a
+/// coincident planar interface whose opposing solid contributes drilled holes
+/// (the drilled-socket → bin-body fuse: the socket's screw-hole rims land as
+/// closed circle sections on the body's coincident bottom plane) loses the hole
+/// caps and the drilled cylinder rims are left as free edges. The impl only
+/// carves closed circles via its single-closed / all-Line-loop fast path, which
+/// never fires when the circles are *mixed* with open sections (the socket
+/// corner-cone arcs) or when there are two or more of them. Peel the cap
+/// circles off, split the plane by the remaining (open) sections, then carve
+/// each cap circle into the sub-face that geometrically contains it via
+/// [`split_face_with_internal_loops`] (which emits the disc cap plus the holed
+/// remainder). A lone cap circle already routes through the impl's fast path, so
+/// leave that untouched.
+///
 /// # Arguments
 /// - `topo` -- the topology arena (immutable read)
 /// - `face_id` -- the face to split
@@ -3105,9 +3122,233 @@ fn clip_sections_to_outer_region(
 /// - `tol` -- tolerance (`.linear` for 3D matching, UV tol derived internally)
 /// - `frame` -- cached `PlaneFrame` for this face (avoids origin mismatch)
 /// - `info` -- cached `SurfaceInfo` for periodicity flags
-#[allow(clippy::too_many_lines)]
 #[allow(clippy::too_many_arguments)]
 pub fn split_face_2d(
+    topo: &Topology,
+    face_id: FaceId,
+    sections: &[SectionEdge],
+    rank: Rank,
+    tol: &brepkit_math::tolerance::Tolerance,
+    frame: Option<&PlaneFrame>,
+    info: Option<&SurfaceInfo>,
+    edge_images: &std::collections::HashMap<
+        brepkit_topology::edge::EdgeId,
+        Vec<brepkit_topology::edge::EdgeId>,
+        impl std::hash::BuildHasher,
+    >,
+    split_registry: Option<&mut std::collections::HashMap<usize, Vec<Point3>>>,
+) -> Vec<SplitSubFace> {
+    // Closed-circle cap sections are salvaged only on plane faces (curved faces
+    // route closed circles through their own band/internal-loop paths).
+    let Ok(face) = topo.face(face_id) else {
+        return split_face_2d_impl(
+            topo,
+            face_id,
+            sections,
+            rank,
+            tol,
+            frame,
+            info,
+            edge_images,
+            split_registry,
+        );
+    };
+    let surface = face.surface().clone();
+    if !matches!(surface, FaceSurface::Plane { .. }) {
+        return split_face_2d_impl(
+            topo,
+            face_id,
+            sections,
+            rank,
+            tol,
+            frame,
+            info,
+            edge_images,
+            split_registry,
+        );
+    }
+
+    // Build the face's outer polygon in UV so a *genuine* cap circle (a full
+    // closed circle strictly interior to the face — a drilled hole rim) can be
+    // told apart from the zero-span arc remnants that the FF/pave machinery
+    // leaves at faceted-corner junctions (those sit ON the boundary, share a
+    // point with an open arc section, and their "circle" is the corner cylinder
+    // tangent to the face outline). Only genuine caps are peeled off; everything
+    // else stays in `sections` and reaches the impl unchanged.
+    let wire_pts = collect_wire_points(topo, face.outer_wire());
+    let owned_frame;
+    let cap_frame = if let Some(f) = frame {
+        f
+    } else {
+        let normal = extract_plane_normal(&surface);
+        owned_frame = PlaneFrame::from_plane_face(normal, &wire_pts);
+        &owned_frame
+    };
+    let outer_poly: Vec<Point2> = wire_pts.iter().map(|&p| cap_frame.project(p)).collect();
+
+    let is_cap_circle = |s: &SectionEdge| -> bool {
+        if (s.start - s.end).length() >= tol.linear {
+            return false; // not a closed loop
+        }
+        let EdgeCurve::Circle(circle) = &s.curve_3d else {
+            return false;
+        };
+        if outer_poly.len() < 3 {
+            return false;
+        }
+        let center_uv = cap_frame.project(circle.center());
+        // Strictly interior: the whole circle clears the face boundary, so its
+        // centre sits inside the outline by more than its radius. A corner
+        // cylinder's section circle is tangent to (its centre exactly a radius
+        // from) the outline, so this rejects it.
+        super::classify_2d::point_in_polygon_2d(center_uv, &outer_poly)
+            && super::classify_2d::distance_to_polygon_boundary(center_uv, &outer_poly)
+                > circle.radius() * 1.05
+    };
+
+    let cap_count = sections.iter().filter(|s| is_cap_circle(s)).count();
+    // Engage only where the impl would silently drop cap circles: at least one
+    // genuine cap circle AND not the single-closed fast path (exactly one
+    // section, that one circle) which the impl already handles correctly.
+    let engage = cap_count > 0 && !(cap_count == 1 && sections.len() == 1);
+    if !engage {
+        return split_face_2d_impl(
+            topo,
+            face_id,
+            sections,
+            rank,
+            tol,
+            frame,
+            info,
+            edge_images,
+            split_registry,
+        );
+    }
+
+    let cap_sections: Vec<SectionEdge> = sections
+        .iter()
+        .filter(|s| is_cap_circle(s))
+        .cloned()
+        .collect();
+    let rest_sections: Vec<SectionEdge> = sections
+        .iter()
+        .filter(|s| !is_cap_circle(s))
+        .cloned()
+        .collect();
+
+    // Split by the open (non-cap) sections through the normal path — identical
+    // to today's output for those, since the cap circles were being dropped
+    // anyway.
+    let base = split_face_2d_impl(
+        topo,
+        face_id,
+        &rest_sections,
+        rank,
+        tol,
+        frame,
+        info,
+        edge_images,
+        split_registry,
+    );
+
+    distribute_cap_circles(topo, face_id, base, &cap_sections, rank, frame)
+}
+
+/// Carve closed cap circles (see [`split_face_2d`]) into the base sub-faces.
+///
+/// Each cap circle is assigned to the base sub-face whose outer boundary
+/// contains the circle's centre in UV, then that sub-face is re-split via
+/// [`split_face_with_internal_loops`] (disc cap + holed remainder). Cap circles
+/// are strictly interior to the parent face by construction, so each lands in
+/// exactly one sub-face; a circle that fails to land anywhere is left out,
+/// matching the pre-salvage behaviour (never worse than baseline).
+fn distribute_cap_circles(
+    topo: &Topology,
+    face_id: FaceId,
+    base: Vec<SplitSubFace>,
+    cap_sections: &[SectionEdge],
+    rank: Rank,
+    frame: Option<&PlaneFrame>,
+) -> Vec<SplitSubFace> {
+    let Ok(face) = topo.face(face_id) else {
+        return base;
+    };
+    let surface = face.surface().clone();
+    if !matches!(surface, FaceSurface::Plane { .. }) {
+        return base;
+    }
+    // Build the containment frame with the SAME convention the impl used so the
+    // sub-faces' stored UVs and the projected circle centres share one frame.
+    let wire_pts = collect_wire_points(topo, face.outer_wire());
+    let owned_frame;
+    let frame = if let Some(f) = frame {
+        f
+    } else {
+        let normal = extract_plane_normal(&surface);
+        owned_frame = PlaneFrame::from_plane_face(normal, &wire_pts);
+        &owned_frame
+    };
+
+    let centers_uv: Vec<Point2> = cap_sections
+        .iter()
+        .map(|s| {
+            let c3d = match &s.curve_3d {
+                EdgeCurve::Circle(c) => c.center(),
+                // Ellipse fallback: a point on the loop still lands inside the
+                // (much larger) containing region, which is all assignment needs.
+                _ => s.start,
+            };
+            frame.project(c3d)
+        })
+        .collect();
+
+    let mut assigned = vec![false; cap_sections.len()];
+    let mut result: Vec<SplitSubFace> = Vec::with_capacity(base.len() + cap_sections.len());
+    for sf in base {
+        let poly = sample_wire_loop_uv(&sf.outer_wire);
+        let contained: Vec<SectionEdge> = if poly.len() < 3 {
+            Vec::new()
+        } else {
+            cap_sections
+                .iter()
+                .enumerate()
+                .filter_map(|(i, cs)| {
+                    if assigned[i] || !super::classify_2d::point_in_polygon_2d(centers_uv[i], &poly)
+                    {
+                        return None;
+                    }
+                    assigned[i] = true;
+                    Some(cs.clone())
+                })
+                .collect()
+        };
+        if contained.is_empty() {
+            result.push(sf);
+        } else {
+            let sub_wire_pts: Vec<Point3> = sf
+                .outer_wire
+                .iter()
+                .flat_map(|e| [e.start_3d, e.end_3d])
+                .collect();
+            let carved = split_face_with_internal_loops(
+                &sf.surface,
+                &sf.outer_wire,
+                &sf.inner_wires,
+                &contained,
+                rank,
+                sf.reversed,
+                face_id,
+                &sub_wire_pts,
+            );
+            result.extend(carved);
+        }
+    }
+    result
+}
+
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_arguments)]
+fn split_face_2d_impl(
     topo: &Topology,
     face_id: FaceId,
     sections: &[SectionEdge],

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5637,3 +5637,94 @@ fn cut_cylinder_by_box_slot_perpendicular_walls_is_watertight() {
         "the cylinder body must remain Inside the result"
     );
 }
+
+/// Regression: a coincident planar interface where one operand has drilled
+/// holes must keep the hole caps after a Fuse.
+///
+/// The capping plane (the plain top slab's bottom face, coincident with the
+/// drilled slab's top face) receives one closed circle FF section per hole from
+/// the drilled cylinder walls. With two or more such circles they route through
+/// the planar arrangement decomposition, which dropped every zero-UV-chord
+/// (closed circle) input — so the drilled cylinder rims were left as free edges
+/// and the fuse mesh-fell-back to hundreds of planar faces. `split_face_2d` now
+/// peels the genuine interior cap circles off and carves each into the sub-face
+/// that contains it (disc cap + holed remainder). A single-hole interface never
+/// exercised the bug (it hit the impl's single-closed fast path), so use TWO
+/// holes here.
+#[test]
+fn fuse_capping_slab_preserves_drilled_hole_caps() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+
+    // Bottom slab z in [0, 5] with two through-holes (r = 1.5).
+    let holes = [(6.0, 10.0), (14.0, 10.0)];
+    let mut bottom = crate::primitives::make_box(&mut topo, 20.0, 20.0, 5.0).unwrap();
+    for &(cx, cy) in &holes {
+        let drill = crate::primitives::make_cylinder(&mut topo, 1.5, 20.0).unwrap();
+        crate::transform::transform_solid(&mut topo, drill, &Mat4::translation(cx, cy, -5.0))
+            .unwrap();
+        bottom = boolean(&mut topo, BooleanOp::Cut, bottom, drill).unwrap();
+    }
+    // Plain capping slab z in [5, 10] over the same footprint.
+    let top = crate::primitives::make_box(&mut topo, 20.0, 20.0, 5.0).unwrap();
+    crate::transform::transform_solid(&mut topo, top, &Mat4::translation(0.0, 0.0, 5.0)).unwrap();
+
+    let fused = boolean(&mut topo, BooleanOp::Fuse, bottom, top).unwrap();
+
+    // Watertight: every edge of every wire is used exactly twice. Without the
+    // cap-circle salvage the two hole rims at z = 5 are free (used once).
+    let faces = brepkit_topology::explorer::solid_faces(&topo, fused).unwrap();
+    let mut edge_use: std::collections::HashMap<EdgeId, usize> = std::collections::HashMap::new();
+    for &fid in &faces {
+        let face = topo.face(fid).unwrap();
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *edge_use.entry(oe.edge()).or_default() += 1;
+            }
+        }
+    }
+    let bad_edges = edge_use.values().filter(|&&u| u != 2).count();
+    assert_eq!(
+        bad_edges, 0,
+        "fused result must be a watertight manifold (every edge used twice), got {bad_edges} bad edges"
+    );
+
+    // Analytic, not a mesh fallback: a compact face count, and BOTH drilled
+    // cylinder walls survive as analytic cylinders.
+    assert!(
+        faces.len() < 30,
+        "expected a compact analytic fuse, got {} faces (mesh fallback?)",
+        faces.len()
+    );
+    let cyl_faces = faces
+        .iter()
+        .filter(|&&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Cylinder(_)))
+        .count();
+    assert_eq!(
+        cyl_faces, 2,
+        "both drilled-hole cylinder walls must survive the fuse"
+    );
+
+    // The caps exist and are correctly oriented: over each hole, material caps
+    // the top (Inside above z = 5) while the through-hole stays open below it
+    // (Outside below z = 5). Verified with the robust ray-cast classifier.
+    for &(cx, cy) in &holes {
+        let above = Point3::new(cx, cy, 7.0);
+        let below = Point3::new(cx, cy, 2.5);
+        assert!(
+            matches!(
+                crate::classify::classify_point(&topo, fused, above, 0.01, 1e-7).unwrap(),
+                crate::classify::PointClassification::Inside
+            ),
+            "material must cap the hole above z=5 at ({cx}, {cy})"
+        );
+        assert!(
+            matches!(
+                crate::classify::classify_point(&topo, fused, below, 0.01, 1e-7).unwrap(),
+                crate::classify::PointClassification::Outside
+            ),
+            "the through-hole must stay open below z=5 at ({cx}, {cy})"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the gridfinity **screw-base export family** (task #12): 9 of 13 scenarios go from non-watertight to clean, and the 4×4 stress case drops from **1792 → 3** boundary edges. Root-caused end-to-end with a faithful native repro captured from the real tool pipeline.

## Root cause
The screw/magnet holes are cylinder cuts into the base socket — watertight in isolation. The failure is the final **socket → bin-body `Fuse`**: the socket's top face (Plane z=5) carries the drilled-hole rims as **closed-circle** sections, coincident with the body's bottom plane. `arrangement_regions_from_inputs` retains only inputs with a non-zero UV chord, and a **closed circle has start == end** (zero-length chord) → every hole cap is dropped. The impl's single-closed / all-Line fast path only fires for a *lone* circle, so two-or-more circles (or circles mixed with the socket's corner-cone arcs) lose their caps → the drilled cylinder rims are left as free edges → GFA opens (raw `bd=4`) → operations mesh-falls-back to hundreds of all-planar faces (the 112–1792 export boundary edges).

This was mis-diagnosed twice before landing here (first as a #696 tessellation crack, then as a same-domain inner-wire drop); both were refuted with literal data. The verified root is the closed-circle drop in the planar arrangement splitter.

## Fix
`split_face_2d` now wraps `split_face_2d_impl`: on a **plane** face it peels off **genuine** cap circles (closed `Circle` sections *strictly interior* to the outline — centre inside by more than the radius, which rejects the tangent corner-cylinder remnants the pave machinery leaves at faceted junctions), splits the face by the remaining open sections through the unchanged impl, then carves each cap into its containing sub-face via the existing `split_face_with_internal_loops` (disc cap + holed remainder). A lone cap circle still routes through the impl's fast path untouched, and faces with no interior cap circle are byte-identical to before. General to the coincident-planar-interface-with-drilled-holes class, not screw-specific.

## Verification
- Faithful native repro: raw `gfa::boolean(Fuse)` **bd 4 → 0**; operations result **672 all-plane mesh-fallback → 71 analytic faces, watertight**.
- Tool re-probe (overlay): **screw family 9/13 pass** (was 0/13); 4×4 stress 1792→3; **no regression** (solid-cutouts unchanged 5 fail/23 pass).
- Foils: `algo` 166/0, `operations` 767/0 (incl. new `fuse_capping_slab_preserves_drilled_hole_caps`, verified fails-without/passes-with), `wasm gridfinity` **27/0**, `io` green, clippy `-D warnings` clean.

## Follow-ups (not in scope)
4 residual screw scenarios: 4×4 stress (3 bd — a few near-grid-boundary holes the conservative interiority guard skips), 2 lightweight variants (448 — different base structure), and the scoop+label+lip permutation (132 — separate feature roots).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes planar face splitting to preserve closed-circle hole caps in coincident-plane booleans, preventing free edges and mesh fallbacks. Gridfinity screw-base exports: 9/13 now pass; 4×4 stress drops boundary edges from 1792 to 3.

- **Bug Fixes**
  - Salvage interior closed `Circle` sections on plane faces: peel caps, split by open sections, then carve via `split_face_with_internal_loops`.
  - Prevent zero-UV-chord circles from being dropped by salvaging them before `arrangement_regions_from_inputs`.
  - Keep the single-circle fast path; non-planar and cap-free faces unchanged.
  - Add regression `fuse_capping_slab_preserves_drilled_hole_caps` to assert watertight fuse and cylinder preservation.

- **Refactors**
  - Build containment polygon from traversal-ordered wire points for correct interiority on reversed edges; keep `PlaneFrame` convention unchanged.
  - Add `CAP_INTERIORITY_MARGIN` (5%) and single-pass section partitioning with stored cap centers for robustness.

<sup>Written for commit bfe7c188aeae5d1eca7ba9c28762b700a5bea9af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

