### PR TITLE
fix(algo): gate EF-IN pave blocks on surface deviation vs chord

### DIFF
--- a/crates/algo/src/pave_filler/fill_face_info.rs
+++ b/crates/algo/src/pave_filler/fill_face_info.rs
@@ -135,28 +135,34 @@ fn fill_section_sc(arena: &mut GfaArena) {
     }
 }
 
+/// Distance from `p` to the face's underlying surface (infinite extent).
+///
+/// Returns `None` when the measurement is not trustworthy: NURBS
+/// projection can silently fall back to a domain-midpoint guess on
+/// convergence failure, which would read as a huge distance and falsely
+/// reject a leaf that genuinely hugs the surface.
+fn dist_to_surface(
+    surface: &brepkit_topology::face::FaceSurface,
+    p: brepkit_math::vec::Point3,
+) -> Option<f64> {
+    use brepkit_topology::face::FaceSurface;
+    match surface {
+        FaceSurface::Plane { normal, d } => {
+            Some((normal.dot(brepkit_math::vec::Vec3::new(p.x(), p.y(), p.z())) - d).abs())
+        }
+        FaceSurface::Nurbs(_) => None,
+        other => other
+            .project_point(p)
+            .and_then(|(u, v)| other.evaluate(u, v))
+            .map(|q| (q - p).length()),
+    }
+}
+
 /// Edges from EF interference go into the face's `pave_blocks_in`.
 ///
 /// Only the leaf pave blocks adjacent to the crossing parameter are
 /// inserted — the rest of the edge lies outside the face and would feed
 /// out-of-face fragments into the splitter as degenerate inner wires.
