### PR TITLE
fix(algo): refine closed circle rims at mate-partition vertices in assembly

### DIFF
--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1854,11 +1854,14 @@ fn split_arc_edges_at_collinear_vertices(
 
     let mut replacements: HashMap<EdgeId, Vec<OrientedEdge>> = HashMap::new();
     for (eid, sv, ev, sp, ep, curve) in arc_edges {
-        // Skip closed (full) arcs: start ≈ end means the whole circle/ellipse,
-        // which has no proper interior to cut and is handled elsewhere.
-        if (ep - sp).length() < snap {
-            continue;
-        }
+        // A closed (full) circle/ellipse CAN be refined — at global vertices
+        // that lie on it — but only into 3+ sub-arcs. With a single interior
+        // cut the two halves share BOTH endpoints, and the endpoint-keyed
+        // duplicate merge below would conflate them into one arc. The mate
+        // side of a full rim is typically already split at the crossing
+        // vertices (e.g. a pad bore poking through inset walls), so matching
+        // its partition here is what lets the flood-fill pair the shells.
+        let is_closed = (ep - sp).length() < snap;
         // `snap` is a LINEAR tolerance (model units); the span / branch tests
         // below are in the curve's ANGULAR domain (radians). Convert via the
         // curve's radius scale (arc length ≈ radius·angle) so the angular guard
@@ -1935,7 +1938,7 @@ fn split_arc_edges_at_collinear_vertices(
             }
             cuts.push((a_branch, vid));
         }
-        if cuts.is_empty() {
+        if cuts.is_empty() || (is_closed && cuts.len() < 2) {
             continue;
         }
         // Total order: angle then vertex index (the `vert_at` HashMap iteration
@@ -2627,6 +2630,122 @@ mod tests {
             Some(true),
             "a standard outward cube shell must read outward (growth)"
         );
+    }
+
+    #[test]
+    fn closed_circle_splits_at_matching_mate_vertices() {
+        // A full-circle rim on one face vs the SAME circle split into three
+        // arcs on the mate face (a pad bore whose rim crosses other faces).
+        // The refinement must split the full circle at the mate's vertices so
+        // the duplicate merge can pair the two partitions.
+        use brepkit_math::curves::Circle3D;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::{Face, FaceSurface};
+        use brepkit_topology::wire::Wire;
+
+        let mut topo = Topology::new();
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 2.0).unwrap();
+        let plane = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+
+        // Face A: disc bounded by the full circle (one closed edge).
+        let seam = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(0.0),
+            1e-7,
+        ));
+        let full = topo.add_edge(Edge::new(seam, seam, EdgeCurve::Circle(circle.clone())));
+        let wire_a = topo.add_wire(Wire::new(vec![OrientedEdge::new(full, true)], true).unwrap());
+        let face_a = topo.add_face(Face::new(wire_a, vec![], plane.clone()));
+
+        // Face B: the same circle as three arcs split at 0, 2π/3, 4π/3.
+        let thirds = std::f64::consts::TAU / 3.0;
+        let v0 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(0.0),
+            1e-7,
+        ));
+        let v1 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(thirds),
+            1e-7,
+        ));
+        let v2 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(2.0 * thirds),
+            1e-7,
+        ));
+        let mut oes = Vec::new();
+        for (a, b) in [(v0, v1), (v1, v2), (v2, v0)] {
+            let e = topo.add_edge(Edge::new(a, b, EdgeCurve::Circle(circle.clone())));
+            oes.push(OrientedEdge::new(e, true));
+        }
+        let wire_b = topo.add_wire(Wire::new(oes, true).unwrap());
+        let face_b = topo.add_face(Face::new(wire_b, vec![], plane));
+
+        let mut face_ids = vec![face_a, face_b];
+        split_arc_edges_at_collinear_vertices(&mut topo, &mut face_ids).unwrap();
+        merge_duplicate_edges(&mut topo, &mut face_ids).unwrap();
+
+        let keys_a = face_edge_keys(&topo, face_ids[0]).unwrap();
+        let keys_b = face_edge_keys(&topo, face_ids[1]).unwrap();
+        assert_eq!(keys_a.len(), 3, "full circle must split into 3 arcs");
+        let mut ka = keys_a;
+        let mut kb = keys_b;
+        ka.sort_unstable();
+        kb.sort_unstable();
+        assert_eq!(ka, kb, "the two partitions must pair edge-for-edge");
+    }
+
+    #[test]
+    fn closed_circle_with_single_cut_vertex_stays_whole() {
+        // One interior cut would produce two arcs sharing BOTH endpoints —
+        // the endpoint-keyed merge would conflate them. The refinement must
+        // leave the circle whole in that case.
+        use brepkit_math::curves::Circle3D;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::{Face, FaceSurface};
+        use brepkit_topology::wire::Wire;
+
+        let mut topo = Topology::new();
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 2.0).unwrap();
+        let plane = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+        let seam = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(0.0),
+            1e-7,
+        ));
+        let full = topo.add_edge(Edge::new(seam, seam, EdgeCurve::Circle(circle.clone())));
+        let wire_a = topo.add_wire(Wire::new(vec![OrientedEdge::new(full, true)], true).unwrap());
+        let face_a = topo.add_face(Face::new(wire_a, vec![], plane.clone()));
+
+        // A lone vertex on the circle, referenced by an unrelated line edge.
+        let v_on = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(std::f64::consts::PI),
+            1e-7,
+        ));
+        let v_off = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            Point3::new(5.0, 5.0, 0.0),
+            1e-7,
+        ));
+        let line = topo.add_edge(Edge::new(v_on, v_off, EdgeCurve::Line));
+        let back = topo.add_edge(Edge::new(v_off, v_on, EdgeCurve::Line));
+        let wire_b = topo.add_wire(
+            Wire::new(
+                vec![OrientedEdge::new(line, true), OrientedEdge::new(back, true)],
+                true,
+            )
+            .unwrap(),
+        );
+        let face_b = topo.add_face(Face::new(wire_b, vec![], plane));
+
+        let mut face_ids = vec![face_a, face_b];
+        split_arc_edges_at_collinear_vertices(&mut topo, &mut face_ids).unwrap();
+
+        let keys_a = face_edge_keys(&topo, face_ids[0]).unwrap();
+        assert_eq!(keys_a.len(), 1, "single-cut circle must stay whole");
     }
 
     #[test]

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1880,8 +1880,18 @@ fn split_arc_edges_at_collinear_vertices(
             continue;
         }
         let angular_eps = snap / radius_scale;
