### PR TITLE
fix(heal): stop unify_same_domain discarding closed-curve boundary loops

### DIFF
--- a/crates/heal/src/upgrade/unify_same_domain.rs
+++ b/crates/heal/src/upgrade/unify_same_domain.rs
@@ -418,6 +418,30 @@ fn merge_group_with_holes(
         let end = oe.oriented_end(edge);
         let sp = topo.vertex(start)?.point();
         let ep = topo.vertex(end)?.point();
+        // A full circle is stored as a CLOSED edge: start == end with a zero
+        // chord, which the degenerate-sliver test below cannot tell it apart
+        // from. Sampling the curve interior separates them (the endpoints of a
+        // closed curve carry no extent — see the closed-edge rule in
+        // CLAUDE.md). Such a loop is a real boundary, typically a bore opening,
+        // but it reaches the loop walk as a SINGLE-VERTEX loop, and the
+        // containment classification below needs a UV polygon with area to
+        // decide outer-vs-hole. Dropping the edge instead would erase the hole
+        // and orphan its rim — a drilled pad annulus merged into its coplanar
+        // neighbour leaves the bore rim used once (free) — so defer the whole
+        // group rather than merge it wrongly.
+        if start == end {
+            let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
+            let mid = edge
+                .curve()
+                .evaluate_with_endpoints(0.5 * (t0 + t1), sp, ep);
+            if (mid - sp).length() > lin {
+                log::debug!(
+                    "unify_same_domain: deferring group of {} faces (closed-curve boundary loop)",
+                    group_face_ids.len()
+                );
+                return Ok(None);
+            }
+        }
         if (ep - sp).length() < lin && start == end {
             continue;
         }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5948,3 +5948,46 @@ fn severing_cut_keeps_pocketed_pieces_analytic() {
         "severed volume {volume:.3} should match analytic {expected:.3}"
     );
 }
+
+#[test]
+fn compound_cut_unify_keeps_bore_opening() {
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+
+    // A plate with a pad column standing on it: the pad's bottom disc ends up
+    // COPLANAR with the plate's bottom face, so `unify_same_domain` groups the
+    // two for merging.
+    let plate = crate::primitives::make_box(&mut topo, 20.0, 20.0, 2.0).unwrap();
+    let pad = crate::primitives::make_cylinder(&mut topo, 3.0, 8.0).unwrap();
+    crate::transform::transform_solid(&mut topo, pad, &Mat4::translation(10.0, 10.0, 0.0)).unwrap();
+    let fused = boolean(&mut topo, BooleanOp::Fuse, plate, pad).unwrap();
+
+    // Bore through the pad. The bottom disc becomes an annulus whose inner wire
+    // is a single CLOSED circle edge (start == end, zero chord) — which the
+    // merge's degenerate-sliver filter used to discard, erasing the opening and
+    // leaving the bore rim used once.
+    let drill = crate::primitives::make_cylinder(&mut topo, 1.0, 30.0).unwrap();
+    crate::transform::transform_solid(&mut topo, drill, &Mat4::translation(10.0, 10.0, -5.0))
+        .unwrap();
+
+    let opts = BooleanOptions {
+        unify_faces: true,
+        ..BooleanOptions::default()
+    };
+    let result = compound_cut(&mut topo, fused, &[drill], opts).unwrap();
+
+    let bad_edges = count_non_manifold_edges(&topo, result);
+    assert_eq!(
+        bad_edges, 0,
+        "the bore opening must survive the unify pass (got {bad_edges} unpaired/over-shared edges)"
+    );
+
+    // Both bore walls (pad column outer + drilled inner) stay analytic, and the
+    // pad's annular bottom face is still present rather than merged away.
+    assert_eq!(
+        count_cylinder_faces(&topo, result),
+        2,
+        "both cylindrical walls must survive"
+    );
+}


### PR DESCRIPTION
## The defect

A full circle is stored as a **closed edge** — `start == end` with a zero chord. `merge_group_with_holes` filtered edges with:

```rust
if (ep - sp).length() < lin && start == end { continue; }
```

which cannot tell a real circle from a genuinely degenerate zero-length sliver, so it discarded both. Discarding a real circle **erases a hole boundary**: the drilled annulus merges into its coplanar neighbour and the bore rim is left used once (a free edge).

This is exactly the closed-edge trap CLAUDE.md documents — *"whenever an edge can be closed, sample points along the curve; never derive from endpoints."*

## The fix

Sample the curve interior to separate a real closed curve from a sliver, and **defer** such a group (leave it unmerged) rather than merge it with a boundary silently dropped.

Deferral rather than repair is deliberate: the reassembly classifies loops by UV polygon area, and a closed circle arrives as a **single-vertex loop** that yields no polygon, so the group cannot be reassembled correctly either way. Skipping matches the function's existing contract — it already returns `Ok(None)` for cases it cannot represent (periodic surfaces with holes, non-manifold edges, unclosed loops).

This only makes the merge **more conservative**: groups it previously merged wrongly are now skipped, and no group it previously skipped is now merged. The cost is a few unmerged coplanar faces; the alternative is a hole in the solid.

## How it was found

The gridfinity `2×2 lite + screw pads` export fails with **448 STL boundary edges**. The chain:

`cutAll` → `compound_cut`, whose trailing `unify_same_domain` merged each socket cell's 5 coplanar bottom faces (1 floor + 4 drilled pad annuli) into 1, dropping 16 planes and orphaning all 16 bore rims.

Replaying on captured tool operands isolated it to a single flag:

| | F | E | V | free edges | planes |
|---|---|---|---|---|---|
| tool's `cutAll` output | 284 | 608 | 352 | **16** | 140 |
| `compound_cut` unify **on** | 284 | 608 | 352 | **16** | 140 |
| `compound_cut` unify **off** | 300 | 624 | 368 | 0 | 156 |
| **with this fix**, unify on | 300 | 624 | 368 | **0** | 156 |

The unify-on replay reproduced the tool's result *exactly*, and the fix makes it match the clean one. Worth noting the 16 sequential cuts and a single cut by a 16-component fused tool were both already clean — the drill and phase FF were never at fault.

## Verification

- New regression `compound_cut_unify_keeps_bore_opening` — plate + pad column fused (leaving a coplanar bottom disc), bored through. **Fails without the change** (1 unpaired edge), passes with it.
- Full workspace suite green; `brepkit-heal` 86/0.
- Gridfinity canary 27/0.
- `brepkit-render` GPU tests SIGSEGV identically on clean `main` — pre-existing, unrelated.

## Scope

This closes the B-Rep root behind the screw-pad family. It does **not** by itself make that scenario pass end-to-end — I have not yet re-measured the tool suite with it, so I am claiming the root fix, not the scenario. The lightweight failures are three unrelated roots (this one, a sub-tolerance `nm=2` on the magnet family that a STEP round-trip heals, and two pure 30s timeouts).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops unify_same_domain from dropping closed-circle boundary loops that erased hole openings and created free edges. We now sample the curve interior to tell real circles from zero-length slivers and defer those groups instead of merging.

- Bug Fixes
  - Sample closed edges at mid-parameter; if it’s a real circle, skip merging the whole group to preserve the boundary.
  - Prevents bore rims from becoming free edges when unifying coplanar faces.
  - Adds regression test `compound_cut_unify_keeps_bore_opening`.
  - Behavior is more conservative: previously wrong merges are now skipped; previously skipped cases remain skipped.

<sup>Written for commit 737d1049d28cbdf3cd452d25c25e142a64de900d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

