### PR TITLE
fix(algo): SD midpoint discriminator + sector rescue for under-split periodic strips

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -3850,26 +3850,6 @@ fn split_face_2d_impl(
         return bands;
     }
 
-    // Sector shortcut: full-height ruling sections (u = const lines) split a
-    // u-periodic lateral into angular sectors, with the seam as one more cut
-    // (a wall plane crossing the cylinder; the ruling that coincides with
-    // the seam is supplied by the seam itself).
-    if u_periodic
-        && !is_plane
-        && original_inner_wires.is_empty()
-        && let Some(sectors) = split_periodic_face_into_sectors(
-            &surface,
-            &boundary_edges,
-            sections,
-            rank,
-            reversed,
-            face_id,
-            tol.linear,
-        )
-    {
-        return sectors;
-    }
-
     // Internal section edge shortcut: when section edges form closed loops
     // entirely within the face (not connecting to boundary edges), the wire
     // builder struggles with periodic UV and 4-way junctions. Instead, group
@@ -4949,6 +4929,30 @@ fn split_face_2d_impl(
     let greedy_broken = wire_loops_self_cross(&loops, tol.linear)
         || greedy_outer_loops_nested(&loops, cw_loops)
         || wire_loops_have_degenerate_area(&loops, tol.linear);
+    // Sector rescue for an UNDER-split u-periodic lateral: one full-height
+    // ruling plus the glued seam should sector the strip, but to the glued
+    // walker an annulus cut once is a single wrapped region (the mid-wall
+    // pad whose second wall crossing rides the seam). Fires only when the
+    // greedy produced no split at all, so configs the greedy handles (all
+    // rulings in-face) never take this path.
+    if u_periodic
+        && !v_periodic
+        && loops.len() <= 1
+        && !sections.is_empty()
+        && matches!(&surface, FaceSurface::Cylinder(_))
+        && original_inner_wires.is_empty()
+        && let Some(sectors) = split_periodic_face_into_sectors(
+            &surface,
+            &all_edges[..n_boundary_edges],
+            sections,
+            rank,
+            reversed,
+            face_id,
+            tol.linear,
+        )
+    {
+        return sectors;
+    }
     if u_periodic
         && !v_periodic
         && !sections.is_empty()

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -39,7 +39,8 @@ use edge_splitting::{
 use sampling::{sample_wire_loop_uv, sample_wire_loop_uv_periodic, sample_wire_loop_uv_via_frame};
 use special_cases::{
     split_face_with_internal_loops, split_noseam_face_direct, split_periodic_face_into_bands,
-    split_torus_band_by_arrangement, try_split_crossing_plane_face, try_split_disk_by_chords,
+    split_periodic_face_into_sectors, split_torus_band_by_arrangement,
+    try_split_crossing_plane_face, try_split_disk_by_chords,
 };
 
 /// Number of probe points (plus one for the closing sample) walked along a
@@ -3847,6 +3848,26 @@ fn split_face_2d_impl(
         )
     {
         return bands;
+    }
+
+    // Sector shortcut: full-height ruling sections (u = const lines) split a
+    // u-periodic lateral into angular sectors, with the seam as one more cut
+    // (a wall plane crossing the cylinder; the ruling that coincides with
+    // the seam is supplied by the seam itself).
+    if u_periodic
+        && !is_plane
+        && original_inner_wires.is_empty()
+        && let Some(sectors) = split_periodic_face_into_sectors(
+            &surface,
+            &boundary_edges,
+            sections,
+            rank,
+            reversed,
+            face_id,
+            tol.linear,
+        )
+    {
+        return sectors;
     }
 
     // Internal section edge shortcut: when section edges form closed loops

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1144,9 +1144,13 @@ pub(super) fn split_periodic_face_into_sectors(
     // Vertical edge (ruling or seam) at relative angle `u_rel`, oriented
     // bottom -> top when `up`, top -> bottom otherwise.
     let mk_vertical = |u_rel: f64, up: bool| -> Option<OrientedPCurveEdge> {
-        let u = (seam_u + u_rel).rem_euclid(TAU);
-        let pa = surface.evaluate(u, v_bot)?;
-        let pb = surface.evaluate(u, v_top)?;
+        // 3D evaluation wraps the angle; the UV coordinate stays UNWRAPPED
+        // (seam_u + u_rel) so it agrees with the rim arcs' monotone pcurves
+        // at the u_rel = TAU boundary.
+        let u3 = (seam_u + u_rel).rem_euclid(TAU);
+        let u = seam_u + u_rel;
+        let pa = surface.evaluate(u3, v_bot)?;
+        let pb = surface.evaluate(u3, v_top)?;
         let (s3, e3, vs, ve) = if up {
             (pa, pb, v_bot, v_top)
         } else {
@@ -1193,6 +1197,16 @@ pub(super) fn split_periodic_face_into_sectors(
         let (from, to) = if ccw { (a_rel, b_rel) } else { (b_rel, a_rel) };
         let pa = surface.evaluate((seam_u + from).rem_euclid(TAU), v)?;
         let pb = surface.evaluate((seam_u + to).rem_euclid(TAU), v)?;
+        // A stored arc edge spans the CCW range of ITS OWN circle frame from
+        // start to end; a traversal running against that frame must carry
+        // forward=false so emission un-swaps the vertices (otherwise the
+        // edge flips to the complementary arc). The rims' circle frames need
+        // not agree with the surface +u direction, so compare tangents.
+        let step = if to > from { 1e-4 } else { -1e-4 };
+        let near = surface.evaluate((seam_u + from + step).rem_euclid(TAU), v)?;
+        let traversal_tan = near - pa;
+        let circle_tan = circle.tangent(circle.project(pa));
+        let forward = traversal_tan.dot(circle_tan) > 0.0;
         let dir = Vec2::new(if to > from { 1.0 } else { -1.0 }, 0.0);
         let pcurve = Curve2D::Line(Line2D::new(Point2::new(seam_u + from, v), dir).ok()?);
         Some(OrientedPCurveEdge {
@@ -1202,7 +1216,7 @@ pub(super) fn split_periodic_face_into_sectors(
             end_uv: Point2::new(seam_u + to, v),
             start_3d: pa,
             end_3d: pb,
-            forward: true,
+            forward,
             source_edge_idx: None,
             pave_block_id: None,
         })

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1027,6 +1027,240 @@ pub(super) fn split_periodic_face_into_bands(
     Some(bands)
 }
 
+/// Split a u-periodic face (cylinder lateral) into angular SECTORS at its
+/// full-height ruling sections (u = const lines from rim to rim).
+///
+/// The dual of [`split_periodic_face_into_bands`]: rulings partition the
+/// strip angularly, with the seam as one more cut (a wall plane crossing the
+/// cylinder yields two rulings; when one of them coincides with the seam its
+/// per-face section copy is boundary-collinear and dropped, and the seam
+/// itself supplies that cut). Each sector is bounded by a bottom rim arc, a
+/// ruling (or seam) up, a top rim arc back, and a ruling (or seam) down. Rim
+/// arcs are emitted as sub-arcs of the boundary circles; the assembly-stage
+/// closed-rim refinement pairs them with the cap sides.
+///
+/// Preconditions (returns `None` so the caller can fall back otherwise):
+/// - surface is a cylinder
+/// - boundary is exactly 2 closed circle edges plus seam Line edges at one u
+/// - every section is a straight Line with one endpoint on each rim at the
+///   same u (a ruling); at least one ruling not coincident with the seam
+#[allow(clippy::too_many_lines)]
+pub(super) fn split_periodic_face_into_sectors(
+    surface: &FaceSurface,
+    boundary_edges: &[OrientedPCurveEdge],
+    sections: &[SectionEdge],
+    rank: Rank,
+    reversed: bool,
+    face_id: FaceId,
+    tol: f64,
+) -> Option<Vec<SplitSubFace>> {
+    use brepkit_math::curves2d::{Curve2D, Line2D};
+    use brepkit_math::vec::{Point2, Vec2};
+    use std::f64::consts::{PI, TAU};
+
+    if !matches!(surface, FaceSurface::Cylinder(_)) {
+        return None;
+    }
+    let close_tol = tol * 100.0;
+
+    let mut boundary_circles: Vec<&OrientedPCurveEdge> = Vec::new();
+    let mut seam_edges: Vec<&OrientedPCurveEdge> = Vec::new();
+    for e in boundary_edges {
+        let is_closed = (e.start_3d - e.end_3d).length() < close_tol;
+        match (&e.curve_3d, is_closed) {
+            (EdgeCurve::Circle(_), true) => boundary_circles.push(e),
+            (EdgeCurve::Line, false) => seam_edges.push(e),
+            _ => return None,
+        }
+    }
+    if boundary_circles.len() != 2 || seam_edges.is_empty() {
+        return None;
+    }
+
+    let (seam_u, _) = surface.project_point(seam_edges[0].start_3d)?;
+    for e in &seam_edges {
+        for p in [e.start_3d, e.end_3d] {
+            let (u, _) = surface.project_point(p)?;
+            let du = (u - seam_u + PI).rem_euclid(TAU) - PI;
+            if du.abs() > 1e-6 {
+                return None;
+            }
+        }
+    }
+
+    let rim_v = |e: &OrientedPCurveEdge| -> Option<f64> {
+        let (_, v) = surface.project_point(e.start_3d)?;
+        Some(v)
+    };
+    let v0 = rim_v(boundary_circles[0])?;
+    let v1 = rim_v(boundary_circles[1])?;
+    let (v_bot, bot_edge, v_top, top_edge) = if v0 < v1 {
+        (v0, boundary_circles[0], v1, boundary_circles[1])
+    } else {
+        (v1, boundary_circles[1], v0, boundary_circles[0])
+    };
+    if v_top - v_bot < close_tol {
+        return None;
+    }
+
+    // Collect the rulings: each section must be a Line from one rim to the
+    // other at a single u — stored as (u relative to the seam, section).
+    let mut rulings: Vec<(f64, SectionEdge)> = Vec::new();
+    for sec in sections {
+        if !matches!(sec.curve_3d, EdgeCurve::Line) {
+            return None;
+        }
+        let (us, vs) = surface.project_point(sec.start)?;
+        let (ue, ve) = surface.project_point(sec.end)?;
+        let du = (us - ue + PI).rem_euclid(TAU) - PI;
+        if du.abs() > 1e-6 {
+            return None;
+        }
+        let (v_lo, v_hi) = if vs < ve { (vs, ve) } else { (ve, vs) };
+        if (v_lo - v_bot).abs() > close_tol || (v_hi - v_top).abs() > close_tol {
+            return None;
+        }
+        let u_rel = (us - seam_u).rem_euclid(TAU);
+        // A ruling riding the seam adds no cut beyond the seam itself.
+        if u_rel < 1e-6 || (TAU - u_rel) < 1e-6 {
+            continue;
+        }
+        rulings.push((u_rel, sec.clone()));
+    }
+    if rulings.is_empty() {
+        return None;
+    }
+    rulings.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    if rulings.windows(2).any(|w| w[1].0 - w[0].0 < 1e-6) {
+        return None;
+    }
+
+    // Cut positions CCW from the seam (u_rel = 0), wrapping back to TAU.
+    let mut cuts: Vec<f64> = Vec::with_capacity(rulings.len() + 2);
+    cuts.push(0.0);
+    cuts.extend(rulings.iter().map(|r| r.0));
+    cuts.push(TAU);
+
+    // Vertical edge (ruling or seam) at relative angle `u_rel`, oriented
+    // bottom -> top when `up`, top -> bottom otherwise.
+    let mk_vertical = |u_rel: f64, up: bool| -> Option<OrientedPCurveEdge> {
+        let u = (seam_u + u_rel).rem_euclid(TAU);
+        let pa = surface.evaluate(u, v_bot)?;
+        let pb = surface.evaluate(u, v_top)?;
+        let (s3, e3, vs, ve) = if up {
+            (pa, pb, v_bot, v_top)
+        } else {
+            (pb, pa, v_top, v_bot)
+        };
+        let dir = Vec2::new(0.0, if up { 1.0 } else { -1.0 });
+        let pcurve = Curve2D::Line(Line2D::new(Point2::new(u, vs), dir).ok()?);
+        // Reuse the matching ruling's pave block so cross-face edge sharing
+        // works through resolve_edge_vertices (seam verticals have none).
+        let pb_id = rulings
+            .iter()
+            .find(|r| (r.0 - u_rel).abs() < 1e-9)
+            .and_then(|r| r.1.pave_block_id);
+        Some(OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Line,
+            pcurve,
+            start_uv: Point2::new(u, vs),
+            end_uv: Point2::new(u, ve),
+            start_3d: s3,
+            end_3d: e3,
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: pb_id,
+        })
+    };
+
+    // Rim arc between two relative angles at height `v`, traversed CCW when
+    // `ccw` (bottom rim of an outward cylinder) and CW otherwise. UV runs on
+    // the unwrapped angle so each sector's pcurve segment stays monotone.
+    let rim_circle = |e: &OrientedPCurveEdge| -> Option<brepkit_math::curves::Circle3D> {
+        match &e.curve_3d {
+            EdgeCurve::Circle(c) => Some(c.clone()),
+            _ => None,
+        }
+    };
+    let bot_circle = rim_circle(bot_edge)?;
+    let top_circle = rim_circle(top_edge)?;
+    let mk_arc = |circle: &brepkit_math::curves::Circle3D,
+                  v: f64,
+                  a_rel: f64,
+                  b_rel: f64,
+                  ccw: bool|
+     -> Option<OrientedPCurveEdge> {
+        let (from, to) = if ccw { (a_rel, b_rel) } else { (b_rel, a_rel) };
+        let pa = surface.evaluate((seam_u + from).rem_euclid(TAU), v)?;
+        let pb = surface.evaluate((seam_u + to).rem_euclid(TAU), v)?;
+        let dir = Vec2::new(if to > from { 1.0 } else { -1.0 }, 0.0);
+        let pcurve = Curve2D::Line(Line2D::new(Point2::new(seam_u + from, v), dir).ok()?);
+        Some(OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Circle(circle.clone()),
+            pcurve,
+            start_uv: Point2::new(seam_u + from, v),
+            end_uv: Point2::new(seam_u + to, v),
+            start_3d: pa,
+            end_3d: pb,
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: None,
+        })
+    };
+
+    // Sector loop orientation must match the original boundary traversal:
+    // the bottom rim's traversal direction at the seam decides whether the
+    // sector floor runs CCW (+u) or CW (-u).
+    let bot_tangent = {
+        let c = &bot_circle;
+        let t = c.tangent(c.project(bot_edge.start_3d));
+        if bot_edge.forward { t } else { -t }
+    };
+    let du_dir = {
+        // Surface partial in +u at the seam/bottom corner.
+        let p0 = surface.evaluate(seam_u, v_bot)?;
+        let p1 = surface.evaluate(seam_u + 1e-4, v_bot)?;
+        (p1 - p0).normalize().ok()?
+    };
+    let floor_ccw = bot_tangent.dot(du_dir) > 0.0;
+
+    let mut sectors = Vec::with_capacity(cuts.len() - 1);
+    for w in cuts.windows(2) {
+        let (a, b) = (w[0], w[1]);
+        // floor: a->b (CCW) or b->a; then up at the far cut, ceiling back,
+        // down at the near cut. Choose edge order so the loop is connected.
+        let wire = if floor_ccw {
+            vec![
+                mk_arc(&bot_circle, v_bot, a, b, true)?,
+                mk_vertical(b, true)?,
+                mk_arc(&top_circle, v_top, a, b, false)?,
+                mk_vertical(a, false)?,
+            ]
+        } else {
+            vec![
+                mk_arc(&bot_circle, v_bot, a, b, false)?,
+                mk_vertical(a, true)?,
+                mk_arc(&top_circle, v_top, a, b, true)?,
+                mk_vertical(b, false)?,
+            ]
+        };
+        let interior = surface.evaluate(
+            (seam_u + f64::midpoint(a, b)).rem_euclid(TAU),
+            f64::midpoint(v_bot, v_top),
+        )?;
+        sectors.push(SplitSubFace {
+            surface: surface.clone(),
+            outer_wire: wire,
+            inner_wires: Vec::new(),
+            reversed,
+            parent: face_id,
+            rank,
+            precomputed_interior: Some(interior),
+        });
+    }
+    Some(sectors)
+}
+
 /// Build an `OrientedPCurveEdge` (forward) from a section on this (torus) face.
 fn torus_section_to_edge(
     section: &SectionEdge,

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -104,7 +104,14 @@ type QVert = (i64, i64, i64);
 ///
 /// Each edge is stored as a sorted quantized vertex pair `(min, max)`.
 /// The set of pairs is sorted for deterministic comparison.
-type EdgeSet = Vec<(QVert, QVert)>;
+// Endpoint pair + weld-quantized curve midpoint. The midpoint discriminates
+// co-endpoint edges with different geometry: the two halves of a chord-split
+// cap disc share BOTH vertices (chord + arc), and endpoint-only sets made
+// them false within-rank duplicates — the outside half was silently dropped
+// as "SD residue". The midpoint bucket is 100x coarser than the endpoint
+// bucket so marched/fitted geometry (~1e-6 off exact) cannot split a true
+// duplicate pair across buckets.
+type EdgeSet = Vec<(QVert, QVert, QVert)>;
 
 /// Detect same-domain face pairs using edge-set hashing.
 ///
@@ -483,7 +490,7 @@ fn compute_edge_set_quantized(
     let face = topo.face(face_id).ok()?;
     let wire = topo.wire(face.outer_wire()).ok()?;
 
-    let mut pairs: Vec<(QVert, QVert)> = Vec::with_capacity(wire.edges().len());
+    let mut pairs: Vec<(QVert, QVert, QVert)> = Vec::with_capacity(wire.edges().len());
 
     // Cache resolved vertex positions to avoid redundant resolve_vertex() calls
     // when the same vertex appears in multiple edges.
@@ -505,8 +512,20 @@ fn compute_edge_set_quantized(
         let qs = resolve_and_quantize(edge.start())?;
         let qe = resolve_and_quantize(edge.end())?;
 
+        let sp = topo
+            .vertex(arena.resolve_vertex(edge.start()))
+            .ok()?
+            .point();
+        let ep = topo.vertex(arena.resolve_vertex(edge.end())).ok()?.point();
+        let mid = crate::builder::pcurve_compute::evaluate_edge_at_t(edge.curve(), sp, ep, 0.5);
+        let qmid = quantize_point(mid, scale * 100.0);
+
         // Canonical ordering: smaller first
-        let pair = if qs <= qe { (qs, qe) } else { (qe, qs) };
+        let pair = if qs <= qe {
+            (qs, qe, qmid)
+        } else {
+            (qe, qs, qmid)
+        };
         pairs.push(pair);
     }
 

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -517,8 +517,17 @@ fn compute_edge_set_quantized(
             .ok()?
             .point();
         let ep = topo.vertex(arena.resolve_vertex(edge.end())).ok()?.point();
+        // The midpoint is evaluated in STORED order deliberately: arcs
+        // follow the CCW start-to-end convention, so (A,B) and (B,A) are
+        // complementary arcs — different geometry that must hash apart
+        // (they are exactly the two halves this discriminator separates).
+        // Identical geometry always stores identical direction under that
+        // convention, so a true duplicate pair cannot hash apart here.
         let mid = crate::builder::pcurve_compute::evaluate_edge_at_t(edge.curve(), sp, ep, 0.5);
-        let qmid = quantize_point(mid, scale * 100.0);
+        // quantize_point MULTIPLIES by the scale, so the 100x-coarser
+        // midpoint bucket (fit-error tolerance for marched geometry) needs
+        // scale / 100, not scale * 100.
+        let qmid = quantize_point(mid, scale / 100.0);
 
         // Canonical ordering: smaller first
         let pair = if qs <= qe {

--- a/crates/algo/src/builder/same_domain/tests.rs
+++ b/crates/algo/src/builder/same_domain/tests.rs
@@ -1031,3 +1031,73 @@ fn coaxial_cylinder_opposite_sides_do_not_pair() {
         result.pairs.len()
     );
 }
+
+/// The two halves of a chord-split disc share BOTH vertices (chord + arc per
+/// half): with endpoint-only edge sets they hash identically and one half was
+/// silently marked a within-rank duplicate of the other (the mid-wall pad's
+/// outside cap half dropped from the fuse). The curve-midpoint discriminator
+/// must keep them distinct.
+#[test]
+fn chord_split_disc_halves_are_not_duplicates() {
+    use brepkit_math::curves::Circle3D;
+    use brepkit_topology::edge::{Edge, EdgeCurve};
+    use brepkit_topology::face::{Face, FaceSurface};
+    use brepkit_topology::vertex::Vertex;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    let mut topo = Topology::new();
+    let circle =
+        Circle3D::new(Point3::new(10.0, 10.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 3.0).unwrap();
+    let plane = FaceSurface::Plane {
+        normal: Vec3::new(0.0, 0.0, 1.0),
+        d: 0.0,
+    };
+    let va = topo.add_vertex(Vertex::new(Point3::new(7.0, 10.0, 0.0), 1e-7));
+    let vb = topo.add_vertex(Vertex::new(Point3::new(13.0, 10.0, 0.0), 1e-7));
+
+    let half = |topo: &mut Topology, arc_fwd: bool| {
+        let chord = topo.add_edge(Edge::new(va, vb, EdgeCurve::Line));
+        let (s, e) = if arc_fwd { (vb, va) } else { (va, vb) };
+        let arc = topo.add_edge(Edge::new(s, e, EdgeCurve::Circle(circle.clone())));
+        let wire = topo.add_wire(
+            Wire::new(
+                vec![OrientedEdge::new(chord, true), OrientedEdge::new(arc, true)],
+                true,
+            )
+            .unwrap(),
+        );
+        topo.add_face(Face::new(wire, vec![], plane.clone()))
+    };
+    let inside = half(&mut topo, true);
+    let outside = half(&mut topo, false);
+
+    let sub_faces = vec![
+        SubFace {
+            face_id: inside,
+            source_face: inside,
+            classification: FaceClass::Unknown,
+            rank: Rank::B,
+            interior_point: Some(Point3::new(10.0, 8.5, 0.0)),
+        },
+        SubFace {
+            face_id: outside,
+            source_face: outside,
+            classification: FaceClass::Unknown,
+            rank: Rank::B,
+            interior_point: Some(Point3::new(10.0, 11.5, 0.0)),
+        },
+    ];
+    let arena = GfaArena::new();
+    let ranks: HashMap<FaceId, Rank> = HashMap::new();
+    let result = detect_same_domain(&topo, &arena, &sub_faces, &ranks, Tolerance::new());
+    assert!(
+        result.within_rank_dups.is_empty(),
+        "chord/arc co-endpoint halves must not conflate: {:?}",
+        result
+            .within_rank_dups
+            .iter()
+            .map(|d| (d.representative, d.duplicate))
+            .collect::<Vec<_>>()
+    );
+    assert!(result.pairs.is_empty());
+}


### PR DESCRIPTION
## Summary

Two stacked hardening fixes from the last-lightweight-failure frontier dig (the mid-wall poking-cylinder repro), plus their tests. No end-to-end scenario flips yet — the repro's remaining root (A-side boundary-crossing circle treated as an internal loop) is tracked separately — but both fixes remove real, empirically confirmed defects and the repro now fails SAFE with more of its topology correct (F=9→10, outside cap halves restored).

### 1. Same-domain edge sets: curve-midpoint discriminator

The SD edge-set hash keyed on quantized endpoint pairs only. The two halves of a chord-split cap disc share BOTH vertices (chord + arc each), so they hashed identically and one half was silently marked a within-rank duplicate of the other — **the outside cap half-disc dropped from the fuse as "SD residue"** (empirically: `sd_within_rank_dups = [11,12,14]` on the repro, all legitimate distinct faces). Each edge's key now includes its curve midpoint, quantized 100× coarser than the endpoints so marched/fitted geometry (~1e-6 off exact) cannot split a true duplicate pair across buckets.

### 2. Sector rescue for under-split u-periodic laterals

New `split_periodic_face_into_sectors` (the dual of the band splitter): full-height ruling sections + the seam partition a cylinder strip into angular sectors with per-sector interior points. **Fires only when the greedy walker produced no split at all** (≤1 loop): an annulus cut once is a single wrapped region to the glued walker (the pad whose second wall crossing rides the seam), while configs with all rulings in-face split fine via the greedy and never take this path — that gate is load-bearing (an earlier ungated version regressed `fuse_corner_poking_cylinder_stays_analytic`; the gated version keeps it green).

## Tests

- `chord_split_disc_halves_are_not_duplicates` — co-endpoint chord/arc halves must not conflate (the exact repro geometry).
- `fuse_corner_poking_cylinder_stays_analytic` — guards the sector gate (fails on the ungated version).
- algo 191 / ops 779 / gridfinity canary / full workspace / clippy green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes same-domain duplicate detection and adds a gated sector splitter for under‑split u‑periodic cylinder faces. Hardens midpoint hashing and sector edges to avoid duplicate drops and rim/vertical mismatches while keeping corner-cylinder cases green.

- **Bug Fixes**
  - Same-domain edge sets now include a weld-quantized curve midpoint (100× coarser than endpoints, evaluated in stored curve direction) to distinguish co-endpoint chord/arc halves. Prevents dropping the outside cap half; adds a unit test.
  - Added `split_periodic_face_into_sectors`, gated to u-periodic cylinder laterals when the greedy walker produced no split (≤1 loop) and full-height rulings exist. Uses rulings + seam to partition into angular sectors, reuses ruling pave block IDs, computes circle-frame arc direction to avoid complementary arcs, and keeps UV angles unwrapped to align at TAU. Keeps `fuse_corner_poking_cylinder_stays_analytic` green.

<sup>Written for commit f885e680c0c1b650efdb4b97f83523193d528ad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

