### PR TITLE
fix(algo): sample a closed rim circle's full period in the line-clip polygon

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2258,7 +2258,8 @@ fn clip_line_to_face_boundary(
     // clipped to the TRUE arc rather than its chord.
     let edges = wire.edges();
     let mut boundary_segments: Vec<(Point3, Point3)> = Vec::with_capacity(edges.len());
-    let mut boundary_arcs: Vec<Option<(EdgeCurve, Point3, Point3)>> =
+    // (curve, oriented start/end points, closed-by-vertex-identity)
+    let mut boundary_arcs: Vec<Option<(EdgeCurve, Point3, Point3, bool)>> =
         Vec::with_capacity(edges.len());
     for oe in edges {
         let edge = topo.edge(oe.edge()).ok()?;
@@ -2267,7 +2268,8 @@ fn clip_line_to_face_boundary(
         boundary_segments.push((sp, ep));
         match edge.curve() {
             EdgeCurve::Circle(_) | EdgeCurve::Ellipse(_) => {
-                boundary_arcs.push(Some((edge.curve().clone(), sp, ep)));
+                let closed = oe.oriented_start(edge) == oe.oriented_end(edge);
+                boundary_arcs.push(Some((edge.curve().clone(), sp, ep, closed)));
             }
             // A straight edge already equals its chord, and a NURBS boundary edge
             // has no analytic arc to clip against, so neither contributes a
@@ -2298,7 +2300,7 @@ fn clip_line_to_face_boundary(
         // chord crossing the existing cases rely on — it only reaches farther
         // out when the arc genuinely does. Arcs the line misses contribute
         // nothing (the lip-cut sections that graze a corner chord keep working).
-        if let Some((curve, asp, aep)) = &boundary_arcs[seg_idx] {
+        if let Some((curve, asp, aep, _)) = &boundary_arcs[seg_idx] {
             // Intersect the arc with the EXTENDED line, not just the segment: a
             // section whose FF-clipped endpoint lies in the sliver between a
             // convex arc and its chord (the slot walls crossing a socket-edge
@@ -2417,25 +2419,31 @@ fn clip_line_to_face_boundary(
         let mut poly = Vec::new();
         for (seg_idx, (sp, ep)) in boundary_segments.iter().enumerate() {
             poly.push(frame.project(*sp));
-            if let Some((curve, asp, aep)) = &boundary_arcs[seg_idx] {
+            if let Some((curve, asp, aep, closed)) = &boundary_arcs[seg_idx] {
                 // Dense sampling: at 12 samples an r=4 quarter-arc's chord
                 // sagitta is ~0.14 — larger than the ~0.1 mm groove-mouth
                 // slivers this polygon must classify. 96 samples keep the
                 // polygon error well under the features decided by it.
                 //
-                // A CLOSED circle edge (a disc rim: seam vertex at both ends)
-                // has a degenerate endpoint span — `evaluate_edge_at_t` would
-                // collapse every sample to the seam and the polygon to a
-                // point, so everything but the seam neighbourhood classified
-                // outside (the lite pad top-disc's wall chords). Sample its
-                // full period from the seam angle instead.
-                if let EdgeCurve::Circle(c) = curve
-                    && (*asp - *aep).length() < tol
-                {
+                // A CLOSED rim edge (a disc rim: the same seam vertex at both
+                // ends) has a degenerate endpoint span — `evaluate_edge_at_t`
+                // would collapse every sample to the seam and the polygon to
+                // a point, so everything but the seam neighbourhood
+                // classified outside (the lite pad top-disc's wall chords).
+                // Sample its full period from the seam angle instead.
+                // Closedness is vertex IDENTITY, so a genuine open arc with
+                // near-coincident endpoints keeps the span sampling.
+                if *closed && let EdgeCurve::Circle(c) = curve {
                     let a_seam = c.project(*asp);
                     for k in 1..96 {
                         let a = std::f64::consts::TAU.mul_add(f64::from(k) / 96.0, a_seam);
                         poly.push(frame.project(c.evaluate(a)));
+                    }
+                } else if *closed && let EdgeCurve::Ellipse(el) = curve {
+                    let a_seam = el.project(*asp);
+                    for k in 1..96 {
+                        let a = std::f64::consts::TAU.mul_add(f64::from(k) / 96.0, a_seam);
+                        poly.push(frame.project(el.evaluate(a)));
                     }
                 } else {
                     for k in 1..96 {
@@ -3106,7 +3114,7 @@ mod clip_tests {
         let half = (4.45_f64 * 4.45 - 4.4 * 4.4).sqrt();
         assert!((a.x().abs() - half).abs() < 1e-6, "start {a:?}");
         assert!((b.x().abs() - half).abs() < 1e-6, "end {b:?}");
-        assert!((a.y() - 4.4).abs() < 1e-9 && (b.y() - 4.4).abs() < 1e-9);
+        assert!((a.y() - 4.4).abs() < 1e-6 && (b.y() - 4.4).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2422,10 +2422,27 @@ fn clip_line_to_face_boundary(
                 // sagitta is ~0.14 — larger than the ~0.1 mm groove-mouth
                 // slivers this polygon must classify. 96 samples keep the
                 // polygon error well under the features decided by it.
-                for k in 1..96 {
-                    let f = f64::from(k) / 96.0;
-                    let p3 = super::pcurve_compute::evaluate_edge_at_t(curve, *asp, *aep, f);
-                    poly.push(frame.project(p3));
+                //
+                // A CLOSED circle edge (a disc rim: seam vertex at both ends)
+                // has a degenerate endpoint span — `evaluate_edge_at_t` would
+                // collapse every sample to the seam and the polygon to a
+                // point, so everything but the seam neighbourhood classified
+                // outside (the lite pad top-disc's wall chords). Sample its
+                // full period from the seam angle instead.
+                if let EdgeCurve::Circle(c) = curve
+                    && (*asp - *aep).length() < tol
+                {
+                    let a_seam = c.project(*asp);
+                    for k in 1..96 {
+                        let a = std::f64::consts::TAU.mul_add(f64::from(k) / 96.0, a_seam);
+                        poly.push(frame.project(c.evaluate(a)));
+                    }
+                } else {
+                    for k in 1..96 {
+                        let f = f64::from(k) / 96.0;
+                        let p3 = super::pcurve_compute::evaluate_edge_at_t(curve, *asp, *aep, f);
+                        poly.push(frame.project(p3));
+                    }
                 }
             }
             let _ = ep;
@@ -3063,6 +3080,33 @@ mod clip_tests {
                 d: 0.0,
             },
         ))
+    }
+
+    #[test]
+    fn through_chord_far_from_seam_clips_to_rim_crossings() {
+        // A chord crossing the disc well away from its seam vertex (the seam
+        // sits at (+r, 0)). The rim is ONE closed circle edge; sampling it
+        // through the endpoint span collapses every polygon vertex to the
+        // seam, so the in-face interval's midpoint classified outside and the
+        // whole chord was dropped (the lite pad top-disc's north wall chord —
+        // its east twin only survived by passing within the boundary band of
+        // the degenerate seam-point polygon).
+        let mut topo = Topology::new();
+        let face = disc_face(&mut topo, 4.45);
+        let out = clip_line_to_face_boundary(
+            &topo,
+            face,
+            Point3::new(-20.0, 4.4, 0.0),
+            Point3::new(20.0, 4.4, 0.0),
+            1e-7,
+        );
+        let segs = out.expect("a through-chord far from the seam must be kept");
+        assert_eq!(segs.len(), 1);
+        let (a, b) = segs[0];
+        let half = (4.45_f64 * 4.45 - 4.4 * 4.4).sqrt();
+        assert!((a.x().abs() - half).abs() < 1e-6, "start {a:?}");
+        assert!((b.x().abs() - half).abs() < 1e-6, "end {b:?}");
+        assert!((a.y() - 4.4).abs() < 1e-9 && (b.y() - 4.4).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
## Root

Continuation of the lite magnet-pad family (#1136, #1138, #1140), fold-2 dig. `clip_line_to_face_boundary` classifies each candidate interval midpoint against the face's arc-true boundary polygon — but a **closed** circle boundary edge (a disc rim, seam vertex at both ends) has a degenerate endpoint span, so `evaluate_edge_at_t` collapsed every polygon sample to the seam point. Any midpoint away from the seam classified outside and its section chord was silently dropped.

Concretely: the diagonal pad's top disc is crossed by two wall chords. The east chord happened to pass within the boundary band of the degenerate seam-point polygon and survived; the geometrically identical north chord (90° from the seam) vanished — the disc never split and the junction edges went unpaired. A pure orientation-dependent asymmetry from a collapsed polygon.

## Fix

When the boundary arc edge is a closed circle, sample its full period from the seam angle instead of the endpoint span. One-branch change, everything else untouched.

## Result

On the captured fold-2 operands the raw fuse improves from free=12 over=15 to free=14 over=8 (posBad 27 → 22); the remaining imbalance is the pad-wall/wall-plane partition (tracked in the follow-up dig).

## Verification

- Regression test `through_chord_far_from_seam_clips_to_rim_crossings` (fails pre-fix: the chord is dropped entirely; passes now with exact rim crossings).
- Foil web green: algo 173, ops lib 773, wasm gridfinity canary 27/27, full io fixture suite (incl. the #1136 fixture), clippy/fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes line clipping against faces with a closed circular or elliptical rim by sampling the rim over its full 360° from the seam instead of the degenerate endpoint span. Detects closure by vertex identity to prevent polygon collapse and preserve correct rim crossings.

- **Bug Fixes**
  - Closed rims (circle/ellipse): if start/end vertices are identical, sample 96 points over TAU from the seam angle; genuine open arcs with near-coincident endpoints keep span sampling.
  - Tests: added `through_chord_far_from_seam_clips_to_rim_crossings`; aligned tolerances with the module’s convention.

<sup>Written for commit a724f37caf6068f0783fca49bc7aa5f70a5ef8e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

