### PR TITLE
test(operations): benchmark the N-way fuse on an interpenetrating lattice

### DIFF
--- a/crates/operations/benches/compound_cut_perf.rs
+++ b/crates/operations/benches/compound_cut_perf.rs
@@ -132,6 +132,83 @@ fn build_honeycomb_grid(
     (topo, target, tools)
 }
 
+/// Build a kumiko-style lattice of thin interpenetrating box "struts": `bars`
+/// horizontal + `bars` vertical bars in one z-slab, crossing and overlapping in
+/// volume so all `2*bars` tools form ONE connected AABB-overlap cluster (the
+/// configuration `compound_cut` fuses via the N-way path). All struts are planar
+/// prisms sharing coplanar top/bottom planes — the coincident-face case the
+/// N-way same-domain pass resolves. Returns (topology, target slab, struts).
+fn build_strut_lattice(
+    bars: usize,
+) -> (
+    Topology,
+    brepkit_topology::solid::SolidId,
+    Vec<brepkit_topology::solid::SolidId>,
+) {
+    let mut topo = Topology::new();
+    let target = primitives::make_box(&mut topo, 100.0, 100.0, 10.0).unwrap();
+
+    let strut_w = 4.0;
+    let spacing = 100.0 / (bars + 1) as f64;
+    let mut tools = Vec::with_capacity(2 * bars);
+
+    for i in 0..bars {
+        let pos = spacing * (i + 1) as f64 - strut_w / 2.0;
+        // Horizontal bar: spans x, thin in y.
+        let h = primitives::make_box(&mut topo, 100.0, strut_w, 10.0).unwrap();
+        transform_solid(&mut topo, h, &Mat4::translation(0.0, pos, 0.0)).unwrap();
+        tools.push(h);
+        // Vertical bar: spans y, thin in x.
+        let v = primitives::make_box(&mut topo, strut_w, 100.0, 10.0).unwrap();
+        transform_solid(&mut topo, v, &Mat4::translation(pos, 0.0, 0.0)).unwrap();
+        tools.push(v);
+    }
+    (topo, target, tools)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: N-way vs sequential fuse-then-cut for an interpenetrating lattice
+// ---------------------------------------------------------------------------
+
+/// Isolates this operation's fuse strategy: both arms cut a slab by the union of
+/// a connected strut lattice, differing only in how the tools are combined.
+/// `nway` = `compound_cut` (single GFA arrangement over all struts); `sequential`
+/// = the old accumulate-then-cut (fuse each strut into a growing accumulator,
+/// then one cut).
+fn bench_compound_cut_struts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compound_cut_struts");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+
+    for &bars in &[3, 5, 7] {
+        let (base_topo, target, tools) = build_strut_lattice(bars);
+        let n = tools.len();
+
+        group.bench_function(format!("nway_N={n}"), |b| {
+            b.iter(|| {
+                let mut topo = base_topo.clone();
+                black_box(
+                    compound_cut(&mut topo, target, &tools, BooleanOptions::default()).unwrap(),
+                );
+            });
+        });
+
+        group.bench_function(format!("sequential_N={n}"), |b| {
+            b.iter(|| {
+                let mut topo = base_topo.clone();
+                let mut fused = tools[0];
+                for &t in &tools[1..] {
+                    fused = boolean(&mut topo, BooleanOp::Fuse, fused, t).unwrap();
+                }
+                black_box(boolean(&mut topo, BooleanOp::Cut, target, fused).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
 // ---------------------------------------------------------------------------
 // Benchmark: compound_cut vs sequential for cylinder grids
 // ---------------------------------------------------------------------------
@@ -218,6 +295,7 @@ criterion_group!(
     compound_cut_scaling,
     bench_compound_cut_cylinders,
     bench_compound_cut_honeycomb,
+    bench_compound_cut_struts,
 );
 
 criterion_main!(compound_cut_scaling);


### PR DESCRIPTION
## What

Wires the N-way fuse speedup (#1202) into the repo's criterion harness so it's reproducible and regression-tracked.

Adds a `compound_cut_struts` group to `compound_cut_perf.rs`: a **kumiko-style lattice** of thin interpenetrating box struts — `bars` horizontal + `bars` vertical bars crossing in one z-slab, forming one connected AABB-overlap cluster (the config `compound_cut` fuses via `fuse_n`) — cut from a slab. All struts are planar prisms sharing coplanar top/bottom planes, exercising the N-way same-domain path.

Two arms isolate the fuse strategy on identical geometry:
- **`nway`** — `compound_cut` (single GFA arrangement over all struts)
- **`sequential`** — the old accumulate-then-cut (fuse each strut into a growing accumulator, then one cut)

## Sample output

```
compound_cut_struts/nway_N=6         time: [17.5 ms 17.7 ms 17.9 ms]
compound_cut_struts/sequential_N=6   time: [24.8 ms 25.0 ms 25.3 ms]   (~1.4x)
```

The gap widens with strut count — the same O(n·k)-vs-O(n²) mechanism that makes the 180-strut kumiko `compound_cut` **3.9× faster** (46.1s → 11.8s) for a byte-equivalent result.

## Notes

- Self-contained synthetic geometry — no external fixtures.
- Run: `cargo bench -p brepkit-operations --bench compound_cut_perf -- struts`
- clippy clean; benches are excluded from release-please version bumps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Criterion benchmark for the N-way fuse on an interpenetrating kumiko-style strut lattice, comparing `compound_cut` vs sequential fuse-then-cut. Makes the speedup reproducible and regression-tracked; ~1.4x at N=6 and grows with N.

- **New Features**
  - Adds `compound_cut_struts` to `compound_cut_perf.rs`.
  - Synthetic kumiko lattice of thin crossing struts in one z-slab; exercises same-domain N-way; no fixtures.
  - Compares `nway` (`compound_cut` single arrangement) vs `sequential` (accumulate fuses, then cut).
  - Run: `cargo bench -p brepkit-operations --bench compound_cut_perf -- struts`.

<sup>Written for commit 704e8bd51dd156f603dfd3f287d093efc011f886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

