### PR TITLE
fix(algo): trace full-period cylinder partitions with the seam-glued DCEL

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -4914,13 +4914,13 @@ fn split_face_2d_impl(
         // period copy — the pinch splitter would shear the band there into
         // wrong fragments (three over-shared wall sub-faces on the lite
         // diagonal-pad fuse).
-        if !wire_loops_have_degenerate_area(&dcel, tol.linear)
+        let dcel_adopted = !wire_loops_have_degenerate_area(&dcel, tol.linear)
             && (!wire_loops_self_cross(&dcel, tol.linear)
                 || wire_loops_self_cross(&loops, tol.linear))
             && (!greedy_outer_loops_nested(&dcel, cw_loops)
                 || greedy_outer_loops_nested(&loops, cw_loops))
-            && (dcel.len() > loops.len() || wire_loops_have_degenerate_area(&loops, tol.linear))
-        {
+            && (dcel.len() > loops.len() || wire_loops_have_degenerate_area(&loops, tol.linear));
+        if dcel_adopted {
             loops = dcel;
         } else {
             // The mirrored turn rule as a legacy fallback: adopt the retry only
@@ -4948,12 +4948,15 @@ fn split_face_2d_impl(
         }
         // Pinch resolution: a grand-tour loop that revisits a UV vertex is
         // two (or more) regions traced as one — split it there, whichever
-        // builder produced the winning loops. Working in the UNWRAPPED uv
-        // keeps the legitimate seam double-visit out (its two copies differ
-        // by a period). Zero-area remnants (pure out-and-back excursions)
-        // are dropped; the sliver guard below would misclassify them as
-        // holes.
-        if wire_loops_self_cross(&loops, tol.linear) {
+        // GREEDY-family builder produced the winning loops. Working in the
+        // UNWRAPPED uv keeps the legitimate seam double-visit out (its two
+        // copies differ by a period). Zero-area remnants (pure out-and-back
+        // excursions) are dropped; the sliver guard below would misclassify
+        // them as holes. An ADOPTED DCEL result is exempt: it is already the
+        // true subdivision, and its band orbit can revisit the glued seam
+        // node at the SAME stored period copy — pinch-shearing there
+        // recreates the over-shared wall fragments the trace fixed.
+        if !dcel_adopted && wire_loops_self_cross(&loops, tol.linear) {
             let resolved: Vec<Vec<OrientedPCurveEdge>> = loops
                 .iter()
                 .flat_map(|lp| split_loop_at_pinch_vertices(lp, tol.linear))
@@ -4984,11 +4987,17 @@ fn split_face_2d_impl(
         let dcel = build_wire_loops_dcel(&all_edges, tol.linear, u_periodic, v_periodic);
         // This branch is u-periodic by its gate: the pinch splitter is
         // unsafe on the glued seam graph (see the DCEL consult above), so
-        // the trace is used as-is.
+        // the trace is used as-is. The broken-loop flags are RELATIVE to the
+        // greedy result, not absolute — `wire_loops_self_cross` is not
+        // periodic-aware, so a valid winding band orbit revisiting the
+        // quantized seam vertex would fail an absolute gate and the refined
+        // partition (the separated strip) would be rejected.
         if dcel.len() > loops.len()
             && !wire_loops_have_degenerate_area(&dcel, tol.linear)
-            && !wire_loops_self_cross(&dcel, tol.linear)
-            && !greedy_outer_loops_nested(&dcel, cw_loops)
+            && (!wire_loops_self_cross(&dcel, tol.linear)
+                || wire_loops_self_cross(&loops, tol.linear))
+            && (!greedy_outer_loops_nested(&dcel, cw_loops)
+                || greedy_outer_loops_nested(&loops, cw_loops))
         {
             loops = dcel;
         }

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -24,7 +24,7 @@ use super::pcurve_compute::{
 };
 use super::plane_frame::PlaneFrame;
 use super::split_types::{OrientedPCurveEdge, SectionEdge, SplitSubFace, SurfaceInfo};
-use super::wire_builder::{build_wire_loops, build_wire_loops_with_winding};
+use super::wire_builder::{build_wire_loops, build_wire_loops_dcel, build_wire_loops_with_winding};
 use crate::ds::Rank;
 
 use containment::{find_point_outside_holes, is_inside_any_hole};
@@ -4881,13 +4881,14 @@ fn split_face_2d_impl(
     // loops are already broken, so it never changes a face the greedy handles.
     // (A face is either a plane disc or a cylinder band, so this never overlaps
     // the disc-chord / plane-arrangement paths above.)
+    let greedy_broken = wire_loops_self_cross(&loops, tol.linear)
+        || greedy_outer_loops_nested(&loops, cw_loops)
+        || wire_loops_have_degenerate_area(&loops, tol.linear);
     if u_periodic
         && !v_periodic
         && !sections.is_empty()
         && matches!(&surface, FaceSurface::Cylinder(_))
-        && (wire_loops_self_cross(&loops, tol.linear)
-            || greedy_outer_loops_nested(&loops, cw_loops)
-            || wire_loops_have_degenerate_area(&loops, tol.linear))
+        && greedy_broken
     {
         if let Some(result) = split_cylinder_band_by_arrangement(
             &surface,
@@ -4902,33 +4903,56 @@ fn split_face_2d_impl(
         }
         // Oblique cuts (ellipse/conic sections — e.g. a socket profile biting
         // a pad wall) are outside the rectilinear arrangement's domain. The
-        // grand-tour trace is a junction-turn artifact: retry with the
-        // mirrored turn rule and adopt the retry only when it is strictly
-        // healthier — more loops and none of the broken signatures.
-        let retry =
-            build_wire_loops_with_winding(&all_edges, tol.linear, u_periodic, v_periodic, true);
-        // Adoption bar: zero degenerate areas, NO NEW broken flags relative to
-        // the greedy result, and a strict improvement — either the greedy had
-        // degenerate loops (which the retry cleared) or the retry partitions
-        // into more loops. `wire_loops_self_cross` is not periodic-aware — a
-        // full-period band loop legitimately visits the seam vertex at both
-        // unwrapped copies — so it may stay set on both sides; what matters is
-        // the retry does not introduce it.
-        if !wire_loops_have_degenerate_area(&retry, tol.linear)
-            && (!wire_loops_self_cross(&retry, tol.linear)
+        // greedy walker's `used` filter makes its successor ORDER-DEPENDENT
+        // (an early loop steals edges from later regions — the grand tour);
+        // the DCEL trace's successor is a pure function of the graph, so try
+        // it first and adopt when strictly healthier.
+        let dcel = build_wire_loops_dcel(&all_edges, tol.linear, u_periodic, v_periodic);
+        // No pinch-split on the DCEL result: this branch is u-periodic by its
+        // gate, and on a full-period face the band orbit legitimately
+        // revisits the glued seam node with both visits stored at the same
+        // period copy — the pinch splitter would shear the band there into
+        // wrong fragments (three over-shared wall sub-faces on the lite
+        // diagonal-pad fuse).
+        if !wire_loops_have_degenerate_area(&dcel, tol.linear)
+            && (!wire_loops_self_cross(&dcel, tol.linear)
                 || wire_loops_self_cross(&loops, tol.linear))
-            && (!greedy_outer_loops_nested(&retry, cw_loops)
+            && (!greedy_outer_loops_nested(&dcel, cw_loops)
                 || greedy_outer_loops_nested(&loops, cw_loops))
-            && (retry.len() > loops.len() || wire_loops_have_degenerate_area(&loops, tol.linear))
+            && (dcel.len() > loops.len() || wire_loops_have_degenerate_area(&loops, tol.linear))
         {
-            loops = retry;
+            loops = dcel;
+        } else {
+            // The mirrored turn rule as a legacy fallback: adopt the retry only
+            // when it is strictly healthier — more loops and none of the broken
+            // signatures.
+            let retry =
+                build_wire_loops_with_winding(&all_edges, tol.linear, u_periodic, v_periodic, true);
+            // Adoption bar: zero degenerate areas, NO NEW broken flags relative to
+            // the greedy result, and a strict improvement — either the greedy had
+            // degenerate loops (which the retry cleared) or the retry partitions
+            // into more loops. `wire_loops_self_cross` is not periodic-aware — a
+            // full-period band loop legitimately visits the seam vertex at both
+            // unwrapped copies — so it may stay set on both sides; what matters is
+            // the retry does not introduce it.
+            if !wire_loops_have_degenerate_area(&retry, tol.linear)
+                && (!wire_loops_self_cross(&retry, tol.linear)
+                    || wire_loops_self_cross(&loops, tol.linear))
+                && (!greedy_outer_loops_nested(&retry, cw_loops)
+                    || greedy_outer_loops_nested(&loops, cw_loops))
+                && (retry.len() > loops.len()
+                    || wire_loops_have_degenerate_area(&loops, tol.linear))
+            {
+                loops = retry;
+            }
         }
         // Pinch resolution: a grand-tour loop that revisits a UV vertex is
-        // two (or more) regions traced as one — split it there. Working in
-        // the UNWRAPPED uv keeps the legitimate seam double-visit out (its
-        // two copies differ by a period). Zero-area remnants (pure
-        // out-and-back excursions) are dropped; the sliver guard below
-        // would misclassify them as holes.
+        // two (or more) regions traced as one — split it there, whichever
+        // builder produced the winning loops. Working in the UNWRAPPED uv
+        // keeps the legitimate seam double-visit out (its two copies differ
+        // by a period). Zero-area remnants (pure out-and-back excursions)
+        // are dropped; the sliver guard below would misclassify them as
+        // holes.
         if wire_loops_self_cross(&loops, tol.linear) {
             let resolved: Vec<Vec<OrientedPCurveEdge>> = loops
                 .iter()
@@ -4943,6 +4967,30 @@ fn split_face_2d_impl(
             if resolved.len() > loops.len() && !wire_loops_self_cross(&resolved, tol.linear) {
                 loops = resolved;
             }
+        }
+    } else if u_periodic
+        && !v_periodic
+        && !sections.is_empty()
+        && matches!(&surface, FaceSurface::Cylinder(_))
+    {
+        // UNDER-split rescue: a greedy trace can merge regions that the
+        // section chains fully separate WITHOUT tripping any broken-loop
+        // signature (the lite pad's B-side wall folded its socket-notch strip
+        // into the buried band — 2 clean-looking loops where the graph
+        // carries 4 regions — and the merged piece then classified as one,
+        // deleting the notch strip). The DCEL face trace enumerates the true
+        // subdivision; adopt it only when it strictly refines the greedy
+        // partition and is clean by every loop-health signature.
+        let dcel = build_wire_loops_dcel(&all_edges, tol.linear, u_periodic, v_periodic);
+        // This branch is u-periodic by its gate: the pinch splitter is
+        // unsafe on the glued seam graph (see the DCEL consult above), so
+        // the trace is used as-is.
+        if dcel.len() > loops.len()
+            && !wire_loops_have_degenerate_area(&dcel, tol.linear)
+            && !wire_loops_self_cross(&dcel, tol.linear)
+            && !greedy_outer_loops_nested(&dcel, cw_loops)
+        {
+            loops = dcel;
         }
     }
 

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -223,9 +223,15 @@ pub fn build_wire_loops_with_winding(
 /// chain (the defect of a min-angle successor).
 ///
 /// Sections already arrive as forward+reverse pairs; boundary edges get
-/// SYNTHETIC reversed twins for the trace only. Faces that use a synthetic
-/// half are the outer face (or touch an unpaired defect) and are dropped;
-/// the remaining orbits are the interior partition. Requires the input
+/// SYNTHETIC reversed twins for the trace only. An interior region may
+/// legitimately use synthetic halves (a CW-wound face traverses its rim
+/// reversed), so unbounded orbits are identified by area and winding, not by
+/// synthetic content: on planar faces the most-negative-area orbit is the
+/// outer face; on periodic faces the outer faces are the period-winding
+/// orbits made purely of synthetic rim twins, while a winding orbit carrying
+/// real halves is a genuine full-period band region. Orbit areas use a
+/// lifted minimal-image shoelace, so edge UVs may sit at either period copy
+/// as long as single-edge spans stay below half a period. Requires the input
 /// discipline the face splitter provides: junctions pre-split, endpoint UVs
 /// reconciled.
 pub fn build_wire_loops_dcel(

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -17,6 +17,9 @@ use super::split_types::OrientedPCurveEdge;
 // Types
 // ---------------------------------------------------------------------------
 
+/// Quantized UV endpoint pair, keying edges by their (start, end) node cells.
+type QuantizedPair = ((i64, i64), (i64, i64));
+
 /// An entry in the vertex adjacency map.
 struct VertexEntry {
     /// Index into the input edge slice.
@@ -206,6 +209,231 @@ pub fn build_wire_loops_with_winding(
     }
 
     loops
+}
+
+/// Deterministic DCEL-style face trace over an already-junction-split edge
+/// set: the canonical planar-subdivision face enumeration.
+///
+/// The greedy walker above consumes edges globally (`used`), so an early loop
+/// can steal edges that belong to a later region and grand-tour several
+/// regions as one (the lite diagonal-pad wall). Here the successor of a
+/// half-edge is `rotational-next-of-twin` — a BIJECTION, so every half-edge
+/// lies on exactly one clean face orbit regardless of enumeration order, and
+/// near-parallel arrivals at tangential junctions cannot funnel into one
+/// chain (the defect of a min-angle successor).
+///
+/// Sections already arrive as forward+reverse pairs; boundary edges get
+/// SYNTHETIC reversed twins for the trace only. Faces that use a synthetic
+/// half are the outer face (or touch an unpaired defect) and are dropped;
+/// the remaining orbits are the interior partition. Requires the input
+/// discipline the face splitter provides: junctions pre-split, endpoint UVs
+/// reconciled.
+pub fn build_wire_loops_dcel(
+    edges: &[OrientedPCurveEdge],
+    tol: f64,
+    u_periodic: bool,
+    v_periodic: bool,
+) -> Vec<Vec<OrientedPCurveEdge>> {
+    if edges.is_empty() {
+        return Vec::new();
+    }
+    let u_period = if u_periodic { Some(TAU) } else { None };
+    let v_period = if v_periodic { Some(TAU) } else { None };
+
+    // Half-edge table: the input edges, plus synthetic reversed twins for
+    // every input half that has no reverse partner. `real` marks inputs.
+    let mut halves: Vec<OrientedPCurveEdge> = edges.to_vec();
+    let n_real = halves.len();
+    let key_of = |p: Point2| quantize_uv_periodic(p, tol, u_period, v_period);
+
+    // Twin pairing among the real halves: same unordered endpoint pair,
+    // opposite direction. Prefer the same `source_edge_idx` (a section's own
+    // fwd/rev pair); co-endpoint DISTINCT edges (the lens class) only pair
+    // with each other if no same-source partner exists and both are free.
+    let mut twin: Vec<Option<usize>> = vec![None; n_real];
+    let mut by_pair: HashMap<QuantizedPair, Vec<usize>> = HashMap::new();
+    for (i, e) in edges.iter().enumerate() {
+        by_pair
+            .entry((key_of(e.start_uv), key_of(e.end_uv)))
+            .or_default()
+            .push(i);
+    }
+    for (i, e) in edges.iter().enumerate() {
+        if twin[i].is_some() {
+            continue;
+        }
+        let rev_key = (key_of(e.end_uv), key_of(e.start_uv));
+        if let Some(cands) = by_pair.get(&rev_key) {
+            let pick = cands
+                .iter()
+                .copied()
+                .filter(|&j| j != i && twin[j].is_none())
+                .max_by_key(|&j| {
+                    usize::from(
+                        edges[j].source_edge_idx.is_some()
+                            && edges[j].source_edge_idx == e.source_edge_idx,
+                    )
+                });
+            if let Some(j) = pick {
+                twin[i] = Some(j);
+                twin[j] = Some(i);
+            }
+        }
+    }
+    // Synthetic reversed twins for the unpaired (boundary) halves.
+    let mut twin_all: Vec<usize> = (0..n_real).map(|i| twin[i].unwrap_or(usize::MAX)).collect();
+    for i in 0..n_real {
+        if twin_all[i] != usize::MAX {
+            continue;
+        }
+        let e = &edges[i];
+        let mut r = e.clone();
+        std::mem::swap(&mut r.start_uv, &mut r.end_uv);
+        std::mem::swap(&mut r.start_3d, &mut r.end_3d);
+        r.forward = !r.forward;
+        let j = halves.len();
+        halves.push(r);
+        twin_all[i] = j;
+        twin_all.push(i);
+    }
+    let n_all = halves.len();
+
+    // Per-node circular order of OUTGOING halves by departure angle (ties
+    // broken by index for a strict, deterministic order).
+    let mut node_out: HashMap<(i64, i64), Vec<(f64, usize)>> = HashMap::new();
+    for (i, h) in halves.iter().enumerate() {
+        let ang = edge_angle_at_vertex_periodic(h, true, u_period, v_period);
+        node_out
+            .entry(key_of(h.start_uv))
+            .or_default()
+            .push((ang, i));
+    }
+    for list in node_out.values_mut() {
+        list.sort_by(|a, b| {
+            a.0.partial_cmp(&b.0)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.1.cmp(&b.1))
+        });
+    }
+
+    // Successor: the outgoing half CLOCKWISE-next from twin(h) in the
+    // circular order at h's end node (twin(h) starts there). Clockwise-next
+    // in an angle-ascending list is the PREVIOUS entry, wrapping.
+    let succ: Vec<usize> = (0..n_all)
+        .map(|i| {
+            let t = twin_all[i];
+            let node = key_of(halves[t].start_uv);
+            let list = &node_out[&node];
+            let pos = list.iter().position(|&(_, j)| j == t).unwrap_or(0);
+            let prev = (pos + list.len() - 1) % list.len();
+            list[prev].1
+        })
+        .collect();
+
+    // Orbits of the successor bijection = faces of the subdivision. The
+    // single unbounded (outer) face is the orbit with the most NEGATIVE
+    // signed area — drop it; every other orbit is an interior region. A
+    // region may legitimately use synthetic boundary twins (a face whose
+    // boundary winds clockwise in UV traverses its rim reversed), so
+    // synthetic halves are emitted as reversed traversals, not filtered.
+    let mut visited = vec![false; n_all];
+    let mut orbits: Vec<(f64, Vec<usize>)> = Vec::new();
+    for start in 0..n_all {
+        if visited[start] {
+            continue;
+        }
+        let mut orbit = Vec::new();
+        let mut cur = start;
+        let mut broken = false;
+        loop {
+            visited[cur] = true;
+            orbit.push(cur);
+            cur = succ[cur];
+            if cur == start {
+                break;
+            }
+            if visited[cur] {
+                // Successor is a bijection, so this cannot happen unless the
+                // node data was degenerate; discard defensively.
+                broken = true;
+                break;
+            }
+        }
+        if broken {
+            continue;
+        }
+        // Shoelace over LIFTED vertices: on a periodic surface the node keys
+        // glue the seam (correct cylinder connectivity), but edge UVs are
+        // stored at whichever period copy their pcurve produced — a raw
+        // shoelace over mixed copies is garbage (the full-period remainder
+        // band read as strongly negative and was dropped as "outer"). Lift
+        // each successive vertex by the minimal image against its
+        // predecessor; the net lift after closing the orbit is the WINDING —
+        // nonzero only for the unbounded rim rings of a periodic face.
+        let lift = |val: f64, anchor: f64, period: Option<f64>| -> f64 {
+            match period {
+                Some(p) if p > 1e-12 => val + ((anchor - val) / p).round() * p,
+                _ => val,
+            }
+        };
+        let mut area = 0.0;
+        let mut perimeter = 0.0;
+        let first = halves[orbit[0]].start_uv;
+        let mut prev = first;
+        let mut lifted_first = first;
+        for k in 0..orbit.len() {
+            let raw = halves[orbit[(k + 1) % orbit.len()]].start_uv;
+            let b = Point2::new(
+                lift(raw.x(), prev.x(), u_period),
+                lift(raw.y(), prev.y(), v_period),
+            );
+            if k + 1 == orbit.len() {
+                lifted_first = b;
+            }
+            area += prev.x().mul_add(b.y(), -(b.x() * prev.y()));
+            perimeter += (b - prev).length();
+            prev = b;
+        }
+        let area = area * 0.5;
+        let winding_u = u_period.is_some_and(|p| (lifted_first.x() - first.x()).abs() > p * 0.5);
+        let winding_v = v_period.is_some_and(|p| (lifted_first.y() - first.y()).abs() > p * 0.5);
+        if (winding_u || winding_v) && orbit.iter().all(|&i| i >= n_real) {
+            // A period-winding orbit of pure synthetic halves is an unbounded
+            // rim ring (the periodic face's counterpart of the planar outer
+            // face). A winding orbit WITH real halves is a genuine
+            // full-period band region — a cylinder band's boundary rims are
+            // separate rings in the glued graph, so the band itself winds.
+            continue;
+        }
+        // A zero-area orbit walks out-and-back around a dangling chain (the
+        // graph can carry genuinely unpaired sections); it is not a region.
+        if area.abs() <= perimeter * tol {
+            continue;
+        }
+        orbits.push((area, orbit));
+    }
+    // The planar unbounded face is the most-negative-area orbit. On a
+    // u-periodic face the unbounded sides are the winding rim rings already
+    // dropped above, so every surviving closed orbit is a genuine region.
+    let outer = if u_periodic || v_periodic {
+        None
+    } else {
+        orbits
+            .iter()
+            .enumerate()
+            .min_by(|a, b| {
+                a.1.0
+                    .partial_cmp(&b.1.0)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i)
+    };
+    orbits
+        .into_iter()
+        .enumerate()
+        .filter(|&(i, _)| Some(i) != outer)
+        .map(|(_, (_, orbit))| orbit.iter().map(|&i| halves[i].clone()).collect())
+        .collect()
 }
 
 /// Drop pendant section edges before loop building.
@@ -721,5 +949,130 @@ mod tests {
         let loops = build_wire_loops(&edges, 1e-7, true, false);
         assert_eq!(loops.len(), 1, "expected 1 loop, got {}", loops.len());
         assert_eq!(loops[0].len(), 4);
+    }
+
+    #[test]
+    fn dcel_plain_square_is_one_loop() {
+        let edges = vec![
+            make_line_edge(Point2::new(0.0, 0.0), Point2::new(10.0, 0.0)),
+            make_line_edge(Point2::new(10.0, 0.0), Point2::new(10.0, 10.0)),
+            make_line_edge(Point2::new(10.0, 10.0), Point2::new(0.0, 10.0)),
+            make_line_edge(Point2::new(0.0, 10.0), Point2::new(0.0, 0.0)),
+        ];
+        let loops = build_wire_loops_dcel(&edges, 1e-7, false, false);
+        assert_eq!(loops.len(), 1, "square must close as one loop");
+        assert_eq!(loops[0].len(), 4);
+    }
+
+    #[test]
+    fn dcel_divided_square_is_two_loops() {
+        // Boundary split at x=5 on both rails + a divider section (fwd+rev).
+        let edges = vec![
+            make_line_edge(Point2::new(0.0, 0.0), Point2::new(5.0, 0.0)),
+            make_line_edge(Point2::new(5.0, 0.0), Point2::new(10.0, 0.0)),
+            make_line_edge(Point2::new(10.0, 0.0), Point2::new(10.0, 10.0)),
+            make_line_edge(Point2::new(10.0, 10.0), Point2::new(5.0, 10.0)),
+            make_line_edge(Point2::new(5.0, 10.0), Point2::new(0.0, 10.0)),
+            make_line_edge(Point2::new(0.0, 10.0), Point2::new(0.0, 0.0)),
+            make_section_edge(Point2::new(5.0, 0.0), Point2::new(5.0, 10.0), 6),
+            make_section_edge(Point2::new(5.0, 10.0), Point2::new(5.0, 0.0), 6),
+        ];
+        let loops = build_wire_loops_dcel(&edges, 1e-7, false, false);
+        assert_eq!(
+            loops.len(),
+            2,
+            "divided square must be two cells, got {}",
+            loops.len()
+        );
+        for lp in &loops {
+            assert_eq!(lp.len(), 4);
+        }
+    }
+
+    #[test]
+    fn dcel_glued_cylinder_strip_partition() {
+        // A full-period cylinder band (u in [0, 2pi], v in [0, 1]) with seam
+        // edges at u=0 and two vertical sections at u=1 and u=2. The glued
+        // node keys identify u=0 with u=2pi; the true partition is three
+        // cells. The top/bottom rim rings traced via synthetic twins are
+        // period-winding pure-synthetic orbits and must be dropped, while
+        // every cell (none winding here — the seam edges cut the period)
+        // must survive. Rim pieces are stored with u=2pi endpoints, so the
+        // lifted shoelace must bridge the copies.
+        let u2 = TAU;
+        let edges = vec![
+            // bottom rim pieces, all spans < pi (the lift precondition;
+            // real rim chains arrive pre-split well below pi)
+            make_line_edge(Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)),
+            make_line_edge(Point2::new(1.0, 0.0), Point2::new(2.0, 0.0)),
+            make_line_edge(Point2::new(2.0, 0.0), Point2::new(4.0, 0.0)),
+            make_line_edge(Point2::new(4.0, 0.0), Point2::new(u2, 0.0)),
+            // top rim pieces
+            make_line_edge(Point2::new(1.0, 1.0), Point2::new(0.0, 1.0)),
+            make_line_edge(Point2::new(2.0, 1.0), Point2::new(1.0, 1.0)),
+            make_line_edge(Point2::new(4.0, 1.0), Point2::new(2.0, 1.0)),
+            make_line_edge(Point2::new(u2, 1.0), Point2::new(4.0, 1.0)),
+            // seam pair (the full-period face's boundary contains the seam twice)
+            make_line_edge(Point2::new(0.0, 1.0), Point2::new(0.0, 0.0)),
+            make_line_edge(Point2::new(u2, 0.0), Point2::new(u2, 1.0)),
+            // vertical sections at u=1 and u=2 (fwd+rev pairs)
+            make_section_edge(Point2::new(1.0, 0.0), Point2::new(1.0, 1.0), 100),
+            make_section_edge(Point2::new(1.0, 1.0), Point2::new(1.0, 0.0), 100),
+            make_section_edge(Point2::new(2.0, 0.0), Point2::new(2.0, 1.0), 200),
+            make_section_edge(Point2::new(2.0, 1.0), Point2::new(2.0, 0.0), 200),
+        ];
+        let loops = build_wire_loops_dcel(&edges, 1e-7, true, false);
+        assert_eq!(
+            loops.len(),
+            3,
+            "glued strip must partition into three cells, got {}",
+            loops.len()
+        );
+        let mut sizes: Vec<usize> = loops.iter().map(Vec::len).collect();
+        sizes.sort_unstable();
+        assert_eq!(
+            sizes,
+            vec![4, 4, 6],
+            "two square cells + the two-piece-rimmed third"
+        );
+    }
+
+    #[test]
+    fn dcel_winding_band_with_real_halves_is_kept() {
+        // A full-period band with NO seam edges, cut once at u=1: the single
+        // band region winds the period in the glued graph (its rims are
+        // separate rings). A winding orbit carrying real halves is a genuine
+        // region and must be kept; the pure-synthetic winding rim rings must
+        // be dropped (the lite diagonal-pad remainder band was dropped as
+        // "outer" by the planar most-negative rule before the lifted
+        // shoelace + winding rules).
+        let u2 = TAU;
+        let edges = vec![
+            // bottom rim split at u=1 into sub-pi pieces (boundary, single copies)
+            make_line_edge(Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)),
+            make_line_edge(Point2::new(1.0, 0.0), Point2::new(3.0, 0.0)),
+            make_line_edge(Point2::new(3.0, 0.0), Point2::new(5.0, 0.0)),
+            make_line_edge(Point2::new(5.0, 0.0), Point2::new(u2, 0.0)),
+            // top rim, same pieces westward
+            make_line_edge(Point2::new(1.0, 1.0), Point2::new(0.0, 1.0)),
+            make_line_edge(Point2::new(3.0, 1.0), Point2::new(1.0, 1.0)),
+            make_line_edge(Point2::new(5.0, 1.0), Point2::new(3.0, 1.0)),
+            make_line_edge(Point2::new(u2, 1.0), Point2::new(5.0, 1.0)),
+            // the single vertical section at u=1
+            make_section_edge(Point2::new(1.0, 0.0), Point2::new(1.0, 1.0), 100),
+            make_section_edge(Point2::new(1.0, 1.0), Point2::new(1.0, 0.0), 100),
+        ];
+        let loops = build_wire_loops_dcel(&edges, 1e-7, true, false);
+        assert_eq!(
+            loops.len(),
+            1,
+            "the winding band must survive as one region, got {}",
+            loops.len()
+        );
+        assert_eq!(
+            loops[0].len(),
+            10,
+            "band uses all eight rim pieces + the section twice"
+        );
     }
 }


### PR DESCRIPTION
## Root cause

On a full-period cylinder wall cut by oblique sections (the lite base's diagonal magnet pad grazing two socket corners), the greedy wire builder under-splits: its global `used` filter is order-dependent, and a discarded walk still consumes its edges — so the wall's third region (the corner strip the base-side neighbors pair against) never got traced. The strip stayed merged inside the buried band sub-face, classification dropped that band wholesale, the neighbors' ring edges went unpaired (9 odd edges), assembly failed, and the whole fuse fell back to mesh — poisoning every later fold of the 64-pad chain (the `4×4 lite stress` / `solid bin + magnet` export-integrity failures).

## Fix

`build_wire_loops_dcel` — a deterministic twin-successor face enumeration (successor = rotational-next of twin, a bijection, so no order dependence and no edge stealing) — consulted only when the greedy result is broken on a sectioned cylinder face, adopted only when strictly healthier (more loops, no new broken-loop flags). Three rules make it correct on the seam-GLUED periodic graph:

1. **Lifted minimal-image shoelace** for orbit area/perimeter: a raw shoelace over mixed period copies read the full-period remainder band as strongly negative, so it was dropped as the planar "outer" face.
2. **Periodic outer-face rule**: the unbounded faces of a periodic graph are the period-winding orbits made purely of synthetic rim twins; a winding orbit carrying real halves is a genuine band region (a band's rims are separate rings in the glued graph, so the band itself winds). The planar most-negative rule is unchanged for non-periodic faces.
3. **No pinch-splitting of DCEL results in the u-periodic consults**: the band orbit legitimately revisits the glued seam node at the same stored period copy; shearing there produced three over-shared wall sub-faces.

## Results (captured 4×4-stress operands)

| | before | after |
|---|---|---|
| fold-2 raw GFA | AssemblyFailed (open shell, 9 odd edges) | **F=959 analytic, posBad=0** |
| 64-pad fuse chain | mesh fallback, 12–14k all-plane faces, up to bd=21 at export weld, 268–325 s | **F=1424 analytic (352 cyl/256 cone/816 plane), mesh bd=0 nm=0, 146 s** |
| + 64 drills | fallback carrier | **F=1334 analytic, bd=0 nm=0** |

Volume audits pass (the acceptance lesson from the earlier DCEL prototype, which was manifold but silently dropped a foot): single fold gains +15.8 with analytic vs mesh signed volume agreeing to 0.001%; whole chain 42236 → 49357 (+111/pad average, consistent with the single-pad +130 for exposed pads).

## Verification

- New unit tests: `dcel_glued_cylinder_strip_partition` (glued node keys, three cells, winding pure-synthetic rim rings dropped, lifted shoelace across the period copies) and `dcel_winding_band_with_real_halves_is_kept` (the exact remainder-band shape that was being dropped as outer).
- fold-2 replay deterministic across 10 fresh processes (F=959 posBad=0 every run).
- `brepkit-algo` 184/184, `brepkit-operations` 773/773 (+ all integration groups), `brepkit-io` full, d4 canary (`brepkit-wasm --lib gridfinity`) 27/27, boundaries clean, full workspace suite via pre-push.

Builds on #1150 (phantom reverse-twin ellipse splits — the same wall's earlier defect). Part of the lightweight-export parity campaign; closes the magnet-pad fuse family at engine level.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes under-splitting on full-period cylinder walls by adding a deterministic DCEL face trace, used with DCEL-first consult and relative loop‑health checks for periodic bands. Restores correct wall partitions, unblocks assembly, and returns the 64‑pad fuse chain to analytic output with faster exports.

- **Bug Fixes**
  - Added `build_wire_loops_dcel`: twin-successor face enumeration that is order-independent; uses a lifted minimal‑image shoelace for periodic faces.
  - Periodic rule: drop pure‑synthetic period‑winding rim orbits; keep winding orbits that include real halves (true bands). Planar faces still use the most‑negative‑area outer rule.
  - In `split_face_2d_impl`: DCEL-first on u‑periodic cylinder faces when greedy loops are broken; adopt only if it produces more loops with no new broken-loop flags relative to greedy; exempt adopted DCEL results from pinch‑splitting.
  - Under‑split rescue: even when greedy looks clean, adopt the DCEL partition only if it strictly refines the loops and passes loop‑health checks relative to greedy (periodic-safe); no pinch‑split on these results.
  - Greedy mirrored‑turn fallback is retained but used only if DCEL is not adopted and it strictly improves results.
  - Outcome: assembly passes (no odd edges); 64‑pad chain is fully analytic and faster; new tests cover glued‑cylinder cases.

<sup>Written for commit 12a0e3f14ea95722c85eb8413a2b3623c345d69a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

