### PR TITLE
perf(operations): batch compound_cut when the tools form one cluster

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -854,17 +854,19 @@ pub fn compound_cut(
     //
     // A SINGLE cluster batches too. That case used to fall through to the
     // sequential loop on the assumption that fusing one overlapping blob costs
-    // more than it saves, but the kumiko wall lattice refutes it: 180 struts
-    // connected at their crossings are one cluster, and on the captured
-    // operands batching runs 51.1s against 83.7s sequential for an identical
-    // 1146-face result. Fusing scales with the tools (small prisms); the
-    // sequential loop re-cuts the whole target once per tool. Any failure
-    // falls back to the sequential loop.
+    // more than it saves, but a connected lattice of many small tools refutes
+    // it — fusing scales with the tools, while the sequential loop re-cuts the
+    // whole target once per tool, and the target only grows more fragmented.
+    // Measured on the kumiko wall lattice (180 strut prisms, one cluster):
+    // batching is comfortably faster for an identical result. Replay it with
+    // the captured operands under `kumiko-goma` in the parity-capture cache.
+    // Any failure falls back to the sequential loop.
     let mut result = target;
     let mut batched = false;
-    let clusters = cluster_tools_by_aabb(topo, tools);
-    if tools.len() >= 2 && clusters.as_ref().is_some_and(|c| !c.is_empty()) {
-        let clusters = clusters.unwrap_or_default();
+    if tools.len() >= 2
+        && let Some(clusters) = cluster_tools_by_aabb(topo, tools)
+        && !clusters.is_empty()
+    {
         let merged = clusters.iter().try_fold(None::<SolidId>, |acc, cluster| {
             let fused = cluster[1..]
                 .iter()

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -850,14 +850,20 @@ pub fn compound_cut(
     // identical. Tools are first grouped into AABB-overlap clusters
     // (union-find): tools in one cluster get a real fuse (the coaxial
     // magnet+screw drill pair), while the pairwise-disjoint cluster
-    // representatives merge via the free disjoint-shell shortcut. Batching
-    // needs ≥2 disjoint clusters — with everything in one overlapping blob
-    // the sequential loop is kept unchanged. Any failure falls back to the
-    // sequential loop.
+    // representatives merge via the free disjoint-shell shortcut.
+    //
+    // A SINGLE cluster batches too. That case used to fall through to the
+    // sequential loop on the assumption that fusing one overlapping blob costs
+    // more than it saves, but the kumiko wall lattice refutes it: 180 struts
+    // connected at their crossings are one cluster, and on the captured
+    // operands batching runs 51.1s against 83.7s sequential for an identical
+    // 1146-face result. Fusing scales with the tools (small prisms); the
+    // sequential loop re-cuts the whole target once per tool. Any failure
+    // falls back to the sequential loop.
     let mut result = target;
     let mut batched = false;
     let clusters = cluster_tools_by_aabb(topo, tools);
-    if tools.len() >= 2 && clusters.as_ref().is_some_and(|c| c.len() >= 2) {
+    if tools.len() >= 2 && clusters.as_ref().is_some_and(|c| !c.is_empty()) {
         let clusters = clusters.unwrap_or_default();
         let merged = clusters.iter().try_fold(None::<SolidId>, |acc, cluster| {
             let fused = cluster[1..]

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -146,10 +146,10 @@ fn compound_cut_disjoint_drills_matches_sequential() {
 }
 
 #[test]
-fn compound_cut_overlapping_tools_stays_sequential_correct() {
-    // Two tools that overlap EACH OTHER must not take the batched shortcut's
-    // disjoint-merge assumption; whatever path runs, the result must equal
-    // the union-cut volume.
+fn compound_cut_overlapping_tools_batches_correctly() {
+    // Two tools that overlap EACH OTHER form ONE AABB cluster, so they take the
+    // batched path via a real fuse rather than the disjoint-merge shortcut.
+    // Whichever path runs, the result must equal the union-cut volume.
     use crate::measure::solid_volume;
     use crate::transform::transform_solid;
     use brepkit_math::mat::Mat4;

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -146,10 +146,11 @@ fn compound_cut_disjoint_drills_matches_sequential() {
 }
 
 #[test]
-fn compound_cut_overlapping_tools_batches_correctly() {
-    // Two tools that overlap EACH OTHER form ONE AABB cluster, so they take the
-    // batched path via a real fuse rather than the disjoint-merge shortcut.
-    // Whichever path runs, the result must equal the union-cut volume.
+fn compound_cut_overlapping_tools_match_union_cut_volume() {
+    // Two tools that overlap EACH OTHER form ONE AABB cluster, so this exercises
+    // the batched path — though the batch falls back to the sequential loop on
+    // any failure, so the invariant asserted here is the one that holds either
+    // way: the result equals the volume of cutting their union.
     use crate::measure::solid_volume;
     use crate::transform::transform_solid;
     use brepkit_math::mat::Mat4;


### PR DESCRIPTION
## What

`compound_cut` merged its tools and cut once only when they fell into **two or more** AABB-disjoint clusters. A single overlapping blob fell through to the sequential loop, which re-cuts the whole target once per tool.

## Why that assumption was wrong

The kumiko wall lattice refutes it. Its 180 strut prisms are connected at their crossings, so union-find puts them in **one** cluster and the batch was declined. On the captured operands:

| path | time | result |
|---|---|---|
| sequential (as shipped) | **83.7 s** | F=1146 |
| batched (this change) | **50.3 s** | F=1146 |

Identical face count, 1.66× faster. Fusing scales with the tools — small prisms — while the sequential loop scales with the target, which grows more fragmented with every cut.

## Repro

Captured from the tool's `goma carves a 1×1×6 bin` scenario, which traps in wasm (`RuntimeError: unreachable` out of `compoundCut`, then poisons the kernel so all 13 kumiko scenarios fail from one root). The same operands run to completion **natively**, so the trap is resource exhaustion rather than a logic fault — which makes the cost itself the defect.

Operands and driver are cached at `~/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma/` + `replay_kumiko.rs` (`MODE=fuse|split`, `N=<k>`).

## Refuted while measuring — recorded so it is not retried

**Balanced pairwise fuse.** Replacing the linear `try_fold` with a halving tree looked like the obvious O(n²)→O(n log n) win, since the fuse is 80% of the time (39.9 s fuse vs 10.0 s final cut). It measured **worse: 69.8 s vs 50.3 s**. Adding one small prism to the accumulator often hits the free disjoint-shell shortcut; pairing multi-lump intermediates loses it. Reverted.

**An earlier synthetic said the opposite of the truth.** A hand-built crossing-lattice benchmark showed `compound_cut` *faster* than fuse-then-cut and nearly linear — it stopped being faithful at n≥120, where its struts merged and consumed the slab. The ordering reverses on captured operands. This PR trusts the capture.

## Verification

- Full workspace suite `--no-fail-fast`: green
- `brepkit-io` fixtures (the calibrated foils): 0 failures
- `cargo test -p brepkit-wasm --lib gridfinity`: 27/27
- `compound_cut` unit tests: 8/8, including the disjoint-drill case that motivated batching (unchanged — it already had ≥2 clusters)
- fmt + clippy clean

## Not sufficient on its own

50 s is a real improvement but still far off the bar — the reference kernel completes the entire 13-scenario kumiko suite in 265 s. The remaining cost is dominated by the 180-tool fuse (≈40 s of the 50 s). Closing that gap needs profiling of the per-fuse GFA cost, not another batching strategy; the two obvious restructurings are now both measured and refuted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch `compound_cut` when tools form a single AABB-overlap cluster, not only when there are ≥2 clusters. On the kumiko wall lattice this drops time from 83.7s to ≈50s with the same 1,146-face result.

- **Refactors**
  - Enable batching for single-cluster tool sets.
  - Use a let-chain to destructure `clusters`; preserve fallback to the sequential loop on any failure.
  - Point the source comment to the cached replay instead of exact timings; rename the overlapping-tools test to assert union-cut volume and cover the batched path.

<sup>Written for commit 4d00b5b36b137ce63c3f2fc066533032e87a29cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

