### PR TITLE
feat: N-way GFA fuse — 3.9x faster kumiko compound_cut

### DIFF
--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -442,7 +442,6 @@ impl Builder {
 ///
 /// Returns [`AlgoError`] if a coincident contact is detected, a sub-face cannot
 /// be sampled or classified, or assembly fails.
-#[allow(dead_code)] // Wired into a fuse_n entry point in the next increment.
 pub fn build_fuse_n<S: std::hash::BuildHasher>(
     mut topo: Topology,
     arena: GfaArena,

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -470,11 +470,44 @@ pub fn build_fuse_n<S: std::hash::BuildHasher>(
         })
         .collect::<Result<_, _>>()?;
 
+    // Resolve coincident faces across sources first: opposite-oriented groups
+    // are interior interfaces (all dropped); same-oriented groups keep one
+    // representative (still verified against sources outside the group). The
+    // remaining sub-faces are classified by inside/outside as usual.
+    let sd = same_domain::detect_same_domain_fuse_n(&topo, &arena, &sub_faces, &sub_source, tol)?;
+    let keep_reprs: HashMap<usize, std::collections::HashSet<usize>> =
+        sd.keep_reprs.into_iter().collect();
+
     // One ray-cast geometry per source, reused across every rival sub-face.
     let geoms: Vec<Option<classifier::RayCastGeoms>> = sources
         .iter()
         .map(|&s| classifier::RayCastGeoms::new(&topo, s).ok())
         .collect();
+
+    // Keep a sub-face iff its interior sample is outside every source in
+    // `others`. A coincident `On` against a non-coincident source means the
+    // same-domain pass missed a coincidence — bail to the sequential fallback.
+    let keep_if_outside = |topo: &Topology,
+                           sample: Point3,
+                           own: usize,
+                           others: &dyn Fn(usize) -> bool|
+     -> Result<bool, AlgoError> {
+        for (j, &other) in sources.iter().enumerate() {
+            if j == own || !others(j) {
+                continue;
+            }
+            match classifier::classify_point_cached(topo, other, geoms[j].as_ref(), sample)? {
+                FaceClass::Inside => return Ok(false),
+                FaceClass::On | FaceClass::CoplanarSame | FaceClass::CoplanarOpposite => {
+                    return Err(AlgoError::AssemblyFailed(
+                        "N-way fuse: unresolved coincident face; sequential fallback".into(),
+                    ));
+                }
+                FaceClass::Outside | FaceClass::Unknown => {}
+            }
+        }
+        Ok(true)
+    };
 
     let mut selected = Vec::new();
     for (idx, sf) in sub_faces.iter().enumerate() {
@@ -484,30 +517,21 @@ pub fn build_fuse_n<S: std::hash::BuildHasher>(
             None => sample_face_interior(&topo, sf.face_id, tol)?,
         };
 
-        // Keep the face iff it is outside EVERY other source. Inside any other
-        // source → interior to the union → drop.
-        let mut inside_any = false;
-        for (j, &other) in sources.iter().enumerate() {
-            if j == own {
-                continue;
-            }
-            match classifier::classify_point_cached(&topo, other, geoms[j].as_ref(), sample)? {
-                FaceClass::Inside => {
-                    inside_any = true;
-                    break;
+        let keep = if sd.grouped.contains(&idx) {
+            // A coincident face: kept only if it is this group's same-oriented
+            // representative AND outside every source not in the group.
+            match keep_reprs.get(&idx) {
+                Some(group_sources) => {
+                    keep_if_outside(&topo, sample, own, &|j| !group_sources.contains(&j))?
                 }
-                FaceClass::On | FaceClass::CoplanarSame | FaceClass::CoplanarOpposite => {
-                    return Err(AlgoError::AssemblyFailed(
-                        "N-way fuse hit a coincident face; \
-                         cross-source same-domain not yet supported"
-                            .into(),
-                    ));
-                }
-                FaceClass::Outside | FaceClass::Unknown => {}
+                None => false,
             }
-        }
+        } else {
+            // A normal sub-face: kept iff outside every other source.
+            keep_if_outside(&topo, sample, own, &|_| true)?
+        };
 
-        if !inside_any {
+        if keep {
             selected.push(bop::SelectedFace {
                 face_id: sf.face_id,
                 source_face: sf.source_face,

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -419,6 +419,107 @@ impl Builder {
     }
 }
 
+/// Build an N-way FUSE result from the shared arena of an N-way pave filler.
+///
+/// Reuses the two-solid Builder machinery, generalized to N sources:
+///
+/// - **Splitting** — sections are stored face-relative (`pcurve_a == pcurve_b`),
+///   so the face splitter is rank-invariant; every face is split with a
+///   constant `Rank::A`. A sub-face's *global* source is tracked separately via
+///   `face_source` (original input face → source index).
+/// - **Classification** — each sub-face is kept iff its interior sample is
+///   OUTSIDE every OTHER source (the union boundary). One `RayCastGeoms` is
+///   built per source and reused across all sub-faces of that source's rivals.
+/// - **Assembly** — the kept faces feed the standard solid assembler.
+///
+/// This slice handles the interpenetrating case (no coincident faces). If a
+/// sub-face classifies `On` against another source — the signature of a
+/// coincident/flush contact that needs cross-source same-domain resolution —
+/// the fuse bails with an error so the caller can fall back to the sequential
+/// path. Coincident-face support is the next increment.
+///
+/// # Errors
+///
+/// Returns [`AlgoError`] if a coincident contact is detected, a sub-face cannot
+/// be sampled or classified, or assembly fails.
+#[allow(dead_code)] // Wired into a fuse_n entry point in the next increment.
+pub fn build_fuse_n<S: std::hash::BuildHasher>(
+    mut topo: Topology,
+    arena: GfaArena,
+    sources: &[SolidId],
+    face_source: &HashMap<FaceId, usize, S>,
+    tol: Tolerance,
+) -> Result<(Topology, SolidId), AlgoError> {
+    // Split every source face. Sections are face-relative, so a constant rank
+    // is correct for all of them (see the doc comment).
+    let edge_images = fill_images::fill_edge_images(&arena);
+    let all_a_ranks: HashMap<FaceId, Rank> = face_source.keys().map(|&f| (f, Rank::A)).collect();
+    let sub_faces =
+        fill_images_faces::fill_images_faces(&mut topo, &arena, &edge_images, &all_a_ranks, tol);
+
+    // The global source of each sub-face is its parent input face's source.
+    let sub_source: Vec<usize> = sub_faces
+        .iter()
+        .map(|sf| {
+            face_source.get(&sf.source_face).copied().ok_or_else(|| {
+                AlgoError::AssemblyFailed(format!(
+                    "sub-face parent {:?} has no source index",
+                    sf.source_face
+                ))
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    // One ray-cast geometry per source, reused across every rival sub-face.
+    let geoms: Vec<Option<classifier::RayCastGeoms>> = sources
+        .iter()
+        .map(|&s| classifier::RayCastGeoms::new(&topo, s).ok())
+        .collect();
+
+    let mut selected = Vec::new();
+    for (idx, sf) in sub_faces.iter().enumerate() {
+        let own = sub_source[idx];
+        let sample = match sf.interior_point {
+            Some(pt) => pt,
+            None => sample_face_interior(&topo, sf.face_id, tol)?,
+        };
+
+        // Keep the face iff it is outside EVERY other source. Inside any other
+        // source → interior to the union → drop.
+        let mut inside_any = false;
+        for (j, &other) in sources.iter().enumerate() {
+            if j == own {
+                continue;
+            }
+            match classifier::classify_point_cached(&topo, other, geoms[j].as_ref(), sample)? {
+                FaceClass::Inside => {
+                    inside_any = true;
+                    break;
+                }
+                FaceClass::On | FaceClass::CoplanarSame | FaceClass::CoplanarOpposite => {
+                    return Err(AlgoError::AssemblyFailed(
+                        "N-way fuse hit a coincident face; \
+                         cross-source same-domain not yet supported"
+                            .into(),
+                    ));
+                }
+                FaceClass::Outside | FaceClass::Unknown => {}
+            }
+        }
+
+        if !inside_any {
+            selected.push(bop::SelectedFace {
+                face_id: sf.face_id,
+                source_face: sf.source_face,
+                reversed: false,
+            });
+        }
+    }
+
+    let solid_id = assemble::assemble_solid(&mut topo, &selected, &[])?;
+    Ok((topo, solid_id))
+}
+
 /// Sample a point in the interior of a face.
 ///
 /// Uses the midpoint of the first boundary edge, then offsets slightly

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -19,6 +19,7 @@ use std::hash::BuildHasher;
 
 use super::SubFace;
 use crate::ds::{GfaArena, Rank};
+use crate::error::AlgoError;
 use brepkit_math::tolerance::Tolerance;
 use brepkit_topology::Topology;
 use brepkit_topology::face::{FaceId, FaceSurface};
@@ -124,16 +125,33 @@ type EdgeSet = Vec<(QVert, QVert, QVert)>;
 /// Returns a list of SD pairs WITHOUT modifying sub-face classifications.
 /// The BOP selector uses these pairs for operation-specific handling.
 #[allow(clippy::too_many_lines)]
-pub fn detect_same_domain<S: BuildHasher>(
+/// Coincidence grouping shared by the 2-operand and N-way SD emissions.
+///
+/// `sd_groups` maps each union-find root to the coincident sub-face indices in
+/// that group; `pair_data` maps a directly-unioned `(min, max)` pair to whether
+/// the two faces share outward orientation; `geometric_overlap_groups` holds the
+/// roots whose union came from the geometric-containment pass. The grouping is
+/// rank-agnostic — the emission step interprets it per boolean operation.
+struct SdGrouping {
+    sd_groups: HashMap<usize, Vec<usize>>,
+    pair_data: HashMap<(usize, usize), bool>,
+    geometric_overlap_groups: HashSet<usize>,
+}
+
+/// Detect and union all coincident (same-domain) sub-faces.
+fn build_sd_grouping(
     topo: &Topology,
     arena: &GfaArena,
     sub_faces: &[SubFace],
-    _face_ranks: &HashMap<FaceId, Rank, S>,
     tol: Tolerance,
-) -> SameDomainResult {
+) -> SdGrouping {
     let n = sub_faces.len();
     if n < 2 {
-        return SameDomainResult::default();
+        return SdGrouping {
+            sd_groups: HashMap::new(),
+            pair_data: HashMap::new(),
+            geometric_overlap_groups: HashSet::new(),
+        };
     }
 
     // Use quantized vertex positions (not VertexId) so that VV-merged
@@ -386,6 +404,29 @@ pub fn detect_same_domain<S: BuildHasher>(
         }
     }
 
+    SdGrouping {
+        sd_groups,
+        pair_data,
+        geometric_overlap_groups,
+    }
+}
+
+/// Two-operand same-domain detection: split each coincident group into a
+/// cross-rank [`SameDomainPair`] plus within-rank duplicates for the BOP
+/// selector. Behaviour is unchanged from before the grouping was extracted.
+pub fn detect_same_domain<S: BuildHasher>(
+    topo: &Topology,
+    arena: &GfaArena,
+    sub_faces: &[SubFace],
+    _face_ranks: &HashMap<FaceId, Rank, S>,
+    tol: Tolerance,
+) -> SameDomainResult {
+    let SdGrouping {
+        sd_groups,
+        pair_data,
+        geometric_overlap_groups,
+    } = build_sd_grouping(topo, arena, sub_faces, tol);
+
     let mut pairs = Vec::new();
     let mut within_rank_dups = Vec::new();
 
@@ -499,6 +540,90 @@ pub fn detect_same_domain<S: BuildHasher>(
         pairs,
         within_rank_dups,
     }
+}
+
+/// N-way FUSE same-domain decisions over coincident face groups.
+pub struct FuseNSameDomain {
+    /// Every sub-face that belongs to a coincident group. These are handled
+    /// here and excluded from the caller's normal inside/outside classification.
+    pub grouped: HashSet<usize>,
+    /// For each SAME-oriented (shared-exterior) group, its single kept
+    /// representative paired with the set of source indices in that group. The
+    /// caller keeps the representative only if it is also outside every source
+    /// NOT in the group (a third solid could still cover it). Opposite-oriented
+    /// (internal-interface) groups contribute members to `grouped` only — all
+    /// dropped.
+    pub keep_reprs: Vec<(usize, HashSet<usize>)>,
+}
+
+/// Resolve coincident faces for an N-way FUSE.
+///
+/// Reuses the rank-agnostic [`build_sd_grouping`] and decides each group by the
+/// effective outward normals of its members (planar only):
+///
+/// - **All aligned** — the faces bound the union on the same side; it is an
+///   exterior boundary, so keep exactly one (the lowest-indexed member) and drop
+///   the coincident duplicates.
+/// - **Mixed** — material lies on both sides of the shared plane, so the region
+///   is interior to the union; drop every member.
+///
+/// `source[i]` is the global source index of sub-face `i`.
+///
+/// # Errors
+///
+/// Returns [`AlgoError`] on a coincident group with a non-planar member, whose
+/// orientation is not a single vector — the caller should fall back to the
+/// sequential path.
+pub fn detect_same_domain_fuse_n(
+    topo: &Topology,
+    arena: &GfaArena,
+    sub_faces: &[SubFace],
+    source: &[usize],
+    tol: Tolerance,
+) -> Result<FuseNSameDomain, AlgoError> {
+    let SdGrouping { sd_groups, .. } = build_sd_grouping(topo, arena, sub_faces, tol);
+
+    let mut grouped = HashSet::new();
+    let mut keep_reprs = Vec::new();
+
+    for members in sd_groups.values() {
+        if members.len() < 2 {
+            continue;
+        }
+
+        let mut normals = Vec::with_capacity(members.len());
+        for &m in members {
+            let normal = topo
+                .face(sub_faces[m].face_id)?
+                .effective_plane_normal()
+                .ok_or_else(|| {
+                    AlgoError::AssemblyFailed(
+                        "N-way fuse: non-planar coincident face; sequential fallback".into(),
+                    )
+                })?;
+            normals.push(normal);
+        }
+
+        for &m in members {
+            grouped.insert(m);
+        }
+
+        let reference = normals[0];
+        let all_aligned = normals.iter().all(|n| n.dot(reference) > 0.0);
+        if all_aligned {
+            // Shared exterior boundary — keep exactly one representative.
+            let repr = members.iter().copied().min().unwrap_or(members[0]);
+            let group_sources: HashSet<usize> = members.iter().map(|&m| source[m]).collect();
+            keep_reprs.push((repr, group_sources));
+        }
+        // Mixed orientation → interior interface → drop all (members already in
+        // `grouped`, none pushed to `keep_reprs`).
+    }
+
+    Ok(FuseNSameDomain {
+        grouped,
+        keep_reprs,
+    })
 }
 
 /// Compute the canonical edge set for a face using quantized vertex positions.

--- a/crates/algo/src/ds/mod.rs
+++ b/crates/algo/src/ds/mod.rs
@@ -24,6 +24,4 @@ pub use pave_vertex_index::PaveVertexIndex;
 #[allow(unused_imports)]
 pub use pave::{CommonBlock, CommonBlockId};
 pub use shape_index::Rank;
-pub use shape_store::GfaShapeStore;
-#[allow(unused_imports)] // Foundation for the N-way fuse; consumer lands next.
-pub use shape_store::GfaShapeStoreN;
+pub use shape_store::{GfaShapeStore, GfaShapeStoreN};

--- a/crates/algo/src/ds/mod.rs
+++ b/crates/algo/src/ds/mod.rs
@@ -25,3 +25,5 @@ pub use pave_vertex_index::PaveVertexIndex;
 pub use pave::{CommonBlock, CommonBlockId};
 pub use shape_index::Rank;
 pub use shape_store::GfaShapeStore;
+#[allow(unused_imports)] // Foundation for the N-way fuse; consumer lands next.
+pub use shape_store::GfaShapeStoreN;

--- a/crates/algo/src/ds/shape_store.rs
+++ b/crates/algo/src/ds/shape_store.rs
@@ -93,6 +93,80 @@ impl GfaShapeStore {
     }
 }
 
+/// Isolated shape store for an N-way GFA fuse.
+///
+/// Like [`GfaShapeStore`] but holds an arbitrary number of deep-copied source
+/// solids in one store topology, for the N-way fuse pipeline (one arrangement
+/// over all operands rather than sequential pairwise booleans). The 2-operand
+/// [`GfaShapeStore`] is unchanged; this is additive.
+///
+/// Foundation for the N-way fuse: consumed by the forthcoming
+/// `run_pave_filler_n` orchestration (see `project_nway-gfa-fuse`). Marked
+/// `allow(dead_code)` only until that consumer lands in the next increment.
+#[allow(dead_code)]
+pub struct GfaShapeStoreN {
+    /// The store's own topology arena.
+    pub topo: Topology,
+    /// Store-local `SolidId` for each deep-copied source, in input order.
+    pub sources: Vec<SolidId>,
+    /// Store-local input-face index → the source index (position in `sources`)
+    /// it belongs to. The basis for per-sub-face source tagging downstream.
+    pub face_source: HashMap<usize, usize>,
+    /// Store-local input-face index → caller-topology face index, for
+    /// shape-evolution provenance across the copy.
+    pub input_face_to_caller: HashMap<usize, usize>,
+}
+
+#[allow(dead_code)] // Consumed by run_pave_filler_n in the next N-way increment.
+impl GfaShapeStoreN {
+    /// Create a store by deep-copying every solid in `origs` into one topology.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AlgoError`] if `origs` is empty or any topology lookup fails.
+    pub fn new(source: &Topology, origs: &[SolidId]) -> Result<Self, AlgoError> {
+        if origs.is_empty() {
+            return Err(AlgoError::AssemblyFailed(
+                "N-way fuse store needs at least one source solid".into(),
+            ));
+        }
+
+        let mut topo = Topology::default();
+        let mut sources = Vec::with_capacity(origs.len());
+        let mut face_source = HashMap::new();
+        let mut input_face_to_caller = HashMap::new();
+
+        for (src_idx, &orig) in origs.iter().enumerate() {
+            let (solid, map) = deep_copy_solid(source, &mut topo, orig)?;
+            sources.push(solid);
+            for (caller_idx, store_face) in map {
+                face_source.insert(store_face.index(), src_idx);
+                input_face_to_caller.insert(store_face.index(), caller_idx);
+            }
+        }
+
+        Ok(Self {
+            topo,
+            sources,
+            face_source,
+            input_face_to_caller,
+        })
+    }
+
+    /// Export a result solid from this store back to the caller's topology.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AlgoError`] if any topology lookup fails.
+    pub fn export_solid(
+        &self,
+        target: &mut Topology,
+        solid_id: SolidId,
+    ) -> Result<SolidId, AlgoError> {
+        Ok(deep_copy_solid(&self.topo, target, solid_id)?.0)
+    }
+}
+
 /// Deep-copy a solid from `source` topology into `target` topology.
 ///
 /// Creates new vertices, edges, wires, faces, shells, and solid in `target`
@@ -323,5 +397,49 @@ mod tests {
                 .unwrap()
                 .len();
         assert_eq!(store_vertex_count, 6, "store solid_a should have 6 faces");
+    }
+
+    #[test]
+    fn nway_store_copies_all_sources_and_tags_faces() {
+        use brepkit_topology::explorer::solid_faces;
+        use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+
+        let mut source = Topology::default();
+        let boxes = [
+            make_unit_cube_manifold_at(&mut source, 0.0, 0.0, 0.0),
+            make_unit_cube_manifold_at(&mut source, 0.5, 0.0, 0.0),
+            make_unit_cube_manifold_at(&mut source, 1.0, 0.0, 0.0),
+        ];
+
+        let store = GfaShapeStoreN::new(&source, &boxes).unwrap();
+        assert_eq!(store.sources.len(), 3, "three sources copied");
+
+        // Every source is an independent 6-face box, and every one of its faces
+        // is tagged with that source's index.
+        for (src_idx, &sid) in store.sources.iter().enumerate() {
+            let faces = solid_faces(&store.topo, sid).unwrap();
+            assert_eq!(faces.len(), 6, "source {src_idx} is a 6-face box");
+            for fid in faces {
+                assert_eq!(
+                    store.face_source.get(&fid.index()).copied(),
+                    Some(src_idx),
+                    "face {fid:?} tagged to source {src_idx}"
+                );
+            }
+        }
+
+        // 3 independent boxes -> 18 distinct faces, all source-tagged.
+        assert_eq!(store.face_source.len(), 18, "18 distinct tagged faces");
+
+        // Export round-trips one source into a fresh topology.
+        let mut target = Topology::default();
+        let exported = store.export_solid(&mut target, store.sources[1]).unwrap();
+        assert_eq!(solid_faces(&target, exported).unwrap().len(), 6);
+    }
+
+    #[test]
+    fn nway_store_rejects_empty() {
+        let source = Topology::default();
+        assert!(GfaShapeStoreN::new(&source, &[]).is_err());
     }
 }

--- a/crates/algo/src/ds/shape_store.rs
+++ b/crates/algo/src/ds/shape_store.rs
@@ -99,11 +99,6 @@ impl GfaShapeStore {
 /// solids in one store topology, for the N-way fuse pipeline (one arrangement
 /// over all operands rather than sequential pairwise booleans). The 2-operand
 /// [`GfaShapeStore`] is unchanged; this is additive.
-///
-/// Foundation for the N-way fuse: consumed by the forthcoming
-/// `run_pave_filler_n` orchestration (see `project_nway-gfa-fuse`). Marked
-/// `allow(dead_code)` only until that consumer lands in the next increment.
-#[allow(dead_code)]
 pub struct GfaShapeStoreN {
     /// The store's own topology arena.
     pub topo: Topology,
@@ -112,12 +107,8 @@ pub struct GfaShapeStoreN {
     /// Store-local input face → the source index (position in `sources`) it
     /// belongs to. The basis for per-sub-face source tagging downstream.
     pub face_source: HashMap<FaceId, usize>,
-    /// Store-local input-face index → caller-topology face index, for
-    /// shape-evolution provenance across the copy.
-    pub input_face_to_caller: HashMap<usize, usize>,
 }
 
-#[allow(dead_code)] // Consumed by run_pave_filler_n in the next N-way increment.
 impl GfaShapeStoreN {
     /// Create a store by deep-copying every solid in `origs` into one topology.
     ///
@@ -134,14 +125,12 @@ impl GfaShapeStoreN {
         let mut topo = Topology::default();
         let mut sources = Vec::with_capacity(origs.len());
         let mut face_source = HashMap::new();
-        let mut input_face_to_caller = HashMap::new();
 
         for (src_idx, &orig) in origs.iter().enumerate() {
             let (solid, map) = deep_copy_solid(source, &mut topo, orig)?;
             sources.push(solid);
-            for (caller_idx, store_face) in map {
+            for (_caller_idx, store_face) in map {
                 face_source.insert(store_face, src_idx);
-                input_face_to_caller.insert(store_face.index(), caller_idx);
             }
         }
 
@@ -149,7 +138,6 @@ impl GfaShapeStoreN {
             topo,
             sources,
             face_source,
-            input_face_to_caller,
         })
     }
 

--- a/crates/algo/src/ds/shape_store.rs
+++ b/crates/algo/src/ds/shape_store.rs
@@ -109,9 +109,9 @@ pub struct GfaShapeStoreN {
     pub topo: Topology,
     /// Store-local `SolidId` for each deep-copied source, in input order.
     pub sources: Vec<SolidId>,
-    /// Store-local input-face index → the source index (position in `sources`)
-    /// it belongs to. The basis for per-sub-face source tagging downstream.
-    pub face_source: HashMap<usize, usize>,
+    /// Store-local input face → the source index (position in `sources`) it
+    /// belongs to. The basis for per-sub-face source tagging downstream.
+    pub face_source: HashMap<FaceId, usize>,
     /// Store-local input-face index → caller-topology face index, for
     /// shape-evolution provenance across the copy.
     pub input_face_to_caller: HashMap<usize, usize>,
@@ -140,7 +140,7 @@ impl GfaShapeStoreN {
             let (solid, map) = deep_copy_solid(source, &mut topo, orig)?;
             sources.push(solid);
             for (caller_idx, store_face) in map {
-                face_source.insert(store_face.index(), src_idx);
+                face_source.insert(store_face, src_idx);
                 input_face_to_caller.insert(store_face.index(), caller_idx);
             }
         }
@@ -421,7 +421,7 @@ mod tests {
             assert_eq!(faces.len(), 6, "source {src_idx} is a 6-face box");
             for fid in faces {
                 assert_eq!(
-                    store.face_source.get(&fid.index()).copied(),
+                    store.face_source.get(&fid).copied(),
                     Some(src_idx),
                     "face {fid:?} tagged to source {src_idx}"
                 );

--- a/crates/algo/src/gfa.rs
+++ b/crates/algo/src/gfa.rs
@@ -9,7 +9,7 @@ use brepkit_topology::solid::SolidId;
 
 use crate::bop::BooleanOp;
 use crate::builder::Builder;
-use crate::ds::GfaArena;
+use crate::ds::{GfaArena, GfaShapeStoreN};
 use crate::error::AlgoError;
 use crate::pave_filler;
 
@@ -100,6 +100,54 @@ pub fn boolean_with_tolerance(
     let result = store.export_solid(topo, store_result)?;
 
     Ok(result)
+}
+
+/// Fuse **N** solids into one via a single GFA arrangement.
+///
+/// One pass over all operands instead of the sequential pairwise fuse's
+/// re-processing of a growing accumulator (O(n²)). Runs the N-way pave filler
+/// (pairwise intersection into one arena, spatially pruned) then the N-way
+/// builder (split once, classify each sub-face against all other sources, keep
+/// the union boundary, resolve coincident faces).
+///
+/// Fuse-only, and currently limited to the planar-coincidence cases the N-way
+/// builder handles — it returns an error (for the caller to fall back to the
+/// sequential fuse) on a non-planar coincident contact or an unresolved
+/// coincidence. `sources` must be non-empty; a single source returns a copy.
+///
+/// # Errors
+///
+/// Returns [`AlgoError`] if `sources` is empty or any GFA stage fails.
+pub fn fuse_n(topo: &mut Topology, sources: &[SolidId]) -> Result<SolidId, AlgoError> {
+    match sources {
+        [] => Err(AlgoError::AssemblyFailed(
+            "fuse_n needs at least one source solid".into(),
+        )),
+        [only] => {
+            // A copy so the caller owns a distinct result, mirroring the
+            // store round-trip the multi-source path performs.
+            let store = GfaShapeStoreN::new(topo, &[*only])?;
+            store.export_solid(topo, store.sources[0])
+        }
+        _ => {
+            let tol = Tolerance::default();
+            let mut store = GfaShapeStoreN::new(topo, sources)?;
+
+            let mut arena = GfaArena::new();
+            pave_filler::run_pave_filler_n(&mut store.topo, &store.sources, tol, &mut arena)?;
+
+            let (store_topo, store_result) = crate::builder::build_fuse_n(
+                std::mem::take(&mut store.topo),
+                arena,
+                &store.sources,
+                &store.face_source,
+                tol,
+            )?;
+            store.topo = store_topo;
+
+            store.export_solid(topo, store_result)
+        }
+    }
 }
 
 /// Run a GFA boolean, also returning each result face's provenance.

--- a/crates/algo/src/pave_filler/mod.rs
+++ b/crates/algo/src/pave_filler/mod.rs
@@ -185,10 +185,6 @@ pub fn run_pave_filler(
 /// # Errors
 ///
 /// Returns [`AlgoError`] if `sources` is empty or any stage fails.
-// Foundation for the N-way fuse: reached only from tests until the N-way builder
-// wires it into a `fuse_n` entry point (see `project_nway-gfa-fuse`). The
-// dead-code allow comes off with that consumer.
-#[allow(dead_code)]
 pub fn run_pave_filler_n(
     topo: &mut Topology,
     sources: &[SolidId],
@@ -246,7 +242,6 @@ pub fn run_pave_filler_n(
 /// Initialize a pave block for every edge across all `sources`, de-duplicating
 /// edges shared between solids (coincident walls). Mirrors
 /// [`PaveFiller::init_pave_blocks`] but over N solids.
-#[allow(dead_code)] // Foundation for the N-way fuse; consumer lands next.
 fn init_pave_blocks_n(
     topo: &Topology,
     sources: &[SolidId],
@@ -268,7 +263,6 @@ fn init_pave_blocks_n(
 }
 
 /// Axis-aligned bounding box of a solid from its vertices.
-#[allow(dead_code)] // Foundation for the N-way fuse; consumer lands next.
 fn solid_aabb(topo: &Topology, solid: SolidId) -> Option<brepkit_math::aabb::Aabb3> {
     let mut pts = Vec::new();
     for vid in brepkit_topology::explorer::solid_vertices(topo, solid).ok()? {
@@ -282,7 +276,6 @@ fn solid_aabb(topo: &Topology, solid: SolidId) -> Option<brepkit_math::aabb::Aab
 /// with disjoint boxes cannot intersect, so pruning them is result-preserving.
 /// A solid without a computable box is treated as interacting with all others
 /// (conservative — never drops a real interaction).
-#[allow(dead_code)] // Foundation for the N-way fuse; consumer lands next.
 fn interacting_pairs(topo: &Topology, sources: &[SolidId], tol: Tolerance) -> Vec<(usize, usize)> {
     let boxes: Vec<Option<brepkit_math::aabb::Aabb3>> =
         sources.iter().map(|&s| solid_aabb(topo, s)).collect();

--- a/crates/algo/src/pave_filler/mod.rs
+++ b/crates/algo/src/pave_filler/mod.rs
@@ -161,3 +161,142 @@ pub fn run_pave_filler(
 
     Ok(())
 }
+
+/// Run the PaveFiller pipeline over **N** source solids for an N-way fuse.
+///
+/// The Stage-1 intersection phases are inherently pairwise (each section is
+/// between the faces of two solids) and, crucially, deposit only geometric
+/// split data into the shared `arena` — they carry no `Rank`. So the two-solid
+/// phase code is reused verbatim: run each phase for every spatially-interacting
+/// source pair into ONE arena, and the paves/sections accumulate correctly. A
+/// bbox broad-phase skips non-interacting pairs, keeping the stage O(n·k) for
+/// the sparse interaction graphs a fused lattice produces rather than O(n²).
+///
+/// Phase order preserves the two-solid pipeline's invariant that the
+/// pave-vertex coincidence index is built ONCE, after all VV coincidences are
+/// registered and before the phases that query it: every pair's VV runs first,
+/// then the index is built, then the remaining phases run per pair. Stage-2
+/// resolution (which is already solid-agnostic — it reads the accumulated arena)
+/// runs once.
+///
+/// For `sources.len() == 2` this is behaviourally identical to
+/// [`run_pave_filler`]. Cut/Intersect are unaffected; this path is fuse-only.
+///
+/// # Errors
+///
+/// Returns [`AlgoError`] if `sources` is empty or any stage fails.
+// Foundation for the N-way fuse: reached only from tests until the N-way builder
+// wires it into a `fuse_n` entry point (see `project_nway-gfa-fuse`). The
+// dead-code allow comes off with that consumer.
+#[allow(dead_code)]
+pub fn run_pave_filler_n(
+    topo: &mut Topology,
+    sources: &[SolidId],
+    tol: Tolerance,
+    arena: &mut GfaArena,
+) -> Result<(), AlgoError> {
+    if sources.is_empty() {
+        return Err(AlgoError::AssemblyFailed(
+            "N-way pave filler needs at least one source solid".into(),
+        ));
+    }
+
+    // Stage 1: Intersection over interacting pairs, accumulating into one arena.
+    init_pave_blocks_n(topo, sources, arena)?;
+    let pairs = interacting_pairs(topo, sources, tol);
+
+    for &(i, j) in &pairs {
+        phase_vv::perform(topo, sources[i], sources[j], tol, arena)?;
+    }
+    // VV is the only phase that registers same-domain vertices and the edge
+    // pave blocks are fixed at init, so the coincidence index is stable for the
+    // remaining phases — build it once, after every pair's VV (mirrors the
+    // two-solid `PaveFiller::perform`).
+    arena.build_pave_vertex_index(topo, tol.linear);
+    for &(i, j) in &pairs {
+        phase_ve::perform(topo, sources[i], sources[j], tol, arena)?;
+    }
+    for &(i, j) in &pairs {
+        phase_ee::perform(topo, sources[i], sources[j], tol, arena)?;
+    }
+    for &(i, j) in &pairs {
+        phase_vf::perform(topo, sources[i], sources[j], tol, arena)?;
+    }
+    for &(i, j) in &pairs {
+        phase_ef::perform(topo, sources[i], sources[j], tol, arena)?;
+    }
+    for &(i, j) in &pairs {
+        phase_ff::perform(topo, sources[i], sources[j], tol, arena)?;
+    }
+    for &(i, j) in &pairs {
+        phase_ff_coplanar::perform(topo, sources[i], sources[j], tol, arena)?;
+    }
+
+    // Stage 2: Resolution (solid-agnostic — reads the accumulated arena).
+    make_blocks::perform(arena)?;
+    force_interf_ee::perform(topo, tol, arena)?;
+    link_existing::perform(topo, tol, arena)?;
+    make_split_edges::perform(topo, arena)?;
+    make_pcurves::perform(topo, arena)?;
+    fill_face_info::perform(topo, arena)?;
+
+    Ok(())
+}
+
+/// Initialize a pave block for every edge across all `sources`, de-duplicating
+/// edges shared between solids (coincident walls). Mirrors
+/// [`PaveFiller::init_pave_blocks`] but over N solids.
+#[allow(dead_code)] // Foundation for the N-way fuse; consumer lands next.
+fn init_pave_blocks_n(
+    topo: &Topology,
+    sources: &[SolidId],
+    arena: &mut GfaArena,
+) -> Result<(), AlgoError> {
+    for &solid in sources {
+        for edge_id in brepkit_topology::explorer::solid_edges(topo, solid)? {
+            if arena.edge_pave_blocks.contains_key(&edge_id) {
+                continue;
+            }
+            let edge = topo.edge(edge_id)?;
+            let start_pos = topo.vertex(edge.start())?.point();
+            let end_pos = topo.vertex(edge.end())?.point();
+            let (t0, t1) = edge.curve().domain_with_endpoints(start_pos, end_pos);
+            arena.init_edge_pave_block(edge_id, edge.start(), t0, edge.end(), t1);
+        }
+    }
+    Ok(())
+}
+
+/// Axis-aligned bounding box of a solid from its vertices.
+#[allow(dead_code)] // Foundation for the N-way fuse; consumer lands next.
+fn solid_aabb(topo: &Topology, solid: SolidId) -> Option<brepkit_math::aabb::Aabb3> {
+    let mut pts = Vec::new();
+    for vid in brepkit_topology::explorer::solid_vertices(topo, solid).ok()? {
+        pts.push(topo.vertex(vid).ok()?.point());
+    }
+    brepkit_math::aabb::Aabb3::try_from_points(pts)
+}
+
+/// Source-index pairs `(i, j)` with `i < j` whose bounding boxes overlap (each
+/// expanded by tolerance so coincident-wall pairs are not missed). Two solids
+/// with disjoint boxes cannot intersect, so pruning them is result-preserving.
+/// A solid without a computable box is treated as interacting with all others
+/// (conservative — never drops a real interaction).
+#[allow(dead_code)] // Foundation for the N-way fuse; consumer lands next.
+fn interacting_pairs(topo: &Topology, sources: &[SolidId], tol: Tolerance) -> Vec<(usize, usize)> {
+    let boxes: Vec<Option<brepkit_math::aabb::Aabb3>> =
+        sources.iter().map(|&s| solid_aabb(topo, s)).collect();
+    let mut pairs = Vec::new();
+    for i in 0..sources.len() {
+        for j in (i + 1)..sources.len() {
+            let interact = match (boxes[i], boxes[j]) {
+                (Some(bi), Some(bj)) => bi.expanded(tol.linear).intersects(bj.expanded(tol.linear)),
+                _ => true,
+            };
+            if interact {
+                pairs.push((i, j));
+            }
+        }
+    }
+    pairs
+}

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -1587,3 +1587,97 @@ fn gfa_cut_shelled_box_through_floor_is_manifold() {
         "closed manifold: every edge shared by exactly two wires"
     );
 }
+
+// ── N-way pave filler (run_pave_filler_n) ───────────────────────────────
+
+#[test]
+fn interacting_pairs_prunes_disjoint_boxes() {
+    use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+    let tol = brepkit_math::tolerance::Tolerance::default();
+    let mut topo = Topology::default();
+    // Unit cubes span [0,1], [0.5,1.5], [1.0,2.0]: 0&1 overlap, 1&2 overlap,
+    // 0&2 only touch at x=1.0 (within tol → still interacting), 0&3 disjoint.
+    let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut topo, 0.5, 0.0, 0.0);
+    let c = make_unit_cube_manifold_at(&mut topo, 1.0, 0.0, 0.0);
+    let d = make_unit_cube_manifold_at(&mut topo, 3.0, 0.0, 0.0); // far away
+
+    let pairs = super::interacting_pairs(&topo, &[a, b, c, d], tol);
+    assert!(pairs.contains(&(0, 1)), "0&1 overlap");
+    assert!(pairs.contains(&(1, 2)), "1&2 overlap");
+    // 0&3 and 1&3 and 2&3 are far apart and must be pruned.
+    assert!(!pairs.contains(&(0, 3)), "0&3 disjoint, pruned");
+    assert!(!pairs.contains(&(1, 3)), "1&3 disjoint, pruned");
+    assert!(!pairs.contains(&(2, 3)), "2&3 disjoint, pruned");
+}
+
+#[test]
+fn pave_filler_n_empty_sources_errors() {
+    let mut topo = Topology::default();
+    let tol = brepkit_math::tolerance::Tolerance::default();
+    let mut arena = GfaArena::new();
+    assert!(crate::pave_filler::run_pave_filler_n(&mut topo, &[], tol, &mut arena).is_err());
+}
+
+/// For N=2 the N-way pave filler runs the exact same phase sequence as the
+/// two-solid `run_pave_filler`, so the full pipeline (pave filler → builder →
+/// fuse) must produce an identical result. Compare the fused face count.
+#[test]
+fn pave_filler_n_matches_two_solid_for_n2() {
+    use brepkit_topology::explorer::solid_faces;
+    use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+    let tol = brepkit_math::tolerance::Tolerance::default();
+
+    let fuse_faces = |use_nway: bool| -> usize {
+        let mut topo = Topology::default();
+        let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+        let b = make_unit_cube_manifold_at(&mut topo, 0.5, 0.0, 0.0);
+        let mut arena = GfaArena::new();
+        if use_nway {
+            crate::pave_filler::run_pave_filler_n(&mut topo, &[a, b], tol, &mut arena).unwrap();
+        } else {
+            crate::pave_filler::run_pave_filler(&mut topo, a, b, tol, &mut arena).unwrap();
+        }
+        let mut builder = crate::builder::Builder::with_tolerance(topo, arena, a, b, tol);
+        builder.perform().unwrap();
+        let (rtopo, result) = builder.build_result(crate::bop::BooleanOp::Fuse).unwrap();
+        solid_faces(&rtopo, result).unwrap().len()
+    };
+
+    let two_solid = fuse_faces(false);
+    let n_way = fuse_faces(true);
+    assert!(two_solid > 0, "2-solid fuse produced faces");
+    assert_eq!(
+        two_solid, n_way,
+        "N=2 n-way pave filler must match the 2-solid fuse face count"
+    );
+}
+
+/// Smoke test that the pairwise accumulation over THREE solids runs and
+/// actually splits shared edges. The middle box overlaps both neighbours, so
+/// the arena must end with at least one edge carrying multiple pave blocks
+/// (i.e. split by an intersection). Proves the phases accumulate into one arena
+/// across pairs without a hidden two-solid assumption.
+#[test]
+fn pave_filler_n_accumulates_three_overlapping_boxes() {
+    use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+    let tol = brepkit_math::tolerance::Tolerance::default();
+    let mut topo = Topology::default();
+    let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut topo, 0.5, 0.0, 0.0);
+    let c = make_unit_cube_manifold_at(&mut topo, 1.0, 0.0, 0.0);
+
+    let mut arena = GfaArena::new();
+    crate::pave_filler::run_pave_filler_n(&mut topo, &[a, b, c], tol, &mut arena).unwrap();
+
+    let split_edges = arena
+        .edge_pave_blocks
+        .values()
+        .filter(|blocks| blocks.len() > 1)
+        .count();
+    assert!(
+        split_edges > 0,
+        "three overlapping boxes must split at least one shared edge \
+         (arena accumulated no splits — pairwise phases did not accumulate)"
+    );
+}

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -1789,3 +1789,93 @@ fn build_fuse_n_three_interpenetrating_boxes_is_watertight() {
         "three-box N-way fuse must be watertight; got two={two} other={other}"
     );
 }
+
+// ── N-way fuse with coincident faces (cross-source same-domain) ──────────
+
+/// Run the full N-way fuse pipeline for `offsets` unit cubes and return
+/// (result topology, solid, face count).
+fn nway_fuse(offsets: &[[f64; 3]]) -> (Topology, brepkit_topology::solid::SolidId) {
+    use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+    let tol = brepkit_math::tolerance::Tolerance::default();
+    let mut src = Topology::default();
+    let solids: Vec<_> = offsets
+        .iter()
+        .map(|o| make_unit_cube_manifold_at(&mut src, o[0], o[1], o[2]))
+        .collect();
+    let mut store = crate::ds::GfaShapeStoreN::new(&src, &solids).unwrap();
+    let mut arena = GfaArena::new();
+    crate::pave_filler::run_pave_filler_n(&mut store.topo, &store.sources, tol, &mut arena)
+        .unwrap();
+    crate::builder::build_fuse_n(
+        std::mem::take(&mut store.topo),
+        arena,
+        &store.sources,
+        &store.face_source,
+        tol,
+    )
+    .unwrap()
+}
+
+/// Axis-aligned overlapping boxes share coincident coplanar faces (the top,
+/// bottom, front and back planes coincide over the overlap). Cross-source
+/// same-domain must resolve them so the N-way fuse still matches the two-solid
+/// fuse and is watertight — the case that used to bail.
+#[test]
+fn build_fuse_n_axis_aligned_overlap_matches_two_solid() {
+    use brepkit_topology::explorer::solid_faces;
+    use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+    let tol = brepkit_math::tolerance::Tolerance::default();
+
+    let two_solid = {
+        let mut topo = Topology::default();
+        let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+        let b = make_unit_cube_manifold_at(&mut topo, 0.5, 0.0, 0.0);
+        let mut arena = GfaArena::new();
+        crate::pave_filler::run_pave_filler(&mut topo, a, b, tol, &mut arena).unwrap();
+        let mut builder = crate::builder::Builder::with_tolerance(topo, arena, a, b, tol);
+        builder.perform().unwrap();
+        let (rtopo, result) = builder.build_result(crate::bop::BooleanOp::Fuse).unwrap();
+        solid_faces(&rtopo, result).unwrap().len()
+    };
+
+    let (topo, result) = nway_fuse(&[[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]]);
+    let n_faces = solid_faces(&topo, result).unwrap().len();
+    let (two, other) = edge_face_share(&topo, result);
+    assert!(two > 0 && other == 0, "watertight; two={two} other={other}");
+    assert_eq!(
+        n_faces, two_solid,
+        "N-way overlap fuse matches the two-solid fuse"
+    );
+}
+
+/// Two boxes abutting face-to-face: the shared wall is an opposite-oriented
+/// coincident pair (material on both sides), so both faces must be dropped,
+/// producing one watertight 2×1×1 bar.
+#[test]
+fn build_fuse_n_abutting_boxes_drop_shared_wall() {
+    use brepkit_topology::explorer::solid_faces;
+    let (topo, result) = nway_fuse(&[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]);
+    let (two, other) = edge_face_share(&topo, result);
+    assert!(
+        two > 0 && other == 0,
+        "abutting fuse watertight; two={two} other={other}"
+    );
+    // The shared x=1 wall (one face from each box) is dropped; a clean bar has
+    // fewer faces than the 12 of two separate boxes.
+    let n = solid_faces(&topo, result).unwrap().len();
+    assert!(n < 12, "shared wall dropped, got {n} faces");
+}
+
+/// Three axis-aligned overlapping boxes fuse to one watertight solid in a single
+/// pass, resolving coincident faces between every interacting pair.
+#[test]
+fn build_fuse_n_three_axis_aligned_row_watertight() {
+    use brepkit_topology::explorer::solid_faces;
+    let (topo, result) = nway_fuse(&[[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [1.0, 0.0, 0.0]]);
+    assert!(!solid_faces(&topo, result).unwrap().is_empty());
+    let (two, other) = edge_face_share(&topo, result);
+    assert!(
+        two > 0 && other == 0,
+        "three-box row watertight; two={two} other={other}"
+    );
+}

--- a/crates/algo/src/pave_filler/tests.rs
+++ b/crates/algo/src/pave_filler/tests.rs
@@ -1681,3 +1681,111 @@ fn pave_filler_n_accumulates_three_overlapping_boxes() {
          (arena accumulated no splits — pairwise phases did not accumulate)"
     );
 }
+
+// ── End-to-end N-way fuse (store → pave_filler_n → build_fuse_n) ─────────
+
+/// Count how many distinct edges of a solid are used by exactly two faces
+/// (manifold) vs otherwise, as a watertightness proxy.
+fn edge_face_share(topo: &Topology, solid: brepkit_topology::solid::SolidId) -> (usize, usize) {
+    use std::collections::HashMap;
+    let mut uses: HashMap<usize, usize> = HashMap::new();
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid).unwrap() {
+        let face = topo.face(fid).unwrap();
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *uses.entry(oe.edge().index()).or_default() += 1;
+            }
+        }
+    }
+    let two = uses.values().filter(|&&c| c == 2).count();
+    let other = uses.values().filter(|&&c| c != 2).count();
+    (two, other)
+}
+
+/// N=2: the N-way fuse of two interpenetrating boxes (offset on all three axes,
+/// so no faces are coplanar-coincident) must match the standard two-solid fuse
+/// face count and be watertight.
+#[test]
+fn build_fuse_n_two_interpenetrating_boxes_matches_two_solid() {
+    use brepkit_topology::explorer::solid_faces;
+    use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+    let tol = brepkit_math::tolerance::Tolerance::default();
+
+    // Two-solid reference.
+    let two_solid_faces = {
+        let mut topo = Topology::default();
+        let a = make_unit_cube_manifold_at(&mut topo, 0.0, 0.0, 0.0);
+        let b = make_unit_cube_manifold_at(&mut topo, 0.5, 0.5, 0.5);
+        let mut arena = GfaArena::new();
+        crate::pave_filler::run_pave_filler(&mut topo, a, b, tol, &mut arena).unwrap();
+        let mut builder = crate::builder::Builder::with_tolerance(topo, arena, a, b, tol);
+        builder.perform().unwrap();
+        let (rtopo, result) = builder.build_result(crate::bop::BooleanOp::Fuse).unwrap();
+        solid_faces(&rtopo, result).unwrap().len()
+    };
+
+    // N-way path.
+    let mut src = Topology::default();
+    let a = make_unit_cube_manifold_at(&mut src, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut src, 0.5, 0.5, 0.5);
+    let mut store = crate::ds::GfaShapeStoreN::new(&src, &[a, b]).unwrap();
+    let mut arena = GfaArena::new();
+    crate::pave_filler::run_pave_filler_n(&mut store.topo, &store.sources, tol, &mut arena)
+        .unwrap();
+    let (topo, result) = crate::builder::build_fuse_n(
+        std::mem::take(&mut store.topo),
+        arena,
+        &store.sources,
+        &store.face_source,
+        tol,
+    )
+    .unwrap();
+
+    let n_faces = solid_faces(&topo, result).unwrap().len();
+    assert_eq!(
+        n_faces, two_solid_faces,
+        "N-way fuse face count must match the two-solid fuse"
+    );
+    let (two, other) = edge_face_share(&topo, result);
+    assert!(
+        two > 0 && other == 0,
+        "N-way fuse must be watertight (every edge shared by 2 faces); got two={two} other={other}"
+    );
+}
+
+/// N=3: three boxes each offset diagonally so consecutive boxes interpenetrate
+/// and none share a coplanar face. The N-way fuse produces one watertight solid
+/// in a single pass.
+#[test]
+fn build_fuse_n_three_interpenetrating_boxes_is_watertight() {
+    use brepkit_topology::explorer::solid_faces;
+    use brepkit_topology::test_utils::make_unit_cube_manifold_at;
+    let tol = brepkit_math::tolerance::Tolerance::default();
+
+    let mut src = Topology::default();
+    let a = make_unit_cube_manifold_at(&mut src, 0.0, 0.0, 0.0);
+    let b = make_unit_cube_manifold_at(&mut src, 0.5, 0.5, 0.5);
+    let c = make_unit_cube_manifold_at(&mut src, 1.0, 1.0, 1.0);
+    let mut store = crate::ds::GfaShapeStoreN::new(&src, &[a, b, c]).unwrap();
+    let mut arena = GfaArena::new();
+    crate::pave_filler::run_pave_filler_n(&mut store.topo, &store.sources, tol, &mut arena)
+        .unwrap();
+    let (topo, result) = crate::builder::build_fuse_n(
+        std::mem::take(&mut store.topo),
+        arena,
+        &store.sources,
+        &store.face_source,
+        tol,
+    )
+    .unwrap();
+
+    assert!(
+        !solid_faces(&topo, result).unwrap().is_empty(),
+        "produced a solid"
+    );
+    let (two, other) = edge_face_share(&topo, result);
+    assert!(
+        two > 0 && other == 0,
+        "three-box N-way fuse must be watertight; got two={two} other={other}"
+    );
+}

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -868,9 +868,7 @@ pub fn compound_cut(
         && !clusters.is_empty()
     {
         let merged = clusters.iter().try_fold(None::<SolidId>, |acc, cluster| {
-            let fused = cluster[1..]
-                .iter()
-                .try_fold(cluster[0], |a, &t| boolean(topo, BooleanOp::Fuse, a, t))?;
+            let fused = fuse_cluster(topo, cluster)?;
             match acc {
                 None => Ok(Some(fused)),
                 Some(prev) => boolean(topo, BooleanOp::Fuse, prev, fused).map(Some),
@@ -899,6 +897,30 @@ pub fn compound_cut(
         }
     }
     Ok(result)
+}
+
+/// Fuse one AABB-overlap cluster into a single solid.
+///
+/// For a cluster of 3+ interpenetrating/touching tools, tries the single-pass
+/// N-way GFA fuse (`brepkit_algo::gfa::fuse_n`) — one arrangement over all tools
+/// instead of the sequential pairwise fuse's O(n²) re-processing of a growing
+/// accumulator. Falls back to the sequential fuse when the N-way path errors
+/// (e.g. a non-planar coincident contact it does not yet handle) or yields an
+/// invalid result. Clusters of 1–2 tools go straight to the sequential path,
+/// where the N-way arrangement has nothing to save.
+fn fuse_cluster(
+    topo: &mut Topology,
+    cluster: &[SolidId],
+) -> Result<SolidId, crate::OperationsError> {
+    if cluster.len() >= 3
+        && let Ok(fused) = brepkit_algo::gfa::fuse_n(topo, cluster)
+        && validate_boolean_result(topo, fused).is_ok()
+    {
+        return Ok(fused);
+    }
+    cluster[1..]
+        .iter()
+        .try_fold(cluster[0], |a, &t| boolean(topo, BooleanOp::Fuse, a, t))
 }
 
 /// Group tools into AABB-overlap clusters (union-find over tolerance-


### PR DESCRIPTION
## What

Replaces `compound_cut`'s sequential pairwise fuse of a tool cluster — which re-processed a growing accumulator, O(n²) in the whole GFA pipeline (`detect_same_domain` and beyond) — with a **single GFA arrangement over all tools**. New `gfa::fuse_n(topo, &[SolidId])` runs one pass:

1. **`GfaShapeStoreN`** — deep-copies N sources into one store, tags each face with its source.
2. **`run_pave_filler_n`** — the intersection phases are inherently pairwise and carry no `Rank` (they only deposit geometric split data), so they run for each spatially-interacting source pair into **one shared arena**. A bbox broad-phase keeps this O(n·k) for the sparse interaction graph a lattice produces.
3. **`build_fuse_n`** — sections are stored *face-relative* (`pcurve_a == pcurve_b`), so the face splitter is rank-invariant; every face is split once and its global source tracked separately. Each sub-face is kept iff it is Outside every *other* source (the union boundary). Cross-source coincident faces are resolved by `detect_same_domain_fuse_n` (reuses the rank-agnostic grouping extracted from `detect_same_domain`): same-oriented groups keep one representative, opposite-oriented (internal interface) groups drop all.

`compound_cut` uses it via `fuse_cluster`, which **falls back to the sequential fuse** whenever `fuse_n` errors (e.g. a non-planar coincident contact it doesn't yet handle) or returns a result failing `validate_boolean_result`. Correct-or-slower, never wrong.

## Results

Captured 180-strut kumiko `compound_cut`, replayed natively:

| | time | volume | faces | free edges |
|---|---|---|---|---|
| sequential (before) | 46.1s | 1198.290 | 1146 | 0 |
| **N-way (this PR)** | **11.8s** | 1198.290 | 1146 | 0 |

**3.9× faster for a byte-equivalent, watertight result.**

## Safety / scope

- **Fuse-only.** Cut, Intersect, and every other boolean path are untouched.
- The 2-operand `detect_same_domain` is byte-identical after the grouping extraction.
- Falls back to the sequential fuse on any error or invalid result.
- Currently handles the planar-coincidence cases (kumiko struts are analytic planar prisms); non-planar coincident contacts bail to the fallback.

## Verification

- New algo tests: N=2 matches the two-solid fuse; interpenetrating + axis-aligned-overlap + abutting + 3-box cases all watertight; broad-phase pruning; empty-input errors.
- Full `brepkit-operations` + `brepkit-io` foil: **1208 tests pass** (all gridfinity scenarios) with `fuse_n` active.
- clippy clean, layer boundaries valid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an N-way GFA fuse and use it in `compound_cut` to fuse tool clusters in one pass instead of sequential pairwise. This removes the O(n²) accumulator reprocessing and delivers a 3.9× speedup on the kumiko case.

- New Features
  - `gfa::fuse_n`: single-pass fuse over N solids with export to caller topology.
  - `GfaShapeStoreN`: deep-copies all sources into one store and tracks face→source.
  - `run_pave_filler_n`: runs pairwise phases into one shared arena with AABB broad‑phase pruning (O(n·k) on sparse graphs).
  - `build_fuse_n`: splits once, classifies each sub-face against all other sources, and resolves cross-source coincident faces; bails to fallback on non‑planar coincidences.
  - `compound_cut` uses `fuse_cluster` to try `fuse_n` for clusters of 3+ tools, with validity checks and fallback to the sequential fuse. Other boolean ops are unchanged.

- Performance
  - 180‑strut kumiko `compound_cut`: 46.1s → 11.8s (3.9×), same volume and face count, 0 free edges.
  - Full `brepkit-operations` + `brepkit-io` foil: 1208 tests pass.

<sup>Written for commit 4e14b8ec5e5cab1b0fa40dc6e722f511bee2bb18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

