### PR TITLE
fix(operations): guard fuse_cluster against empty input

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -913,15 +913,19 @@ pub(crate) fn fuse_cluster(
     topo: &mut Topology,
     cluster: &[SolidId],
 ) -> Result<SolidId, crate::OperationsError> {
+    let Some((&first, rest)) = cluster.split_first() else {
+        return Err(crate::OperationsError::InvalidInput {
+            reason: "fuse_cluster requires a non-empty cluster".into(),
+        });
+    };
     if cluster.len() >= 3
         && let Ok(fused) = brepkit_algo::gfa::fuse_n(topo, cluster)
         && validate_boolean_result(topo, fused).is_ok()
     {
         return Ok(fused);
     }
-    cluster[1..]
-        .iter()
-        .try_fold(cluster[0], |a, &t| boolean(topo, BooleanOp::Fuse, a, t))
+    rest.iter()
+        .try_fold(first, |a, &t| boolean(topo, BooleanOp::Fuse, a, t))
 }
 
 /// Group tools into AABB-overlap clusters (union-find over tolerance-

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -475,6 +475,16 @@ fn empty_intersect_survives_measure_and_tessellate() {
 }
 
 #[test]
+fn fuse_cluster_empty_errors_not_panics() {
+    let mut topo = Topology::new();
+    let err = super::fuse_cluster(&mut topo, &[]);
+    assert!(
+        matches!(err, Err(crate::OperationsError::InvalidInput { .. })),
+        "empty cluster must return InvalidInput, not panic"
+    );
+}
+
+#[test]
 fn intersect_overlapping_boxes_is_nonempty() {
     use brepkit_topology::explorer::solid_faces;
 

--- a/crates/operations/src/compound_ops.rs
+++ b/crates/operations/src/compound_ops.rs
@@ -372,10 +372,10 @@ mod tests {
     }
 
     /// A connected chain of four overlapping unit cubes forms ONE cluster, so
-    /// `fuse_all` fuses it via the N-way path. The result must match a sequential
-    /// fuse of the same boxes: the union is a solid [0,2.5]×[0,1]×[0,1] bar.
+    /// `fuse_all` fuses it via the N-way path. The union is a solid
+    /// [0,2.5]×[0,1]×[0,1] bar, so the result must be watertight with volume 2.5.
     #[test]
-    fn fuse_all_connected_cluster_matches_sequential() {
+    fn fuse_all_connected_cluster_is_watertight_bar() {
         use brepkit_math::mat::Mat4;
 
         let offsets = [0.0, 0.5, 1.0, 1.5];


### PR DESCRIPTION
Follow-up addressing the two cubic findings on #1205 (which auto-merged before they were read):

1. **`fuse_cluster` empty-slice panic** — it's `pub(crate)` and documented as requiring a non-empty cluster, but `cluster[0]`/`cluster[1..]` would panic on empty input. Now guards with `split_first` and returns `OperationsError::InvalidInput`. Adds a test asserting the error path.

2. **Misleading test name** — `fuse_all_connected_cluster_matches_sequential` didn't actually compare against a sequential fuse; it checks watertightness + union volume. Renamed to `_is_watertight_bar` and reworded the doc to match.

clippy clean; the guard test and existing `fuse_all` tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `fuse_cluster` against empty input to prevent a panic. It now returns `OperationsError::InvalidInput`. Also renamed a misleading test to match what it actually checks.

- **Bug Fixes**
  - Use `split_first` to reject empty clusters; return `InvalidInput` instead of panicking.
  - Add regression test: `fuse_cluster_empty_errors_not_panics`.

- **Refactors**
  - Rename `fuse_all_connected_cluster_matches_sequential` to `fuse_all_connected_cluster_is_watertight_bar` and update the doc to reflect the watertightness + volume check.

<sup>Written for commit 7703f62f3fc2344e39fa95297daebd228f3adf4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

