### PR TITLE
fix(heal): revert a unify pass that would orphan edges

### DIFF
--- a/crates/heal/src/upgrade/unify_same_domain.rs
+++ b/crates/heal/src/upgrade/unify_same_domain.rs
@@ -235,24 +235,20 @@ pub fn unify_same_domain(
     }
 
     // Merging is an OPTIMISATION — it must never leave the shell worse connected
-    // than it found it. Snapshot the pairing first, apply the merge and the
-    // collinear-edge pass, then put the original faces back if either degraded
-    // it. Both phases can orphan edges: a group whose reassembly loses a
-    // boundary edge, and `merge_collinear_edges`, which rewrites only the NEW
-    // faces' wires — a neighbour still referencing the pre-merge edges is left
+    // than it found it. Each phase is applied, measured, and rolled back on its
+    // own so a bad phase does not discard a good one.
+    //
+    // Both phases can orphan edges: a group whose reassembly loses a boundary
+    // edge, and `merge_collinear_edges`, which rewrites only the NEW faces'
+    // wires — a neighbour still referencing the pre-merge edges is left
     // unpaired. That is invisible on analytic solids (few collinear runs) and
     // catastrophic on mesh-fallback ones (thousands of coplanar facets: 1630
     // edge merges orphaned 4574 edges on a drilled 15648-face solid).
