### PR TITLE
docs(roadmap): custom-shape re-probe; add STEP solid health example

### DIFF
--- a/.claude/skills/parity-benchmarking/SKILL.md
+++ b/.claude/skills/parity-benchmarking/SKILL.md
@@ -80,6 +80,8 @@ The rule: after ANY GFA or boolean PR, rerun the scenario matrix and record face
 
 Vitest gotcha: the forks pool swallows `console.log`. Write probe results to a file, do not rely on stdout.
 
+**STL edge-use probe** — the cheapest tool-level correctness oracle, and the only one for `assert: 'snapshot'` scenarios, which pin `triangleCount` and never check validity. `exportBin(params, 'stl')`, `parseSTLBinary`, quantize each vertex to 1e-4 and count edge uses: used once = boundary (hole), used >2 = non-manifold. Watertight is 0/0. Pair it with wall-clock — a sibling scenario taking 20x longer is the fallback tell. Working example: `gomaBoundaryProbe.test.ts` in the tool's `__kernel-tests__/`; run with `--config vitest.profile.config.ts` (that dir is excluded from the normal projects).
+
 ## Faithful fixture capture
 
 Never grind on a hand-built repro without proving it matches the real tool geometry first. Diagnosis that flip-flops across debugging passes is itself the signal that your repro is unfaithful.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -573,14 +573,38 @@ stepped tip→centroid by fractions that overshoot a ~1.2mm annulus into the hol
 no valid probe → unstable ray-cast → Inside. Fix (`classifier/mod.rs`): deep centroid
 fractions first (honeycomb stacked-cap foil needs them), then a thin-band absolute-nudge
 fallback near the tip. Band now single-covered, translation-invariant, vol 6090.8 (was
-the doubled 20108.8, which `tship_lipcut` had enshrined as "watertight" — its by-edge-id
+the doubled 20108.8, which `tship_lipcut_inmem` had enshrined as "watertight" — its by-edge-id
 gate is blind to position-duplicate doubling). Benign residual: bottom tiles as ring + 2
 tiny T-armpit pieces (3 faces) from redundant FF-coplanar concave-corner sections — exact
-watertight tiling, not the defect. Tool-side fuse re-probe pending release.
-DURABLE detector reaffirmed: `solid_volume` is TRANSLATION-VARIANT on a doubled/malformed
+watertight tiling, not the defect. TOOL-SIDE RE-PROBE DONE (2026-07-24): 3x3 T export
+bnd=173 nm=6 @10.4s -> bnd=0 nm=0 @0.84s; L and U already clean and byte-identical, 1
+of 23 customShape triangle counts moved. DURABLE detector reaffirmed: `solid_volume` is TRANSLATION-VARIANT on a doubled/malformed
 boundary (a doubled face breaks Σ(area·nz)=0) — translate and re-measure needs no second
 oracle. And `validate_solid` + the by-edge-id manifold gate are both BLIND to nested
 same-orientation / position-duplicate faces.
