### PR TITLE
fix(algo): keep chord crossings at a closed rim's seam angle

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2187,6 +2187,7 @@ fn arc_segment_crossings(
     curve: &EdgeCurve,
     edge_start: Point3,
     edge_end: Point3,
+    closed: bool,
     line_start: Point3,
     line_end: Point3,
     tol: f64,
@@ -2216,11 +2217,12 @@ fn arc_segment_crossings(
         d.min(std::f64::consts::TAU - d)
     };
     let span = ang_dist(a_start, a_end);
-    // A CLOSED rim edge covers the whole circle: every hit is on the arc.
-    // Without this, the major-arc complement filter below excludes a hit
-    // that lands exactly at the seam angle (dsa + dae = 0), losing one of a
-    // cap disc's two chord crossings and with it the cap's half-disc split.
-    if (edge_start - edge_end).length() < tol * 100.0 && span < 1e-6 {
+    // A CLOSED rim edge (vertex identity, per the caller) covers the whole
+    // circle: every hit is on the arc. Without this, the major-arc
+    // complement filter below excludes a hit that lands exactly at the seam
+    // angle (dsa + dae = 0), losing one of a cap disc's two chord crossings
+    // and with it the cap's half-disc split.
+    if closed {
         return hits;
     }
     // `a` is on the arc iff dist(start,a)+dist(a,end) ≈ the arc span that
@@ -2307,7 +2309,7 @@ fn clip_line_to_face_boundary(
         // chord crossing the existing cases rely on — it only reaches farther
         // out when the arc genuinely does. Arcs the line misses contribute
         // nothing (the lip-cut sections that graze a corner chord keep working).
-        if let Some((curve, asp, aep, _)) = &boundary_arcs[seg_idx] {
+        if let Some((curve, asp, aep, closed)) = &boundary_arcs[seg_idx] {
             // Intersect the arc with the EXTENDED line, not just the segment: a
             // section whose FF-clipped endpoint lies in the sliver between a
             // convex arc and its chord (the slot walls crossing a socket-edge
@@ -2318,7 +2320,8 @@ fn clip_line_to_face_boundary(
             // original segment, so extension can never grow the section.
             let ext_start = line_start - line_dir;
             let ext_end = line_end + line_dir;
-            let arc_hits = arc_segment_crossings(curve, *asp, *aep, ext_start, ext_end, tol);
+            let arc_hits =
+                arc_segment_crossings(curve, *asp, *aep, *closed, ext_start, ext_end, tol);
             for (p, _) in arc_hits {
                 let t = (p - line_start).dot(line_dir) / (line_len * line_len);
                 crossings_ext.push(t);
@@ -3189,6 +3192,7 @@ mod tests {
             &EdgeCurve::Circle(circle),
             seam,
             seam,
+            true,
             Point3::new(20.0, 10.0, 0.0),
             Point3::new(0.0, 10.0, 0.0),
             1e-7,

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -2216,6 +2216,13 @@ fn arc_segment_crossings(
         d.min(std::f64::consts::TAU - d)
     };
     let span = ang_dist(a_start, a_end);
+    // A CLOSED rim edge covers the whole circle: every hit is on the arc.
+    // Without this, the major-arc complement filter below excludes a hit
+    // that lands exactly at the seam angle (dsa + dae = 0), losing one of a
+    // cap disc's two chord crossings and with it the cap's half-disc split.
+    if (edge_start - edge_end).length() < tol * 100.0 && span < 1e-6 {
+        return hits;
+    }
     // `a` is on the arc iff dist(start,a)+dist(a,end) ≈ the arc span that
     // contains the midpoint. Validate the midpoint satisfies this first so a
     // degenerate (near-full) circle doesn't admit everything.
@@ -3159,5 +3166,39 @@ mod clip_tests {
             1e-7,
         );
         assert!(out.is_none());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use brepkit_math::curves::Circle3D;
+    use brepkit_math::vec::Vec3;
+
+    #[test]
+    fn closed_rim_chord_crossing_keeps_seam_angle_hit() {
+        // A diameter chord of a closed cap rim crosses it twice; one of the
+        // crossings lands exactly at the rim's seam angle. The closed-rim
+        // path must keep BOTH (the major-arc complement filter used to drop
+        // the seam-angle hit, costing the cap its half-disc split).
+        let circle =
+            Circle3D::new(Point3::new(10.0, 10.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+        let seam = brepkit_math::traits::ParametricCurve::evaluate(&circle, 0.0);
+        let hits = arc_segment_crossings(
+            &EdgeCurve::Circle(circle),
+            seam,
+            seam,
+            Point3::new(20.0, 10.0, 0.0),
+            Point3::new(0.0, 10.0, 0.0),
+            1e-7,
+        );
+        assert_eq!(hits.len(), 2, "both chord crossings must survive");
+        let xs: Vec<f64> = hits.iter().map(|(p, _)| p.x()).collect();
+        assert!(
+            xs.iter().any(|&x| (x - 13.0).abs() < 1e-6)
+                && xs.iter().any(|&x| (x - 7.0).abs() < 1e-6),
+            "expected crossings at x=7 and x=13, got {xs:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Found while digging the last lightweight failure's frontier (the mid-wall poking-cylinder repro). `arc_segment_crossings` classifies circle-line hits against the boundary arc's angular span. For a **CLOSED rim edge** (start == end at the seam vertex) the span is zero, the midpoint lands on the "complement" branch, and the major-arc filter — `dsa + dae > 1e-9` — excludes any hit landing **exactly at the seam angle** (its angular distance sum is 0).

Consequence: a cap disc crossed by a chord passing through its seam point lost one of its two rim crossings, `clip_line_to_face_boundary` saw a single-crossing miss and returned `None`, and the cap never split into its half-discs — one of the stacked roots that keeps the box ∪ mid-wall-cylinder fuse (and the solid-bin magnet-pad fuse family) on the mesh-fallback path.

## Fix

A closed rim covers the whole circle, so every intersection is on the arc: detect the closed case (coincident endpoints + zero angular span) and return the hits unfiltered.

## Tests

- `closed_rim_chord_crossing_keeps_seam_angle_hit` — diameter chord through the seam of a closed r=3 rim must yield BOTH crossings (x=7 and x=13). Fails on main (1 hit).
- algo 190 / ops 779 / gridfinity canary / io fixture tests / clippy green.

Note: the mid-wall repro still falls back overall (the cylinder-strip sector split is the remaining frontier, tracked in the state notes with a parked WIP branch) — but it now fails SAFE with the caps correctly split, and the fix applies engine-wide to every cap-chord configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chord/arc intersections on closed rim edges so seam-angle hits are kept. Uses topological closedness to keep both crossings and restore correct cap splitting when a chord passes through a closed rim’s seam.

- **Bug Fixes**
  - In `arc_segment_crossings`, take a `closed` flag from the caller and, when true, return hits unfiltered; short open arcs with near-coincident endpoints still use angular-span filtering.
  - Threaded `closed` through boundary clipping and added `closed_rim_chord_crossing_keeps_seam_angle_hit` to verify both crossings are preserved.

<sup>Written for commit 1d02de45d739046e69c5763dbf17bca19c926a75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

