### PR TITLE
fix(algo): assemble the label-tab attach fuse analytically

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -534,6 +534,33 @@ against the real honeycomb+funnel operands first (the roadmap's own warning). Th
 did NOT move tool parity; the headline failing families (scoop #11, screw base #12, solid
 cutouts #13, honeycomb-cut) remain open.
 
+Label-sockets family — BOTH roots CLOSED (fixture
+`crates/io/tests/labeltab_attach_inmem.rs`, one test covering both). (1) The bd=24/14
+export was a GATE LEAK, not a build defect: `validate_boolean_result` checked unclosed
+wires and c>2 non-manifold but never c==1 FREE edges, so a warm-cache run whose GFA
+happened to complete with 8 free edges and an accidentally-balanced Euler was accepted
+(#1192, free_edges>0 now hard-fails; the cold run aborted to the fallback and passed —
+which is why the scenarios passed solo and failed only after an earlier scenario warmed
+`getCellSocketTemplate`). (2) The remaining analytic root — the tab-attach fuse itself
+never assembling ("open hole shell with 97 faces would be dropped", both variants) —
+was the CORNER CRESCENT: the tab's square top corners overhang the cavity's rounded
+corners, and the tab's back-plane chord RIDES the cavity's collinear back line for most
+of its span while jutting ~2.55mm into each crescent. Two coordinated fixes: (a)
+`line_section_boundary_extensions` in `fill_images_faces.rs` — the boundary re-trace
+test samples interior points, all of which land on the covered middle, so the whole
+section read as a re-trace and the crescents were never split off; the uncovered
+extensions are now recovered by exact interval arithmetic (NOT sampling — the extension
+fraction can be arbitrarily small) and re-queued through the interval loop, which
+terminates because an extension's own coverage set is empty. (b) A third arrangement
+entry condition in `face_splitter/mod.rs` keyed to a DEMONSTRATED failure rather than a
+predicted one: `loops_have_out_and_back` detects the angular walker's own signature of
+having woven twin section edges into a single loop (an edge immediately followed by its
+exact UV reverse). Result: analytic fuse, watertight, volume 20462.5 by
+inclusion-exclusion (17421.32 + 3046.86 − 5.71). DURABLE: any coverage/containment test
+that decides a section's fate by INTERIOR SAMPLING is blind to overhang at the ends —
+prefer exact interval math wherever the salvageable fraction can be arbitrarily small;
+and an arrangement trigger keyed to a post-hoc failure signature cannot demote a
+working case, which is the cheap way past this splitter's web of mutual calibrations.
 
 combinedFeatures re-read (2026-07-10, 2.124.13-based overlay, full 11-case suite):
 all 6 structural cases PASS including "handles + label (back skip)" (7167 tris,

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -3151,6 +3151,37 @@ fn clip_sections_to_outer_region(
     (kept, anchors)
 }
 
+/// Whether any greedy loop contains an out-and-back spur: an edge immediately
+/// followed (cyclically) by its exact UV reverse. The angular walker emits
+/// this signature only when it has woven twin section edges into one loop
+/// instead of closing a region between them; a clean partition never does.
+///
+/// Loops of two edges are exempt: consecutive edges always share a vertex, so
+/// for `n == 2` closure alone forces the reverse pattern and every lens region
+/// (an arc plus its co-endpoint chord) matches. Only at three or more edges
+/// does the pattern actually mean the walker doubled back — at two it fired on
+/// the honeycomb cap arrangement's legitimate lens and cost `pcut3` its zero
+/// free-edge pin.
+fn loops_have_out_and_back(loops: &[Vec<OrientedPCurveEdge>], tol: f64) -> bool {
+    for lp in loops {
+        let n = lp.len();
+        if n < 3 {
+            continue;
+        }
+        for i in 0..n {
+            let a = &lp[i];
+            let b = &lp[(i + 1) % n];
+            if (a.start_uv - a.end_uv).length() > tol
+                && (a.start_uv - b.end_uv).length() < tol
+                && (a.end_uv - b.start_uv).length() < tol
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Split a face by its section edges, producing sub-faces.
 ///
 /// If there are no section edges, returns a single sub-face covering
@@ -4811,9 +4842,22 @@ fn split_face_2d_impl(
     } else {
         &all_edges
     };
+    // Third entry condition: the angular walker demonstrably WOVE the greedy
+    // loops — some loop contains an edge immediately followed by its exact
+    // reverse (an out-and-back spur, the label-tab corner-crescent weave where
+    // both twins of a salvaged corner chord ride one loop instead of closing
+    // the crescent). A clean partition never produces that signature, so this
+    // trigger cannot demote a correctly-split single-hole cap; it only engages
+    // the arrangement where the calibrated wire-builder path has already
+    // failed.
+    let woven_spur = is_plane
+        && holes_integrated
+        && !woven_inner_wires.is_empty()
+        && loops_have_out_and_back(&loops, tol.linear);
     if is_plane
         && ((holes_integrated && original_inner_wires.len() >= 2 && !woven_inner_wires.is_empty())
-            || bay_mouth_arrangement)
+            || bay_mouth_arrangement
+            || woven_spur)
         && let Some(mut result) = arrangement_regions_from_combined(
             &surface,
             arr_input,

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1400,6 +1400,17 @@ fn build_section_edges(
                     Some((start, end)),
                     tol,
                 ) {
+                    // Salvage the parts of a straight section that extend past
+                    // the collinear boundary edge it rides — see the PaveBlock
+                    // arm below for the full rationale (label-tab corner
+                    // crescents).
+                    if matches!(curve_ds.curve, EdgeCurve::Line) {
+                        for (es, ee) in
+                            line_section_boundary_extensions(topo, face_id, start, end, tol)
+                        {
+                            push_plain_line_section(&mut sections, face, es, ee);
+                        }
+                    }
                     continue;
                 }
 
@@ -1599,7 +1610,11 @@ fn build_section_edges(
                     } else {
                         vec![(raw_start, raw_end)]
                     };
-                for (start, end) in intervals {
+                let mut work: Vec<(Point3, Point3)> = intervals;
+                let mut work_i = 0;
+                while work_i < work.len() {
+                    let (start, end) = work[work_i];
+                    work_i += 1;
                     // Skip a degenerate curved section: a Circle/Ellipse PaveBlock
                     // fragment whose arc has collapsed to a point (3D chord below
                     // tolerance AND a near-zero parametric span). A coincident-edge
@@ -1654,6 +1669,23 @@ fn build_section_edges(
                         Some((start, end)),
                         tol,
                     ) {
+                        // A straight section can ride a collinear boundary edge
+                        // for most of its span yet extend past it at one or both
+                        // ends (the label-tab corner: the tab's back-plane chord
+                        // rides the cavity's back line but juts 2.55mm into each
+                        // rounded-corner crescent). The interior samples all land
+                        // on the covered middle, so the whole section reads as a
+                        // re-trace and the crescent is never split off. Salvage
+                        // the uncovered extensions — they carry the genuine
+                        // interior split. Exact interval math, not sampling: the
+                        // extension fraction can be arbitrarily small.
+                        if matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Line) {
+                            for ext in
+                                line_section_boundary_extensions(topo, face_id, start, end, tol)
+                            {
+                                work.push(ext);
+                            }
+                        }
                         continue;
                     }
 
@@ -2075,6 +2107,121 @@ fn curve_endpoints(
         }
     }
     (Some(start_3d), Some(end_3d))
+}
+
+/// Sub-intervals of the straight section `start..end` NOT covered by any
+/// collinear boundary Line edge of `face_id` (outer or inner wires).
+///
+/// A section flagged as a boundary re-trace can still extend past the edge it
+/// rides at one or both ends; those extensions are genuine interior splitters
+/// (the label-tab back-plane chord riding the cavity back line but jutting
+/// into each rounded-corner crescent). Coverage is computed with exact
+/// interval arithmetic so an arbitrarily small extension survives. Extensions
+/// shorter than the weld band (100·tol) are noise and skipped.
+fn line_section_boundary_extensions(
+    topo: &Topology,
+    face_id: FaceId,
+    start: Point3,
+    end: Point3,
+    tol: f64,
+) -> Vec<(Point3, Point3)> {
+    let weld = tol * 100.0;
+    let dir = end - start;
+    let len = dir.length();
+    if len <= weld {
+        return Vec::new();
+    }
+    let u = dir * (1.0 / len);
+    let Ok(face) = topo.face(face_id) else {
+        return Vec::new();
+    };
+    let mut cover: Vec<(f64, f64)> = Vec::new();
+    for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+        let Ok(wire) = topo.wire(wid) else { continue };
+        for oe in wire.edges() {
+            let Ok(edge) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            if !matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Line) {
+                continue;
+            }
+            let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
+                continue;
+            };
+            let (bs, be) = (sv.point(), ev.point());
+            let off0 = ((bs - start) - u * (bs - start).dot(u)).length();
+            let off1 = ((be - start) - u * (be - start).dot(u)).length();
+            if off0 > weld || off1 > weld {
+                continue;
+            }
+            let t0 = (bs - start).dot(u);
+            let t1 = (be - start).dot(u);
+            let (lo, hi) = (t0.min(t1).max(0.0), t0.max(t1).min(len));
+            if hi - lo > tol {
+                cover.push((lo, hi));
+            }
+        }
+    }
+    if cover.is_empty() {
+        return Vec::new();
+    }
+    cover.sort_by(|a, b| a.0.total_cmp(&b.0));
+    let mut exts = Vec::new();
+    let mut cur = 0.0_f64;
+    for &(lo, hi) in &cover {
+        if lo > cur + weld {
+            exts.push((cur, lo));
+        }
+        cur = cur.max(hi);
+    }
+    if len > cur + weld {
+        exts.push((cur, len));
+    }
+    exts.into_iter()
+        .map(|(a, b)| (start + u * a, start + u * b))
+        .collect()
+}
+
+/// Push a plain straight section with a Line2D pcurve (the PaveBlock-arm
+/// construction) — used for salvaged boundary-extension segments.
+fn push_plain_line_section(
+    sections: &mut Vec<SectionEdge>,
+    face: &brepkit_topology::face::Face,
+    start: Point3,
+    end: Point3,
+) {
+    use brepkit_math::curves2d::{Curve2D, Line2D};
+    use brepkit_math::vec::{Point2, Vec2};
+
+    let start_uv = face.surface().project_point(start);
+    let end_uv = face.surface().project_point(end);
+    let s2 = start_uv.map_or(Point2::new(0.0, 0.0), |(u, v)| Point2::new(u, v));
+    let e2 = end_uv.map_or(Point2::new(1.0, 0.0), |(u, v)| Point2::new(u, v));
+    let d = e2 - s2;
+    let dl = d.length();
+    let direction = if dl > 1e-12 {
+        Vec2::new(d.x() / dl, d.y() / dl)
+    } else {
+        Vec2::new(1.0, 0.0)
+    };
+    let Ok(line) = Line2D::new(s2, direction).or_else(|_| Line2D::new(s2, Vec2::new(1.0, 0.0)))
+    else {
+        return;
+    };
+    let pcurve = Curve2D::Line(line);
+    sections.push(SectionEdge {
+        curve_3d: brepkit_topology::edge::EdgeCurve::Line,
+        pcurve_a: pcurve.clone(),
+        pcurve_b: pcurve,
+        start,
+        end,
+        start_uv_a: start_uv.map(|(u, v)| Point2::new(u, v)),
+        end_uv_a: end_uv.map(|(u, v)| Point2::new(u, v)),
+        start_uv_b: start_uv.map(|(u, v)| Point2::new(u, v)),
+        end_uv_b: end_uv.map(|(u, v)| Point2::new(u, v)),
+        target_face: None,
+        pave_block_id: None,
+    });
 }
 
 /// Remove section edges that are subsets of longer collinear edges.

--- a/crates/io/tests/labeltab_attach_inmem.rs
+++ b/crates/io/tests/labeltab_attach_inmem.rs
@@ -11,9 +11,14 @@
 //! be dropped"), which is why the scenario passed solo but failed after a
 //! 1×1 scenario warmed the cell-socket template cache.
 //!
-//! With the free-edge hard-fail in the strict gate, both variants reach the
-//! watertight fallback. The assertion is watertightness, not analyticity —
-//! the GFA assembly root (the dropped hole shell) is tracked separately.
+//! With the free-edge hard-fail in the strict gate, both variants reached the
+//! watertight mesh fallback. The corner-crescent fixes (boundary-extension
+//! salvage in `fill_images_faces` + the woven-spur arrangement trigger in the
+//! face splitter) then made the fuse assemble analytically: the tab's square
+//! top corners overhang the cavity's rounded corners, and the bin's top ring
+//! must re-square there. The volume pin is calibrated by inclusion-exclusion
+//! (bin + tab − intersect = 20462.5); the coarse-deflection measurement of
+//! the analytic result reads a few mm³ low from chording its cylinder faces.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -62,11 +67,21 @@ fn labeltab_attach_fuse_is_watertight() {
         "tab attach must be manifold, got {over} over-shared"
     );
 
-    let vol = brepkit_operations::measure::solid_volume(&topo, result, 0.05).unwrap();
-    // bin 17421.29 + tab 3046.86 minus their overlap; the open-shell result
-    // measured 20483.12 with faces missing. Pin near the correct fused value.
+    let curved = faces
+        .iter()
+        .filter(|&&fid| topo.face(fid).unwrap().surface().type_tag() != "plane")
+        .count();
     assert!(
-        (vol - 20466.5).abs() < 5.0,
+        curved >= 12,
+        "expected an analytic result with the pocket/cavity cylinders, got {curved} curved faces"
+    );
+
+    let vol = brepkit_operations::measure::solid_volume(&topo, result, 0.005).unwrap();
+    // Truth by inclusion-exclusion: 17421.32 + 3046.86 − 5.71 = 20462.5.
+    // The band covers coarse-tessellation error on the curved faces; the bad
+    // open-shell result measured ~20483 with faces missing and stays outside.
+    assert!(
+        (vol - 20462.5).abs() < 15.0,
         "fused volume {vol:.2} out of range"
     );
 }