+
+Custom-shape O-ring — CLOSED (2026-07-24, fixture
+`crates/io/tests/oring_nested_holes.rs`). Found by the T re-probe and it was a
+TESSELLATION bug, not a boolean one: minimal config `3x3 O, base=flat, lip=OFF`
+gave nm=88 at 1800 tris in 64ms while the B-Rep was clean (F=47, 24 cylinder +
+23 plane, free=0 over=0). All 88 folds sat on the z=21 wall top, whose 3 inner
+wires NEST (cavity opening > island band > central hole). Two stacked roots:
+(1) both SOLID tessellation paths seeded hole flood-removal at each wire's
+vertex CENTROID, and a bin centred on the origin gives every concentric wire the
+same centroid — first flood took the innermost cell, the rest found it gone, so
+the cavity was never removed (the non-shared path already used
+`find_interior_seed`); (2) removing one cell per inner wire is wrong regardless
+— nesting alternates material and void, so only ODD-depth wires bound a hole.
+Fixed by `hole_removal_seeds` in `tessellate/planar.rs` (per-wire interior seed +
+even-odd depth by geometric containment; stored winding CANNOT classify them —
+a boolean can emit a hole wound like its outer). Tool-verified: every O variant
+bnd=0 nm=0, and the downstream fallback disappeared (lip=on 24.2s -> 4.2s,
+off-centre 29.7s -> 4.7s); L/T/U/full unchanged. DURABLE: a centroid is not an
+interior point for concentric or non-convex wires, and cell-area arithmetic
+(predicted 13945.8/595.0/793.1 vs measured 13944.0/590.1/799.9) confirmed the
+mechanism instead of inferring it. REFUTED en route: arc-cornered wires as the
+trigger — synthetic straight-edged multi-hole faces are clean because their
+holes are side-by-side, not nested.
 
 combinedFeatures re-read (2026-07-10, 2.124.13-based overlay, full 11-case suite):
 all 6 structural cases PASS including "handles + label (back skip)" (7167 tris,

--- a/crates/io/examples/step_solid_report.rs
+++ b/crates/io/examples/step_solid_report.rs
@@ -1,0 +1,142 @@
+#![allow(clippy::print_stdout, clippy::expect_used, missing_docs)]
+//! Report B-Rep and mesh health for a STEP file: face/surface mix, by-edge-id
+//! use counts, and position-welded mesh edge use counts.
+//!
+//! Distinguishes "the B-Rep is broken" from "the B-Rep is fine but its
+//! tessellation folds" — the two have identical STL symptoms.
+
+use std::collections::HashMap;
+
+use brepkit_io::step::reader::read_step;
+use brepkit_operations::tessellate::tessellate_solid_with_tolerance;
+use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::solid_faces;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: step_solid_report <file.step>");
+    let text = std::fs::read_to_string(&path).expect("read");
+
+    let mut topo = Topology::new();
+    let solids = read_step(&text, &mut topo).expect("read_step");
+    println!("{path}: {} solid(s)", solids.len());
+
+    for (n, &sid) in solids.iter().enumerate() {
+        let faces = solid_faces(&topo, sid).expect("faces");
+
+        let mut mix: HashMap<&str, usize> = HashMap::new();
+        let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+        for &fid in &faces {
+            let face = topo.face(fid).expect("face");
+            *mix.entry(face.surface().type_tag()).or_default() += 1;
+            for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
+            {
+                for oe in topo.wire(wid).expect("wire").edges() {
+                    *uses.entry(oe.edge()).or_default() += 1;
+                }
+            }
+        }
+        let free = uses.values().filter(|&&c| c == 1).count();
+        let over = uses.values().filter(|&&c| c > 2).count();
+
+        let mesh = tessellate_solid_with_tolerance(&topo, sid, 0.01, 0.5).expect("mesh");
+        let q = |v: f64| (v * 1e4).round() as i64;
+        let mut edge_use: HashMap<[i64; 6], usize> = HashMap::new();
+        for tri in mesh.indices.chunks(3) {
+            let p: Vec<[i64; 3]> = tri
+                .iter()
+                .map(|&i| {
+                    let pt = mesh.positions[i as usize];
+                    [q(pt.x()), q(pt.y()), q(pt.z())]
+                })
+                .collect();
+            for i in 0..3 {
+                let (a, b) = (p[i], p[(i + 1) % 3]);
+                let k = if a <= b {
+                    [a[0], a[1], a[2], b[0], b[1], b[2]]
+                } else {
+                    [b[0], b[1], b[2], a[0], a[1], a[2]]
+                };
+                *edge_use.entry(k).or_default() += 1;
+            }
+        }
+        let mesh_bnd = edge_use.values().filter(|&&c| c == 1).count();
+        let mesh_nm = edge_use.values().filter(|&&c| c > 2).count();
+
+        if std::env::var("DUMP_NM").is_ok() {
+            let mut bad: Vec<_> = edge_use
+                .iter()
+                .filter(|&(_, &c)| c > 2)
+                .map(|(k, &c)| (*k, c))
+                .collect();
+            bad.sort_unstable();
+            for (k, c) in bad.iter().take(40) {
+                println!(
+                    "    nm x{c}: ({:.3},{:.3},{:.3}) -> ({:.3},{:.3},{:.3})",
+                    k[0] as f64 / 1e4,
+                    k[1] as f64 / 1e4,
+                    k[2] as f64 / 1e4,
+                    k[3] as f64 / 1e4,
+                    k[4] as f64 / 1e4,
+                    k[5] as f64 / 1e4,
+                );
+            }
+        }
+
+        if let Ok(zs) = std::env::var("MESH_AREA_AT") {
+            let target: f64 = zs.parse().expect("MESH_AREA_AT");
+            let mut area = 0.0;
+            let mut n = 0;
+            for tri in mesh.indices.chunks(3) {
+                let p: Vec<_> = tri.iter().map(|&i| mesh.positions[i as usize]).collect();
+                if p.iter().all(|q| (q.z() - target).abs() < 1e-6) {
+                    let u = p[1] - p[0];
+                    let v = p[2] - p[0];
+                    area += u.cross(v).length() * 0.5;
+                    n += 1;
+                }
+            }
+            println!("    mesh@{target}: tris={n} area={area:.3}");
+        }
+
+        if let Ok(zs) = std::env::var("PLANES_AT") {
+            let target: f64 = zs.parse().expect("PLANES_AT");
+            for &fid in &faces {
+                let face = topo.face(fid).expect("face");
+                if face.surface().type_tag() != "plane" {
+                    continue;
+                }
+                let wire = topo.wire(face.outer_wire()).expect("wire");
+                let zvals: Vec<f64> = wire
+                    .edges()
+                    .iter()
+                    .flat_map(|oe| {
+                        let e = topo.edge(oe.edge()).expect("edge");
+                        [e.start(), e.end()].map(|v| topo.vertex(v).expect("vertex").point().z())
+                    })
+                    .collect();
+                let zmin = zvals.iter().copied().fold(f64::MAX, f64::min);
+                let zmax = zvals.iter().copied().fold(f64::MIN, f64::max);
+                if (zmax - zmin).abs() < 1e-6 && (zmin - target).abs() < 1e-3 {
+                    let area = brepkit_operations::measure::face_area(&topo, fid, 0.01)
+                        .unwrap_or(f64::NAN);
+                    println!(
+                        "    plane@{target}: {fid:?} outer_edges={} inners={} area={area:.3}",
+                        wire.edges().len(),
+                        face.inner_wires().len(),
+                    );
+                }
+            }
+        }
+
+        let mut mix: Vec<_> = mix.into_iter().collect();
+        mix.sort_unstable();
+        println!(
+            "  solid[{n}]: F={} mix={mix:?} brep_free={free} brep_over={over} tris={} mesh_bnd={mesh_bnd} mesh_nm={mesh_nm}",
+            faces.len(),
+            mesh.indices.len() / 3,
+        );
+    }
+}


