### PR TITLE
fix(geometry): document the per-segment span invariant on arc conversion

### DIFF
--- a/crates/geometry/src/convert/curve_to_nurbs.rs
+++ b/crates/geometry/src/convert/curve_to_nurbs.rs
@@ -63,7 +63,9 @@ pub fn circle_to_nurbs(
 ///
 /// Ruled-surface construction pairs two arcs' control nets one-to-one; when
 /// float jitter makes two same-span arcs segment differently, the caller
-/// re-converts one with the other's count.
+/// re-converts BOTH at the larger count. Each segment must span at most
+/// π/2 for the rational quadratic construction to be exact — the count is
+/// validated against that invariant.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
Releases the stranded #1180 loft fix. Release-please could not parse #1180's comma multi-scope squash title ("unexpected token '('" in its log), and the empty follow-up commit (#1182) was dropped by path splitting (no files). This real one-line doc clarification on the affected function carries a parseable, path-matching `fix(geometry)` commit so 2.127.26 can cut. (Process notes recorded: single scopes in PR titles; empty commits can't trigger release-please.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies arc-to-NURBS conversion docs to prevent mismatched segments in ruled-surface pairing. States that both arcs are re-converted to the larger segment count and that each segment must be ≤ π/2, which is validated.

<sup>Written for commit 315c05c84e76e2a10aa94ca4328e1ec63f4bfd94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

