### PR TITLE
perf(algo): batch edge sampler for the same-domain polygon builders

### DIFF
--- a/crates/algo/src/builder/pcurve_compute.rs
+++ b/crates/algo/src/builder/pcurve_compute.rs
@@ -644,4 +644,88 @@ mod tests {
         );
         assert_eq!(surface_periods(&torus), (Some(TAU), Some(TAU)));
     }
+
+    /// The batch sampler must agree with per-sample `evaluate_edge_at_t` on
+    /// every curve arm and both traversal directions — it exists only to
+    /// hoist the per-arm setup, never to change the sampled points.
+    #[test]
+    fn sample_edge_uniform_matches_evaluate_edge_at_t() {
+        use brepkit_math::curves::{Circle3D, Ellipse3D};
+        use brepkit_math::nurbs::fitting::interpolate;
+        use brepkit_math::vec::Vec3;
+        use brepkit_topology::edge::EdgeCurve;
+
+        let circle = Circle3D::new_with_ref(
+            Point3::new(1.0, 2.0, 3.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            2.5,
+            Vec3::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let ellipse = Ellipse3D::new(
+            Point3::new(-1.0, 0.5, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            3.0,
+            1.5,
+        )
+        .unwrap();
+        let nurbs = {
+            let pts: Vec<Point3> = (0..=6)
+                .map(|k| {
+                    let x = f64::from(k) * 0.5;
+                    Point3::new(x, x * x * 0.2, 0.1 * x)
+                })
+                .collect();
+            interpolate(&pts, 3).unwrap()
+        };
+        let nurbs_mid_a = ParametricCurve::evaluate(&nurbs, 0.2);
+        let nurbs_mid_b = ParametricCurve::evaluate(&nurbs, 0.75);
+
+        let cases: Vec<(EdgeCurve, Point3, Point3)> = vec![
+            (
+                EdgeCurve::Line,
+                Point3::new(0.0, 1.0, 2.0),
+                Point3::new(3.0, -1.0, 0.5),
+            ),
+            (
+                EdgeCurve::Circle(circle.clone()),
+                circle.evaluate(0.3),
+                circle.evaluate(2.1),
+            ),
+            // Closed circle (start == end): domain-based arm.
+            (
+                EdgeCurve::Circle(circle.clone()),
+                circle.evaluate(0.3),
+                circle.evaluate(0.3),
+            ),
+            (
+                EdgeCurve::Ellipse(ellipse.clone()),
+                ellipse.evaluate(1.0),
+                ellipse.evaluate(2.4),
+            ),
+            // NURBS trimmed sub-span: the arm whose per-call domain
+            // re-derivation the sampler exists to hoist.
+            (EdgeCurve::NurbsCurve(nurbs), nurbs_mid_a, nurbs_mid_b),
+        ];
+
+        for (curve, start, end) in cases {
+            for forward in [true, false] {
+                let n = 7usize;
+                let mut batch = Vec::new();
+                sample_edge_uniform(&curve, start, end, n, forward, &mut batch);
+                assert_eq!(batch.len(), n);
+                for (k, got) in batch.iter().enumerate() {
+                    #[allow(clippy::cast_precision_loss)]
+                    let frac = k as f64 / n as f64;
+                    let frac = if forward { frac } else { 1.0 - frac };
+                    let want = evaluate_edge_at_t(&curve, start, end, frac);
+                    assert!(
+                        (*got - want).length() < 1e-12,
+                        "{} fwd={forward} k={k}: {got:?} vs {want:?}",
+                        curve.type_tag()
+                    );
+                }
+            }
+        }
+    }
 }

--- a/crates/algo/src/builder/pcurve_compute.rs
+++ b/crates/algo/src/builder/pcurve_compute.rs
@@ -238,6 +238,61 @@ pub(super) fn evaluate_edge_at_t(curve: &EdgeCurve, start: Point3, end: Point3, 
     }
 }
 
+/// Uniformly sample an edge curve at `n` points (`t = k/n`, `k` in `0..n`),
+/// honouring the wire traversal direction (`forward = false` samples
+/// `1 - k/n`).
+///
+/// Matches [`evaluate_edge_at_t`]'s conventions per curve arm but hoists the
+/// per-arm setup OUT of the sample loop: `evaluate_edge_at_t` re-derives
+/// `domain_with_endpoints` on every call, and for a trimmed NURBS sub-span
+/// that is two iterative point-to-curve projections per sample — the
+/// same-domain samplers over spline-carrying faces paid hundreds of
+/// milliseconds per boolean for it.
+pub(super) fn sample_edge_uniform(
+    curve: &EdgeCurve,
+    start: Point3,
+    end: Point3,
+    n: usize,
+    forward: bool,
+    out: &mut Vec<Point3>,
+) {
+    #[allow(clippy::cast_precision_loss)]
+    let frac_at = |k: usize| -> f64 {
+        let f = k as f64 / n as f64;
+        if forward { f } else { 1.0 - f }
+    };
+    match curve {
+        EdgeCurve::Line => {
+            let d = end - start;
+            for k in 0..n {
+                let t = frac_at(k);
+                out.push(start + d * t);
+            }
+        }
+        EdgeCurve::Circle(c) if (start - end).length() > 1e-12 => {
+            let t0 = c.project(start);
+            let d = shorter_arc_delta(c.project(end) - t0);
+            for k in 0..n {
+                out.push(ParametricCurve::evaluate(c, frac_at(k).mul_add(d, t0)));
+            }
+        }
+        EdgeCurve::Ellipse(e) if (start - end).length() > 1e-12 => {
+            let t0 = e.project(start);
+            let d = shorter_arc_delta(e.project(end) - t0);
+            for k in 0..n {
+                out.push(ParametricCurve::evaluate(e, frac_at(k).mul_add(d, t0)));
+            }
+        }
+        _ => {
+            let (t0, t1) = curve.domain_with_endpoints(start, end);
+            let span = t1 - t0;
+            for k in 0..n {
+                out.push(curve.evaluate_with_endpoints(frac_at(k).mul_add(span, t0), start, end));
+            }
+        }
+    }
+}
+
 /// Wrap an angular difference into (-pi, pi] — the shorter way around.
 pub(super) fn shorter_arc_delta(d: f64) -> f64 {
     let w = d.rem_euclid(TAU);

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -571,17 +571,14 @@ fn planar_faces_overlap(
             // parameterization, and domain-based sampling would then trace
             // the complementary (long-way) arc, corrupting the polygon used
             // for the containment tests below.
-            for k in 0..samples_per_edge {
-                #[allow(clippy::cast_precision_loss)]
-                let frac = k as f64 / samples_per_edge as f64;
-                let frac = if oe.is_forward() { frac } else { 1.0 - frac };
-                pts.push(super::pcurve_compute::evaluate_edge_at_t(
-                    edge.curve(),
-                    sp,
-                    ep,
-                    frac,
-                ));
-            }
+            super::pcurve_compute::sample_edge_uniform(
+                edge.curve(),
+                sp,
+                ep,
+                samples_per_edge,
+                oe.is_forward(),
+                &mut pts,
+            );
         }
         pts
     };
@@ -791,17 +788,14 @@ fn planar_face_area(topo: &Topology, face_id: FaceId) -> Option<f64> {
         let (sp, ep) = (sv.point(), ev.point());
         // Sample each edge so arc boundaries contribute their true swept area,
         // mirroring `planar_faces_overlap`'s shorter-arc sampling.
-        for k in 0..SD_EDGE_SAMPLES {
-            #[allow(clippy::cast_precision_loss)]
-            let frac = k as f64 / SD_EDGE_SAMPLES as f64;
-            let frac = if oe.is_forward() { frac } else { 1.0 - frac };
-            pts.push(super::pcurve_compute::evaluate_edge_at_t(
-                edge.curve(),
-                sp,
-                ep,
-                frac,
-            ));
-        }
+        super::pcurve_compute::sample_edge_uniform(
+            edge.curve(),
+            sp,
+            ep,
+            SD_EDGE_SAMPLES,
+            oe.is_forward(),
+            &mut pts,
+        );
     }
     if pts.len() < 3 {
         return None;
@@ -836,17 +830,14 @@ fn wire_points_3d(topo: &Topology, face_id: FaceId) -> Option<Vec<brepkit_math::
         let sv = topo.vertex(edge.start()).ok()?;
         let ev = topo.vertex(edge.end()).ok()?;
         let (sp, ep) = (sv.point(), ev.point());
-        for k in 0..SD_EDGE_SAMPLES {
-            #[allow(clippy::cast_precision_loss)]
-            let frac = k as f64 / SD_EDGE_SAMPLES as f64;
-            let frac = if oe.is_forward() { frac } else { 1.0 - frac };
-            pts.push(super::pcurve_compute::evaluate_edge_at_t(
-                edge.curve(),
-                sp,
-                ep,
-                frac,
-            ));
-        }
+        super::pcurve_compute::sample_edge_uniform(
+            edge.curve(),
+            sp,
+            ep,
+            SD_EDGE_SAMPLES,
+            oe.is_forward(),
+            &mut pts,
+        );
     }
     if pts.len() < 3 {
         return None;
@@ -1144,17 +1135,14 @@ fn face_outer_aabb(topo: &Topology, face_id: FaceId) -> Option<brepkit_math::aab
         // `planar_faces_overlap` / `planar_face_area` polygons exactly: the next
         // edge's `frac=0` already covers each shared vertex, so this drops the
         // redundant per-vertex duplicate without changing the AABB.
-        for k in 0..SD_EDGE_SAMPLES {
-            #[allow(clippy::cast_precision_loss)]
-            let frac = k as f64 / SD_EDGE_SAMPLES as f64;
-            let frac = if oe.is_forward() { frac } else { 1.0 - frac };
-            pts.push(super::pcurve_compute::evaluate_edge_at_t(
-                edge.curve(),
-                sp,
-                ep,
-                frac,
-            ));
-        }
+        super::pcurve_compute::sample_edge_uniform(
+            edge.curve(),
+            sp,
+            ep,
+            SD_EDGE_SAMPLES,
+            oe.is_forward(),
+            &mut pts,
+        );
     }
     brepkit_math::aabb::Aabb3::try_from_points(pts)
 }


