### PR TITLE
perf(algo): hoist the NURBS section domain out of the split-finder eval loop

### DIFF
--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -317,8 +317,19 @@ pub(super) fn find_splits_on_nurbs_section(
     tol: f64,
 ) -> Vec<(f64, Point3)> {
     let n_samples = 64usize;
-    let eval_at =
-        |t: f64| -> Point3 { evaluate_edge_at_t(&edge.curve_3d, edge.start_3d, edge.end_3d, t) };
+    // Hoist the domain: `evaluate_edge_at_t` re-derives `domain_with_endpoints`
+    // on EVERY call, and for a trimmed NURBS sub-span that is two iterative
+    // point-to-curve projections per evaluation — this finder makes ~115
+    // evaluations per candidate point, which turned each pad-fuse face split
+    // into ~700ms (the lite magnet scenarios' timeout class). One domain
+    // computation per edge, then direct parametric evaluation.
+    let (dom0, dom1) = edge
+        .curve_3d
+        .domain_with_endpoints(edge.start_3d, edge.end_3d);
+    let eval_at = |t: f64| -> Point3 {
+        edge.curve_3d
+            .evaluate_with_endpoints(dom0 + (dom1 - dom0) * t, edge.start_3d, edge.end_3d)
+    };
     let samples: Vec<Point3> = (0..=n_samples)
         .map(|i| {
             #[allow(clippy::cast_precision_loss)]

--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -326,9 +326,10 @@ pub(super) fn find_splits_on_nurbs_section(
     let (dom0, dom1) = edge
         .curve_3d
         .domain_with_endpoints(edge.start_3d, edge.end_3d);
+    let dom_span = dom1 - dom0;
     let eval_at = |t: f64| -> Point3 {
         edge.curve_3d
-            .evaluate_with_endpoints(dom0 + (dom1 - dom0) * t, edge.start_3d, edge.end_3d)
+            .evaluate_with_endpoints(t.mul_add(dom_span, dom0), edge.start_3d, edge.end_3d)
     };
     let samples: Vec<Point3> = (0..=n_samples)
         .map(|i| {


### PR DESCRIPTION
## Root cause

`find_splits_on_nurbs_section` evaluated candidate parameters via `evaluate_edge_at_t`, which re-derives `domain_with_endpoints` on **every call** — and for a trimmed NURBS sub-span edge that means two iterative point-to-curve projections per evaluation. The finder makes ~115 evaluations per candidate point (65-sample scan + 50 ternary refinement steps), so any face carrying marched/rescue spline sections paid ~700 ms in `split_sections_at_t_junctions` alone.

Found while profiling the lightweight timeout family (all six remaining lightweight failures are now timeout-class after the correctness wave): the captured `2×2 lite + magnet pads` base build spends 73.8 s in the shell stage, of which the 16-pad fuse is 37.6 s wasm / 23.7 s native — and **23.2 s of that was this finder** (32 faces × ~730 ms, uniform).

## Fix

Compute the domain once per edge; evaluate directly through `evaluate_with_endpoints` (a plain parametric evaluation for NURBS). Semantically identical by construction — the hoisted formula is exactly what `evaluate_edge_at_t`'s fallback arm computes per call.

## Measurements (captured operands, native)

| | before | after |
|---|---|---|
| 16-pad magnet fuse | 23.7 s | **6.9 s** |
| per hot face (`split_sections_at_t_junctions`) | ~690 ms | below the 100 ms log threshold |

The same finder serves boundary-edge splitting (`split_boundary_edges_at_3d_points`), so every op over spline-carrying geometry benefits.

## Verification

- `brepkit-algo` 184/184 (includes `nurbs_section_splits_ordered_along_forward_edge` covering this exact finder), `brepkit-operations` full (0 failures), `brepkit-io` full, d4 canary 27/27, full workspace via pre-push.
- The remaining pad-fuse time is diffuse (~180 ms/face, no single hot spot) — further profiling continues separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hoisted NURBS section domain computation out of the split-finder loop and switched to direct parametric evaluation with endpoints, with fused multiply-add for the t→domain mapping. This removes redundant projections per sample and cuts pad-fuse time from 23.7s to 6.9s while speeding up all spline-edge splits.

- **Performance**
  - Compute domain once per edge; evaluate via `evaluate_with_endpoints` instead of `evaluate_edge_at_t`; use FMA for t mapping.
  - Results: 16-pad magnet fuse 23.7s → 6.9s; per hot face ~690ms → <100ms; benefits boundary-edge splitting too.

<sup>Written for commit ba68804c80dc63c341f0d013eaba1b387e6d4d29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

