### PR TITLE
perf(operations): batch pairwise-disjoint compound_cut tools into one cut

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -840,9 +840,35 @@ pub fn compound_cut(
     tools: &[SolidId],
     opts: BooleanOptions,
 ) -> Result<SolidId, crate::OperationsError> {
+    // Batched fast path for pairwise-DISJOINT tools (a drill pattern): merge
+    // them into one multi-piece tool (the disjoint-shell merge shortcut makes
+    // that free) and cut ONCE. Sequential cutting re-runs the full GFA
+    // against the whole target per tool — O(target × tools); the lite
+    // magnet-drill pass was 8.4s sequential vs 0.75s batched for the exact
+    // same result volume. A ∖ (T₁ ∪ T₂ ∪ …) ≡ (A ∖ T₁) ∖ T₂ ∖ …, so the
+    // batch is semantically identical; restricting it to disjoint tools
+    // keeps the merged tool trivial and preserves the sequential path's
+    // behaviour for overlapping-tool inputs. Any failure falls back to the
+    // sequential loop.
     let mut result = target;
-    for &tool in tools {
-        result = boolean(topo, BooleanOp::Cut, result, tool)?;
+    let mut batched = false;
+    if tools.len() >= 2 && tools_pairwise_disjoint(topo, tools) {
+        let merged = tools[1..]
+            .iter()
+            .try_fold(tools[0], |acc, &t| boolean(topo, BooleanOp::Fuse, acc, t));
+        if let Ok(tool) = merged
+            && let Ok(cut) = boolean(topo, BooleanOp::Cut, target, tool)
+        {
+            result = cut;
+            batched = true;
+        } else {
+            log::debug!("compound_cut: batched tool path failed, using sequential cuts");
+        }
+    }
+    if !batched {
+        for &tool in tools {
+            result = boolean(topo, BooleanOp::Cut, result, tool)?;
+        }
     }
     if opts.unify_faces {
         let unify_opts = brepkit_heal::upgrade::unify_same_domain::UnifyOptions::default();
@@ -853,6 +879,26 @@ pub fn compound_cut(
         }
     }
     Ok(result)
+}
+
+/// True when every pair of tool AABBs (tolerance-expanded) is disjoint.
+fn tools_pairwise_disjoint(topo: &Topology, tools: &[SolidId]) -> bool {
+    let tol = brepkit_math::tolerance::Tolerance::new().linear;
+    let mut boxes = Vec::with_capacity(tools.len());
+    for &t in tools {
+        match crate::measure::solid_bounding_box(topo, t) {
+            Ok(bb) => boxes.push(bb),
+            Err(_) => return false,
+        }
+    }
+    for i in 0..boxes.len() {
+        for j in (i + 1)..boxes.len() {
+            if boxes[i].expanded(tol).intersects(boxes[j]) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// Perform a boolean operation and return an [`crate::evolution::EvolutionMap`]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -119,10 +119,15 @@ fn compound_cut_disjoint_drills_matches_sequential() {
     }
     let vol_seq = solid_volume(&topo_seq, seq, 0.05).unwrap();
 
+    // unify_faces off so the differential compares the raw cut paths, not
+    // the trailing unification pass.
+    let opts = BooleanOptions {
+        unify_faces: false,
+        ..BooleanOptions::default()
+    };
     let mut topo = Topology::new();
     let (base, drills) = make(&mut topo);
-    let result =
-        crate::boolean::compound_cut(&mut topo, base, &drills, BooleanOptions::default()).unwrap();
+    let result = crate::boolean::compound_cut(&mut topo, base, &drills, opts).unwrap();
 
     let vol = solid_volume(&topo, result, 0.05).unwrap();
     assert!(

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -92,6 +92,84 @@ fn intersect_multi_piece_operand_keeps_disjoint_chunks() {
 }
 
 #[test]
+fn compound_cut_disjoint_drills_matches_sequential() {
+    // The magnet-drill pattern: many disjoint cylindrical tools cut from one
+    // base. The batched path (merge tools, cut once) must produce the same
+    // volume as the sequential loop and keep the drilled walls analytic.
+    use crate::measure::solid_volume;
+    use crate::transform::transform_solid;
+    use brepkit_math::mat::Mat4;
+
+    let make = |topo: &mut Topology| -> (SolidId, Vec<SolidId>) {
+        let base = crate::primitives::make_box(topo, 20.0, 20.0, 5.0).unwrap();
+        let mut drills = Vec::new();
+        for (x, y) in [(4.0, 4.0), (16.0, 4.0), (4.0, 16.0), (16.0, 16.0)] {
+            let d = crate::primitives::make_cylinder(topo, 1.5, 3.0).unwrap();
+            transform_solid(topo, d, &Mat4::translation(x, y, -1.0)).unwrap();
+            drills.push(d);
+        }
+        (base, drills)
+    };
+
+    let mut topo_seq = Topology::new();
+    let (base, drills) = make(&mut topo_seq);
+    let mut seq = base;
+    for &d in &drills {
+        seq = boolean(&mut topo_seq, BooleanOp::Cut, seq, d).unwrap();
+    }
+    let vol_seq = solid_volume(&topo_seq, seq, 0.05).unwrap();
+
+    let mut topo = Topology::new();
+    let (base, drills) = make(&mut topo);
+    let result =
+        crate::boolean::compound_cut(&mut topo, base, &drills, BooleanOptions::default()).unwrap();
+
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        (vol - vol_seq).abs() < 0.05,
+        "batched volume {vol} must match sequential {vol_seq}"
+    );
+    let faces = brepkit_topology::explorer::solid_faces(&topo, result).unwrap();
+    let cylinders = faces
+        .iter()
+        .filter(|&&f| topo.face(f).unwrap().surface().type_tag() == "cylinder")
+        .count();
+    assert!(
+        cylinders >= 4,
+        "each drilled bore must keep its cylinder wall, got {cylinders}"
+    );
+}
+
+#[test]
+fn compound_cut_overlapping_tools_stays_sequential_correct() {
+    // Two tools that overlap EACH OTHER must not take the batched shortcut's
+    // disjoint-merge assumption; whatever path runs, the result must equal
+    // the union-cut volume.
+    use crate::measure::solid_volume;
+    use crate::transform::transform_solid;
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let base = crate::primitives::make_box(&mut topo, 10.0, 10.0, 4.0).unwrap();
+    let t1 = crate::primitives::make_box(&mut topo, 4.0, 4.0, 6.0).unwrap();
+    transform_solid(&mut topo, t1, &Mat4::translation(2.0, 2.0, -1.0)).unwrap();
+    let t2 = crate::primitives::make_box(&mut topo, 4.0, 4.0, 6.0).unwrap();
+    transform_solid(&mut topo, t2, &Mat4::translation(4.0, 4.0, -1.0)).unwrap();
+
+    let result =
+        crate::boolean::compound_cut(&mut topo, base, &[t1, t2], BooleanOptions::default())
+            .unwrap();
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
+    // Union of the two 4×4 pockets overlapping in a 2×2 square: 16+16-4 = 28
+    // removed from the 10×10×4 slab (pockets span full height inside).
+    let expected = 400.0 - 28.0 * 4.0;
+    assert!(
+        (vol - expected).abs() < 0.1,
+        "expected {expected}, got {vol}"
+    );
+}
+
+#[test]
 fn fuse_six_disjoint_boxes_2x3_grid() {
     // Mirrors brepjs's `rectangularPattern() > creates a 2x3 grid` test:
     // 6 boxes of 5×5×5 at (col*10, row*10, 0), fused pairwise via


### PR DESCRIPTION
## Summary

`compound_cut` runs the full boolean pipeline against the whole target once per tool — O(target × tools). For **pairwise-disjoint** tools (the gridfinity magnet / screw drill patterns: 16–32 disjoint cylinders cut from one base plate) this is almost all redundant work: every cut re-paves and re-splits the same untouched base faces.

This PR adds a batched fast path: when every pair of tool AABBs (tolerance-expanded) is disjoint, merge the tools into one multi-piece solid (the disjoint-shell merge shortcut makes that essentially free — sub-millisecond) and cut **once**. Set-theoretically identical: A ∖ (T₁ ∪ T₂ ∪ …) ≡ (A ∖ T₁) ∖ T₂ ∖ ….

Guard rails:
- Tools whose AABBs touch or overlap each other keep the sequential loop (the merge there is a real fuse, and sequential behaviour is preserved bit-for-bit).
- Any failure in the merge or the batched cut falls back to the sequential loop (`log::debug` breadcrumb).
- The trailing `unify_faces` pass is unchanged and runs on either path's result.

## Measured

Captured 16-drill lite magnet pad (native, release):

| path | time | volume | free edges |
|---|---|---|---|
| sequential (before) | 8.41s | 11214.8185 | 0 |
| batched (after) | **0.71s** | 11214.8185 (exact match) | 0 |

Drilled bores stay analytic (cylinder walls preserved); trailing unify produces the same F=380 face census.

## Tests

- `compound_cut_disjoint_drills_matches_sequential` — differential: batched volume must equal the sequential loop's, bores stay cylinders.
- `compound_cut_overlapping_tools_stays_sequential_correct` — overlapping tools: exact union-cut volume (400 − 28·4).
- Existing `compound_cut_matches_sequential_4x4_grid` / `compound_cut_shelled_target_many_tools` now exercise the batched path and still pass.
- Full workspace tests + gridfinity canary green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch pairwise-disjoint tools in `compound_cut` into a single cut to avoid repeated boolean passes. Results match the sequential path; 16-drill case drops from 8.41s to 0.71s.

- **Performance**
  - Merge tools with disjoint AABBs, then cut once (A \ (T1 ∪ T2 …) equivalence).
  - Eliminates O(target × tools) work; disjoint-shell merge is near-free.
  - Verified identical volume and preserved analytic cylinder walls.

- **Safety**
  - Tolerance-expanded AABB check; touching/overlapping tools stay sequential (bit-for-bit).
  - Any merge/cut failure falls back to sequential; `unify_faces` unchanged.
  - Tests include disjoint-drill and overlap cases; differential compares raw cut paths with `unify_faces` off.

<sup>Written for commit 77753776ddc50904a6a26fd97310711e0ae5f04d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