### PR DESCRIPTION
## What

The label-tab attach fuse never assembled analytically — it aborted with `open hole shell with 97 faces would be dropped` and fell back to a tessellated result. This was the remaining analytic root recorded when the free-edge gate leak was fixed in #1192.

## Root

The tab's square top corners overhang the cavity's rounded corners, and the tab's back-plane chord **rides the cavity's collinear back line for most of its span while jutting ~2.55mm into each corner crescent**.

The boundary re-trace test decides a section's fate by sampling interior points. All of those samples land on the covered middle, so the whole section read as a re-trace and was dropped — and the crescents were never split off.

## Fixes

**`line_section_boundary_extensions`** (`fill_images_faces.rs`) recovers the sub-intervals of a straight section not covered by any collinear boundary Line edge. Coverage is computed with exact interval arithmetic rather than sampling, because the uncovered fraction can be arbitrarily small. Extensions are re-queued through the interval loop; this terminates because an extension's own coverage set is empty.

**`loops_have_out_and_back`** (`face_splitter/mod.rs`) adds a third arrangement entry condition. Rather than predicting when the greedy angular walker will fail, it detects the walker's own signature of having already failed: an edge immediately followed by its exact UV reverse, which is what weaving the crescent's twin section edges into one loop produces. A clean partition never emits that, so the trigger cannot demote a working case — and it is purely additive (the arrangement returns `Option` and falls through to greedy).

