### PR TITLE
fix(operations): admit Intersect to the multi-region acceptance gate

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -671,17 +671,36 @@ pub fn boolean(
                         .is_none_or(|cls_b| {
                             all_component_centers_outside(topo, &components_vec, cls_b, tol)
                         });
+                // Intersect's mirror hazard: GFA could emit a piece that is not
+                // part of A∩B at all. Reject when any component's interior
+                // sample classifies OUTSIDE either operand; `On`/unknown stay
+                // accepted (thin clip pieces legitimately touch both
+                // boundaries). Same heuristic strength as `cut_safe`'s
+                // B-interior probe — a false accept needs a non-convex piece
+                // whose AABB centre escapes it, and rejection just falls back.
+                let intersect_safe = op != BooleanOp::Intersect
+                    || [a, b].iter().all(|&operand| {
+                        brepkit_algo::classifier::try_build_analytic_classifier(topo, operand)
+                            .as_ref()
+                            .is_none_or(|cls| {
+                                no_component_center_outside(topo, &components_vec, cls, tol)
+                            })
+                    });
                 // Fuse shares this gate: fusing a tool into ONE piece of a
                 // multi-component operand (the lite base's 16 disjoint feet
                 // before their web joins them) legitimately leaves N disjoint
                 // closed manifolds, which the single-component Euler gate above
                 // can never accept. The same conditions apply; `cut_safe`'s
                 // B-interior probe is Cut-specific and passes vacuously here.
-                if matches!(op, BooleanOp::Cut | BooleanOp::Fuse)
+                // Intersect joins for the same reason: clipping a multi-piece
+                // operand (the lite void against a divider-column prism)
+                // legitimately yields N disjoint chunks.
+                if matches!(op, BooleanOp::Cut | BooleanOp::Fuse | BooleanOp::Intersect)
                     && components >= 2
                     && euler_corrected == expected_euler
                     && components_are_disjoint_pieces(topo, &components_vec)
                     && cut_safe
+                    && intersect_safe
                     // Reuse the `closed_manifold` computed above: nothing between
                     // it and here mutates the result (only read-only component
                     // and classifier queries run in between).
@@ -2340,6 +2359,64 @@ fn all_component_centers_outside(
         }
     }
     true
