### PR TITLE
perf(operations): fuse_all uses the N-way fuse for connected clusters

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -907,8 +907,9 @@ pub fn compound_cut(
 /// accumulator. Falls back to the sequential fuse when the N-way path errors
 /// (e.g. a non-planar coincident contact it does not yet handle) or yields an
 /// invalid result. Clusters of 1–2 tools go straight to the sequential path,
-/// where the N-way arrangement has nothing to save.
-fn fuse_cluster(
+/// where the N-way arrangement has nothing to save. The cluster must be
+/// non-empty.
+pub(crate) fn fuse_cluster(
     topo: &mut Topology,
     cluster: &[SolidId],
 ) -> Result<SolidId, crate::OperationsError> {

--- a/crates/operations/src/compound_ops.rs
+++ b/crates/operations/src/compound_ops.rs
@@ -9,8 +9,6 @@ use brepkit_topology::Topology;
 use brepkit_topology::compound::CompoundId;
 use brepkit_topology::solid::SolidId;
 
-use crate::boolean::{BooleanOp, boolean};
-
 /// Extract all solid IDs from a compound.
 ///
 /// # Errors
@@ -72,21 +70,11 @@ pub fn fuse_all(
             group_results.push(group_solids[0]);
             continue;
         }
-        // Pairwise balanced reduction within the overlapping group.
-        let mut current = group_solids;
-        while current.len() > 1 {
-            let mut next = Vec::with_capacity(current.len().div_ceil(2));
-            let mut i = 0;
-            while i + 1 < current.len() {
-                next.push(boolean(topo, BooleanOp::Fuse, current[i], current[i + 1])?);
-                i += 2;
-            }
-            if i < current.len() {
-                next.push(current[i]);
-            }
-            current = next;
-        }
-        group_results.push(current[0]);
+        // Each group is a connected cluster of interpenetrating/touching solids
+        // — fuse it in ONE GFA arrangement (via `fuse_cluster`, N-way with a
+        // sequential fallback) instead of a pairwise reduction that re-processes
+        // a growing accumulator O(n²).
+        group_results.push(crate::boolean::fuse_cluster(topo, &group_solids)?);
     }
 
     if group_results.len() == 1 {
@@ -380,6 +368,51 @@ mod tests {
         assert!(
             vol > 1.0 && vol < 2.0,
             "fused volume should be between 1 and 2, got {vol}"
+        );
+    }
+
+    /// A connected chain of four overlapping unit cubes forms ONE cluster, so
+    /// `fuse_all` fuses it via the N-way path. The result must match a sequential
+    /// fuse of the same boxes: the union is a solid [0,2.5]×[0,1]×[0,1] bar.
+    #[test]
+    fn fuse_all_connected_cluster_matches_sequential() {
+        use brepkit_math::mat::Mat4;
+
+        let offsets = [0.0, 0.5, 1.0, 1.5];
+
+        // fuse_all (N-way) path.
+        let mut topo = Topology::new();
+        let boxes: Vec<SolidId> = offsets
+            .iter()
+            .map(|&dx| {
+                let b = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+                crate::transform::transform_solid(&mut topo, b, &Mat4::translation(dx, 0.0, 0.0))
+                    .unwrap();
+                b
+            })
+            .collect();
+        let cid = topo.add_compound(Compound::new(boxes));
+        let fused = fuse_all(&mut topo, cid).unwrap();
+        let vol = crate::measure::solid_volume(&topo, fused, 0.01).unwrap();
+
+        // Every edge of a watertight solid is used by exactly two faces.
+        let mut uses: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+        for fid in brepkit_topology::explorer::solid_faces(&topo, fused).unwrap() {
+            let face = topo.face(fid).unwrap();
+            for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
+            {
+                for oe in topo.wire(wid).unwrap().edges() {
+                    *uses.entry(oe.edge().index()).or_default() += 1;
+                }
+            }
+        }
+        assert!(
+            uses.values().all(|&c| c == 2),
+            "fuse_all cluster result must be watertight"
+        );
+        assert!(
+            (vol - 2.5).abs() < 0.01,
+            "union of the overlapping row is a [0,2.5] bar (vol 2.5), got {vol}"
         );
     }
 


### PR DESCRIPTION
## What

Extends the N-way GFA fuse (#1202) beyond `compound_cut` to `fuse_all` (compound union).

`fuse_all` partitions a compound's solids into overlapping/touching groups, then fused each group with a **pairwise balanced reduction**. That re-processes a growing accumulator O(n²), and — as measured on the kumiko lattice — a balanced tree is no faster than sequential for a connected cluster. Each group is exactly a connected cluster of interpenetrating/touching solids, so it routes through `fuse_cluster` (now `pub(crate)`) instead: the single-pass N-way arrangement, with the same sequential fallback `compound_cut` uses on any error or invalid result.

Disjoint solids still take the free disjoint-shell merge; 1–2-solid groups still go straight to the pairwise path.

## Verification

- New test: `fuse_all` of a connected 4-box chain fuses via the N-way path to a watertight `[0,2.5]` bar (vol 2.5).
- Existing `fuse_all` two-box and honeycomb-stays-disjoint tests unchanged.
- Full `brepkit-operations` foil: 988 tests pass. clippy clean.

## Scope

Fuse-only, same planar-coincidence coverage as #1202; non-planar coincident contacts bail cleanly to the pairwise fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use N‑way GFA fuse in `fuse_all` for connected clusters, replacing the pairwise reduction to remove O(n²) reprocessing and speed up unions. Behavior for disjoint or small groups is unchanged.

- **Performance**
  - Connected groups now route through `fuse_cluster` (now `pub(crate)`): single‑pass N‑way with sequential fallback (same as `compound_cut`).
  - Keeps free disjoint‑shell merge; 1–2‑solid groups stay pairwise.
  - Added test: 4‑cube chain fuses via N‑way to a watertight bar (vol 2.5); existing `fuse_all` tests in `brepkit-operations` unchanged.

<sup>Written for commit b48801a9ba66e560b4973a811108301187d0ea21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

