### PR TITLE
chore(deps): resolve new RustSec advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,5 +10,11 @@
 # time and never touches runtime input. wayland-scanner pins quick-xml ^0.39, so
 # this copy cannot advance until that upstream chain updates. Re-check and drop
 # these entries when winit/wayland-scanner move off quick-xml 0.39.
+#
+# RUSTSEC-2026-0192 is an informational "unmaintained" advisory against
+# ttf-parser, which enters solely through sctk-adwaita -> ab_glyph (winit's
+# Wayland client-side decorations, behind brepkit-render's `window` feature).
+# It never parses untrusted fonts at runtime in this workspace. Drop when the
+# winit decoration chain moves to a maintained font parser (e.g. skrifa).
 [advisories]
-ignore = ["RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]
+ignore = ["RUSTSEC-2026-0194", "RUSTSEC-2026-0195", "RUSTSEC-2026-0192"]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -17,4 +17,4 @@
 # It never parses untrusted fonts at runtime in this workspace. Drop when the
 # winit decoration chain moves to a maintained font parser (e.g. skrifa).
 [advisories]
-ignore = ["RUSTSEC-2026-0194", "RUSTSEC-2026-0195", "RUSTSEC-2026-0192"]
+ignore = ["RUSTSEC-2026-0192", "RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]


### PR DESCRIPTION
## Summary

Main's CI went red this morning on the Security Audit job — a new upstream advisory, unrelated to the code changes it landed on:

- **RUSTSEC-2026-0192** (informational, `ttf-parser` unmaintained): enters solely through winit's Wayland client-side decorations (`sctk-adwaita` → `ab_glyph`) behind brepkit-render's `window` feature; no untrusted font parsing at runtime. Added to the cargo-audit ignore list with rationale, same class as the existing quick-xml entries (cargo-deny does not flag it, so deny.toml is unchanged).
- **RUSTSEC-2026-0204** (`crossbeam-epoch` invalid pointer deref in `fmt::Pointer`, dev-dependency path via criterion): resolved locally by `cargo update -p crossbeam-epoch` (0.9.18 → 0.9.20; Cargo.lock is not tracked, so CI resolves the patched version on its own).

`cargo deny check advisories` and the ops suite green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the Security Audit job by resolving two new RustSec advisories. Updates `crossbeam-epoch` and ignores an informational `ttf-parser` advisory limited to Wayland decorations.

- **Dependencies**
  - Updated `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204). Dev-only via `criterion`; `Cargo.lock` untracked so CI pulls the patched version.
  - Added RUSTSEC-2026-0192 to the `cargo-audit` ignore list and sorted entries (`ttf-parser` unmaintained). Path: `sctk-adwaita` → `ab_glyph` (winit Wayland CSD) behind `brepkit-render` `window`; no untrusted font parsing at runtime.

<sup>Written for commit 4d0727c5974a52d72d32837844d760ac835ca462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