### PR DESCRIPTION
## Root cause

Second instance of the class #1158 fixed: the four same-domain sampling loops (planar overlap polygons, analytic wire points, face AABBs) called `evaluate_edge_at_t` **per sample**, re-deriving `domain_with_endpoints` — two iterative point-to-curve projections per sample on trimmed NURBS sub-span edges. Every face carrying rescue-spline boundary edges (all post-pad-fuse lite geometry) paid it on every boolean's same-domain pass.

## Fix

`sample_edge_uniform` hoists the per-arm setup out of the sample loop (shorter-arc origin for open circle/ellipse, domain for NURBS/closed) and matches `evaluate_edge_at_t`'s conventions arm for arm; all four loops converted.

## Measurements (captured lite magnet operands, native)

| | before | after |
|---|---|---|
| `detect_same_domain` per drill cut | ~500 ms | **78 ms** |
| `analytic_faces_overlap` (32 tests) | 244 ms | 36 ms |
| 16-drill `compound_cut` | 17.2 s | **8.9 s** |
| 16-pad fuse | 7.0 s | 6.4 s |

Combined with #1158, the tool-side `2×2 lite + magnet pads` scenario projects from 65 s (pre-wave) → ~29 s, at the 30 s export cap.

## Verification

- `brepkit-algo` 184/184, `brepkit-operations` full (no failures), `brepkit-io` full, d4 canary 27/27, full workspace via pre-push. The same-domain foils (coaxial band pairing, planar containment, complementary-split guards) all exercise the converted samplers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch edge sampling for same-domain polygon builders to avoid per-sample domain recomputation; adds differential tests to pin parity with `evaluate_edge_at_t`. detect_same_domain drops ~500 ms → 78 ms per drill cut; 16‑drill compound_cut 17.2 s → 8.9 s; pad fuse 7.0 s → 6.4 s.

- **Refactors**
  - Added `sample_edge_uniform` to precompute per-curve setup and sample n points honoring wire direction.
  - Replaced per-sample `evaluate_edge_at_t` loops in planar overlap polygons, planar face area, wire points (3D), and face outer AABB.
  - Keeps shorter-arc sampling for circles/ellipses and uses endpoint domains for NURBS/closed curves.
  - Added differential tests to ensure the sampler matches `evaluate_edge_at_t` for line, open/closed circle, ellipse, and trimmed NURBS in both directions.

<sup>Written for commit 465733ca9a8b57f87fe10bb207d609d4635252b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

