### PR TITLE
fix(operations): apply the hole correction in the multi-region boolean gate

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -621,11 +621,13 @@ pub fn boolean(
                 // distinguishes a "cut into N pieces" from a hollow solid
                 // (outer surface + cavity surface — same number of
                 // components, same Euler relation, but AABBs overlap).
-                // N closed manifolds satisfy the Euler-Poincare relation
-                // `V - E + F - inner_wires = 2 * (N - genus)`. The hole term is
-                // NOT optional: a piece carrying a blind pocket (a face with an
-                // inner wire) shifts raw Euler away from 2*N, so comparing raw
-                // Euler here would reject every pocketed piece. This mirrors the
+                // N closed manifolds satisfy `V - E + F - inner_wires =
+                // 2 * (N - genus)`, which this gate pins at the genus-0 case
+                // `... = 2 * N` (as it always has — a handled piece is left to
+                // the mesh fallback). The hole term, however, is NOT optional:
+                // a piece carrying a blind pocket (a face with an inner wire)
+                // shifts raw Euler away from 2*N even at genus 0, so comparing
+                // raw Euler here rejected every pocketed piece. This mirrors the
                 // `euler_balanced(euler_eff, inner_wire_count)` correction the
                 // single-component gate above applies.
                 let components_vec = crate::boolean::assembly::face_components(topo, result);

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -621,10 +621,18 @@ pub fn boolean(
                 // distinguishes a "cut into N pieces" from a hollow solid
                 // (outer surface + cavity surface — same number of
                 // components, same Euler relation, but AABBs overlap).
+                // N closed manifolds satisfy the Euler-Poincare relation
+                // `V - E + F - inner_wires = 2 * (N - genus)`. The hole term is
+                // NOT optional: a piece carrying a blind pocket (a face with an
+                // inner wire) shifts raw Euler away from 2*N, so comparing raw
+                // Euler here would reject every pocketed piece. This mirrors the
+                // `euler_balanced(euler_eff, inner_wire_count)` correction the
+                // single-component gate above applies.
                 let components_vec = crate::boolean::assembly::face_components(topo, result);
                 let components = components_vec.len();
                 #[allow(clippy::cast_possible_wrap)]
                 let expected_euler = (components as i64) * 2;
+                let euler_corrected = euler - inner_wire_count;
                 // For Cut, also verify no component is a "B-interior piece" —
                 // GFA can produce N closed manifolds where one of them is the
                 // tool's interior (sphere - cylinder example: 3 pieces =
@@ -641,7 +649,7 @@ pub fn boolean(
                         });
                 if op == BooleanOp::Cut
                     && components >= 2
-                    && euler == expected_euler
+                    && euler_corrected == expected_euler
                     && components_are_disjoint_pieces(topo, &components_vec)
                     && cut_safe
                     // Reuse the `closed_manifold` computed above: nothing between

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5890,3 +5890,61 @@ fn fuse_counterbore_drops_drill_rims_inside_opening() {
         );
     }
 }
+
+#[test]
+fn severing_cut_keeps_pocketed_pieces_analytic() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+
+    // Bar 20 x 6 x 3 with two blind pockets (r = 1.5, depth 1.5). Blind pockets
+    // keep each piece genus-0 while giving its top face an inner wire — the
+    // combination that made the multi-region gate's raw-Euler comparison fail
+    // (raw euler 6 != 2*components 4, while the hole-corrected 6 - 2 == 4).
+    let pockets = [4.0_f64, 16.0];
+    let mut bar = crate::primitives::make_box(&mut topo, 20.0, 6.0, 3.0).unwrap();
+    for &cx in &pockets {
+        let drill = crate::primitives::make_cylinder(&mut topo, 1.5, 2.0).unwrap();
+        crate::transform::transform_solid(&mut topo, drill, &Mat4::translation(cx, 3.0, 1.5))
+            .unwrap();
+        bar = boolean(&mut topo, BooleanOp::Cut, bar, drill).unwrap();
+    }
+
+    // Sever the bar between the pockets into two spatially disjoint pieces.
+    let slab = crate::primitives::make_box(&mut topo, 2.0, 8.0, 5.0).unwrap();
+    crate::transform::transform_solid(&mut topo, slab, &Mat4::translation(9.0, -1.0, -1.0))
+        .unwrap();
+    let severed = boolean(&mut topo, BooleanOp::Cut, bar, slab).unwrap();
+
+    // Analytic, not a mesh fallback. The fallback for this shape is ~114
+    // all-planar faces and is itself watertight, valid, and correct-volume —
+    // the face census is the only signal that separates the two.
+    let faces = brepkit_topology::explorer::solid_faces(&topo, severed).unwrap();
+    assert!(
+        faces.len() < 30,
+        "expected a compact analytic result, got {} faces (mesh fallback?)",
+        faces.len()
+    );
+    assert_eq!(
+        count_cylinder_faces(&topo, severed),
+        2,
+        "both pocket walls must survive the severing cut as analytic cylinders"
+    );
+
+    let bad_edges = count_non_manifold_edges(&topo, severed);
+    assert_eq!(
+        bad_edges, 0,
+        "severed result must be a watertight manifold, got {bad_edges} bad edges"
+    );
+
+    // Exact analytic volume: bar 360, less two pockets (pi * 1.5^2 * 1.5 each),
+    // less the 2 x 6 x 3 severed slab. Pins that both pockets are still void,
+    // the gap is really cut, and the two pieces were not merged or skinned over.
+    let expected =
+        20.0 * 6.0 * 3.0 - 2.0 * std::f64::consts::PI * 1.5 * 1.5 * 1.5 - 2.0 * 6.0 * 3.0;
+    let volume = crate::measure::solid_volume(&topo, severed, 0.01).unwrap();
+    assert!(
+        (volume - expected).abs() < 0.05,
+        "severed volume {volume:.3} should match analytic {expected:.3}"
+    );
+}


