### PR TITLE
fix(algo): never silently drop a non-trivial open growth shell

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -650,6 +650,13 @@ fn perform_areas(topo: &Topology, shells: &[Vec<FaceId>]) -> (Vec<Vec<FaceId>>, 
         // leaves only an INWARD cavity component is still rejected. Multi-shell
         // results keep the volume-sign split (a Cut can leave the tool's interior
         // as a separate negative-volume cavity shell).
+        if std::env::var("SHELLDBG").is_ok() {
+            log::warn!(
+                "shell: {} faces signed_vol={signed_vol:.2} robust_outward={:?}",
+                shell.len(),
+                shell_is_outward_oriented(topo, shell)
+            );
+        }
         let is_growth = if signed_vol >= 0.0 {
             // Positive corner-fan volume already reads outward — keep the
             // historical behaviour for every solid that integrates cleanly
@@ -1071,6 +1078,25 @@ fn assemble(
         }
         if shell_is_closed(topo, gs) {
             outer_faces.extend_from_slice(gs);
+        } else if gs.len() >= 4 {
+            // An OPEN growth shell of real size is not a fragmentation
+            // sliver — it is a genuine solid lump whose selection left
+            // unpaired junction edges. Silently discarding it deletes its
+            // whole volume from a watertight-looking result (the lite
+            // fused-foot: 72 faces, ~2700 units^3, invisible to every
+            // edge-pairing gate). Fail the analytic assembly instead so the
+            // boolean falls back to the volume-correct mesh path. Note the
+            // OUTER shell is never subjected to this test, so which lump
+            // dodges it historically depended on volume-ordering luck.
+            return Err(AlgoError::AssemblyFailed(format!(
+                "open growth shell with {} faces would be dropped; aborting analytic assembly",
+                gs.len()
+            )));
+        } else {
+            log::debug!(
+                "BuilderSolid: dropping open {}-face growth sliver",
+                gs.len()
+            );
         }
     }
     let outer_shell = Shell::new(outer_faces)

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -650,13 +650,6 @@ fn perform_areas(topo: &Topology, shells: &[Vec<FaceId>]) -> (Vec<Vec<FaceId>>, 
         // leaves only an INWARD cavity component is still rejected. Multi-shell
         // results keep the volume-sign split (a Cut can leave the tool's interior
         // as a separate negative-volume cavity shell).
-        if std::env::var("SHELLDBG").is_ok() {
-            log::warn!(
-                "shell: {} faces signed_vol={signed_vol:.2} robust_outward={:?}",
-                shell.len(),
-                shell_is_outward_oriented(topo, shell)
-            );
-        }
         let is_growth = if signed_vol >= 0.0 {
             // Positive corner-fan volume already reads outward — keep the
             // historical behaviour for every solid that integrates cleanly
@@ -1111,6 +1104,16 @@ fn assemble(
     let mut inner_ids = Vec::new();
     for hole in &hole_shells {
         if !shell_is_closed(topo, hole) {
+            if hole.len() >= 4 {
+                // Same fail-safe as the growth side: a sizeable open "hole"
+                // is a mis-signed or mis-selected LUMP, not a cavity sliver —
+                // silently discarding it deletes real material or cavity
+                // boundary from a watertight-looking result.
+                return Err(AlgoError::AssemblyFailed(format!(
+                    "open hole shell with {} faces would be dropped; aborting analytic assembly",
+                    hole.len()
+                )));
+            }
             log::debug!(
                 "BuilderSolid: dropping open {}-face hole-shell fragment",
                 hole.len()
@@ -2694,5 +2697,85 @@ mod tests {
 
         let angle = angle_with_ref(d1, d2, d_ref);
         assert!(angle.abs() < 1e-10, "0° between X and X: got {angle}");
+    }
+
+    #[test]
+    fn open_growth_shell_aborts_assembly_instead_of_vanishing() {
+        // Outer lump: a closed unit cube. Second lump: a translated cube with
+        // one face REMOVED — a 5-face OPEN shell. Depending on which face is
+        // omitted, the corner-fan volume signs it growth or hole; BOTH silent
+        // discard paths deleted its material from a result that still read
+        // watertight to every edge-pairing gate (the lite fused-foot). The
+        // assembler must abort in every open >=4-face case so the boolean
+        // falls back to the mesh path. Exercise each omission to cover both
+        // branches.
+        for omit in 0..6 {
+            let mut topo = Topology::new();
+            let outer = brepkit_topology::test_utils::make_unit_cube_manifold(&mut topo);
+            let second = brepkit_topology::test_utils::make_unit_cube_manifold(&mut topo);
+            let ids: Vec<_> = brepkit_topology::explorer::solid_faces(&topo, second).unwrap();
+            let mut moved: std::collections::HashSet<brepkit_topology::vertex::VertexId> =
+                std::collections::HashSet::new();
+            for &fid in &ids {
+                let face = topo.face(fid).unwrap();
+                let wires: Vec<_> = std::iter::once(face.outer_wire())
+                    .chain(face.inner_wires().iter().copied())
+                    .collect();
+                for wid in wires {
+                    let oes: Vec<_> = topo.wire(wid).unwrap().edges().to_vec();
+                    for oe in oes {
+                        let e = topo.edge(oe.edge()).unwrap();
+                        for vid in [e.start(), e.end()] {
+                            if moved.insert(vid) {
+                                let pnt = topo.vertex(vid).unwrap().point();
+                                topo.vertex_mut(vid).unwrap().set_point(Point3::new(
+                                    pnt.x() + 10.0,
+                                    pnt.y(),
+                                    pnt.z(),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+            let mut selected: Vec<SelectedFace> = Vec::new();
+            for &fid in &brepkit_topology::explorer::solid_faces(&topo, outer).unwrap() {
+                selected.push(SelectedFace {
+                    face_id: fid,
+                    source_face: fid,
+                    reversed: false,
+                });
+            }
+            for (i, &fid) in ids.iter().enumerate() {
+                if i == omit {
+                    continue;
+                }
+                selected.push(SelectedFace {
+                    face_id: fid,
+                    source_face: fid,
+                    reversed: false,
+                });
+            }
+            // An open shell whose fan volume WINS the outer selection is the
+            // sanctioned-lenient open-outer case (Cut/Fuse keep "best
+            // available" open results); the fail-safe covers NON-outer lumps
+            // only. Skip omissions where the open group becomes the outer.
+            let face_ids: Vec<_> = selected.iter().map(|sf| sf.face_id).collect();
+            let shells = perform_loops(&topo, &face_ids).unwrap();
+            let (growth, _) = perform_areas(&topo, &shells);
+            let outer_is_open = growth
+                .iter()
+                .map(|g| (signed_volume_of_shell(&topo, g), g))
+                .max_by(|a, b| a.0.total_cmp(&b.0))
+                .is_some_and(|(_, g)| !shell_is_closed(&topo, g));
+            if outer_is_open {
+                continue;
+            }
+            let err = build_solid(&mut topo, &selected, &[]);
+            assert!(
+                matches!(err, Err(AlgoError::AssemblyFailed(_))),
+                "omit={omit}: a 5-face open shell must abort assembly, got {err:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Root

Found during the lite magnet-pad fold-2 dig via a **volume audit** (the durable lesson of this family: manifold + position-paired edges is NOT acceptance — no edge-pairing gate can see a dropped chunk).

The assembler joins non-outer growth shells into the result only when `shell_is_closed`; an open one is silently discarded as a "residual fragmentation sliver". But a genuine solid lump whose face selection left unpaired junction edges hits the same path and vanishes wholesale: on the captured fold-2 operands, a 72-face foot (~2700 units³) disappeared from a result that then read watertight, manifold, and position-paired — while enclosing one foot less volume than the base it was fused onto.

Worse, which lump dodges the test is **volume-ordering luck**: the outer shell (largest signed volume) is never subjected to the closure check, so the same defect stays hidden or fires depending on how the corner-fan volume estimates happen to rank the shells.

## Fix

When an open growth shell has 4+ faces, fail the analytic assembly (`AssemblyFailed`) so the boolean falls back to the volume-correct mesh path. True few-face slivers (the case the silent drop was built for) keep the drop, now debug-logged.

## Verification

Foil web green: algo 177, ops lib 773, wasm gridfinity canary 27/27, full io fixture suite (incl. the lite graze-fuse fixture), clippy/fmt clean. On the fold-2 repro the raw assembly now aborts (→ mesh fallback at ops level) instead of silently deleting the foot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort analytic assembly when a non-trivial open growth or hole shell (>=4 faces) is detected, forcing a safe mesh fallback. This prevents real solids or cavities from being silently dropped while the result appears manifold.

- **Bug Fixes**
  - Abort with `AssemblyFailed` for open non-outer growth or hole shells with 4+ faces to trigger mesh fallback.
  - Tiny shells (<4 faces) are still dropped and debug-logged; removed a stray debug block from `perform_areas`.
  - Added a regression test covering a 5-face open lump; skips the sanctioned open-outer case.

<sup>Written for commit f13aeb1d935b483432aa35315326558851144778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

