### PR TITLE
perf(operations): cluster-batch overlapping compound_cut tools

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -840,23 +840,33 @@ pub fn compound_cut(
     tools: &[SolidId],
     opts: BooleanOptions,
 ) -> Result<SolidId, crate::OperationsError> {
-    // Batched fast path for pairwise-DISJOINT tools (a drill pattern): merge
-    // them into one multi-piece tool (the disjoint-shell merge shortcut makes
-    // that free) and cut ONCE. Sequential cutting re-runs the full GFA
-    // against the whole target per tool — O(target × tools); the lite
-    // magnet-drill pass was 8.4s sequential vs 0.75s batched for the exact
-    // same result volume. A ∖ (T₁ ∪ T₂ ∪ …) ≡ (A ∖ T₁) ∖ T₂ ∖ …, so the
-    // batch is semantically identical; restricting it to disjoint tools
-    // keeps the merged tool trivial and preserves the sequential path's
-    // behaviour for overlapping-tool inputs. Any failure falls back to the
+    // Batched fast path: merge the tools into one multi-piece solid and cut
+    // ONCE. Sequential cutting re-runs the full boolean pipeline against the
+    // whole target per tool — O(target × tools); the lite magnet-drill pass
+    // was 8.4s sequential vs 0.75s batched for the exact same result volume.
+    // A ∖ (T₁ ∪ T₂ ∪ …) ≡ (A ∖ T₁) ∖ T₂ ∖ …, so the batch is semantically
+    // identical. Tools are first grouped into AABB-overlap clusters
+    // (union-find): tools in one cluster get a real fuse (the coaxial
+    // magnet+screw drill pair), while the pairwise-disjoint cluster
+    // representatives merge via the free disjoint-shell shortcut. Batching
+    // needs ≥2 disjoint clusters — with everything in one overlapping blob
+    // the sequential loop is kept unchanged. Any failure falls back to the
     // sequential loop.
     let mut result = target;
     let mut batched = false;
-    if tools.len() >= 2 && tools_pairwise_disjoint(topo, tools) {
-        let merged = tools[1..]
-            .iter()
-            .try_fold(tools[0], |acc, &t| boolean(topo, BooleanOp::Fuse, acc, t));
-        if let Ok(tool) = merged
+    let clusters = cluster_tools_by_aabb(topo, tools);
+    if tools.len() >= 2 && clusters.as_ref().is_some_and(|c| c.len() >= 2) {
+        let clusters = clusters.unwrap_or_default();
+        let merged = clusters.iter().try_fold(None::<SolidId>, |acc, cluster| {
+            let fused = cluster[1..]
+                .iter()
+                .try_fold(cluster[0], |a, &t| boolean(topo, BooleanOp::Fuse, a, t))?;
+            match acc {
+                None => Ok(Some(fused)),
+                Some(prev) => boolean(topo, BooleanOp::Fuse, prev, fused).map(Some),
+            }
+        });
+        if let Ok(Some(tool)) = merged
             && let Ok(cut) = boolean(topo, BooleanOp::Cut, target, tool)
         {
             result = cut;
@@ -881,24 +891,40 @@ pub fn compound_cut(
     Ok(result)
 }
 
-/// True when every pair of tool AABBs (tolerance-expanded) is disjoint.
-fn tools_pairwise_disjoint(topo: &Topology, tools: &[SolidId]) -> bool {
+/// Group tools into AABB-overlap clusters (union-find over tolerance-
+/// expanded boxes). Tools within a cluster may interpenetrate; distinct
+/// clusters are pairwise disjoint. `None` when any AABB is unavailable.
+fn cluster_tools_by_aabb(topo: &Topology, tools: &[SolidId]) -> Option<Vec<Vec<SolidId>>> {
+    fn find(parent: &mut Vec<usize>, i: usize) -> usize {
+        if parent[i] != i {
+            let root = find(parent, parent[i]);
+            parent[i] = root;
+        }
+        parent[i]
+    }
     let tol = brepkit_math::tolerance::Tolerance::new().linear;
     let mut boxes = Vec::with_capacity(tools.len());
     for &t in tools {
-        match crate::measure::solid_bounding_box(topo, t) {
-            Ok(bb) => boxes.push(bb),
-            Err(_) => return false,
-        }
+        boxes.push(crate::measure::solid_bounding_box(topo, t).ok()?);
     }
+    let mut parent: Vec<usize> = (0..tools.len()).collect();
     for i in 0..boxes.len() {
         for j in (i + 1)..boxes.len() {
             if boxes[i].expanded(tol).intersects(boxes[j]) {
-                return false;
+                let (ri, rj) = (find(&mut parent, i), find(&mut parent, j));
+                if ri != rj {
+                    parent[ri] = rj;
+                }
             }
         }
     }
-    true
+    let mut clusters: std::collections::BTreeMap<usize, Vec<SolidId>> =
+        std::collections::BTreeMap::new();
+    for i in 0..tools.len() {
+        let root = find(&mut parent, i);
+        clusters.entry(root).or_default().push(tools[i]);
+    }
+    Some(clusters.into_values().collect())
 }
 
 /// Perform a boolean operation and return an [`crate::evolution::EvolutionMap`]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -6265,3 +6265,60 @@ fn fuse_corner_poking_cylinder_stays_analytic() {
     );
     assert_eq!(count_non_manifold_edges(&topo, fused), 0);
 }
+
+#[test]
+fn compound_cut_coaxial_pair_clusters_match_sequential() {
+    // The magnet+screw drill pattern: per position a wide shallow bore and a
+    // narrow through bore share an axis (they interpenetrate), and the four
+    // positions are disjoint from each other. The cluster-batched path must
+    // fuse each coaxial pair, cut once, and match the sequential volume with
+    // analytic bores.
+    use crate::measure::solid_volume;
+    use crate::transform::transform_solid;
+    use brepkit_math::mat::Mat4;
+
+    let make = |topo: &mut Topology| -> (SolidId, Vec<SolidId>) {
+        let base = crate::primitives::make_box(topo, 20.0, 20.0, 6.0).unwrap();
+        let mut drills = Vec::new();
+        for (x, y) in [(4.0, 4.0), (16.0, 4.0), (4.0, 16.0), (16.0, 16.0)] {
+            let magnet = crate::primitives::make_cylinder(topo, 2.0, 3.0).unwrap();
+            transform_solid(topo, magnet, &Mat4::translation(x, y, -1.0)).unwrap();
+            drills.push(magnet);
+            let screw = crate::primitives::make_cylinder(topo, 0.8, 8.0).unwrap();
+            transform_solid(topo, screw, &Mat4::translation(x, y, -1.0)).unwrap();
+            drills.push(screw);
+        }
+        (base, drills)
+    };
+
+    let mut topo_seq = Topology::new();
+    let (base, drills) = make(&mut topo_seq);
+    let mut seq = base;
+    for &d in &drills {
+        seq = boolean(&mut topo_seq, BooleanOp::Cut, seq, d).unwrap();
+    }
+    let vol_seq = solid_volume(&topo_seq, seq, 0.05).unwrap();
+
+    let opts = BooleanOptions {
+        unify_faces: false,
+        ..BooleanOptions::default()
+    };
+    let mut topo = Topology::new();
+    let (base, drills) = make(&mut topo);
+    let result = crate::boolean::compound_cut(&mut topo, base, &drills, opts).unwrap();
+    let vol = solid_volume(&topo, result, 0.05).unwrap();
+    assert!(
+        (vol - vol_seq).abs() < 0.05,
+        "cluster-batched volume {vol} must match sequential {vol_seq}"
+    );
+    let faces = brepkit_topology::explorer::solid_faces(&topo, result).unwrap();
+    let cylinders = faces
+        .iter()
+        .filter(|&&f| topo.face(f).unwrap().surface().type_tag() == "cylinder")
+        .count();
+    assert!(
+        cylinders >= 8,
+        "each stepped bore keeps both cylinder walls, got {cylinders}"
+    );
+    assert_eq!(count_non_manifold_edges(&topo, result), 0);
+}


### PR DESCRIPTION
## Summary

Follow-up to #1164. The batched `compound_cut` path required ALL tools pairwise disjoint, so the magnet-and-screw lite pattern — 32 drills forming 16 disjoint **coaxial pairs** (wide shallow magnet bore + narrow through screw bore per position) — declined batching entirely and paid 32 sequential full-pipeline cuts. That scenario currently misses its 30s budget by ~6s (36.1s on 2.127.20).

This generalizes the gate to **AABB-overlap clusters** (union-find over tolerance-expanded boxes):
- tools within a cluster get a real fuse (coaxial pair → stepped bore),
- the cluster results are pairwise disjoint by construction and merge via the free disjoint-shell shortcut,
- one cut against the target.

Batching still requires ≥2 disjoint clusters (a single all-overlapping blob keeps the sequential loop), and any failure along the batched path falls back to sequential, as before.

## Tests

- `compound_cut_coaxial_pair_clusters_match_sequential` (new) — 4 coaxial magnet+screw pairs: batched volume matches sequential, all 8 bore walls stay cylinders, manifold.
- All 15 existing compound_cut tests pass (the disjoint-drill differential and overlapping-tool cases now route through the cluster gate).
- ops 779 / algo 189 / gridfinity canary green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalizes `compound_cut` batching to support overlapping tools by clustering them via AABB overlap. This enables batching for magnet+screw drill patterns (coaxial pairs), avoiding 32 sequential cuts.

- **New Features**
  - Group tools into tolerance-expanded AABB clusters (union-find); fuse within each cluster, merge disjoint cluster results, then cut once.
  - Batching runs only with 2+ disjoint clusters; single-cluster inputs or any failure fall back to the sequential path.

<sup>Written for commit 1cddb8dbcf45f2778cc0d4826743f03f4e391c0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