### PR DESCRIPTION
## The defect

N closed manifolds satisfy the Euler-Poincaré relation

```
V - E + F - inner_wires = 2 * (N - genus)
```

The multi-region acceptance path in `boolean/mod.rs` compared **raw** Euler against `2 * components`, omitting the `inner_wires` term that the single-component gate immediately above it already applies via `euler_balanced(euler_eff, inner_wire_count)`.

A face carrying a hole shifts raw Euler away from `2 * N` **even at genus 0**, so the multi-region path only ever accepted **hole-free** pieces. Any multi-component result whose pieces have pockets or bores was rejected and silently replaced by a mesh boolean.

## Why it went unnoticed

The fallback masks itself. It is watertight, passes `validate_boolean_result`, and has the correct volume — every downstream check agrees with it. Only the face census distinguishes the two, exactly as the `boolean-debugging` skill warns.

Severing a pocketed bar in two — an ordinary CAD operation — is enough to trigger it:

| | faces | census | volume |
|---|---|---|---|
| before | 114 | `{plane: 114}` | 302.80 |
| after | 16 | `{cylinder: 2, plane: 14}` | 302.80 |

Analytic value is 302.80 (`20×6×3` − two `π·1.5²·1.5` pockets − a `2×6×3` slab), so both results are *geometrically* right; the old path just threw away the analytic one. The arithmetic at the gate:

```
euler=6  inner_wires=2  components=2
  euler - inner_wires = 4  vs  2*components = 4   <- correct relation, holds
  raw euler           = 6  vs  2*components = 4   <- what was compared, fails
```

It needed three properties at once to surface — multi-component **and** genus-0 **and** faces-with-holes — which is why it survived: a severed *un*-pocketed cylinder has no holes and passes fine.

## The fix

Compare `euler - inner_wire_count` against `2 * components`.

The disjointness, closed-manifold, cut-safety, and validation guards are untouched, so the gate is no more permissive about malformed output — it just stops rejecting a shape class it was never meant to exclude. Worth noting the hollow case cannot slip through the relaxed check: a cavity component's AABB lies strictly inside its containing piece's, so `components_are_disjoint_pieces` rejects it on AABB overlap.

## Verification

- New regression `severing_cut_keeps_pocketed_pieces_analytic` **fails without the change** (114 planar faces, 0 cylinders) and passes with it. Asserts compact face count, both pocket walls analytic, 0 non-manifold edges, and volume against the exact analytic value.
- Full workspace suite green (77 test binaries).
- Gridfinity canary 27/0.
- `brepkit-render --test compute_mesh_render` SIGSEGVs, but it does so identically on clean `main` — pre-existing GPU/driver issue, unrelated.

## Note on scope: extending to Fuse was tested and rejected

The multi-region path is still gated `op == BooleanOp::Cut`. I built what looked like a justification for widening it — fusing a lug onto one piece of an already-severed pocketed bar, which mesh-falls-back with 120 planar faces — then instrumented the gate before changing it. The widening gains nothing:

```
op=Fuse comps=2 euler=6 iw=3 corrected=3 expected=4 closed_manifold=FALSE
```

A corrected Euler of **3 is odd**, which no set of closed manifolds can produce, and `closed_manifold` is genuinely false. That GFA output (19 faces) is really broken, so the fallback is the *correct* behaviour there; the actual defect is the pavefiller's single-connected-input assumption — the same root `cut_multi_region_input` works around for Cut. So the Fuse extension is deliberately not included: it would have widened a gate on a false premise.

Found while digging the lightweight-base blocker. It does **not** close that case — that one is a Fuse and is separately blocked by `closed_manifold=false` — but it is a real independent defect with a minimal repro, so it ships on its own.