Loops of two edges are exempt. Consecutive loop edges always share a vertex, so at `n == 2` closure alone forces the reverse pattern and **every lens region** (an arc plus its co-endpoint chord) matches. Without the exemption this fired on the honeycomb cap arrangement's legitimate lens and cost `pcut3` its zero free-edge pin.

## Verification

- `labeltab_attach_inmem` strengthened from watertight-only to asserting the analytic result: curved faces present, volume against the inclusion-exclusion truth `17421.32 + 3046.86 − 5.71 = 20462.5`. Fixtures were already committed in #1192.
- Full workspace suite green (`--no-fail-fast`). The one failing target, `brepkit-render --test compute_mesh_render`, segfaults identically on a clean stashed tree — a sandbox GPU/wgpu limitation, not a regression.
- `cargo test -p brepkit-wasm --lib gridfinity` — 27/27, including the d4 full-bin canary.
- Calibrated foils green, including the honeycomb `pcut1/2/3` residual pins that caught the 2-edge lens false positive during bisection.
- fmt, workspace clippy, and `scripts/check-boundaries.sh` clean.

## Notes

Bisection showed the honeycomb regression came from the arrangement trigger, not the extension salvage. Both changes are load-bearing: disabling the trigger alone drops the fuse back to 0 curved faces (full mesh fallback).

Roadmap skill updated with the label-sockets closure per its own maintenance rule.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the label-tab attach fuse so it assembles analytically instead of falling back to a mesh. The result is watertight with curved faces and the correct fused volume.

- **Bug Fixes**
  - `line_section_boundary_extensions` in `fill_images_faces.rs`: recovers straight-section ends that extend past a collinear boundary edge using exact interval math, then queues those extensions for splitting.
  - `loops_have_out_and_back` in `face_splitter/mod.rs`: adds a safe arrangement entry when a loop contains an edge immediately followed by its UV reverse (excludes 2-edge lenses), catching the crescent weave case.
  - Strengthened `labeltab_attach_inmem` to assert an analytic result (curved faces present) and pin the fused volume to 20462.5 by inclusion–exclusion.

<sup>Written for commit 77ee00b46ed7a4b2b001305179afcf591e9f65e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

