### PR TITLE
docs(algo): correct the offset-search iteration math

### DIFF
--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -597,9 +597,9 @@ fn sample_face_interior(
             // classify differently. A deeper sample is strictly better
             // whenever the polygon containment check admits it; thin slivers
             // reject the large candidates and fall through to the fine
-            // scales. 24 halvings from 64 reach scale ~4e-6 (min offset
-            // ~diag·4e-10), below any physically meaningful strip width, so
-            // the loop only exits to the fallback for a near-zero-area
+            // scales. 28 halvings from 64 reach scale ~2.4e-7 (min offset
+            // ~diag·2.4e-11), below any physically meaningful strip width,
+            // so the loop only exits to the fallback for a near-zero-area
             // (degenerate) face.
             let mut scale = 64.0_f64;
             for _ in 0..28 {


### PR DESCRIPTION
Follow-up to #1189: the loop runs 28 iterations, not 24 — 28 halvings from 64 reach scale ~2.4e-7 (min offset ~diag·2.4e-11). The intended fix from the review round missed the merge window; my reply on #1189 referenced a commit that never landed — this PR is the actual fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the offset-search iteration math: the loop runs 28 halvings from 64, not 24. Comments now match `for _ in 0..28`, and document the resulting scale (~2.4e-7) and min offset (~diag·2.4e-11) to clarify when the fallback applies.

<sup>Written for commit 0328d9a80a06cf36ff686530684209fd74584e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

