### PR TITLE
fix(operations): fold a multi-component fuse tool in piece by piece

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -724,6 +724,21 @@ pub fn boolean(
         }
     }
 
+    // A Fuse whose TOOL carries many disjoint pieces (the lite base's 64
+    // magnet pads arrive as one 64-component union) also defeats the
+    // pavefiller when fed whole. Fuse distributes over a disjoint-union
+    // tool, so fold the pieces in one at a time — each per-piece fuse is
+    // the configuration the engine handles analytically.
+    if op == BooleanOp::Fuse {
+        let tool_components = crate::boolean::assembly::face_components(topo, b);
+        if tool_components.len() >= 2
+            && components_are_disjoint_pieces(topo, &tool_components)
+            && let Ok(result) = fuse_multi_component_tool(topo, a, tool_components)
+        {
+            return Ok(result);
+        }
+    }
+
     // Mesh boolean fallback (no recursion).
     log::debug!(
         target: "brepkit_approx",
@@ -2393,6 +2408,30 @@ fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -
 /// connected input — feeding a 2-piece "solid" into GFA loses one piece
 /// at a time as the cut proceeds (Category B `multiple cuts creating
 /// three pieces` and gear bore are both downstream of this).
+/// Fuse a multi-component TOOL by folding its disjoint pieces into the
+/// target one at a time.
+///
+/// Each piece is copied into a fresh connected solid (the pavefiller
+/// stumbles on shared vertex IDs across what it considers one "solid B")
+/// and fused via the full `boolean` entry, so every per-piece fuse gets the
+/// analytic path, gates, and fallbacks. Fuse distributes over a
+/// disjoint-union tool, so the fold is exact. Recursion terminates: each
+/// piece is single-component, so the recursive call never re-enters this
+/// path.
+fn fuse_multi_component_tool(
+    topo: &mut Topology,
+    a: SolidId,
+    b_components: Vec<Vec<brepkit_topology::face::FaceId>>,
+) -> Result<SolidId, crate::OperationsError> {
+    let mut result = a;
+    for comp_faces in b_components {
+        let comp_solid_raw = make_solid_from_face_subset(topo, &comp_faces)?;
+        let comp_solid = crate::copy::copy_solid(topo, comp_solid_raw)?;
+        result = boolean(topo, BooleanOp::Fuse, result, comp_solid)?;
+    }
+    Ok(result)
+}
+
 fn cut_multi_region_input(
     topo: &mut Topology,
     a: SolidId,

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -729,7 +729,9 @@ pub fn boolean(
     // pavefiller when fed whole. Fuse distributes over a disjoint-union
     // tool, so fold the pieces in one at a time — each per-piece fuse is
     // the configuration the engine handles analytically.
-    if op == BooleanOp::Fuse {
+    // Gated to tools WITHOUT inner (cavity) shells: `face_components` walks
+    // the outer shell only, so a hollow piece would silently lose its cavity.
+    if op == BooleanOp::Fuse && topo.solid(b).is_ok_and(|s| s.inner_shells().is_empty()) {
         let tool_components = crate::boolean::assembly::face_components(topo, b);
         if tool_components.len() >= 2
             && components_are_disjoint_pieces(topo, &tool_components)
@@ -2398,16 +2400,6 @@ fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -
     true
 }
 
-/// Merge duplicate vertices in a solid's shell by position.
-///
-/// Cut a multi-region input solid: split the components, cut each
-/// against `b` independently, then combine the per-component results
-/// back into a single multi-region solid.
-///
-/// This works around the GFA pavefiller's assumption of a single
-/// connected input — feeding a 2-piece "solid" into GFA loses one piece
-/// at a time as the cut proceeds (Category B `multiple cuts creating
-/// three pieces` and gear bore are both downstream of this).
 /// Fuse a multi-component TOOL by folding its disjoint pieces into the
 /// target one at a time.
 ///
@@ -2432,6 +2424,14 @@ fn fuse_multi_component_tool(
     Ok(result)
 }
 
+/// Cut a multi-region input solid: split the components, cut each
+/// against `b` independently, then combine the per-component results
+/// back into a single multi-region solid.
+///
+/// This works around the GFA pavefiller's assumption of a single
+/// connected input — feeding a 2-piece "solid" into GFA loses one piece
+/// at a time as the cut proceeds (Category B `multiple cuts creating
+/// three pieces` and gear bore are both downstream of this).
 fn cut_multi_region_input(
     topo: &mut Topology,
     a: SolidId,

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -6057,3 +6057,43 @@ fn compound_cut_unify_still_merges_normally() {
         "the unified result must stay watertight"
     );
 }
+
+#[test]
+fn fuse_multi_component_tool_folds_each_piece() {
+    use crate::measure::solid_volume;
+    // Target 10x10x2 slab; tool = two disjoint 2x2x4 posts overlapping it,
+    // assembled into ONE two-component solid (the multi-piece tool shape a
+    // pad-union fuse delivers). The fold must merge BOTH posts.
+    let mut topo = Topology::new();
+    let base = crate::primitives::make_box(&mut topo, 10.0, 10.0, 2.0).unwrap();
+    let p1 = crate::primitives::make_box(&mut topo, 2.0, 2.0, 4.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        p1,
+        &brepkit_math::mat::Mat4::translation(1.0, 1.0, 0.0),
+    )
+    .unwrap();
+    let p2 = crate::primitives::make_box(&mut topo, 2.0, 2.0, 4.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        p2,
+        &brepkit_math::mat::Mat4::translation(7.0, 7.0, 0.0),
+    )
+    .unwrap();
+    let mut tool_faces = brepkit_topology::explorer::solid_faces(&topo, p1).unwrap();
+    tool_faces.extend(brepkit_topology::explorer::solid_faces(&topo, p2).unwrap());
+    let tool_shell = topo.add_shell(brepkit_topology::shell::Shell::new(tool_faces).unwrap());
+    let tool = topo.add_solid(brepkit_topology::solid::Solid::new(tool_shell, Vec::new()));
+    let components = super::assembly::face_components(&topo, tool);
+    assert_eq!(components.len(), 2, "tool must split into two pieces");
+
+    let result = super::fuse_multi_component_tool(&mut topo, base, components).unwrap();
+
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
+    // 10*10*2 + 2 posts' above-slab parts (2*2*2 each).
+    assert!(
+        (vol - 216.0).abs() < 0.5,
+        "folded fuse volume {vol}, expected 216"
+    );
+    assert_eq!(count_non_manifold_edges(&topo, result), 0);
+}


### PR DESCRIPTION
## Root

Follow-up to #1136. The lite base's 64 magnet pads arrive at the fuse as ONE 64-component union; feeding the whole thing to GFA collapses the operands (the pavefiller mishandles many-piece operands, same class as the existing multi-piece-input Cut limitation) and the entire fuse falls back to mesh — flattening every analytic socket and poisoning the downstream drills (the lightweight `4×4 stress` chain).

## Fix

Fuse distributes over a disjoint-union tool. When GFA has already failed and the tool splits into 2+ disjoint components, fold them into the target one at a time through the full `boolean()` entry — after #1136, each per-piece pad fuse is exactly the configuration the engine handles analytically. Mirrors the existing `cut_multi_region_input` precedent (including the fresh per-component deep copy). Gated strictly behind the existing GFA failure path, so nothing changes for single-piece tools.

## Result on the captured lite 4×4 chain

- 64-pad fuse export mesh: 18 non-manifold edges → **watertight (bd=0 nm=0)**; pad-wall cylinders survive analytically; F 15648 → 1753.
- Known residual (tracked as follow-up): one per-piece pad fuse against the accumulated base still hits a pathological GFA case (87 faces out after 169 s) and mesh-falls-back, taking its foot's cones with it — the fold contains the damage to that piece instead of the whole base.

## Verification

- Foils green: ops lib 772, algo 169, wasm gridfinity canary 27/27, full io fixture suite (including the #1136 `lite_pad_graze_fuse_inmem` fixture), clippy/fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fuse with multi-piece tools by folding each disjoint component one at a time when GFA fails, preserving analytic geometry and preventing whole-model mesh fallback. On the lite 4×4 chain, the 64‑pad fuse becomes watertight and keeps pad-wall cylinders analytic.

- **Bug Fixes**
  - Only for `Fuse` after GFA failure when the tool splits into 2+ disjoint components and has no inner shells.
  - Builds per-piece solids from face components, deep-copies them, and fuses sequentially via `boolean()`.
  - Exact result (fuse distributes over disjoint union); mirrors `cut_multi_region_input`; single-piece tools unchanged; includes a unit test folding a two-post tool into a slab (volume + manifold).
  - Result: non-manifold edges 18 → 0; faces 15648 → 1753. One per-piece fallback remains and is tracked separately.

<sup>Written for commit de8df0ae4b8b89a14eef9a70a8b734a7b943e9ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