-/// Distance from `p` to the face's underlying surface (infinite extent).
-fn dist_to_surface(
-    surface: &brepkit_topology::face::FaceSurface,
-    p: brepkit_math::vec::Point3,
-) -> f64 {
-    use brepkit_topology::face::FaceSurface;
-    match surface {
-        FaceSurface::Plane { normal, d } => {
-            (normal.dot(brepkit_math::vec::Vec3::new(p.x(), p.y(), p.z())) - d).abs()
-        }
-        other => other
-            .project_point(p)
-            .and_then(|(u, v)| other.evaluate(u, v))
-            .map_or(f64::INFINITY, |q| (q - p).length()),
-    }
-}
-
 fn fill_ef_in(topo: &Topology, arena: &mut GfaArena) {
     // Snapshot EF data
     let ef_data: Vec<_> = arena
@@ -212,8 +218,9 @@ fn fill_ef_in(topo: &Topology, arena: &mut GfaArena) {
             // and feeding it to the splitter plants off-surface section
             // edges whose pcurves collapse onto the boundary (the corner-
             // poking pad's cap-rim arcs on the wall planes). Keep a leaf
-            // only when it actually hugs the face's surface: both pave
-            // endpoints AND the curve midpoint within the weld band.
+            // only when it actually hugs the face's surface: the pave
+            // endpoints and interior curve samples must all sit within
+            // max(weld band, deviation-ratio × chord).
             let on_band = ON_SURFACE_BAND_FACTOR * brepkit_math::tolerance::Tolerance::new().linear;
             let surface = match topo.face(face_id) {
                 Ok(f) => f.surface().clone(),
@@ -239,14 +246,26 @@ fn fill_ef_in(topo: &Topology, arena: &mut GfaArena) {
                         return false;
                     };
                     let (t0, t1) = pb.parameter_range();
-                    let mid = edge
-                        .curve()
-                        .evaluate_with_endpoints(f64::midpoint(t0, t1), osp, oep);
-                    let ds = dist_to_surface(&surface, psv.point());
-                    let de = dist_to_surface(&surface, pev.point());
-                    let dm = dist_to_surface(&surface, mid);
+                    let span = t1 - t0;
+                    let interior = [0.25_f64, 0.5, 0.75].map(|f| {
+                        edge.curve()
+                            .evaluate_with_endpoints(f.mul_add(span, t0), osp, oep)
+                    });
+                    let mut dev: f64 = 0.0;
+                    for p in std::iter::once(psv.point())
+                        .chain(std::iter::once(pev.point()))
+                        .chain(interior)
+                    {
+                        match dist_to_surface(&surface, p) {
+                            Some(d) => dev = dev.max(d),
+                            // Untrustworthy measurement (NURBS projection can
+                            // silently return a wrong foot): keep the leaf —
+                            // the pre-gate behavior — rather than risk a
+                            // false drop.
+                            None => return true,
+                        }
+                    }
                     let chord = (pev.point() - psv.point()).length();
-                    let dev = ds.max(de).max(dm);
                     dev <= on_band.max(IN_FACE_MAX_DEVIATION_RATIO * chord)
                 })
                 .collect();

--- a/crates/algo/src/pave_filler/fill_face_info.rs
+++ b/crates/algo/src/pave_filler/fill_face_info.rs
@@ -23,6 +23,18 @@ use crate::error::AlgoError;
 /// just outside an adjacent block; this widens each interval by that much.
 const LEAF_PARAM_REL_EPS: f64 = 1e-9;
 
+/// Weld-band multiple of the arena tolerance for the EF-IN on-surface test
+/// (marched/fitted geometry sits up to ~100x linear tolerance off exact).
+const ON_SURFACE_BAND_FACTOR: f64 = 100.0;
+
+/// Maximum surface deviation of an EF-IN leaf as a fraction of its chord —
+/// a dimensionless crossing-angle gate. A grazing (near-tangential) contact
+/// hugs the surface (socket-loft corner arcs on box walls: 2-18% measured);
+/// a transversal crossing's adjacent leaves swing away linearly (corner-pad
+/// cap rims on the walls: 24-58% measured). Scale-free by design: absolute
+/// bands cannot separate the two classes.
+const IN_FACE_MAX_DEVIATION_RATIO: f64 = 0.2;
+
 /// Populate [`FaceInfo`] for all faces with their classified pave blocks.
 ///
 /// - `pave_blocks_on`: split boundary edges of each face
@@ -35,7 +47,7 @@ const LEAF_PARAM_REL_EPS: f64 = 1e-9;
 pub fn perform(topo: &Topology, arena: &mut GfaArena) -> Result<(), AlgoError> {
     fill_boundary_on(topo, arena)?;
     fill_section_sc(arena);
-    fill_ef_in(arena);
+    fill_ef_in(topo, arena);
     Ok(())
 }
 
@@ -128,7 +140,24 @@ fn fill_section_sc(arena: &mut GfaArena) {
 /// Only the leaf pave blocks adjacent to the crossing parameter are
 /// inserted — the rest of the edge lies outside the face and would feed
 /// out-of-face fragments into the splitter as degenerate inner wires.
-fn fill_ef_in(arena: &mut GfaArena) {
+/// Distance from `p` to the face's underlying surface (infinite extent).
+fn dist_to_surface(
+    surface: &brepkit_topology::face::FaceSurface,
+    p: brepkit_math::vec::Point3,
+) -> f64 {
+    use brepkit_topology::face::FaceSurface;
+    match surface {
+        FaceSurface::Plane { normal, d } => {
+            (normal.dot(brepkit_math::vec::Vec3::new(p.x(), p.y(), p.z())) - d).abs()
+        }
+        other => other
+            .project_point(p)
+            .and_then(|(u, v)| other.evaluate(u, v))
+            .map_or(f64::INFINITY, |q| (q - p).length()),
+    }
+}
+
+fn fill_ef_in(topo: &Topology, arena: &mut GfaArena) {
     // Snapshot EF data
     let ef_data: Vec<_> = arena
         .interference
@@ -178,8 +207,51 @@ fn fill_ef_in(arena: &mut GfaArena) {
                 }
                 None => leaves,
             };
+            // A leaf adjacent to a TRANSVERSAL crossing only touches the
+            // face at the crossing point — it does not "lie in" the face,
+            // and feeding it to the splitter plants off-surface section
+            // edges whose pcurves collapse onto the boundary (the corner-
+            // poking pad's cap-rim arcs on the wall planes). Keep a leaf
+            // only when it actually hugs the face's surface: both pave
+            // endpoints AND the curve midpoint within the weld band.
+            let on_band = ON_SURFACE_BAND_FACTOR * brepkit_math::tolerance::Tolerance::new().linear;
+            let surface = match topo.face(face_id) {
+                Ok(f) => f.surface().clone(),
+                Err(_) => continue,
+            };
+            let fi_selected: Vec<PaveBlockId> = selected
+                .into_iter()
+                .filter(|&leaf_id| {
+                    let Some(pb) = arena.pave_blocks.get(leaf_id) else {
+                        return false;
+                    };
+                    let Ok(edge) = topo.edge(pb.original_edge) else {
+                        return false;
+                    };
+                    let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
+                    else {
+                        return false;
+                    };
+                    let (osp, oep) = (sv.point(), ev.point());
+                    let (Ok(psv), Ok(pev)) =
+                        (topo.vertex(pb.start.vertex), topo.vertex(pb.end.vertex))
+                    else {
+                        return false;
+                    };
+                    let (t0, t1) = pb.parameter_range();
+                    let mid = edge
+                        .curve()
+                        .evaluate_with_endpoints(f64::midpoint(t0, t1), osp, oep);
+                    let ds = dist_to_surface(&surface, psv.point());
+                    let de = dist_to_surface(&surface, pev.point());
+                    let dm = dist_to_surface(&surface, mid);
+                    let chord = (pev.point() - psv.point()).length();
+                    let dev = ds.max(de).max(dm);
+                    dev <= on_band.max(IN_FACE_MAX_DEVIATION_RATIO * chord)
+                })
+                .collect();
             let fi = arena.face_info_mut(face_id);
-            for leaf_id in selected {
+            for leaf_id in fi_selected {
                 fi.pave_blocks_in.insert(leaf_id);
             }
         }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -6229,3 +6229,39 @@ fn fuse_multi_component_tool_folds_each_piece() {
     );
     assert_eq!(count_non_manifold_edges(&topo, result), 0);
 }
+
+#[test]
+fn fuse_corner_poking_cylinder_stays_analytic() {
+    // A cylinder overlapping a box corner: its cap rims cross both wall
+    // planes, and phase EF used to plant the crossing-adjacent rim arcs as
+    // "IN" pave blocks on the walls. Those off-surface sections (their
+    // pcurves collapse onto the wall boundary) broke one wall's greedy
+    // trace and the fuse fell back to the mesh path (all planes).
+    use crate::measure::solid_volume;
+    use crate::transform::transform_solid;
+    use brepkit_math::mat::Mat4;
+
+    let mut topo = Topology::new();
+    let plate = crate::primitives::make_box(&mut topo, 10.0, 10.0, 5.0).unwrap();
+    let pad = crate::primitives::make_cylinder(&mut topo, 3.0, 5.0).unwrap();
+    transform_solid(&mut topo, pad, &Mat4::translation(9.0, 9.0, 0.0)).unwrap();
+    let fused = boolean(&mut topo, BooleanOp::Fuse, plate, pad).unwrap();
+
+    let faces = brepkit_topology::explorer::solid_faces(&topo, fused).unwrap();
+    let curved = faces
+        .iter()
+        .filter(|&&f| topo.face(f).unwrap().surface().type_tag() == "cylinder")
+        .count();
+    assert!(
+        curved >= 2,
+        "the pad wall must stay a cylinder, got {curved} curved of {} faces",
+        faces.len()
+    );
+    let vol = solid_volume(&topo, fused, 0.05).unwrap();
+    // 500 (box) + the cylinder volume outside the box; analytic reference.
+    assert!(
+        (vol - 571.58).abs() < 0.5,
+        "union volume out of band: got {vol}"
+    );
+    assert_eq!(count_non_manifold_edges(&topo, fused), 0);
+}


### PR DESCRIPTION
## Summary

Second root from the `2×2 lite solid bin + magnet` dig (after #1166). `fill_ef_in` inserted the leaves adjacent to every edge-face crossing into the face's `pave_blocks_in` unconditionally. For a **transversal** crossing those leaves only touch the face at the crossing point — they do not lie in it. The splitter then receives off-surface section edges whose pcurves collapse onto the face boundary, and the greedy wire trace breaks.

Minimal repro (now a regression test): `box(10,10,5) ∪ cylinder(r=3,h=5)` overlapping the corner. The cylinder's cap-rim circles cross both wall planes; the crossing-adjacent rim arcs (including one entirely outside the box, through (12,9,0)) were planted on the walls as sections. One wall failed to split, and the fuse **silently degraded to the mesh path (all planes)**.

## Fix

Keep an EF-IN leaf only when it hugs the face surface: max deviation of its pave endpoints and true curve midpoint ≤ max(weld band, **20% of chord**). The ratio gate is dimensionless — a crossing-angle test:

| class | measured deviation/chord | verdict |
|---|---|---|
| grazing contacts the splitter needs (socket-loft corner arcs on box walls) | 2–18% | kept |
| transversal rim leaves (corner-pad case) | 24–58% | dropped |

An absolute band cannot separate these (the load-bearing grazing arcs sit 1.8e-2 off-plane; the bogus rim arcs 1.4–3.1): the first cut of this fix used a pure weld band and broke `fuse_shelled_box_with_socket_loft`, which is how both populations were measured.

## Results

- `fuse_corner_poking_cylinder_stays_analytic` (new): faces=12, curved=2, analytic volume 571.58, manifold — previously all-planes mesh fallback.
- `fuse_shelled_box_with_socket_loft` still analytic (the grazing class is preserved).
- Same mechanism confirmed on the captured solid-bin magnet-pad fuse: wall faces now receive only the true FF section (remaining pad-fuse fallback is the separate splitter-frontier item).
- ops 778 / algo 189 / gridfinity canary / full workspace green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate EF-IN pave blocks using a surface deviation-to-chord check to drop leaves from transversal crossings. Hardened the gate to avoid false drops and keep unions analytic.

- **Bug Fixes**
  - Gate now measures endpoints and interior curve samples (25%, 50%, 75%) and keeps the leaf only if all are within max(weld band ×100, 20% of chord); distance is exact for planes, projected for other surfaces, and NURBS reads are treated as untrustworthy so the leaf is kept to avoid false drops.
  - Adds regression test `fuse_corner_poking_cylinder_stays_analytic`; `fuse_shelled_box_with_socket_loft` stays analytic.

<sup>Written for commit 994bfe7c72e296c1d861b4aa741aa926bfb40b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