+}
+
+/// True when no component's AABB-centre sample classifies strictly OUTSIDE
+/// the given operand. The Intersect twin of
+/// [`all_component_centers_outside`]: an intersection piece must lie inside
+/// both operands, so an Outside verdict marks a piece GFA should not have
+/// kept. `On`/unclassifiable samples pass — thin clip pieces legitimately
+/// touch the operand boundaries, and rejection only costs the mesh fallback.
+fn no_component_center_outside(
+    topo: &Topology,
+    components: &[Vec<FaceId>],
+    classifier: &brepkit_algo::classifier::AnalyticClassifier,
+    tol: brepkit_math::tolerance::Tolerance,
+) -> bool {
+    use brepkit_algo::FaceClass;
+    for comp in components {
+        let Some(centre) = component_aabb_centre(topo, comp) else {
+            continue;
+        };
+        if matches!(classifier.classify(centre, tol), Some(FaceClass::Outside)) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Centre of a face component's vertex AABB, or `None` for an empty component.
+fn component_aabb_centre(topo: &Topology, comp: &[FaceId]) -> Option<Point3> {
+    let mut min = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+    let mut max = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+    for &fid in comp {
+        let Ok(face) = topo.face(fid) else { continue };
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            let Ok(wire) = topo.wire(wid) else { continue };
+            for oe in wire.edges() {
+                let Ok(edge) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                for vid in [edge.start(), edge.end()] {
+                    if let Ok(v) = topo.vertex(vid) {
+                        let p = v.point();
+                        min =
+                            Point3::new(min.x().min(p.x()), min.y().min(p.y()), min.z().min(p.z()));
+                        max =
+                            Point3::new(max.x().max(p.x()), max.y().max(p.y()), max.z().max(p.z()));
+                    }
+                }
+            }
+        }
+    }
+    if min.x() > max.x() {
+        return None;
+    }
+    Some(Point3::new(
+        (min.x() + max.x()) * 0.5,
+        (min.y() + max.y()) * 0.5,
+        (min.z() + max.z()) * 0.5,
+    ))
 }
 
 fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -> bool {

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -672,19 +672,31 @@ pub fn boolean(
                             all_component_centers_outside(topo, &components_vec, cls_b, tol)
                         });
                 // Intersect's mirror hazard: GFA could emit a piece that is not
-                // part of A∩B at all. Reject when any component's interior
-                // sample classifies OUTSIDE either operand; `On`/unknown stay
-                // accepted (thin clip pieces legitimately touch both
-                // boundaries). Same heuristic strength as `cut_safe`'s
-                // B-interior probe — a false accept needs a non-convex piece
-                // whose AABB centre escapes it, and rejection just falls back.
+                // part of A∩B at all. Reject when any component's AABB-centre
+                // sample classifies OUTSIDE either operand — an intersection
+                // piece must lie inside both. The winding-number classifier
+                // (unlike the analytic one) handles multi-piece operands, the
+                // very case this acceptance exists for; a classification error
+                // rejects (this acceptance is purely an optimization, so
+                // unclassifiable geometry keeps the old fallback behaviour).
+                // `OnBoundary` passes — thin clip pieces legitimately touch
+                // the operand boundaries. The centre need not be interior to a
+                // concave piece, but that failure direction only REJECTS a
+                // valid result into the mesh fallback (the status quo), the
+                // same posture `cut_safe` already accepts.
                 let intersect_safe = op != BooleanOp::Intersect
-                    || [a, b].iter().all(|&operand| {
-                        brepkit_algo::classifier::try_build_analytic_classifier(topo, operand)
-                            .as_ref()
-                            .is_none_or(|cls| {
-                                no_component_center_outside(topo, &components_vec, cls, tol)
-                            })
+                    || components_vec.iter().all(|comp| {
+                        let Some(centre) = component_aabb_centre(topo, comp) else {
+                            return true;
+                        };
+                        [a, b].iter().all(|&operand| {
+                            !matches!(
+                                crate::classify::classify_point_robust(
+                                    topo, operand, centre, 0.1, tol.linear,
+                                ),
+                                Ok(crate::classify::PointClassification::Outside) | Err(_)
+                            )
+                        })
                     });
                 // Fuse shares this gate: fusing a tool into ONE piece of a
                 // multi-component operand (the lite base's 16 disjoint feet
@@ -2355,30 +2367,6 @@ fn all_component_centers_outside(
             (min.z() + max.z()) * 0.5,
         );
         if matches!(classifier.classify(centre, tol), Some(FaceClass::Inside)) {
-            return false;
-        }
-    }
-    true
-}
-
-/// True when no component's AABB-centre sample classifies strictly OUTSIDE
-/// the given operand. The Intersect twin of
-/// [`all_component_centers_outside`]: an intersection piece must lie inside
-/// both operands, so an Outside verdict marks a piece GFA should not have
-/// kept. `On`/unclassifiable samples pass — thin clip pieces legitimately
-/// touch the operand boundaries, and rejection only costs the mesh fallback.
-fn no_component_center_outside(
-    topo: &Topology,
-    components: &[Vec<FaceId>],
-    classifier: &brepkit_algo::classifier::AnalyticClassifier,
-    tol: brepkit_math::tolerance::Tolerance,
-) -> bool {
-    use brepkit_algo::FaceClass;
-    for comp in components {
-        let Some(centre) = component_aabb_centre(topo, comp) else {
-            continue;
-        };
-        if matches!(classifier.classify(centre, tol), Some(FaceClass::Outside)) {
             return false;
         }
     }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -45,11 +45,13 @@ fn fuse_disjoint_cubes() {
 #[test]
 fn intersect_multi_piece_operand_keeps_disjoint_chunks() {
     // The lite divider clip: intersecting a multi-piece solid (two disjoint
-    // cubes merged into one solid) with a bar that crosses both legitimately
-    // yields two disjoint chunks. The multi-region acceptance gate must admit
-    // the analytic Intersect result instead of rejecting it on the
-    // single-component Euler check (which forced a mesh fallback whose open
-    // output poisoned the whole lite export chain).
+    // cylinders merged into one solid) with a bar that crosses both
+    // legitimately yields two disjoint chunks. The multi-region acceptance
+    // gate must admit the analytic Intersect result instead of rejecting it
+    // on the single-component Euler check (which forced a mesh fallback whose
+    // open output poisoned the whole lite export chain). Cylinders, not
+    // boxes: a box fallback re-merges its coplanar facets back to a handful
+    // of planes, so only the curved-wall census discriminates the paths.
     use crate::measure::solid_volume;
     use crate::transform::transform_solid;
     use brepkit_math::mat::Mat4;
@@ -80,6 +82,12 @@ fn intersect_multi_piece_operand_keeps_disjoint_chunks() {
     assert!(
         (vol - expected).abs() < 0.05,
         "two disc slabs expected (vol {expected:.3}), got {vol}"
+    );
+    let components = crate::boolean::assembly::face_components(&topo, result);
+    assert_eq!(
+        components.len(),
+        2,
+        "the two chunks must stay disjoint components"
     );
 }
 

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -43,6 +43,47 @@ fn fuse_disjoint_cubes() {
 }
 
 #[test]
+fn intersect_multi_piece_operand_keeps_disjoint_chunks() {
+    // The lite divider clip: intersecting a multi-piece solid (two disjoint
+    // cubes merged into one solid) with a bar that crosses both legitimately
+    // yields two disjoint chunks. The multi-region acceptance gate must admit
+    // the analytic Intersect result instead of rejecting it on the
+    // single-component Euler check (which forced a mesh fallback whose open
+    // output poisoned the whole lite export chain).
+    use crate::measure::solid_volume;
+    use crate::transform::transform_solid;
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let cyl_a = crate::primitives::make_cylinder(&mut topo, 1.0, 4.0).unwrap();
+    let cyl_b = crate::primitives::make_cylinder(&mut topo, 1.0, 4.0).unwrap();
+    transform_solid(&mut topo, cyl_b, &Mat4::translation(6.0, 0.0, 0.0)).unwrap();
+    let two_cyls = boolean(&mut topo, BooleanOp::Fuse, cyl_a, cyl_b).unwrap();
+    let bar = crate::primitives::make_box(&mut topo, 12.0, 4.0, 1.0).unwrap();
+    transform_solid(&mut topo, bar, &Mat4::translation(-3.0, -2.0, 1.5)).unwrap();
+
+    let result = boolean(&mut topo, BooleanOp::Intersect, two_cyls, bar).unwrap();
+    let n_faces = check_result(&topo, result);
+    // The curved walls are the fallback tell: a mesh fallback re-emits the
+    // chunks as all-plane facets, the analytic path keeps the cylinders.
+    let faces = brepkit_topology::explorer::solid_faces(&topo, result).unwrap();
+    let cylinders = faces
+        .iter()
+        .filter(|&&f| topo.face(f).unwrap().surface().type_tag() == "cylinder")
+        .count();
+    assert!(
+        cylinders >= 2,
+        "analytic chunks must keep their cylinder walls, got {cylinders} of {n_faces} faces"
+    );
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
+    let expected = 2.0 * std::f64::consts::PI; // two r=1 disc slabs of height 1
+    assert!(
+        (vol - expected).abs() < 0.05,
+        "two disc slabs expected (vol {expected:.3}), got {vol}"
+    );
+}
+
+#[test]
 fn fuse_six_disjoint_boxes_2x3_grid() {
     // Mirrors brepjs's `rectangularPattern() > creates a 2x3 grid` test:
     // 6 boxes of 5×5×5 at (col*10, row*10, 0), fused pairwise via


### PR DESCRIPTION
## Root cause

Intersecting a multi-piece operand with a tool that crosses several pieces legitimately yields N disjoint closed chunks — the lite base's divider clip (`intersect(void solid, divider-column prism)` in the gridfinity `2×1 lite + mid-cell dividers` scenario) is exactly this. The multi-region acceptance gate only admitted **Cut and Fuse**, so the clean analytic Intersect result (F=94, by-edge free=0/over=0) failed the single-component Euler check and fell back to mesh — feeding a 700-face all-plane operand into every downstream lite boolean of that scenario.

Found while root-causing the `mid-cell dividers` bd=115 export regression (surfaced by #1146's fail-safe; the version bisect pins 2.127.9). This fix rescues the first fallback in that chain; the scenario itself still needs the mesh-boolean open-output row (the terminal sink) — verified by an end-to-end overlay run, so this PR claims the op-class rescue, not the scenario.

## Fix

Admit `Intersect` to the multi-region gate with a mirror of Cut's B-interior probe: reject when any component's AABB-centre sample classifies strictly **Outside either operand** (an intersection piece must lie inside both). `On`/unclassifiable samples pass — thin clip pieces legitimately touch the operand boundaries, and a false rejection only costs the mesh fallback (the status quo). Same heuristic strength as `cut_safe`.

## Results (captured divider-clip operands)

| | before | after |
|---|---|---|
| clip intersect | 700-face all-plane fallback, 137 ms | analytic F=94, 4 chunks, cyl/cone walls intact, 70 ms |

## Verification

- New regression test `intersect_multi_piece_operand_keeps_disjoint_chunks` (two disjoint cylinders ∩ crossing bar): **fails without the gate change** (0 cylinder faces of 44 — all-plane fallback), passes with it (curved walls kept, volume exact). The first draft used boxes and was vacuous — box fallbacks re-merge to few planes; the curved-wall census is the discriminator.
- `brepkit-operations` 774/774 (+ all integration groups), `brepkit-algo` 184/184, d4 canary 27/27, boundaries clean, full workspace via pre-push.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admits `Intersect` to the multi‑region acceptance gate so analytic intersects that produce multiple disjoint chunks are accepted. This prevents mesh fallbacks in the lite divider clip and preserves curved walls with faster runtimes.

- **Bug Fixes**
  - Admit `Intersect` alongside `Cut` and `Fuse` when components ≥ 2, Euler checks pass, and pieces are disjoint.
  - Add winding‑based `intersect_safe`: reject when any component AABB‑center classifies Outside for either operand; `On` passes; classification errors reject (keeps mesh fallback). Uses `classify_point_robust` to handle multi‑piece operands.
  - Keeps disjoint chunks for the divider‑clip case, avoiding the 700‑plane mesh fallback; observed 94 analytic faces in ~70 ms.
  - Regression test `intersect_multi_piece_operand_keeps_disjoint_chunks`: verifies cylinder walls, exact volume, and that the two chunks remain separate components.

<sup>Written for commit c98bc89791a1dfe00c5e3272c8eefdbbe63a6a9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