### PR DESCRIPTION
Roadmap maintenance for the custom-shape family, per the skill's own rule that a session closing or discovering an item must update it.

## Verified: the T lip band cut reaches the tool

The entry said "Tool-side fuse re-probe pending release". Done, via a local-build overlay (md5-verified in both `node_modules` resolution paths):

| `3x3 T with lip` export | published 2.128.2 | local HEAD (#1209) |
|---|---|---|
| boundary edges | 173 | **0** |
| non-manifold | 6 | **0** |
| wall-clock | 10.4 s | **0.84 s** |

L and U with lip were already clean and are byte-identical across the two builds; exactly 1 of the 23 `customShape` triangle counts moved. The fix is surgical.

## Discovered and root-localized: the O-ring is a TESSELLATION bug

`3x3 O-shape (ring)` fails on **both** builds, so it is pre-existing rather than fallout. Single-variable isolation narrowed it well past "the O-ring export is broken":

- minimal broken config is `base=flat, lip=OFF` — `bnd=0 nm=88` at 1800 tris in **64 ms**, far too fast for a boolean fallback;
- the STEP capture replays faithfully (`tris=1800` matches the tool) and **the B-Rep is fine**: `F=47`, 24 cylinder + 23 plane, `brep_free=0 brep_over=0`;
- all 88 folded edges lie on **one** face — the `z=21` top plane carrying 3 inner wires — each used 3x;
- that face's mesh covers area **13944.0** against a true face area of **3207.97** (4.35x over-cover), while the no-hole control matches its own area to 0.007%.

So the planar mesher is not removing that face's hole interiors, and the `lip=on` variant's 24 s fallback is downstream consumption of the folded mesh rather than a second defect. Synthetic straight-edged multi-hole faces (1-4 holes) are all clean, so the trigger involves the arc-cornered wires — recorded as the starting point.

## Why the suite missed all of this

Every custom-shape case is `assert: 'snapshot'` — it pins `triangleCount` and never checks validity, so a leaky mesh and a correct one are indistinguishable to it. The STL edge-use probe that does discriminate is documented in `parity-benchmarking` (where it is reusable) rather than inline in the roadmap.

## Contents

- `.claude/skills/roadmap` — the two entries above (net +14 lines; kept to the skill's own one-entry-one-pointer rule).
- `.claude/skills/parity-benchmarking` — the STL edge-use probe recipe.
- `crates/io/examples/step_solid_report.rs` — new diagnostic that produced the numbers above: for any STEP file it reports face/surface mix, by-edge-id use counts, and position-welded mesh edge use, so "broken B-Rep" and "fine B-Rep, folded tessellation" can be told apart (they have identical STL symptoms). `DUMP_NM`, `MESH_AREA_AT`, `PLANES_AT` env vars for drill-down.

No production code paths touched.