### PR TITLE
fix(algo): split grand-tour cylinder loops at pinch vertices

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -924,21 +924,6 @@ fn wire_loops_have_degenerate_area(loops: &[Vec<OrientedPCurveEdge>], tol: f64) 
     })
 }
 
-/// True when any wire loop revisits a UV vertex — the signature of a
-/// self-crossing trace from the angular wire builder, which the arrangement
-/// decomposition can replace with simple (non-self-intersecting) regions even
-/// when it produces FEWER loops. A simple closed loop visits each vertex once;
-/// a figure-eight or out-and-back revisits one.
-///
-/// Detection is vertex-topological: it tests only the edges' endpoints
-/// (`start_uv`). That is exactly the failure mode this gate targets — the
-/// angular builder over-splits by walking out-and-back through a shared UV
-/// vertex (see `remove_pendant_sections`), so the bad trace always reuses a
-/// vertex. It deliberately does NOT detect a self-crossing that occurs only
-/// along an edge's interior (e.g. an arc whose curved path crosses another
-/// edge's chord in UV between their endpoints, with no shared vertex). No
-/// wire-builder trace produces such a crossing here, so testing arc interiors
-/// would add cost without changing any outcome.
 /// Split a wire loop at UV vertices it visits more than once (a "pinch"): a
 /// grand-tour trace that absorbed a sub-region as an excursion is separated
 /// into the sub-cycle and the rest, recursively. Pure out-and-back excursions
@@ -995,6 +980,21 @@ fn split_loop_at_pinch_vertices(
     out
 }
 
