### PR TITLE
fix(algo): drop cap circles emerging inside holes; gate salvage early

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -36,7 +36,7 @@ use edge_splitting::{
     find_splits_on_ellipse, find_splits_on_line, find_splits_on_nurbs_section,
     find_splits_on_section_arc, split_boundary_edges_at_3d_points,
 };
-use sampling::{sample_wire_loop_uv, sample_wire_loop_uv_periodic};
+use sampling::{sample_wire_loop_uv, sample_wire_loop_uv_periodic, sample_wire_loop_uv_via_frame};
 use special_cases::{
     split_face_with_internal_loops, split_noseam_face_direct, split_periodic_face_into_bands,
     split_torus_band_by_arrangement, try_split_crossing_plane_face, try_split_disk_by_chords,
@@ -3098,21 +3098,17 @@ fn clip_sections_to_outer_region(
 /// the entire face (pass-through).
 ///
 /// Wraps [`split_face_2d_impl`] to salvage closed-circle *cap* sections on
-/// plane faces. The impl's planar arrangement decomposition
-/// ([`arrangement_regions_from_inputs`]) drops any input whose UV chord is
-/// zero-length, and a closed circle section has `start == end` — so a
-/// coincident planar interface whose opposing solid contributes drilled holes
-/// (the drilled-socket → bin-body fuse: the socket's screw-hole rims land as
-/// closed circle sections on the body's coincident bottom plane) loses the hole
-/// caps and the drilled cylinder rims are left as free edges. The impl only
-/// carves closed circles via its single-closed / all-Line-loop fast path, which
-/// never fires when the circles are *mixed* with open sections (the socket
-/// corner-cone arcs) or when there are two or more of them. Peel the cap
-/// circles off, split the plane by the remaining (open) sections, then carve
-/// each cap circle into the sub-face that geometrically contains it via
-/// [`split_face_with_internal_loops`] (which emits the disc cap plus the holed
-/// remainder). A lone cap circle already routes through the impl's fast path, so
-/// leave that untouched.
+/// plane faces (the drilled-socket → bin-body fuse: the socket's screw-hole
+/// rims land as closed circle sections on the body's coincident bottom plane).
+/// The impl drops closed circles in both its arrangement path
+/// ([`arrangement_regions_from_inputs`] discards any input whose UV chord is
+/// zero-length, and a closed circle has `start == end`) and its wire-builder
+/// fallback, leaving the drilled cylinder rims as free edges; the only impl
+/// path that carves a closed circle is the single-closed fast path (exactly
+/// one section, closed), which never fires when the circle is mixed with open
+/// sections or when there are two or more circles. Peel the cap circles off,
+/// split the plane by the remaining sections, then carve each cap circle into
+/// the sub-face that contains it ([`distribute_cap_circles`]).
 ///
 /// # Arguments
 /// - `topo` -- the topology arena (immutable read)
@@ -3138,34 +3134,37 @@ pub fn split_face_2d(
     >,
     split_registry: Option<&mut std::collections::HashMap<usize, Vec<Point3>>>,
 ) -> Vec<SplitSubFace> {
-    // Closed-circle cap sections are salvaged only on plane faces (curved faces
-    // route closed circles through their own band/internal-loop paths).
-    let Ok(face) = topo.face(face_id) else {
-        return split_face_2d_impl(
+    let run_impl = move |secs: &[SectionEdge]| {
+        split_face_2d_impl(
             topo,
             face_id,
-            sections,
+            secs,
             rank,
             tol,
             frame,
             info,
             edge_images,
             split_registry,
-        );
+        )
+    };
+
+    // Cheap gate for the common case: no closed-circle section, nothing to
+    // salvage — skip all frame and polygon work below.
+    let any_closed_circle = sections.iter().any(|s| {
+        (s.start - s.end).length() < tol.linear && matches!(s.curve_3d, EdgeCurve::Circle(_))
+    });
+    if !any_closed_circle {
+        return run_impl(sections);
+    }
+
+    // Salvage applies only to plane faces (curved faces route closed circles
+    // through their own band/internal-loop paths).
+    let Ok(face) = topo.face(face_id) else {
+        return run_impl(sections);
     };
     let surface = face.surface().clone();
     if !matches!(surface, FaceSurface::Plane { .. }) {
-        return split_face_2d_impl(
-            topo,
-            face_id,
-            sections,
-            rank,
-            tol,
-            frame,
-            info,
-            edge_images,
-            split_registry,
-        );
+        return run_impl(sections);
     }
 
     // Build the face's outer polygon in UV so a *genuine* cap circle (a full
@@ -3175,12 +3174,10 @@ pub fn split_face_2d(
     // point with an open arc section, and their "circle" is the corner cylinder
     // tangent to the face outline). Only genuine caps are peeled off; everything
     // else stays in `sections` and reaches the impl unchanged.
-    // The FRAME must be built from the same points (and thus the same
-    // convention) the impl uses, so the sub-face UVs and the projected circle
-    // centres agree. The containment POLYGON, by contrast, must follow wire
-    // TRAVERSAL order — `collect_wire_points` takes every edge's stored
-    // `start()` and ignores the oriented-edge flag, so a wire carrying reversed
-    // edges would come back scrambled and the containment test meaningless.
+    // The frame must be built from the same points the impl uses, so the
+    // sub-face UVs and the projected circle centres agree; the containment
+    // polygon must follow wire traversal order (see
+    // [`collect_wire_points_oriented`]).
     let frame_pts = collect_wire_points(topo, face.outer_wire());
     let owned_frame;
     let cap_frame = if let Some(f) = frame {
@@ -3195,8 +3192,6 @@ pub fn split_face_2d(
         .map(|&p| cap_frame.project(p))
         .collect();
 
-    // One pass: partition into cap circles (keeping each centre so the carve
-    // step never re-derives it) and everything else.
     let mut cap_sections: Vec<SectionEdge> = Vec::new();
     let mut cap_centers: Vec<Point3> = Vec::new();
     let mut rest_sections: Vec<SectionEdge> = Vec::new();
@@ -3226,33 +3221,13 @@ pub fn split_face_2d(
     // genuine cap circle AND not the single-closed fast path (exactly one
     // section, that one circle) which the impl already handles correctly.
     if cap_sections.is_empty() || (cap_sections.len() == 1 && sections.len() == 1) {
-        return split_face_2d_impl(
-            topo,
-            face_id,
-            sections,
-            rank,
-            tol,
-            frame,
-            info,
-            edge_images,
-            split_registry,
-        );
+        return run_impl(sections);
     }
 
-    // Split by the open (non-cap) sections through the normal path — identical
-    // to today's output for those, since the cap circles were being dropped
-    // anyway.
-    let base = split_face_2d_impl(
-        topo,
-        face_id,
-        &rest_sections,
-        rank,
-        tol,
-        frame,
-        info,
-        edge_images,
-        split_registry,
-    );
+    // The impl ignores closed circles on plane faces outside its single-closed
+    // fast path, so withholding the caps does not change how the remaining
+    // sections split.
+    let base = run_impl(&rest_sections);
 
     distribute_cap_circles(
         topo,
@@ -3265,10 +3240,10 @@ pub fn split_face_2d(
     )
 }
 
-/// Slack on the cap-circle interiority test. A genuine drilled-hole rim clears
-/// the face outline by its full radius, while a corner cylinder's section circle
-/// is exactly tangent (centre one radius out); the 5% margin keeps float noise
-/// on such a tangent circle from reading as interior.
+/// Slack on the cap-circle interiority test. A genuine drilled hole's centre
+/// clears the face outline by more than its radius, while a corner cylinder's
+/// section circle is exactly tangent (centre exactly one radius out); the 5%
+/// margin keeps float noise on such a tangent circle from reading as interior.
 const CAP_INTERIORITY_MARGIN: f64 = 1.05;
 
 /// Wire points in TRAVERSAL order, honouring each oriented edge's direction.
@@ -3301,12 +3276,13 @@ fn collect_wire_points_oriented(
 
 /// Carve closed cap circles (see [`split_face_2d`]) into the base sub-faces.
 ///
-/// Each cap circle is assigned to the base sub-face whose outer boundary
+/// Each cap circle is assigned to the first base sub-face whose outer boundary
 /// contains the circle's centre in UV, then that sub-face is re-split via
-/// [`split_face_with_internal_loops`] (disc cap + holed remainder). Cap circles
-/// are strictly interior to the parent face by construction, so each lands in
-/// exactly one sub-face; a circle that fails to land anywhere is left out,
-/// matching the pre-salvage behaviour (never worse than baseline).
+/// [`split_face_with_internal_loops`] (disc cap + holed remainder). A circle
+/// whose centre lies inside a sub-face hole is air — the rim of a drill
+/// emerging inside an existing opening — and a circle contained by no sub-face
+/// has no home; both are dropped, exactly as the impl's air filter and
+/// arrangement paths drop them.
 fn distribute_cap_circles(
     topo: &Topology,
     face_id: FaceId,
@@ -3323,8 +3299,7 @@ fn distribute_cap_circles(
     if !matches!(surface, FaceSurface::Plane { .. }) {
         return base;
     }
-    // Build the containment frame with the SAME convention the impl used so the
-    // sub-faces' stored UVs and the projected circle centres share one frame.
+    // Same frame convention as the impl (see [`split_face_2d`]).
     let wire_pts = collect_wire_points(topo, face.outer_wire());
     let owned_frame;
     let frame = if let Some(f) = frame {
@@ -3340,7 +3315,10 @@ fn distribute_cap_circles(
     let mut assigned = vec![false; cap_sections.len()];
     let mut result: Vec<SplitSubFace> = Vec::with_capacity(base.len() + cap_sections.len());
     for sf in base {
-        let poly = sample_wire_loop_uv(&sf.outer_wire);
+        // The frame-based sampler is orientation-unambiguous; the stored-pcurve
+        // sampler can fold a loop carrying reversed arc sections into a
+        // self-crossing polygon (see [`sample_wire_loop_uv_via_frame`]).
+        let poly = sample_wire_loop_uv_via_frame(&sf.outer_wire, frame);
         let contained: Vec<SectionEdge> = if poly.len() < 3 {
             Vec::new()
         } else {
@@ -3348,7 +3326,9 @@ fn distribute_cap_circles(
                 .iter()
                 .enumerate()
                 .filter_map(|(i, cs)| {
-                    if assigned[i] || !super::classify_2d::point_in_polygon_2d(centers_uv[i], &poly)
+                    if assigned[i]
+                        || !super::classify_2d::point_in_polygon_2d(centers_uv[i], &poly)
+                        || is_inside_any_hole(&centers_uv[i], &sf.inner_wires)
                     {
                         return None;
                     }
@@ -5870,6 +5850,117 @@ mod tests {
             )
             .is_none(),
             "a non-axis-aligned section must defer to the greedy path"
+        );
+    }
+
+    /// A cap circle whose centre lies inside a sub-face hole is air (the rim
+    /// of a drill emerging inside an existing opening) and must be dropped,
+    /// while a genuine cap over material is carved into disc + remainder.
+    #[test]
+    fn distribute_cap_circles_drops_caps_inside_holes() {
+        use brepkit_math::curves::Circle3D;
+        use brepkit_math::curves2d::{Circle2D, Curve2D};
+
+        let mut topo = Topology::new();
+        let face_id = make_unit_square_face(&mut topo);
+        let face = topo.face(face_id).unwrap();
+        let surface = face.surface().clone();
+        let wire_pts = collect_wire_points(&topo, face.outer_wire());
+        let normal = extract_plane_normal(&surface);
+        let frame = PlaneFrame::from_plane_face(normal, &wire_pts);
+        let boundary =
+            boundary_edges_to_pcurve(&topo, face.outer_wire(), &surface, &wire_pts, Some(&frame));
+
+        // Square hole around (0.3, 0.3). All UVs must come from the same
+        // frame projection the boundary and cap centres use.
+        let hole_corners = [
+            Point3::new(0.15, 0.15, 0.0),
+            Point3::new(0.45, 0.15, 0.0),
+            Point3::new(0.45, 0.45, 0.0),
+            Point3::new(0.15, 0.45, 0.0),
+        ];
+        let hole: Vec<OrientedPCurveEdge> = (0..4)
+            .map(|i| {
+                let (a, b) = (hole_corners[i], hole_corners[(i + 1) % 4]);
+                OrientedPCurveEdge {
+                    curve_3d: EdgeCurve::Line,
+                    pcurve: dummy_pcurve(),
+                    start_uv: frame.project(a),
+                    end_uv: frame.project(b),
+                    start_3d: a,
+                    end_3d: b,
+                    forward: true,
+                    source_edge_idx: None,
+                    pave_block_id: None,
+                }
+            })
+            .collect();
+
+        let base = SplitSubFace {
+            surface,
+            outer_wire: boundary,
+            inner_wires: vec![hole],
+            reversed: false,
+            parent: face_id,
+            rank: Rank::A,
+            precomputed_interior: None,
+        };
+
+        let cap = |cx: f64, cy: f64| -> SectionEdge {
+            let r = 0.05;
+            let circle =
+                Circle3D::new(Point3::new(cx, cy, 0.0), Vec3::new(0.0, 0.0, 1.0), r).unwrap();
+            let rim3 = Point3::new(cx + r, cy, 0.0);
+            let rim_uv = frame.project(rim3);
+            let pcurve =
+                Curve2D::Circle(Circle2D::new(frame.project(Point3::new(cx, cy, 0.0)), r).unwrap());
+            SectionEdge {
+                curve_3d: EdgeCurve::Circle(circle),
+                pcurve_a: pcurve.clone(),
+                pcurve_b: pcurve,
+                start: rim3,
+                end: rim3,
+                start_uv_a: Some(rim_uv),
+                end_uv_a: Some(rim_uv),
+                start_uv_b: Some(rim_uv),
+                end_uv_b: Some(rim_uv),
+                target_face: None,
+                pave_block_id: None,
+            }
+        };
+        let in_hole = cap(0.3, 0.3);
+        let genuine = cap(0.7, 0.7);
+        let centers = [Point3::new(0.3, 0.3, 0.0), Point3::new(0.7, 0.7, 0.0)];
+
+        let result = distribute_cap_circles(
+            &topo,
+            face_id,
+            vec![base],
+            &[in_hole, genuine],
+            &centers,
+            Rank::A,
+            Some(&frame),
+        );
+
+        assert_eq!(
+            result.len(),
+            2,
+            "genuine cap carves disc + remainder; in-hole cap must be dropped"
+        );
+        let discs: Vec<&SplitSubFace> = result
+            .iter()
+            .filter(|sf| {
+                sf.outer_wire.len() == 1
+                    && matches!(sf.outer_wire[0].curve_3d, EdgeCurve::Circle(_))
+            })
+            .collect();
+        assert_eq!(discs.len(), 1, "exactly one cap disc must be carved");
+        let EdgeCurve::Circle(c) = &discs[0].outer_wire[0].curve_3d else {
+            unreachable!();
+        };
+        assert!(
+            (c.center() - Point3::new(0.7, 0.7, 0.0)).length() < 1e-9,
+            "the carved disc must be the genuine cap, not the in-hole one"
         );
     }
 }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -4466,6 +4466,23 @@ fn count_cylinder_faces(topo: &Topology, solid: SolidId) -> usize {
         .count()
 }
 
+/// Count edges not used exactly twice across all face wires of `solid` — zero
+/// for a watertight manifold, and each free (once-used) edge is a rim the
+/// splitter failed to cap.
+fn count_non_manifold_edges(topo: &Topology, solid: SolidId) -> usize {
+    let faces = brepkit_topology::explorer::solid_faces(topo, solid).unwrap();
+    let mut edge_use: std::collections::HashMap<EdgeId, usize> = std::collections::HashMap::new();
+    for &fid in &faces {
+        let face = topo.face(fid).unwrap();
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *edge_use.entry(oe.edge()).or_default() += 1;
+            }
+        }
+    }
+    edge_use.values().filter(|&&u| u != 2).count()
+}
+
 #[test]
 fn rounded_rect_arc_prism_volume_baseline() {
     let mut topo = Topology::new();
@@ -5644,13 +5661,12 @@ fn cut_cylinder_by_box_slot_perpendicular_walls_is_watertight() {
 /// The capping plane (the plain top slab's bottom face, coincident with the
 /// drilled slab's top face) receives one closed circle FF section per hole from
 /// the drilled cylinder walls. With two or more such circles they route through
-/// the planar arrangement decomposition, which dropped every zero-UV-chord
-/// (closed circle) input — so the drilled cylinder rims were left as free edges
-/// and the fuse mesh-fell-back to hundreds of planar faces. `split_face_2d` now
-/// peels the genuine interior cap circles off and carves each into the sub-face
-/// that contains it (disc cap + holed remainder). A single-hole interface never
-/// exercised the bug (it hit the impl's single-closed fast path), so use TWO
-/// holes here.
+/// the planar arrangement decomposition, which drops every zero-UV-chord
+/// (closed circle) input — without the cap-circle salvage in `split_face_2d`,
+/// the drilled cylinder rims are left as free edges and the fuse falls back to
+/// a mesh of planar faces. A single hole routes through the impl's
+/// single-closed fast path and never exercises the salvage, so this test
+/// drills TWO.
 #[test]
 fn fuse_capping_slab_preserves_drilled_hole_caps() {
     use brepkit_math::mat::Mat4;
@@ -5672,19 +5688,9 @@ fn fuse_capping_slab_preserves_drilled_hole_caps() {
 
     let fused = boolean(&mut topo, BooleanOp::Fuse, bottom, top).unwrap();
 
-    // Watertight: every edge of every wire is used exactly twice. Without the
-    // cap-circle salvage the two hole rims at z = 5 are free (used once).
-    let faces = brepkit_topology::explorer::solid_faces(&topo, fused).unwrap();
-    let mut edge_use: std::collections::HashMap<EdgeId, usize> = std::collections::HashMap::new();
-    for &fid in &faces {
-        let face = topo.face(fid).unwrap();
-        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
-            for oe in topo.wire(wid).unwrap().edges() {
-                *edge_use.entry(oe.edge()).or_default() += 1;
-            }
-        }
-    }
-    let bad_edges = edge_use.values().filter(|&&u| u != 2).count();
+    // Watertight: without the cap-circle salvage the two hole rims at z = 5
+    // are free (used once).
+    let bad_edges = count_non_manifold_edges(&topo, fused);
     assert_eq!(
         bad_edges, 0,
         "fused result must be a watertight manifold (every edge used twice), got {bad_edges} bad edges"
@@ -5692,23 +5698,21 @@ fn fuse_capping_slab_preserves_drilled_hole_caps() {
 
     // Analytic, not a mesh fallback: a compact face count, and BOTH drilled
     // cylinder walls survive as analytic cylinders.
+    let faces = brepkit_topology::explorer::solid_faces(&topo, fused).unwrap();
     assert!(
         faces.len() < 30,
         "expected a compact analytic fuse, got {} faces (mesh fallback?)",
         faces.len()
     );
-    let cyl_faces = faces
-        .iter()
-        .filter(|&&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Cylinder(_)))
-        .count();
     assert_eq!(
-        cyl_faces, 2,
+        count_cylinder_faces(&topo, fused),
+        2,
         "both drilled-hole cylinder walls must survive the fuse"
     );
 
     // The caps exist and are correctly oriented: over each hole, material caps
     // the top (Inside above z = 5) while the through-hole stays open below it
-    // (Outside below z = 5). Verified with the robust ray-cast classifier.
+    // (Outside below z = 5).
     for &(cx, cy) in &holes {
         let above = Point3::new(cx, cy, 7.0);
         let below = Point3::new(cx, cy, 2.5);
@@ -5725,6 +5729,164 @@ fn fuse_capping_slab_preserves_drilled_hole_caps() {
                 crate::classify::PointClassification::Outside
             ),
             "the through-hole must stay open below z=5 at ({cx}, {cy})"
+        );
+    }
+}
+
+/// Cap circles mixed with open sections: the receiving plane is also crossed
+/// by a wall of the opposing solid, so the base split yields multiple
+/// sub-faces and the caps must be carved into the one that contains them.
+///
+/// The top block is embedded 2 deep into a wider bottom slab, so the slab's
+/// top face receives one open Line section (the block's x = 20 wall) plus two
+/// closed circle sections (the block's drilled holes crossing z = 5). This is
+/// the mixed route through `split_face_2d`'s salvage that the coincident-slab
+/// test above (empty base split) never reaches.
+#[test]
+fn fuse_embedded_drilled_block_carves_caps_across_split_sub_faces() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+
+    // Wide plain slab z in [0, 5].
+    let slab = crate::primitives::make_box(&mut topo, 30.0, 20.0, 5.0).unwrap();
+
+    // Narrower block z in [3, 8] with two through-holes (r = 1.5), overlapping
+    // the slab by 2 in z.
+    let holes = [(6.0, 10.0), (14.0, 10.0)];
+    let mut block = crate::primitives::make_box(&mut topo, 20.0, 20.0, 5.0).unwrap();
+    crate::transform::transform_solid(&mut topo, block, &Mat4::translation(0.0, 0.0, 3.0)).unwrap();
+    for &(cx, cy) in &holes {
+        let drill = crate::primitives::make_cylinder(&mut topo, 1.5, 20.0).unwrap();
+        crate::transform::transform_solid(&mut topo, drill, &Mat4::translation(cx, cy, 0.0))
+            .unwrap();
+        block = boolean(&mut topo, BooleanOp::Cut, block, drill).unwrap();
+    }
+
+    let fused = boolean(&mut topo, BooleanOp::Fuse, slab, block).unwrap();
+
+    let bad_edges = count_non_manifold_edges(&topo, fused);
+    assert_eq!(
+        bad_edges, 0,
+        "fused result must be a watertight manifold (every edge used twice), got {bad_edges} bad edges"
+    );
+    assert_eq!(
+        count_cylinder_faces(&topo, fused),
+        2,
+        "both drilled-hole cylinder walls must survive the fuse"
+    );
+
+    // Slab material floors each hole (the carved cap discs at z = 5); the
+    // holes stay open above the slab.
+    for &(cx, cy) in &holes {
+        let below = Point3::new(cx, cy, 4.0);
+        let inside_hole = Point3::new(cx, cy, 6.5);
+        assert!(
+            matches!(
+                crate::classify::classify_point(&topo, fused, below, 0.01, 1e-7).unwrap(),
+                crate::classify::PointClassification::Inside
+            ),
+            "slab material must floor the hole below z=5 at ({cx}, {cy})"
+        );
+        assert!(
+            matches!(
+                crate::classify::classify_point(&topo, fused, inside_hole, 0.01, 1e-7).unwrap(),
+                crate::classify::PointClassification::Outside
+            ),
+            "the hole must stay open above z=5 at ({cx}, {cy})"
+        );
+    }
+    // The slab's exposed shelf beyond the block is solid.
+    assert!(matches!(
+        crate::classify::classify_point(&topo, fused, Point3::new(25.0, 10.0, 2.5), 0.01, 1e-7)
+            .unwrap(),
+        crate::classify::PointClassification::Inside
+    ));
+}
+
+/// Closed circles landing inside an existing hole of the receiving plane are
+/// air, not caps: the drilled rims emerge inside the top slab's counterbore
+/// opening, where the top slab has no material to carve.
+/// `distribute_cap_circles` must drop them rather than emit free-floating
+/// discs across the opening (the drop itself is pinned down by
+/// `distribute_cap_circles_drops_caps_inside_holes` in `brepkit-algo`).
+///
+/// The GFA path currently fails post-assembly validation on this interface
+/// and the fuse falls back to the mesh boolean, so this test asserts the
+/// solid-level contract that survives the fallback: watertight, correct
+/// volume, correct in/out classification.
+// TODO: assert analytic cylinder faces once the counterbore interface
+// passes GFA validation.
+#[test]
+fn fuse_counterbore_drops_drill_rims_inside_opening() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+
+    // Bottom slab z in [0, 5] with two small through-holes (r = 1.5).
+    let holes = [(6.0, 10.0), (14.0, 10.0)];
+    let mut bottom = crate::primitives::make_box(&mut topo, 20.0, 20.0, 5.0).unwrap();
+    for &(cx, cy) in &holes {
+        let drill = crate::primitives::make_cylinder(&mut topo, 1.5, 20.0).unwrap();
+        crate::transform::transform_solid(&mut topo, drill, &Mat4::translation(cx, cy, -5.0))
+            .unwrap();
+        bottom = boolean(&mut topo, BooleanOp::Cut, bottom, drill).unwrap();
+    }
+
+    // Top slab z in [5, 10] with one wide through-hole (r = 6) covering both
+    // small drill rims.
+    let mut top = crate::primitives::make_box(&mut topo, 20.0, 20.0, 5.0).unwrap();
+    crate::transform::transform_solid(&mut topo, top, &Mat4::translation(0.0, 0.0, 5.0)).unwrap();
+    let bore = crate::primitives::make_cylinder(&mut topo, 6.0, 20.0).unwrap();
+    crate::transform::transform_solid(&mut topo, bore, &Mat4::translation(10.0, 10.0, 0.0))
+        .unwrap();
+    top = boolean(&mut topo, BooleanOp::Cut, top, bore).unwrap();
+
+    let fused = boolean(&mut topo, BooleanOp::Fuse, bottom, top).unwrap();
+
+    let bad_edges = count_non_manifold_edges(&topo, fused);
+    assert_eq!(
+        bad_edges, 0,
+        "fused result must be a watertight manifold (every edge used twice), got {bad_edges} bad edges"
+    );
+    // Box minus counterbore minus the two small drills (2% slack covers the
+    // mesh fallback's faceted cylinders).
+    let expected = 20.0 * 20.0 * 10.0
+        - std::f64::consts::PI * 6.0 * 6.0 * 5.0
+        - 2.0 * std::f64::consts::PI * 1.5 * 1.5 * 5.0;
+    assert_volume_near(&topo, fused, expected, 0.02);
+
+    // Slab material is solid, the counterbore is open above its floor, and
+    // the small holes are open below it. The material probe sits in the slab
+    // corner: the fallback mesh misclassifies points directly under the bore
+    // as Outside even though the volume above proves the material exists
+    // (same pre-existing artifact as the failed GFA validation).
+    let slab =
+        crate::classify::classify_point(&topo, fused, Point3::new(2.0, 2.0, 2.5), 0.01, 1e-7)
+            .unwrap();
+    assert!(
+        matches!(slab, crate::classify::PointClassification::Inside),
+        "slab material must be Inside, got {slab:?}"
+    );
+    let bore =
+        crate::classify::classify_point(&topo, fused, Point3::new(10.0, 7.3, 7.0), 0.01, 1e-7)
+            .unwrap();
+    assert!(
+        matches!(bore, crate::classify::PointClassification::Outside),
+        "the counterbore must stay open above the floor, got {bore:?}"
+    );
+    for &(cx, cy) in &holes {
+        let hole = crate::classify::classify_point(
+            &topo,
+            fused,
+            Point3::new(cx + 0.4, cy + 0.3, 2.5),
+            0.01,
+            1e-7,
+        )
+        .unwrap();
+        assert!(
+            matches!(hole, crate::classify::PointClassification::Outside),
+            "the small through-hole must stay open below z=5 near ({cx}, {cy}), got {hole:?}"
         );
     }
 }


### PR DESCRIPTION
Follow-up review pass on the cap-circle salvage (#1119).

## Fixes

- **In-hole cap guard**: a closed-circle rim whose centre lands inside an inner wire of the receiving plane is air (a drill emerging inside an existing opening, e.g. a counterbore). The salvage peeled it off before the impl's air filter could drop it, then carved it as a free-floating disc — strictly worse than baseline. `distribute_cap_circles` now skips caps whose centre lies in a sub-face hole, matching the impl's baseline drop.
- **Early gate**: return to the impl before any frame/polygon construction when no section is a closed circle — the common path for every boolean face split.
- **Frame-based containment sampling**: the distribution polygon now uses `sample_wire_loop_uv_via_frame`; the stored-pcurve sampler can fold loops carrying reversed arc sections into self-crossing polygons.
- **Doc corrections**: only the single-closed fast path carves circles (the all-Line loop path never can); the interiority margin is about the *centre* clearing the outline, not the rim; removed the "lands in exactly one sub-face" over-claim and before/after narration.

## Tests

- `distribute_cap_circles_drops_caps_inside_holes` (algo unit test) — fails without the guard.
- `fuse_embedded_drilled_block_carves_caps_across_split_sub_faces` — caps mixed with open sections; exercises multi-sub-face distribution, which the original regression test never reached.
- `fuse_counterbore_drops_drill_rims_inside_opening` — asserts the solid-level contract (watertight, volume, classification). Documents two pre-existing issues, out of scope here: this interface fails GFA post-assembly validation and mesh-falls-back, and the fallback mesh misclassifies points directly under the bore as Outside.

Full `brepkit-algo` + `brepkit-operations` suites green; clippy `--all-targets` warning-free.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cap-circle salvage on plane faces: drop caps whose centers fall inside holes and early-exit when no closed circles are present. This prevents free-floating discs, keeps results watertight, and maintains analytic outputs.

- **Bug Fixes**
  - Drop in-hole caps in `distribute_cap_circles` (centers inside sub-face holes are air).
  - Early gate to the impl when no section is a closed circle to avoid extra work.
  - Use frame-based containment sampling via `sample_wire_loop_uv_via_frame` to handle reversed arcs reliably.
  - Clarified salvage docs (which paths carve circles and the correct interiority margin).

- **Tests**
  - `distribute_cap_circles_drops_caps_inside_holes` — unit test for the in-hole cap guard.
  - `fuse_embedded_drilled_block_carves_caps_across_split_sub_faces` — mixed open/closed sections; verifies caps are carved into the correct sub-faces and watertightness.
  - `fuse_counterbore_drops_drill_rims_inside_opening` — ensures in-hole rims are dropped; asserts watertightness, volume, and classification.

<sup>Written for commit 02ac398d2557ff6d74314eb87187b17b419b36ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

