### PR TITLE
fix(geometry,operations): stabilize arc segmentation for ruled loft pairing

### DIFF
--- a/crates/geometry/src/convert/curve_to_nurbs.rs
+++ b/crates/geometry/src/convert/curve_to_nurbs.rs
@@ -36,12 +36,45 @@ pub fn circle_to_nurbs(
         return Err(GeomError::DegenerateInput("arc span is zero".to_owned()));
     }
 
-    // Split the angular range into arcs of at most π/2.
-    let n_arcs = ((span.abs() / FRAC_PI_2).ceil() as usize).max(1);
+    // Split the angular range into arcs of at most π/2. The epsilon keeps a
+    // span that is an exact multiple of π/2 (a quarter/half/full circle) from
+    // straddling the ceil boundary on float jitter — two same-span arcs
+    // converting to different segment counts breaks ruled-surface pairing.
+    let n_arcs = (((span.abs() / FRAC_PI_2) - 1e-9).ceil() as usize).max(1);
     #[allow(clippy::cast_precision_loss)]
     let delta = span / n_arcs as f64;
 
     arc_segments_to_nurbs(n_arcs, t_start, delta, |t| {
+        let p = circle.evaluate(t);
+        let tangent = circle.tangent(t);
+        (p, tangent * circle.radius())
+    })
+}
+
+/// Convert a [`Circle3D`] arc to NURBS with a CALLER-CHOSEN segment count.
+///
+/// Ruled-surface construction pairs two arcs' control nets one-to-one; when
+/// float jitter makes two same-span arcs segment differently, the caller
+/// re-converts one with the other's count.
+///
+/// # Errors
+///
+/// Returns an error for a zero span or `segments == 0`.
+pub fn circle_to_nurbs_with_segments(
+    circle: &Circle3D,
+    t_start: f64,
+    t_end: f64,
+    segments: usize,
+) -> Result<NurbsCurve, GeomError> {
+    let span = t_end - t_start;
+    if span.abs() < 1e-15 || segments == 0 {
+        return Err(GeomError::DegenerateInput(
+            "arc span is zero or no segments".to_owned(),
+        ));
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let delta = span / segments as f64;
+    arc_segments_to_nurbs(segments, t_start, delta, |t| {
         let p = circle.evaluate(t);
         let tangent = circle.tangent(t);
         (p, tangent * circle.radius())

--- a/crates/geometry/src/convert/curve_to_nurbs.rs
+++ b/crates/geometry/src/convert/curve_to_nurbs.rs
@@ -36,11 +36,19 @@ pub fn circle_to_nurbs(
         return Err(GeomError::DegenerateInput("arc span is zero".to_owned()));
     }
 
-    // Split the angular range into arcs of at most π/2. The epsilon keeps a
-    // span that is an exact multiple of π/2 (a quarter/half/full circle) from
-    // straddling the ceil boundary on float jitter — two same-span arcs
-    // converting to different segment counts breaks ruled-surface pairing.
-    let n_arcs = (((span.abs() / FRAC_PI_2) - 1e-9).ceil() as usize).max(1);
+    // Split the angular range into arcs of at most π/2. Snap the ratio to the
+    // nearest integer when it is within float jitter of one, so a span that is
+    // an exact multiple of π/2 (quarter/half/full circle) cannot straddle the
+    // ceil boundary — two same-span arcs converting to different segment
+    // counts breaks ruled-surface pairing. Spans genuinely above a multiple
+    // still round up, preserving the ≤ π/2 per-segment invariant.
+    let ratio = span.abs() / FRAC_PI_2;
+    let snapped = if (ratio - ratio.round()).abs() < 1e-9 {
+        ratio.round()
+    } else {
+        ratio
+    };
+    let n_arcs = (snapped.ceil() as usize).max(1);
     #[allow(clippy::cast_precision_loss)]
     let delta = span / n_arcs as f64;
 
@@ -70,6 +78,14 @@ pub fn circle_to_nurbs_with_segments(
     if span.abs() < 1e-15 || segments == 0 {
         return Err(GeomError::DegenerateInput(
             "arc span is zero or no segments".to_owned(),
+        ));
+    }
+    // The rational quadratic construction needs each segment ≤ π/2 (jitter
+    // margin for snapped exact multiples).
+    #[allow(clippy::cast_precision_loss)]
+    if span.abs() / segments as f64 > FRAC_PI_2 + 1e-6 {
+        return Err(GeomError::DegenerateInput(
+            "segment span exceeds pi/2".to_owned(),
         ));
     }
     #[allow(clippy::cast_precision_loss)]

--- a/crates/geometry/src/convert/mod.rs
+++ b/crates/geometry/src/convert/mod.rs
@@ -18,7 +18,9 @@ pub mod recognize_curve;
 pub mod recognize_surface;
 pub mod surface_to_nurbs;
 
-pub use curve_to_nurbs::{circle_to_nurbs, ellipse_to_nurbs, line_to_nurbs};
+pub use curve_to_nurbs::{
+    circle_to_nurbs, circle_to_nurbs_with_segments, ellipse_to_nurbs, line_to_nurbs,
+};
 pub use recognize_curve::{DetectedCurveKind, RecognizedCurve, detect_curve_kind, recognize_curve};
 pub use recognize_surface::{
     DetectedSurfaceKind, RecognizedSurface, detect_surface_kind, recognize_surface,

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -511,14 +511,17 @@ fn ruled_arc_surface(
 ) -> Option<NurbsSurface> {
     let (a0, a0e) = EdgeCurve::Circle(c0.clone()).domain_with_endpoints(p0s, p0e);
     let (a1, a1e) = EdgeCurve::Circle(c1.clone()).domain_with_endpoints(p1s, p1e);
-    let nc0 = brepkit_geometry::convert::circle_to_nurbs(c0, a0, a0e).ok()?;
+    let mut nc0 = brepkit_geometry::convert::circle_to_nurbs(c0, a0, a0e).ok()?;
     let mut nc1 = brepkit_geometry::convert::circle_to_nurbs(c1, a1, a1e).ok()?;
     if nc0.control_points().len() != nc1.control_points().len() {
         // Same-shape arcs can still segment differently when their spans sit
         // on opposite sides of the π/2-multiple ceil boundary (float jitter);
-        // re-convert the second arc with the first one's segment count so the
-        // ruled pairing survives.
-        let segs = (nc0.control_points().len() - 1) / 2;
+        // re-convert BOTH arcs at the larger segment count so the ruled
+        // pairing survives. Splitting finer never violates the ≤ π/2
+        // per-segment invariant; the conversion itself rejects a count too
+        // small for either span.
+        let segs = ((nc0.control_points().len() - 1) / 2).max((nc1.control_points().len() - 1) / 2);
+        nc0 = brepkit_geometry::convert::circle_to_nurbs_with_segments(c0, a0, a0e, segs).ok()?;
         nc1 = brepkit_geometry::convert::circle_to_nurbs_with_segments(c1, a1, a1e, segs).ok()?;
     }
     if nc0.degree() != nc1.degree() || nc0.control_points().len() != nc1.control_points().len() {
@@ -1174,7 +1177,7 @@ pub fn loft_smooth(
 mod tests;
 
 #[cfg(test)]
-mod l_loft_tests {
+mod rounded_l_loft_tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
     use brepkit_math::curves::Circle3D;
@@ -1260,7 +1263,7 @@ mod l_loft_tests {
     /// jitter at the pi/2-multiple ceil boundary, failing the pairing and
     /// faceting the whole lip (the 22-scenario custom-shape export family).
     #[test]
-    fn rounded_l_multi_section_loft_stays_analytic() {
+    fn rounded_l_multi_section_loft_stays_curve_preserving() {
         let mut topo = Topology::new();
         let f0 = rounded_l_face(&mut topo, 2.15, 3.75 - 2.15, 0.0);
         let f1 = rounded_l_face(&mut topo, 1.6, 3.75 - 1.6, 0.7);

--- a/crates/operations/src/loft.rs
+++ b/crates/operations/src/loft.rs
@@ -512,7 +512,15 @@ fn ruled_arc_surface(
     let (a0, a0e) = EdgeCurve::Circle(c0.clone()).domain_with_endpoints(p0s, p0e);
     let (a1, a1e) = EdgeCurve::Circle(c1.clone()).domain_with_endpoints(p1s, p1e);
     let nc0 = brepkit_geometry::convert::circle_to_nurbs(c0, a0, a0e).ok()?;
-    let nc1 = brepkit_geometry::convert::circle_to_nurbs(c1, a1, a1e).ok()?;
+    let mut nc1 = brepkit_geometry::convert::circle_to_nurbs(c1, a1, a1e).ok()?;
+    if nc0.control_points().len() != nc1.control_points().len() {
+        // Same-shape arcs can still segment differently when their spans sit
+        // on opposite sides of the π/2-multiple ceil boundary (float jitter);
+        // re-convert the second arc with the first one's segment count so the
+        // ruled pairing survives.
+        let segs = (nc0.control_points().len() - 1) / 2;
+        nc1 = brepkit_geometry::convert::circle_to_nurbs_with_segments(c1, a1, a1e, segs).ok()?;
+    }
     if nc0.degree() != nc1.degree() || nc0.control_points().len() != nc1.control_points().len() {
         return None;
     }
@@ -1164,3 +1172,110 @@ pub fn loft_smooth(
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod l_loft_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use brepkit_math::curves::Circle3D;
+    use brepkit_topology::edge::{Edge, EdgeCurve};
+    use brepkit_topology::face::{Face, FaceId, FaceSurface};
+    use brepkit_topology::vertex::Vertex;
+    use brepkit_topology::wire::{OrientedEdge, Wire};
+
+    fn rounded_l_face(topo: &mut Topology, inset: f64, r: f64, z: f64) -> FaceId {
+        let i = inset;
+        let vs = [
+            (i, i, false),
+            (126.0 - i, i, false),
+            (126.0 - i, 42.0 - i, false),
+            (42.0 - i, 42.0 - i, true),
+            (42.0 - i, 126.0 - i, false),
+            (i, 126.0 - i, false),
+        ];
+        let n = vs.len();
+        let mut t_in = Vec::new();
+        let mut t_out = Vec::new();
+        let mut centers = Vec::new();
+        for k in 0..n {
+            let (px, py, _) = vs[(k + n - 1) % n];
+            let (vx, vy, concave) = vs[k];
+            let (nx, ny, _) = vs[(k + 1) % n];
+            let din = ((vx - px).signum(), (vy - py).signum());
+            let dout = ((nx - vx).signum(), (ny - vy).signum());
+            let ti = (vx - din.0 * r, vy - din.1 * r);
+            let to = (vx + dout.0 * r, vy + dout.1 * r);
+            let c = if concave {
+                (
+                    vx + dout.0.abs() * r + if din.0 == 0.0 { 0.0 } else { -din.0 * r },
+                    vy + if din.1 == 0.0 { 0.0 } else { -din.1 * r } + dout.1.abs() * r,
+                )
+            } else {
+                (ti.0 + (to.0 - vx), ti.1 + (to.1 - vy))
+            };
+            t_in.push(ti);
+            t_out.push(to);
+            centers.push(c);
+        }
+        let mut oes = Vec::new();
+        let vid_at = |topo: &mut Topology, p: (f64, f64)| {
+            topo.add_vertex(Vertex::new(Point3::new(p.0, p.1, z), 1e-7))
+        };
+        let mut prev_out = vid_at(topo, t_out[n - 1]);
+        for k in 0..n {
+            let in_vid = vid_at(topo, t_in[k]);
+            let line = topo.add_edge(Edge::new(prev_out, in_vid, EdgeCurve::Line));
+            oes.push(OrientedEdge::new(line, true));
+            let out_vid = vid_at(topo, t_out[k]);
+            let c = Circle3D::new(
+                Point3::new(centers[k].0, centers[k].1, z),
+                Vec3::new(0.0, 0.0, 1.0),
+                r,
+            )
+            .unwrap();
+            if vs[k].2 {
+                let arc = topo.add_edge(Edge::new(out_vid, in_vid, EdgeCurve::Circle(c)));
+                oes.push(OrientedEdge::new(arc, false));
+            } else {
+                let arc = topo.add_edge(Edge::new(in_vid, out_vid, EdgeCurve::Circle(c)));
+                oes.push(OrientedEdge::new(arc, true));
+            }
+            prev_out = out_vid;
+        }
+        let wire = topo.add_wire(Wire::new(oes, true).unwrap());
+        topo.add_face(Face::new(
+            wire,
+            vec![],
+            FaceSurface::Plane {
+                normal: Vec3::new(0.0, 0.0, 1.0),
+                d: z,
+            },
+        ))
+    }
+
+    /// A multi-section rounded-L loft (the gridfinity custom-shape lip
+    /// frustum) must stay curve-preserving. The concave corner's arc centres
+    /// drift with the inset, so its bands are ruled NURBS — and the two
+    /// semicircle-span conversions used to segment differently on float
+    /// jitter at the pi/2-multiple ceil boundary, failing the pairing and
+    /// faceting the whole lip (the 22-scenario custom-shape export family).
+    #[test]
+    fn rounded_l_multi_section_loft_stays_analytic() {
+        let mut topo = Topology::new();
+        let f0 = rounded_l_face(&mut topo, 2.15, 3.75 - 2.15, 0.0);
+        let f1 = rounded_l_face(&mut topo, 1.6, 3.75 - 1.6, 0.7);
+        let f2 = rounded_l_face(&mut topo, 1.0, 3.75 - 1.0, 4.4);
+        let solid = loft(&mut topo, &[f0, f1, f2]).unwrap();
+        let faces = brepkit_topology::explorer::solid_faces(&topo, solid).unwrap();
+        let curved = faces
+            .iter()
+            .filter(|&&f| topo.face(f).unwrap().surface().type_tag() != "plane")
+            .count();
+        assert_eq!(
+            curved,
+            12,
+            "6 corners x 2 bands must stay curved, got {curved} of {}",
+            faces.len()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Root of the **22-scenario custom-shape export-integrity family** (all L/T/U/O "with lip" bins, bd 28–142).

Chain of custody from the 3×3-L capture: the bin body is clean; the lip solid out of the multi-section frustum loft arrives **faceted** (82 planes) even though the tool's profiles carry real arcs; the faceted lip then drives the frustum cut and the body fuse into open mesh fallbacks that poison the export (bd=40 at STL).

The loft's curve-preserving path declined because `ruled_arc_surface` failed its control-net pairing: `circle_to_nurbs` segments an arc with `ceil(span/(π/2))`, and a span that is an **exact multiple of π/2** straddles the ceil boundary on float jitter — two same-shape arcs converted to 2 vs 3 Bezier segments (5 vs 7 control points; observed live: `span0=3.142 span1=3.142 cps 5/7`). The concave corner of an L outline is exactly this case: its arc centres drift with the inset (non-coaxial across sections), so those bands need the ruled-NURBS pairing.

## Fix (two layers)

1. `circle_to_nurbs`: epsilon inside the ceil so exact π/2 multiples segment consistently.
2. `ruled_arc_surface`: when counts still disagree, re-convert the second arc with the first one's segment count via the new `circle_to_nurbs_with_segments`.

## Result

The native rounded-L 3-section loft (reconstructed from the tool's corner-tangent math) goes **curved=0 → curved=12 of 26 faces** — fully analytic. New regression test `rounded_l_multi_section_loft_stays_analytic` builds that loft and pins curved=12 (fails on main).

geometry 101 / ops 780 / algo 191 / gridfinity canary / clippy green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes arc-to-NURBS segmentation at π/2 multiples so ruled lofts pair correctly and stay analytic, fixing faceted lip frustums in custom-shape exports. Multi‑section lofts (e.g., rounded L) remain curved instead of falling back to planes.

- **Bug Fixes**
  - In `circle_to_nurbs`, snap `span/(π/2)` to the nearest integer when within float jitter so exact multiples segment consistently; non‑multiples still round up (≤ π/2 per segment preserved).
  - Added `circle_to_nurbs_with_segments` with guards (rejects zero segments and per‑segment span > π/2) and updated `ruled_arc_surface` to re‑convert both arcs at the larger segment count when they differ.
  - Updated regression: `rounded_l_multi_section_loft_stays_curve_preserving` (curved 12/26 faces; previously 0/26).

<sup>Written for commit c0ca522daf369110e67e4251cb5de520bb73aeac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