+/// True when any wire loop revisits a UV vertex — the signature of a
+/// self-crossing trace from the angular wire builder, which the arrangement
+/// decomposition can replace with simple (non-self-intersecting) regions even
+/// when it produces FEWER loops. A simple closed loop visits each vertex once;
+/// a figure-eight or out-and-back revisits one.
+///
+/// Detection is vertex-topological: it tests only the edges' endpoints
+/// (`start_uv`). That is exactly the failure mode this gate targets — the
+/// angular builder over-splits by walking out-and-back through a shared UV
+/// vertex (see `remove_pendant_sections`), so the bad trace always reuses a
+/// vertex. It deliberately does NOT detect a self-crossing that occurs only
+/// along an edge's interior (e.g. an arc whose curved path crosses another
+/// edge's chord in UV between their endpoints, with no shared vertex). No
+/// wire-builder trace produces such a crossing here, so testing arc interiors
+/// would add cost without changing any outcome.
 fn wire_loops_self_cross(loops: &[Vec<OrientedPCurveEdge>], tol: f64) -> bool {
     let qscale = 1.0 / tol.max(1e-12);
     let qkey = |p: brepkit_math::vec::Point2| -> (i64, i64) {
@@ -4935,6 +4935,12 @@ fn split_face_2d_impl(
                 .iter()
                 .flat_map(|lp| split_loop_at_pinch_vertices(lp, tol.linear))
                 .collect();
+            // Adopt only when the split UNCOVERED a region (strictly more
+            // loops) and the self-cross cleared. Equal-count adoption (shed
+            // remnant only) was tried and REFUTED: an out-and-back remnant
+            // can be load-bearing — dropping it on the straight-graze pad
+            // wall regressed the lite_pad_graze_fuse fixture to mesh
+            // fallback. Downstream reconciliation consumes those remnants.
             if resolved.len() > loops.len() && !wire_loops_self_cross(&resolved, tol.linear) {
                 loops = resolved;
             }
@@ -6105,5 +6111,74 @@ mod tests {
             (c.center() - Point3::new(0.7, 0.7, 0.0)).length() < 1e-9,
             "the carved disc must be the genuine cap, not the in-hole one"
         );
+    }
+
+    fn uv_line_edge(a: Point2, b: Point2) -> OrientedPCurveEdge {
+        OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Line,
+            pcurve: dummy_pcurve(),
+            start_uv: a,
+            end_uv: b,
+            start_3d: Point3::new(a.x(), a.y(), 0.0),
+            end_3d: Point3::new(b.x(), b.y(), 0.0),
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: None,
+        }
+    }
+
+    #[test]
+    fn pinch_split_separates_figure_eight_into_two_squares() {
+        let p = |x: f64, y: f64| Point2::new(x, y);
+        let wire = vec![
+            uv_line_edge(p(0.0, 0.0), p(1.0, 0.0)),
+            uv_line_edge(p(1.0, 0.0), p(1.0, 1.0)),
+            uv_line_edge(p(1.0, 1.0), p(2.0, 1.0)),
+            uv_line_edge(p(2.0, 1.0), p(2.0, 2.0)),
+            uv_line_edge(p(2.0, 2.0), p(1.0, 2.0)),
+            uv_line_edge(p(1.0, 2.0), p(1.0, 1.0)),
+            uv_line_edge(p(1.0, 1.0), p(0.0, 1.0)),
+            uv_line_edge(p(0.0, 1.0), p(0.0, 0.0)),
+        ];
+        let out = split_loop_at_pinch_vertices(&wire, 1e-7);
+        assert_eq!(out.len(), 2, "figure-eight must split into its two cycles");
+        for lp in &out {
+            assert_eq!(lp.len(), 4);
+            let pts = sample_wire_loop_uv(lp);
+            assert!((signed_area_2d(&pts).abs() - 1.0).abs() < 1e-9);
+        }
+        assert!(!wire_loops_self_cross(&out, 1e-7));
+    }
+
+    #[test]
+    fn pinch_split_drops_pure_out_and_back_excursion() {
+        let p = |x: f64, y: f64| Point2::new(x, y);
+        let wire = vec![
+            uv_line_edge(p(0.0, 0.0), p(1.0, 0.0)),
+            uv_line_edge(p(1.0, 0.0), p(1.0, 1.0)),
+            uv_line_edge(p(1.0, 1.0), p(2.0, 1.0)),
+            uv_line_edge(p(2.0, 1.0), p(1.0, 1.0)),
+            uv_line_edge(p(1.0, 1.0), p(0.0, 1.0)),
+            uv_line_edge(p(0.0, 1.0), p(0.0, 0.0)),
+        ];
+        let out = split_loop_at_pinch_vertices(&wire, 1e-7);
+        assert_eq!(out.len(), 1, "the zero-area excursion must be dropped");
+        assert_eq!(out[0].len(), 4);
+        let pts = sample_wire_loop_uv(&out[0]);
+        assert!((signed_area_2d(&pts).abs() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pinch_split_keeps_simple_loop_whole() {
+        let p = |x: f64, y: f64| Point2::new(x, y);
+        let wire = vec![
+            uv_line_edge(p(0.0, 0.0), p(1.0, 0.0)),
+            uv_line_edge(p(1.0, 0.0), p(1.0, 1.0)),
+            uv_line_edge(p(1.0, 1.0), p(0.0, 1.0)),
+            uv_line_edge(p(0.0, 1.0), p(0.0, 0.0)),
+        ];
+        let out = split_loop_at_pinch_vertices(&wire, 1e-7);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len(), 4);
     }
 }

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -939,6 +939,62 @@ fn wire_loops_have_degenerate_area(loops: &[Vec<OrientedPCurveEdge>], tol: f64) 
 /// edge's chord in UV between their endpoints, with no shared vertex). No
 /// wire-builder trace produces such a crossing here, so testing arc interiors
 /// would add cost without changing any outcome.
+/// Split a wire loop at UV vertices it visits more than once (a "pinch"): a
+/// grand-tour trace that absorbed a sub-region as an excursion is separated
+/// into the sub-cycle and the rest, recursively. Pure out-and-back excursions
+/// separate into zero-area remnants, which are dropped (their edges' other
+/// orientation still lives in the sibling region's loop). Comparison is on
+/// the raw (unwrapped) UV, so a full-period band's two seam copies — one
+/// period apart — never read as a pinch.
+fn split_loop_at_pinch_vertices(
+    wire: &[OrientedPCurveEdge],
+    tol: f64,
+) -> Vec<Vec<OrientedPCurveEdge>> {
+    if wire.len() < 4 {
+        return vec![wire.to_vec()];
+    }
+    let qscale = 1.0 / tol.max(1e-12);
+    #[allow(clippy::cast_possible_truncation)]
+    let qkey = |p: brepkit_math::vec::Point2| -> (i64, i64) {
+        (
+            (p.x() * qscale).round() as i64,
+            (p.y() * qscale).round() as i64,
+        )
+    };
+    let mut seen: std::collections::HashMap<(i64, i64), usize> = std::collections::HashMap::new();
+    let mut pinch: Option<(usize, usize)> = None;
+    for (i, e) in wire.iter().enumerate() {
+        if let Some(&j) = seen.get(&qkey(e.start_uv)) {
+            pinch = Some((j, i));
+            break;
+        }
+        seen.insert(qkey(e.start_uv), i);
+    }
+    let Some((j, i)) = pinch else {
+        return vec![wire.to_vec()];
+    };
+    let sub: Vec<OrientedPCurveEdge> = wire[j..i].to_vec();
+    let mut rest: Vec<OrientedPCurveEdge> = wire[..j].to_vec();
+    rest.extend_from_slice(&wire[i..]);
+    let keep = |lp: Vec<OrientedPCurveEdge>| -> Vec<Vec<OrientedPCurveEdge>> {
+        if lp.is_empty() {
+            return Vec::new();
+        }
+        let pts = sample_wire_loop_uv(&lp);
+        let mut perimeter: f64 = pts.windows(2).map(|w| (w[1] - w[0]).length()).sum();
+        if let (Some(first), Some(last)) = (pts.first(), pts.last()) {
+            perimeter += (*last - *first).length();
+        }
+        if signed_area_2d(&pts).abs() <= perimeter * tol {
+            return Vec::new(); // out-and-back remnant
+        }
+        split_loop_at_pinch_vertices(&lp, tol)
+    };
+    let mut out = keep(sub);
+    out.extend(keep(rest));
+    out
+}
+
 fn wire_loops_self_cross(loops: &[Vec<OrientedPCurveEdge>], tol: f64) -> bool {
     let qscale = 1.0 / tol.max(1e-12);
     let qkey = |p: brepkit_math::vec::Point2| -> (i64, i64) {
@@ -4867,6 +4923,21 @@ fn split_face_2d_impl(
             && (retry.len() > loops.len() || wire_loops_have_degenerate_area(&loops, tol.linear))
         {
             loops = retry;
+        }
+        // Pinch resolution: a grand-tour loop that revisits a UV vertex is
+        // two (or more) regions traced as one — split it there. Working in
+        // the UNWRAPPED uv keeps the legitimate seam double-visit out (its
+        // two copies differ by a period). Zero-area remnants (pure
+        // out-and-back excursions) are dropped; the sliver guard below
+        // would misclassify them as holes.
+        if wire_loops_self_cross(&loops, tol.linear) {
+            let resolved: Vec<Vec<OrientedPCurveEdge>> = loops
+                .iter()
+                .flat_map(|lp| split_loop_at_pinch_vertices(lp, tol.linear))
+                .collect();
+            if resolved.len() > loops.len() && !wire_loops_self_cross(&resolved, tol.linear) {
+                loops = resolved;
+            }
         }
     }
 


### PR DESCRIPTION
## Root

Follow-up in the lite magnet-pad family (#1136, #1138). The DIAGONAL corner pad (axis at the foot's corner) grazes its socket's corner cone AND notches the adjacent socket row's wall — the pad-wall cylinder's greedy wire trace absorbs those sub-regions as excursions, revisiting their junction vertices, and hands back a 2-loop grand tour (self-crossing, edges doubled). The rectilinear arrangement declines (oblique ellipse cuts) and the mirrored-winding retry converges to the *identical* trace, so neither existing rescue helps.

## Fix

Pinch resolution — the named missing primitive from the funnel-family dig: split each self-crossing loop at UV vertices it visits more than once, recursively; sub-cycles become their own regions, pure out-and-back remnants drop as zero-area. Comparison is on the raw **unwrapped** UV, so a full-period band's two seam copies (one period apart) never read as a pinch. Adopted only when the resolution strictly increases the loop count and clears the self-cross flag, and only inside the existing broken-greedy gate.

On the captured fold-2 operands the pad wall's 2-loop grand tour becomes the correct 4-region partition (corner bite, two wall notches, remainder). The fold's remaining defects live on the partner top-disc/wall faces (tracked as the next dig); this piece is shipped on its own because it is deterministic, strictly gated, and the structural primitive the whole grand-tour class needs.

## Verification

Foil web green: wasm gridfinity canary 27/27, algo 169, ops lib 773, full io fixture suite (incl. the #1136 fixture), clippy/fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-crossing grand-tour loops on u-periodic cylinder faces by splitting at repeated (unwrapped) UV vertices. Produces correct region partitions for the diagonal magnet pad wall and similar cases, without seam false positives.

- **Bug Fixes**
  - Added pinch resolution: split at repeated UV vertices, recurse; drop zero-area out-and-backs.
  - Applied only when loop count increases and self-crossing clears; runs inside the broken-greedy gate. Equal-count adoption was tried and rejected due to the `lite_pad_graze_fuse` regression.
  - Added tests (figure-eight split, zero-area drop, simple loop untouched) and restored the `wire_loops_self_cross` doc block.

<sup>Written for commit d125622741e0a685d1b1e24218c4c51485cea388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

