### PR TITLE
docs(roadmap): record the export-integrity baseline and the kumiko root

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -637,12 +637,16 @@ whose full-suite verdict depends on cache warmth and machine load, not on the ke
 as a correctness bug.
 
 Failure families on that baseline: kumiko 14, permutation matrix 7, custom-shape 6, solid cutouts 3,
-then singles. **Kumiko's 14 are ONE root, not fourteen:** `goma carves a 1x1x6 bin` runs ~48s and then
-throws "recursive use of an object detected which would lead to unsafe aliasing in rust" — wasm borrow
-poisoning — and the following scenarios inherit it (two surface as "Shape handle has been disposed").
-Only `mitsukude bold` (bnd=571) has an independent assertion. **This CORRECTS the row above claiming the
-poisoning class is "NOT REPRODUCIBLE on 2.124.13"** — it reproduces on 2.128.2; use `lastPanicMessage()`
-to name the underlying panic. REFUTED: the captured goma `compound_cut`
+then singles. **Kumiko's 14 are ONE root, and that root is PERF, not a crash.** Isolated probe on
+published 2.128.2: the goma 1x1x6 export SUCCEEDS — 2.7MB of STL, `lastPanicMessage()` returns none, no
+panic anywhere — but it takes **849 SECONDS (14 min)**. The "recursive use of an object detected which
+would lead to unsafe aliasing in rust" seen in the suite is a CONSEQUENCE: the export blows through
+vitest's per-test timeout, the abandoned async generation chain stays pending, and it re-enters the
+kernel concurrently with the next test. The following kumiko scenarios then inherit the poisoned object
+(two surface as "Shape handle has been disposed"); only `mitsukude bold` (bnd=571) has an independent
+assertion. So do NOT chase this as a panic — `catch_unwind`/`lastPanicMessage` have nothing to report.
+Chase the 849s. Native `compound_cut` on the captured operands is only 11.8s, so the time is elsewhere in
+the tool's goma chain and needs a per-stage capture. REFUTED: the captured goma `compound_cut`
 (`~/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma/`, replay `crates/io/examples/replay_kumiko_goma.rs`)
 is NOT the culprit — all 180 tools replay in 11.8s with F=1146, free=0, over=0. The poisoning is
 elsewhere in that scenario's chain and needs a fresh capture.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -645,8 +645,7 @@ vitest's per-test timeout, the abandoned async generation chain stays pending, a
 kernel concurrently with the next test. The following kumiko scenarios then inherit the poisoned object
 (two surface as "Shape handle has been disposed"); only `mitsukude bold` (bnd=571) has an independent
 assertion. So do NOT chase this as a panic — `catch_unwind`/`lastPanicMessage` have nothing to report.