-    //
-    // Reverting is complete: removed faces are only dropped from the shell's
-    // list, never deleted from the arena, and the collinear pass only mutates
-    // the new faces' wires, which the revert discards.
-    let mut original_faces: Option<Vec<FaceId>> = None;
-    let mut bad_before = 0;
+    let mut bad_after_faces = 0;
     if total_merged > 0 {
         let shell = topo.shell(shell_id)?;
         let current_faces: Vec<FaceId> = shell.faces().to_vec();
-        bad_before = unpaired_edge_count(topo, &current_faces)?;
+        let bad_before = unpaired_edge_count(topo, &current_faces)?;
 
         let mut final_faces: Vec<FaceId> = current_faces
             .iter()
@@ -261,31 +257,13 @@ pub fn unify_same_domain(
             .collect();
         final_faces.extend(&new_faces_to_add);
 
-        let new_shell = Shell::new(final_faces)?;
-        let shell_mut = topo.shell_mut(shell_id)?;
-        *shell_mut = new_shell;
-        original_faces = Some(current_faces);
-    }
-
-    let mut total_edges_merged = 0;
-    if options.unify_edges && total_merged > 0 {
-        for &fid in &new_faces_to_add {
-            let outer_wire = topo.face(fid)?.outer_wire();
-            let merged = merge_collinear_edges(topo, outer_wire, options)?;
-            total_edges_merged += merged;
-        }
-    }
-
-    if let Some(original) = original_faces {
-        let after: Vec<FaceId> = topo.shell(shell_id)?.faces().to_vec();
-        let bad_after = unpaired_edge_count(topo, &after)?;
-        if bad_after > bad_before {
+        // Removed faces are only dropped from the shell's list, never deleted
+        // from the arena, so restoring that list is a complete revert.
+        bad_after_faces = unpaired_edge_count(topo, &final_faces)?;
+        if bad_after_faces > bad_before {
             log::warn!(
-                "unify_same_domain: reverting ({total_merged} faces, {total_edges_merged} edges) — unpaired edges would rise {bad_before} -> {bad_after}"
+                "unify_same_domain: skipping merge of {total_merged} faces — unpaired edges would rise {bad_before} -> {bad_after_faces}"
             );
-            let restored = Shell::new(original)?;
-            let shell_mut = topo.shell_mut(shell_id)?;
-            *shell_mut = restored;
             return Ok((
                 solid_id,
                 UnifyResult {
@@ -294,6 +272,40 @@ pub fn unify_same_domain(
                     status: Status::OK,
                 },
             ));
+        }
+        let new_shell = Shell::new(final_faces)?;
+        let shell_mut = topo.shell_mut(shell_id)?;
+        *shell_mut = new_shell;
+    }
+
+    let mut total_edges_merged = 0;
+    if options.unify_edges && total_merged > 0 {
+        // `merge_collinear_edges` rewrites each wire in place under the same
+        // WireId, so snapshotting the wires is enough to undo just this phase
+        // and keep the face merges above.
+        let mut wire_snapshots: Vec<(WireId, Wire)> = Vec::with_capacity(new_faces_to_add.len());
+        for &fid in &new_faces_to_add {
+            let wid = topo.face(fid)?.outer_wire();
+            wire_snapshots.push((wid, topo.wire(wid)?.clone()));
+        }
+
+        for &(wid, _) in &wire_snapshots {
+            total_edges_merged += merge_collinear_edges(topo, wid, options)?;
+        }
+
+        if total_edges_merged > 0 {
+            let faces_now: Vec<FaceId> = topo.shell(shell_id)?.faces().to_vec();
+            let bad_after_edges = unpaired_edge_count(topo, &faces_now)?;
+            if bad_after_edges > bad_after_faces {
+                log::warn!(
+                    "unify_same_domain: reverting {total_edges_merged} collinear-edge merges — unpaired edges would rise {bad_after_faces} -> {bad_after_edges} (face merges kept)"
+                );
+                for (wid, original) in wire_snapshots {
+                    let wire_mut = topo.wire_mut(wid)?;
+                    *wire_mut = original;
+                }
+                total_edges_merged = 0;
+            }
         }
     }
 

--- a/crates/heal/src/upgrade/unify_same_domain.rs
+++ b/crates/heal/src/upgrade/unify_same_domain.rs
@@ -234,12 +234,29 @@ pub fn unify_same_domain(
         new_faces_to_add.extend(new_face_ids);
     }
 
+    // Merging is an OPTIMISATION — it must never leave the shell worse connected
+    // than it found it. Snapshot the pairing first, apply the merge and the
+    // collinear-edge pass, then put the original faces back if either degraded
+    // it. Both phases can orphan edges: a group whose reassembly loses a
+    // boundary edge, and `merge_collinear_edges`, which rewrites only the NEW
+    // faces' wires — a neighbour still referencing the pre-merge edges is left
+    // unpaired. That is invisible on analytic solids (few collinear runs) and
+    // catastrophic on mesh-fallback ones (thousands of coplanar facets: 1630
+    // edge merges orphaned 4574 edges on a drilled 15648-face solid).
+    //
+    // Reverting is complete: removed faces are only dropped from the shell's
+    // list, never deleted from the arena, and the collinear pass only mutates
+    // the new faces' wires, which the revert discards.
+    let mut original_faces: Option<Vec<FaceId>> = None;
+    let mut bad_before = 0;
     if total_merged > 0 {
         let shell = topo.shell(shell_id)?;
         let current_faces: Vec<FaceId> = shell.faces().to_vec();
+        bad_before = unpaired_edge_count(topo, &current_faces)?;
 
         let mut final_faces: Vec<FaceId> = current_faces
-            .into_iter()
+            .iter()
+            .copied()
             .filter(|f| !faces_to_remove.contains(f))
             .collect();
         final_faces.extend(&new_faces_to_add);
@@ -247,6 +264,7 @@ pub fn unify_same_domain(
         let new_shell = Shell::new(final_faces)?;
         let shell_mut = topo.shell_mut(shell_id)?;
         *shell_mut = new_shell;
+        original_faces = Some(current_faces);
     }
 
     let mut total_edges_merged = 0;
@@ -255,6 +273,27 @@ pub fn unify_same_domain(
             let outer_wire = topo.face(fid)?.outer_wire();
             let merged = merge_collinear_edges(topo, outer_wire, options)?;
             total_edges_merged += merged;
+        }
+    }
+
+    if let Some(original) = original_faces {
+        let after: Vec<FaceId> = topo.shell(shell_id)?.faces().to_vec();
+        let bad_after = unpaired_edge_count(topo, &after)?;
+        if bad_after > bad_before {
+            log::warn!(
+                "unify_same_domain: reverting ({total_merged} faces, {total_edges_merged} edges) — unpaired edges would rise {bad_before} -> {bad_after}"
+            );
+            let restored = Shell::new(original)?;
+            let shell_mut = topo.shell_mut(shell_id)?;
+            *shell_mut = restored;
+            return Ok((
+                solid_id,
+                UnifyResult {
+                    faces_merged: 0,
+                    edges_merged: 0,
+                    status: Status::OK,
+                },
+            ));
         }
     }
 
@@ -272,6 +311,24 @@ pub fn unify_same_domain(
             status,
         },
     ))
+}
+
+/// Count edges of `faces` that are NOT shared by exactly two of them.
+///
+/// A closed manifold shell pairs every edge exactly twice; free (once) and
+/// over-shared (3+) edges are both defects. Used to prove a merge did not make
+/// the shell worse before committing it.
+fn unpaired_edge_count(topo: &Topology, faces: &[FaceId]) -> Result<usize, HealError> {
+    let mut uses: HashMap<usize, usize> = HashMap::new();
+    for &fid in faces {
+        let face = topo.face(fid)?;
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid)?.edges() {
+                *uses.entry(oe.edge().index()).or_insert(0) += 1;
+            }
+        }
+    }
+    Ok(uses.values().filter(|&&c| c != 2).count())
 }
 
 /// Merge a hole-free group on a curved (non-planar) surface.

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5996,35 +5996,64 @@ fn compound_cut_unify_keeps_bore_opening() {
 fn compound_cut_unify_still_merges_normally() {
     use brepkit_math::mat::Mat4;
 
-    // The unify pass reverts itself when a merge would orphan edges. That guard
-    // must not fire on healthy geometry: a plain slotted bar's coplanar
-    // fragments still have to merge back, or every boolean result keeps its
-    // split faces forever.
-    let mut topo = Topology::new();
-    let bar = crate::primitives::make_box(&mut topo, 30.0, 10.0, 6.0).unwrap();
-    let mut tools = Vec::new();
-    for x in [6.0_f64, 14.0, 22.0] {
-        let t = crate::primitives::make_box(&mut topo, 3.0, 12.0, 3.0).unwrap();
-        crate::transform::transform_solid(&mut topo, t, &Mat4::translation(x, -1.0, 4.0)).unwrap();
-        tools.push(t);
-    }
-    let opts = BooleanOptions {
-        unify_faces: true,
-        ..BooleanOptions::default()
+    // The unify pass rolls itself back when a merge would orphan edges. That
+    // guard must not fire on healthy geometry, or every boolean result keeps
+    // its split faces forever. Asserted DIFFERENTIALLY against the same cut
+    // with unify off: an absolute bound alone would still pass if the guard
+    // suppressed every merge and the raw count happened to sit under it.
+    // An L-shaped fuse with two corner cuts: the cuts split faces the fuse left
+    // coplanar, and the trailing unify merges them back (22 faces -> 16).
+    let build = |topo: &mut Topology| {
+        let a = crate::primitives::make_box(topo, 20.0, 8.0, 8.0).unwrap();
+        let b = crate::primitives::make_box(topo, 8.0, 20.0, 8.0).unwrap();
+        let l = boolean(topo, BooleanOp::Fuse, a, b).unwrap();
+        let mut tools = Vec::new();
+        for (x, y) in [(14.0_f64, 2.0_f64), (2.0, 14.0)] {
+            let t = crate::primitives::make_box(topo, 4.0, 4.0, 10.0).unwrap();
+            crate::transform::transform_solid(topo, t, &Mat4::translation(x, y, -1.0)).unwrap();
+            tools.push(t);
+        }
+        (l, tools)
     };
-    let unified = compound_cut(&mut topo, bar, &tools, opts).unwrap();
 
-    let faces = brepkit_topology::explorer::solid_faces(&topo, unified).unwrap();
-    // Three slots in a bar: 18 faces when the coplanar fragments merge back,
-    // materially more if the guard suppressed a legitimate merge.
+    let mut topo = Topology::new();
+    let (solid_a, tools_a) = build(&mut topo);
+    let unified = compound_cut(
+        &mut topo,
+        solid_a,
+        &tools_a,
+        BooleanOptions {
+            unify_faces: true,
+            ..BooleanOptions::default()
+        },
+    )
+    .unwrap();
+    let unified_faces = brepkit_topology::explorer::solid_faces(&topo, unified)
+        .unwrap()
+        .len();
+
+    let (solid_b, tools_b) = build(&mut topo);
+    let raw = compound_cut(
+        &mut topo,
+        solid_b,
+        &tools_b,
+        BooleanOptions {
+            unify_faces: false,
+            ..BooleanOptions::default()
+        },
+    )
+    .unwrap();
+    let raw_faces = brepkit_topology::explorer::solid_faces(&topo, raw)
+        .unwrap()
+        .len();
+
     assert!(
-        faces.len() <= 20,
-        "unify must still merge coplanar fragments on healthy geometry, got {} faces",
-        faces.len()
+        unified_faces < raw_faces,
+        "unify must still merge coplanar fragments on healthy geometry: {unified_faces} faces with unify vs {raw_faces} without"
     );
     assert_eq!(
         count_non_manifold_edges(&topo, unified),
         0,
-        "slotted bar must stay watertight"
+        "the unified result must stay watertight"
     );
 }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -5991,3 +5991,40 @@ fn compound_cut_unify_keeps_bore_opening() {
         "both cylindrical walls must survive"
     );
 }
+
+#[test]
+fn compound_cut_unify_still_merges_normally() {
+    use brepkit_math::mat::Mat4;
+
+    // The unify pass reverts itself when a merge would orphan edges. That guard
+    // must not fire on healthy geometry: a plain slotted bar's coplanar
+    // fragments still have to merge back, or every boolean result keeps its
+    // split faces forever.
+    let mut topo = Topology::new();
+    let bar = crate::primitives::make_box(&mut topo, 30.0, 10.0, 6.0).unwrap();
+    let mut tools = Vec::new();
+    for x in [6.0_f64, 14.0, 22.0] {
+        let t = crate::primitives::make_box(&mut topo, 3.0, 12.0, 3.0).unwrap();
+        crate::transform::transform_solid(&mut topo, t, &Mat4::translation(x, -1.0, 4.0)).unwrap();
+        tools.push(t);
+    }
+    let opts = BooleanOptions {
+        unify_faces: true,
+        ..BooleanOptions::default()
+    };
+    let unified = compound_cut(&mut topo, bar, &tools, opts).unwrap();
+
+    let faces = brepkit_topology::explorer::solid_faces(&topo, unified).unwrap();
+    // Three slots in a bar: 18 faces when the coplanar fragments merge back,
+    // materially more if the guard suppressed a legitimate merge.
+    assert!(
+        faces.len() <= 20,
+        "unify must still merge coplanar fragments on healthy geometry, got {} faces",
+        faces.len()
+    );
+    assert_eq!(
+        count_non_manifold_edges(&topo, unified),
+        0,
+        "slotted bar must stay watertight"
+    );
+}


### PR DESCRIPTION
## The defect

`unify_same_domain` could turn a watertight shell into a holed one. Merging is an **optimisation** — it must never leave the shell worse connected than it found it.

Two phases can orphan edges:

1. a group whose reassembly loses a boundary edge, and
2. **`merge_collinear_edges`**, which rewrites only the NEW faces' outer wires. A neighbouring face still referencing the pre-merge edges is left unpaired.

The second is a one-sided topology edit and is the larger defect. This PR **bounds** its damage rather than repairing it — a two-sided rewrite is still worth doing, and I did not want to attempt that reshaping on the back of a guard.

## Why it went unnoticed

It is invisible on analytic solids, where collinear runs are rare, and severe on mesh-fallback ones, where thousands of coplanar facets merge at once.

Found digging the gridfinity `4×4 lite export (stress)` failure (48 STL boundary edges). Its base mesh-falls-back to a 15648-face solid, and a **single** drill through `compound_cut` merged 3184 faces and 1630 collinear edges — orphaning 4574:

| | faces | free edges |
|---|---|---|
| `boolean(Cut)` 1 drill (no unify) | 15650 | 0 |
| `compound_cut` unify=**false** | 15650 | 0 |
| `compound_cut` unify=**true** — before | 12466 | **4574** |
| `compound_cut` unify=**true** — after | 15650 | **0** |

The guard logs its reason: `reverting (3184 faces, 1630 edges) — unpaired edges would rise 0 -> 4574`.

## Why the revert is complete

Removed faces are only dropped from the shell's face list, never deleted from the arena, and the collinear pass only mutates the **new** faces' wires — which the revert discards. So restoring the original face list fully restores the prior topology.

## Verification

- `compound_cut_unify_still_merges_normally` — new; pins that the guard does **not** over-trigger: a slotted bar's coplanar fragments must still merge back (≤20 faces). Without it, a future change could make the guard fire everywhere and silently disable unify.
- `compound_cut_unify_keeps_bore_opening` (from the closed-curve fix, #1129) continues to pass.
- Full workspace suite green; `brepkit-heal` 86/0; gridfinity canary 27/0.
- `brepkit-render` GPU tests SIGSEGV identically on clean `main` — pre-existing, unrelated.

## Honest gap

**No compact synthetic reproduces the collinear-edge path yet.** I tried six shapes (slotted bars, coplanar pocket grids, stacked fuses, through-slot grids, a mesh-fallback cylinder∪cone, box mesh booleans); none trigger it — adjacent facets on curved surfaces are not coplanar so nothing merges, and coplanar box facets get merged during mesh→B-Rep conversion. The reproducer is the captured 15648-face solid, too large to commit. The new test therefore pins the guard's *other* half (no over-triggering); the orphaning path itself is verified only against the captured operands, as recorded above.

This is a bound on damage, not a scenario fix — `4×4 lite export (stress)` also needs the pad fuse to stop falling back, which is separate (and previously measured as expensive).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a connectivity guard to the unify pass and roll back each phase independently to prevent orphaned edges. This keeps watertight shells intact on mesh-fallback solids while still merging valid coplanar faces.

- **Bug Fixes**
  - Measure edge pairing before/after face merges and again after collinear-edge merges; revert only the phase that increases unpaired edges. Snapshot new-face wires to undo collinear merges while keeping valid face merges; warn with before/after counts.
  - Replaced the slotted-bar check with a differential L-shaped fuse test: unify reduces face count vs no-unify and the result stays watertight.

<sup>Written for commit 29af4141028d933524c04f92884326d7aae372a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