-        // The arc's CCW angular span [a0, a1] with a1 > a0.
-        let (a0, a1) = curve.domain_with_endpoints(sp, ep);
+        // The arc's CCW angular span [a0, a1] with a1 > a0. For a CLOSED edge
+        // the endpoint-derived domain is the curve's intrinsic 0..TAU, but the
+        // replacement chain below starts at the edge's seam vertex — anchor
+        // the span at the seam's angle instead, or cuts sort in the intrinsic
+        // frame and the sub-arcs overlap past one revolution (seam at pi with
+        // cuts at pi/2 and 3pi/2 would sweep 4pi total).
+        let (a0, a1) = if is_closed {
+            let seam = project_angle_on_curve(&curve, sp);
+            (seam, seam + std::f64::consts::TAU)
+        } else {
+            curve.domain_with_endpoints(sp, ep)
+        };
         let span = a1 - a0;
         if span < angular_eps {
             continue;
@@ -2746,6 +2756,125 @@ mod tests {
 
         let keys_a = face_edge_keys(&topo, face_ids[0]).unwrap();
         assert_eq!(keys_a.len(), 1, "single-cut circle must stay whole");
+    }
+
+    #[test]
+    fn closed_circle_with_offset_seam_splits_into_single_revolution() {
+        // Seam at pi, cuts at pi/2 and 3pi/2: the sub-arc spans must be
+        // anchored at the seam, or they overlap past one revolution. The
+        // three arcs must partition the rim exactly (total sweep TAU) and
+        // pair with the mate's partition, which shares the seam vertex.
+        use brepkit_math::curves::Circle3D;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::{Face, FaceSurface};
+        use brepkit_topology::wire::Wire;
+
+        let mut topo = Topology::new();
+        let circle =
+            Circle3D::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 2.0).unwrap();
+        let plane = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+        let pi = std::f64::consts::PI;
+        let seam = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(pi),
+            1e-7,
+        ));
+        let full = topo.add_edge(Edge::new(seam, seam, EdgeCurve::Circle(circle.clone())));
+        let wire_a = topo.add_wire(Wire::new(vec![OrientedEdge::new(full, true)], true).unwrap());
+        let face_a = topo.add_face(Face::new(wire_a, vec![], plane.clone()));
+
+        let vs = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(pi),
+            1e-7,
+        ));
+        let v1 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(pi / 2.0),
+            1e-7,
+        ));
+        let v2 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            circle.evaluate(3.0 * pi / 2.0),
+            1e-7,
+        ));
+        let mut oes = Vec::new();
+        for (a, b) in [(vs, v2), (v2, v1), (v1, vs)] {
+            let e = topo.add_edge(Edge::new(a, b, EdgeCurve::Circle(circle.clone())));
+            oes.push(OrientedEdge::new(e, true));
+        }
+        let wire_b = topo.add_wire(Wire::new(oes, true).unwrap());
+        let face_b = topo.add_face(Face::new(wire_b, vec![], plane));
+
+        let mut face_ids = vec![face_a, face_b];
+        split_arc_edges_at_collinear_vertices(&mut topo, &mut face_ids).unwrap();
+        merge_duplicate_edges(&mut topo, &mut face_ids).unwrap();
+
+        let mut ka = face_edge_keys(&topo, face_ids[0]).unwrap();
+        let mut kb = face_edge_keys(&topo, face_ids[1]).unwrap();
+        assert_eq!(ka.len(), 3, "offset-seam circle must split into 3 arcs");
+        ka.sort_unstable();
+        kb.sort_unstable();
+        assert_eq!(ka, kb, "seam-anchored partitions must pair edge-for-edge");
+    }
+
+    #[test]
+    fn closed_ellipse_splits_at_matching_mate_vertices() {
+        use brepkit_math::curves::Ellipse3D;
+        use brepkit_topology::edge::{Edge, EdgeCurve};
+        use brepkit_topology::face::{Face, FaceSurface};
+        use brepkit_topology::wire::Wire;
+
+        let mut topo = Topology::new();
+        let ellipse = Ellipse3D::new(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            3.0,
+            1.5,
+        )
+        .unwrap();
+        let plane = FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        };
+        let seam = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            ellipse.evaluate(0.0),
+            1e-7,
+        ));
+        let full = topo.add_edge(Edge::new(seam, seam, EdgeCurve::Ellipse(ellipse.clone())));
+        let wire_a = topo.add_wire(Wire::new(vec![OrientedEdge::new(full, true)], true).unwrap());
+        let face_a = topo.add_face(Face::new(wire_a, vec![], plane.clone()));
+
+        let thirds = std::f64::consts::TAU / 3.0;
+        let v0 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            ellipse.evaluate(0.0),
+            1e-7,
+        ));
+        let v1 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            ellipse.evaluate(thirds),
+            1e-7,
+        ));
+        let v2 = topo.add_vertex(brepkit_topology::vertex::Vertex::new(
+            ellipse.evaluate(2.0 * thirds),
+            1e-7,
+        ));
+        let mut oes = Vec::new();
+        for (a, b) in [(v0, v1), (v1, v2), (v2, v0)] {
+            let e = topo.add_edge(Edge::new(a, b, EdgeCurve::Ellipse(ellipse.clone())));
+            oes.push(OrientedEdge::new(e, true));
+        }
+        let wire_b = topo.add_wire(Wire::new(oes, true).unwrap());
+        let face_b = topo.add_face(Face::new(wire_b, vec![], plane));
+
+        let mut face_ids = vec![face_a, face_b];
+        split_arc_edges_at_collinear_vertices(&mut topo, &mut face_ids).unwrap();
+        merge_duplicate_edges(&mut topo, &mut face_ids).unwrap();
+
+        let mut ka = face_edge_keys(&topo, face_ids[0]).unwrap();
+        let mut kb = face_edge_keys(&topo, face_ids[1]).unwrap();
+        assert_eq!(ka.len(), 3, "full ellipse must split into 3 arcs");
+        ka.sort_unstable();
+        kb.sort_unstable();
+        assert_eq!(ka, kb, "ellipse partitions must pair edge-for-edge");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Found while digging the `2×2 lite solid bin + magnet` export failure (bd=92 — newly *visible* because #1164 removed the timeout that used to mask it; the batched and sequential cut paths produce identical results, so this is a pre-existing chain failure, not a regression).

The chain's degrading op is the pad fuse: `fuse(hollowed cups F=236, magnet pad)`. The GFA aborted analytic assembly with **"open growth shell with 60 faces would be dropped"**. Root: the pad bore's bottom rim is a **full-circle edge** on the pad wall, while the mate side (the bore's bottom cap, where the pad pokes through the foot's inset walls) carries the *same* circle **already split into arcs** at 4 wall-crossing vertices. The assembly-stage arc refinement (`split_arc_edges_at_collinear_vertices`) skipped closed edges entirely, so the partitions never matched, `merge_duplicate_edges` (endpoint-keyed) couldn't pair them, and the flood-fill isolated the bottom-cap fragment in its own shell → open growth shell → mesh fallback.

## Fix

Closed circles/ellipses are now refined at global vertices lying on them — **but only into 3+ sub-arcs**. With a single interior cut, the two halves would share BOTH endpoints and the endpoint-keyed duplicate merge would conflate them into one arc, so that case keeps the existing skip. (Circle arcs evaluate CCW-from-start, not shorter-arc, so sub-arcs over π are safe.)

## Verified on the captured repro

- Before: assembly aborts (open 60-face growth shell), mesh fallback.
- After: the z=-5 bore rim pairs (4 crossing vertices), the isolated bottom-cap fragment merges into its growth shell, and assembly completes analytically. (The fuse still falls back at final validation for a *different*, downstream root — an unsplit periodic pad wall, the known cylinder-arrangement-rescue item — tracked separately with a 290ms captured repro.)

## Tests

- `closed_circle_splits_at_matching_mate_vertices` — full circle vs 3-arc mate: refinement + merge must pair the partitions edge-for-edge (fails without the fix).
- `closed_circle_with_single_cut_vertex_stays_whole` — the conflation guard: one on-circle vertex must NOT split.
- Full workspace tests + gridfinity canary green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines closed circle/ellipse rim edges at mate-partition vertices so analytic assembly can align arc partitions and keep shells connected. Anchors closed-rim cut ordering at the seam vertex to prevent overlapping sub-arcs when the seam is offset; avoids open-growth-shell aborts seen in the 2×2 lite solid bin + magnet fuse while preserving the single-cut case.

- **Bug Fixes**
  - Split closed circle/ellipse rims at on-curve vertices into 3+ arcs; skip the single-cut case.
  - Anchor the angular span at the edge’s seam angle so sub-arcs sweep one revolution and pair with the mate partition.
  - Added tests for 3-arc pairing, single-cut guard, offset-seam circles, and closed-ellipse splits.

<sup>Written for commit 37110e172fbc4d4d9fedfb606d0ae9065339742d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