-Chase the 849s. Native `compound_cut` on the captured operands is only 11.8s, so the time is elsewhere in
-the tool's goma chain and needs a per-stage capture. REFUTED: the captured goma `compound_cut`
+Chase the 849s. MEASURED SPLIT: `generateBin` alone is **847s** of the 849 — tessellation and STL are noise, so this is the boolean chain, not the mesher. Native `compound_cut` on the captured operands is only 11.8s (F=1146, clean), so one call is not the story. STRUCTURE (code, `kumikoWrapBuilder.ts` ~line 411): the carve loops `cutAll(region, family)` once PER FAMILY over an ACCUMULATING region, and that whole function runs per perimeter chunk — so there are many such calls, each starting from a more complex region than the capture. NOT YET MEASURED whether the total is simply their sum, or whether brepjs's bisecting `cutAll` (try the whole batch, on failure split and recurse) is thrashing on a failing batch. Next probe: count and time the actual cutAll invocations and their tool counts during one goma generation — do not assume the single capture is representative. REFUTED: the captured goma `compound_cut`
 (`~/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma/`, replay `crates/io/examples/replay_kumiko_goma.rs`)
 is NOT the culprit — all 180 tools replay in 11.8s with F=1146, free=0, over=0. The poisoning is
 elsewhere in that scenario's chain and needs a fresh capture.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -626,6 +626,31 @@ CLOSED, do not re-open as deferred: honeycomb wall-pattern cut (#925/#928,
 top-face (#932, `extrude_half_*_reversed_edge_volume` pass), multi-arc hemisphere gap
 (#1006).
 
+Export-integrity matrix baseline (2026-07-24, `binGenerator.scenario.export-integrity`, 408 tests
+asserting zero boundary edges + bounded non-manifold on the exported STL — the tool's own version of
+the STL edge-use oracle). Published 2.128.2: **43 failed / 365 passed**. Local main (T-lip #1209 +
+O-ring #1212): **37 failed / 371 passed**. Fixed: both `3x3 T with lip` cases, `3x3 O-shape (ring)
+with lip`, `O-shape + magnet base + lip`, plus pathfinder/permutation/scoop rows. NO regressions —
+the one apparent regression (`wall patterns > slots carves 3x3x5 walls (scale 0.5)`) fails IDENTICALLY
+on both kernels in isolation (63.3s published vs 64.3s main), i.e. it is a timing-borderline scenario
+whose full-suite verdict depends on cache warmth and machine load, not on the kernel. Do not chase it
+as a correctness bug.
+
+Failure families on that baseline: kumiko 14, permutation matrix 7, custom-shape 6, solid cutouts 3,
+then singles. **Kumiko's 14 are ONE root, not fourteen:** `goma carves a 1x1x6 bin` runs ~48s and then
+throws "recursive use of an object detected which would lead to unsafe aliasing in rust" — wasm borrow
+poisoning — and the following scenarios inherit it (two surface as "Shape handle has been disposed").
+Only `mitsukude bold` (bnd=571) has an independent assertion. **This CORRECTS the row above claiming the
+poisoning class is "NOT REPRODUCIBLE on 2.124.13"** — it reproduces on 2.128.2; use `lastPanicMessage()`
+to name the underlying panic. REFUTED: the captured goma `compound_cut`
+(`~/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma/`, replay `crates/io/examples/replay_kumiko_goma.rs`)
+is NOT the culprit — all 180 tools replay in 11.8s with F=1146, free=0, over=0. The poisoning is
+elsewhere in that scenario's chain and needs a fresh capture.
+
+CAUTION on counting: the baseline's classified kinds (23 boundary-edge, 2 non-manifold, 4 poisoning,
+1 timeout) sum to 30 of 43, so ~13 failures carry no recognised error form — probably cascade
+casualties, unconfirmed. Never quote the raw failure count as a defect count.
+
 ## Subsystem trap notes (crates without their own skill)
 
 - **heal `fix_duplicate_faces` IS implemented** (solid-scoped, `crates/heal/src/fix/solid.rs`,

--- a/crates/io/examples/replay_kumiko_goma.rs
+++ b/crates/io/examples/replay_kumiko_goma.rs
@@ -1,0 +1,92 @@
+#![allow(clippy::print_stdout, clippy::expect_used, missing_docs)]
+//! Replay the captured kumiko `goma` compound_cut operands natively.
+//!
+//! The tool's `kumiko › goma carves a 1×1×6 bin` export runs ~48s and then
+//! throws "recursive use of an object detected which would lead to unsafe
+//! aliasing in rust" — wasm borrow poisoning, i.e. a panic inside the kernel.
+//! Native replay turns that into a real panic with a backtrace.
+//!
+//! REFUTED 2026-07-24: this captured `compound_cut` is NOT where the poisoning
+//! happens. Full 180-tool replay completes in 11.8s with F=1146, free=0,
+//! over=0 — a clean result. The goma export failure is somewhere else in that
+//! scenario's chain, so do not replay this capture expecting a repro.
+//!
+//! Capture: `~/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma/`
+//! Usage: `cargo run --release --example replay_kumiko_goma -p brepkit-io -- [N]`
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use brepkit_io::arena_io::deserialize_solid;
+use brepkit_operations::boolean::compound_cut;
+use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::solid_faces;
+
+fn main() {
+    let dir = PathBuf::from(std::env::var("CAPTURE_DIR").unwrap_or_else(|_| {
+        format!(
+            "{}/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma",
+            std::env::var("HOME").expect("HOME")
+        )
+    }));
+    let limit: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(usize::MAX);
+
+    let mut topo = Topology::new();
+    let region = deserialize_solid(
+        &std::fs::read(dir.join("cut1-region.bin")).expect("region"),
+        &mut topo,
+    )
+    .expect("region parse");
+
+    let mut tools = Vec::new();
+    for i in 0.. {
+        let p = dir.join(format!("cut1-tool{i}.bin"));
+        if !p.exists() || tools.len() >= limit {
+            break;
+        }
+        tools.push(
+            deserialize_solid(&std::fs::read(&p).expect("tool"), &mut topo).expect("tool parse"),
+        );
+    }
+    println!("loaded region + {} tools", tools.len());
+
+    let t0 = Instant::now();
+    let result = compound_cut(
+        &mut topo,
+        region,
+        &tools,
+        brepkit_operations::boolean::BooleanOptions::default(),
+    );
+    let ms = t0.elapsed().as_millis();
+
+    match result {
+        Ok(sid) => {
+            let faces = solid_faces(&topo, sid).expect("faces");
+            let mut mix: HashMap<&str, usize> = HashMap::new();
+            let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+            for &fid in &faces {
+                let f = topo.face(fid).expect("face");
+                *mix.entry(f.surface().type_tag()).or_default() += 1;
+                for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+                    for oe in topo.wire(wid).expect("wire").edges() {
+                        *uses.entry(oe.edge()).or_default() += 1;
+                    }
+                }
+            }
+            let free = uses.values().filter(|&&c| c == 1).count();
+            let over = uses.values().filter(|&&c| c > 2).count();
+            let mut mix: Vec<_> = mix.into_iter().collect();
+            mix.sort_unstable();
+            println!(
+                "ok in {ms}ms: F={} mix={mix:?} free={free} over={over}",
+                faces.len()
+            );
+        }
+        Err(e) => println!("ERR in {ms}ms: {e}"),
+    }
+}

--- a/crates/io/examples/replay_kumiko_goma.rs
+++ b/crates/io/examples/replay_kumiko_goma.rs
@@ -25,12 +25,17 @@ use brepkit_topology::edge::EdgeId;
 use brepkit_topology::explorer::solid_faces;
 
 fn main() {
-    let dir = PathBuf::from(std::env::var("CAPTURE_DIR").unwrap_or_else(|_| {
-        format!(
-            "{}/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma",
-            std::env::var("HOME").expect("HOME")
-        )
-    }));
+    let dir = std::env::var_os("CAPTURE_DIR").map_or_else(
+        || {
+            let mut p = PathBuf::from(std::env::var_os("HOME").unwrap_or_default());
+            p.push(".cache");
+            p.push("brepkit-parity-captures");
+            p.push("2026-07-23");
+            p.push("kumiko-goma");
+            p
+        },
+        PathBuf::from,
+    );
     let limit: usize = std::env::args()
         .nth(1)
         .and_then(|a| a.parse().ok())


### PR DESCRIPTION
First full before/after over the tool's 408-test `export-integrity` matrix — its own version of the STL edge-use oracle (zero boundary edges, bounded non-manifold). Docs plus one diagnostic harness; no production code.

## Result

| | published 2.128.2 | local main |
|---|---|---|
| passed | 365 | **371** |
| failed | 43 | **37** |

Fixed: both `3×3 T with lip` cases (#1209), `3×3 O-shape (ring) with lip` and `O-shape + magnet base + lip` (#1212), plus pathfinder / permutation-matrix / scoop rows.

**No regressions.** One scenario looked like one — `wall patterns › slots carves 3×3×5 walls (scale 0.5)` passed in the baseline and failed after. Isolated A/B says otherwise: **63.3 s on published, 64.3 s on main**. It is a timing-borderline scenario whose full-suite verdict depends on cache warmth and machine load, not on the kernel. Recorded so nobody chases it as a correctness bug.

## Kumiko's 14 failures are ONE root

Families: kumiko 14, permutation matrix 7, custom-shape 6, solid cutouts 3, then singles.

`goma carves a 1×1×6 bin` runs ~48 s and then throws `recursive use of an object detected which would lead to unsafe aliasing in rust` — wasm borrow poisoning. The scenarios after it inherit the poisoned kernel; two surface as `Shape handle has been disposed`. Only `mitsukude bold` (bnd=571) has an independent assertion.

**This corrects an existing roadmap row** which records that poisoning class as "NOT REPRODUCIBLE on 2.124.13". It reproduces on 2.128.2. The panic-capture hardening already shipped, so `lastPanicMessage()` should name the underlying panic — that is the next probe.

**Refuted en route:** the captured goma `compound_cut` is *not* the culprit. All 180 tools replay natively in 11.8 s with `F=1146, free=0, over=0` — a clean result. Harness added as `crates/io/examples/replay_kumiko_goma.rs` with the refutation in its doc comment, so the next session doesn't burn an iteration replaying it expecting a repro.

## A counting caveat

The baseline's classified failure kinds (23 boundary-edge, 2 non-manifold, 4 poisoning, 1 timeout) sum to **30 of 43** — about a dozen failures carry no recognised error form, most likely cascade casualties but unconfirmed. Kumiko already shows how badly the raw number misleads: 14 failures, one root. The roadmap now says never to quote the failure count as a defect count.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded the 408‑test `export-integrity` baseline (2.128.2: 365 pass/43 fail; local `main`: 371 pass/37 fail) with no regressions. Corrected the kumiko root to a generation‑side perf overrun that triggers a test timeout and wasm borrow‑poisoning (not a kernel panic); added `crates/io/examples/replay_kumiko_goma.rs` and fixed capture path joins with `PathBuf`.

- **New Findings**
  - The cost is in `generateBin`: ~849 s total, ~847 s in generation; tessellation/STL are negligible.
  - Bottleneck is the boolean chain, not the mesher; `compound_cut` capture replays clean in 11.8 s (F=1146, free=0, over=0).
  - Structure: `kumikoWrapBuilder.ts` carves per family over an accumulating region, repeating `cutAll`; next step is to count/time those `cutAll` calls during one goma run.

<sup>Written for commit e936ac8e7f77e05d70fc1caae0471c69401ca9ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

