### PR TITLE
fix(algo): drop boundary-collinear line sections on plane faces

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -4686,6 +4686,43 @@ fn split_face_2d_impl(
             .collect()
     };
 
+    // Drop boundary-collinear section edges on plane faces: a section whose
+    // whole UV image lies ON the boundary polyline cannot partition the face
+    // interior (its endpoints already split the boundary edges), but its twin
+    // pair double-covers the boundary segment and derails the angular walker
+    // (the pad bottom-cap chord riding the inset wall's bottom edge left the
+    // wall unsplit at both true crossings).
+    let all_edges: Vec<OrientedPCurveEdge> = if is_plane && !u_periodic && !v_periodic {
+        let boundary_poly = sample_wire_loop_uv(&all_edges[..n_boundary_edges]);
+        let eps = tol.linear * 10.0;
+        let n_b = n_boundary_edges;
+        all_edges
+            .into_iter()
+            .enumerate()
+            .filter(|(i, e)| {
+                if *i < n_b {
+                    return true;
+                }
+                // Only straight (Line-pcurve) sections can be fully
+                // boundary-collinear without interior evidence; arcs bulge
+                // and are kept. Probe endpoints + chord midpoint.
+                if !matches!(e.pcurve, brepkit_math::curves2d::Curve2D::Line(_)) {
+                    return true;
+                }
+                let mid = Point2::new(
+                    f64::midpoint(e.start_uv.x(), e.end_uv.x()),
+                    f64::midpoint(e.start_uv.y(), e.end_uv.y()),
+                );
+                ![e.start_uv, e.end_uv, mid].iter().all(|&p| {
+                    super::classify_2d::distance_to_polygon_boundary(p, &boundary_poly) <= eps
+                })
+            })
+            .map(|(_, e)| e)
+            .collect()
+    } else {
+        all_edges
+    };
+
     // Build wire loops via angular-sorting traversal.
     let mut loops = build_wire_loops(&all_edges, tol.linear, u_periodic, v_periodic);
 

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -4693,7 +4693,10 @@ fn split_face_2d_impl(
     // (the pad bottom-cap chord riding the inset wall's bottom edge left the
     // wall unsplit at both true crossings).
     let all_edges: Vec<OrientedPCurveEdge> = if is_plane && !u_periodic && !v_periodic {
-        let boundary_poly = sample_wire_loop_uv(&all_edges[..n_boundary_edges]);
+        // Via-frame sampling: stored pcurves fold on reversed boundary arcs
+        // (two orientation conventions coexist), which would corrupt the
+        // polygon and mis-measure every distance below.
+        let boundary_poly = sample_wire_loop_uv_via_frame(&all_edges[..n_boundary_edges], frame);
         let eps = tol.linear * 10.0;
         let n_b = n_boundary_edges;
         all_edges
@@ -4705,15 +4708,19 @@ fn split_face_2d_impl(
                 }
                 // Only straight (Line-pcurve) sections can be fully
                 // boundary-collinear without interior evidence; arcs bulge
-                // and are kept. Probe endpoints + chord midpoint.
+                // and are kept. Probe nine points along the chord — a
+                // splitter across a concave region keeps interior evidence
+                // at some interior fraction.
                 if !matches!(e.pcurve, brepkit_math::curves2d::Curve2D::Line(_)) {
                     return true;
                 }
-                let mid = Point2::new(
-                    f64::midpoint(e.start_uv.x(), e.end_uv.x()),
-                    f64::midpoint(e.start_uv.y(), e.end_uv.y()),
-                );
-                ![e.start_uv, e.end_uv, mid].iter().all(|&p| {
+                let (s, t) = (e.start_uv, e.end_uv);
+                !(0..=8).all(|k| {
+                    let f = f64::from(k) / 8.0;
+                    let p = Point2::new(
+                        f.mul_add(t.x() - s.x(), s.x()),
+                        f.mul_add(t.y() - s.y(), s.y()),
+                    );
                     super::classify_2d::distance_to_polygon_boundary(p, &boundary_poly) <= eps
                 })
             })

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -727,7 +727,7 @@ pub fn boolean(
                 }
             }
             log::warn!(
-                "GFA result failed validation in {:.1}ms (faces={result_faces}, \
+                "GFA result not accepted in {:.1}ms (faces={result_faces}, \
                  validate={:?}), falling back",
                 timer_elapsed_ms(gfa_start),
                 validate_boolean_result(topo, result).err()

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -727,8 +727,10 @@ pub fn boolean(
                 }
             }
             log::warn!(
-                "GFA result failed validation in {:.1}ms (faces={result_faces}), falling back",
-                timer_elapsed_ms(gfa_start)
+                "GFA result failed validation in {:.1}ms (faces={result_faces}, \
+                 validate={:?}), falling back",
+                timer_elapsed_ms(gfa_start),
+                validate_boolean_result(topo, result).err()
             );
         }
         Err(e) => {


### PR DESCRIPTION
## Summary

Step 3 of the solid-bin+magnet pad-fuse dig (after #1166, #1168). The foot inset wall faces (1.4mm bands the magnet pad pokes through) receive three sections: two legitimate vertical splitters and the pad bottom-cap **chord that rides exactly ON the wall's bottom boundary edge**. The boundary-collinear twin pair double-covers that boundary segment and derails the angular wire walker: both walls stayed UNSPLIT at their true crossings (3 sections → 1 sub-face).

## Fix

In `split_face_2d` on plane (non-periodic) faces, drop section edges whose whole UV image lies on the boundary polyline — their endpoints already split the boundary edges, so they carry no partition information. Guard rails:

- **Line-pcurve sections only**: an arc between boundary-collinear endpoints bulges into the interior and is kept.
- Probes = both UV endpoints **and the chord midpoint** (a boundary-to-boundary splitter has both endpoints on the boundary; the midpoint is its interior evidence).

Verified on the captured repro: both inset walls now split into the correct 3-rung ladder (`3 sections → 3 sub-faces`). The overall pad fuse still falls back on the remaining curved-face roots (unsplit pad cylinder wall + corner NURBS web — 11 free edges, tracked as the splitter frontier with a fresh minimal repro: `box ∪ mid-wall-poking cylinder`), so no end-to-end scenario flips yet; this removes one of the three stacked roots.

Also: the GFA fallback warn now includes the `validate_boolean_result` error detail — "failed validation" alone hid which gate (free edges vs non-manifold vs Euler) rejected the result.

## Tests

algo 189 / ops 779 / gridfinity canary / io fixture tests / clippy green (filter is regression-neutral across all suites; corner-poking and socket-loft fuses unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes face splitting on plane faces by dropping boundary‑collinear line sections so boundary segments aren’t double‑covered. This restores correct partitioning in the magnet pad fuse; the inset walls now split into the expected three sub‑faces.

- **Bug Fixes**
  - On plane, non‑periodic faces, filter section edges whose UV chord lies entirely on the boundary polygon (Line p‑curves only). The boundary is sampled via the plane frame, and nine chord fractions are probed to keep splitters with interior evidence over concave regions.
  - GFA fallback log now says "not accepted" and includes `validate_boolean_result` error details for faster diagnosis.

<sup>Written for commit 79bb1417fceb9c56254c09a7300d595caad8c42b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

