### PR TITLE
perf(algo): reject coplanar-but-disjoint SD pairs with an oriented box

### DIFF
--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -246,9 +246,11 @@ pub fn detect_same_domain<S: BuildHasher>(
     {
         // Per planar face, from one outer-wire sampling: an AABB (drives the
         // grid broad-phase) and a tol-expanded OBB (tighter oriented reject in
-        // the pair loop below).
+        // the pair loop below). `planar_obbs` is indexed directly by sub-face
+        // index — dense and hasher-free in the hot loop; an entry is `Some`
+        // exactly for the faces that also entered `planar_aabbs`.
         let mut planar_aabbs: Vec<(usize, brepkit_math::aabb::Aabb3)> = Vec::new();
-        let mut planar_obbs: HashMap<usize, brepkit_math::obb::Obb3> = HashMap::new();
+        let mut planar_obbs: Vec<Option<brepkit_math::obb::Obb3>> = vec![None; n];
         for (idx, surf) in surfaces.iter().enumerate() {
             let Some(FaceSurface::Plane { normal, .. }) = surf else {
                 continue;
@@ -267,7 +269,7 @@ pub fn detect_same_domain<S: BuildHasher>(
                 continue;
             };
             planar_aabbs.push((idx, aabb));
-            planar_obbs.insert(idx, obb);
+            planar_obbs[idx] = Some(obb);
         }
         // Broad-phase: only test pairs whose AABBs overlap. Two planar faces
         // that don't share 3D space (expanded by tol for boundary-coincident
@@ -290,9 +292,9 @@ pub fn detect_same_domain<S: BuildHasher>(
             // is result-preserving and prunes the coplanar-but-disjoint lattice
             // pairs the axis-aligned box admits — a thin diagonal strut's AABB
             // is a large square overlapping every lattice member it crosses,
-            // while its OBB hugs the strut. Missing OBBs (degenerate faces)
-            // fall through to the full test unchanged.
-            if let (Some(oi), Some(oj)) = (planar_obbs.get(&i), planar_obbs.get(&j))
+            // while its OBB hugs the strut. Both `i` and `j` come from
+            // `planar_aabbs`, so their OBB entries are always `Some`.
+            if let (Some(oi), Some(oj)) = (&planar_obbs[i], &planar_obbs[j])
                 && !oi.intersects(oj)
             {
                 continue;
@@ -1186,13 +1188,14 @@ fn face_outer_aabb(topo: &Topology, face_id: FaceId) -> Option<brepkit_math::aab
 /// the polygons the overlap tests build. Samples `0..SD_EDGE_SAMPLES` (not
 /// `..=`) so each shared vertex is covered once, by the next edge's `frac=0`.
 fn face_outer_wire_points(topo: &Topology, face_id: FaceId) -> Vec<brepkit_math::vec::Point3> {
-    let mut pts: Vec<brepkit_math::vec::Point3> = Vec::new();
     let Ok(face) = topo.face(face_id) else {
-        return pts;
+        return Vec::new();
     };
     let Ok(wire) = topo.wire(face.outer_wire()) else {
-        return pts;
+        return Vec::new();
     };
+    let mut pts: Vec<brepkit_math::vec::Point3> =
+        Vec::with_capacity(wire.edges().len() * SD_EDGE_SAMPLES);
     for oe in wire.edges() {
         let Ok(edge) = topo.edge(oe.edge()) else {
             continue;

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -244,13 +244,30 @@ pub fn detect_same_domain<S: BuildHasher>(
     // patches that rarely accumulate residue, and a 2D containment test on
     // their parametric domains needs surface-specific handling.
     {
+        // Per planar face, from one outer-wire sampling: an AABB (drives the
+        // grid broad-phase) and a tol-expanded OBB (tighter oriented reject in
+        // the pair loop below).
         let mut planar_aabbs: Vec<(usize, brepkit_math::aabb::Aabb3)> = Vec::new();
+        let mut planar_obbs: HashMap<usize, brepkit_math::obb::Obb3> = HashMap::new();
         for (idx, surf) in surfaces.iter().enumerate() {
-            if matches!(surf, Some(FaceSurface::Plane { .. }))
-                && let Some(bb) = face_outer_aabb(topo, sub_faces[idx].face_id)
-            {
-                planar_aabbs.push((idx, bb));
+            let Some(FaceSurface::Plane { normal, .. }) = surf else {
+                continue;
+            };
+            let pts = face_outer_wire_points(topo, sub_faces[idx].face_id);
+            if pts.len() < 3 {
+                continue;
             }
+            // Thickness axis pinned to the plane normal, in-plane axes from PCA,
+            // expanded by tol so a boundary-coincident pair still passes.
+            let mut obb = brepkit_math::obb::Obb3::from_slice_with_normal(&pts, *normal);
+            for e in &mut obb.half_extents {
+                *e += tol.linear;
+            }
+            let Some(aabb) = brepkit_math::aabb::Aabb3::try_from_points(pts) else {
+                continue;
+            };
+            planar_aabbs.push((idx, aabb));
+            planar_obbs.insert(idx, obb);
         }
         // Broad-phase: only test pairs whose AABBs overlap. Two planar faces
         // that don't share 3D space (expanded by tol for boundary-coincident
@@ -266,6 +283,20 @@ pub fn detect_same_domain<S: BuildHasher>(
                 _ => None,
             };
             let Some(same_dir) = same_dir else { continue };
+            // Oriented-bound reject: an OBB conservatively contains its face
+            // (both are tol-expanded), so OBB-disjoint means the faces cannot
+            // share any point — no interior point of one can lie in the other,
+            // so `planar_faces_overlap` would return false. Skipping the pair
+            // is result-preserving and prunes the coplanar-but-disjoint lattice
+            // pairs the axis-aligned box admits — a thin diagonal strut's AABB
+            // is a large square overlapping every lattice member it crosses,
+            // while its OBB hugs the strut. Missing OBBs (degenerate faces)
+            // fall through to the full test unchanged.
+            if let (Some(oi), Some(oj)) = (planar_obbs.get(&i), planar_obbs.get(&j))
+                && !oi.intersects(oj)
+            {
+                continue;
+            }
             // Complementary partition regions of one split (same source, distinct
             // interiors) are not overlapping duplicates; a coincident same-source
             // duplicate (same interior) still reaches `planar_faces_overlap`.
@@ -1148,9 +1179,20 @@ fn repr_face_area(topo: &Topology, face_id: FaceId) -> Option<f64> {
 /// `true` when the two faces share real 3D area, which requires their AABBs
 /// (expanded by tolerance for boundary-coincident cases) to intersect.
 fn face_outer_aabb(topo: &Topology, face_id: FaceId) -> Option<brepkit_math::aabb::Aabb3> {
-    let face = topo.face(face_id).ok()?;
-    let wire = topo.wire(face.outer_wire()).ok()?;
+    brepkit_math::aabb::Aabb3::try_from_points(face_outer_wire_points(topo, face_id))
+}
+
+/// Sample a face's outer wire at [`SD_EDGE_SAMPLES`] points per edge, matching
+/// the polygons the overlap tests build. Samples `0..SD_EDGE_SAMPLES` (not
+/// `..=`) so each shared vertex is covered once, by the next edge's `frac=0`.
+fn face_outer_wire_points(topo: &Topology, face_id: FaceId) -> Vec<brepkit_math::vec::Point3> {
     let mut pts: Vec<brepkit_math::vec::Point3> = Vec::new();
+    let Ok(face) = topo.face(face_id) else {
+        return pts;
+    };
+    let Ok(wire) = topo.wire(face.outer_wire()) else {
+        return pts;
+    };
     for oe in wire.edges() {
         let Ok(edge) = topo.edge(oe.edge()) else {
             continue;
@@ -1158,21 +1200,16 @@ fn face_outer_aabb(topo: &Topology, face_id: FaceId) -> Option<brepkit_math::aab
         let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
             continue;
         };
-        let (sp, ep) = (sv.point(), ev.point());
-        // Sample `0..SD_EDGE_SAMPLES` (not `..=`) to match the
-        // `planar_faces_overlap` / `planar_face_area` polygons exactly: the next
-        // edge's `frac=0` already covers each shared vertex, so this drops the
-        // redundant per-vertex duplicate without changing the AABB.
         super::pcurve_compute::sample_edge_uniform(
             edge.curve(),
-            sp,
-            ep,
+            sv.point(),
+            ev.point(),
             SD_EDGE_SAMPLES,
             oe.is_forward(),
             &mut pts,
         );
     }
-    brepkit_math::aabb::Aabb3::try_from_points(pts)
+    pts
 }
 
 /// Generate the spatially-overlapping candidate pairs among `indices` using a


### PR DESCRIPTION
## What

The planar geometric-containment pass (Step 3b of `detect_same_domain`) grid-prunes candidate pairs by axis-aligned AABB, then runs the full `planar_faces_overlap` containment test on every survivor. An axis-aligned box is a poor bound for a thin **diagonal** face: a diagonal strut's AABB is a large square that overlaps every lattice member it crosses. On a dense coplanar lattice (the kumiko wall pattern) the broad-phase barely prunes, and the pass runs tens of thousands of full containment tests per boolean that find nothing.

This adds a per-planar-face **oriented bounding box** (thickness axis pinned to the plane normal, in-plane axes from PCA), built from the same outer-wire sampling already used for the AABB, and rejects a candidate pair when the two tol-expanded OBBs are disjoint — before the full test.

## Why it's safe

An OBB conservatively contains its face (both are tol-expanded), so OBB-disjoint proves the faces share no point, and `planar_faces_overlap` could only return `false`. The reject is **result-preserving**. Candidate iteration order and the union-find sequence are unchanged, so representative selection is identical.

## Measurements

Captured 180-strut kumiko fuse (replayed natively from the parity-capture cache):

- coplanar full-test count per boolean: **~40k -> ~10k (approx 4x)**
- sequential fuse chain: **40.9s -> 36.4s (~11%)**, **byte-identical result volume** (13776.89)

The AABB grid, candidate ordering, and all downstream SD logic are untouched.

## Verification

- `brepkit-algo` unit tests: pass
- Full `brepkit-io` + `brepkit-operations` foil: **1208 tests pass** (8 skipped are `#[ignore]` ready-repros), including the SD-load-bearing gridfinity lip/socket/honeycomb fuses
- clippy clean on the changed crate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an oriented-bounding-box early reject to the planar containment pass to skip coplanar‑but‑disjoint pairs. On the 180‑strut kumiko capture this yields ~4x fewer full overlap tests and ~11% faster runtime, with byte‑identical results.

- **Performance**
  - Build a tol‑expanded OBB per planar face from the same outer‑wire samples as the AABB (normal pinned to the plane; in‑plane axes via PCA).
  - After AABB pruning, reject pairs whose OBBs don’t intersect; OBBs are stored in a dense `Vec<Option<Obb3>>` by sub‑face index (no hashing in the hot loop), and candidates from the AABB set always have OBBs. Minor: preallocate outer‑wire sampling.
  - Verified: `brepkit-algo` unit tests and the `brepkit-io` + `brepkit-operations` suite (1208) pass; clippy clean.

<sup>Written for commit ea5acdfa146639cbfd23277fe219d8e983ffb692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

