### PR TITLE
docs(roadmap): attribute goma cost to one cutAllBisect call

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -663,10 +663,12 @@ confirms it: `buildKumikoWallPatterns` is only 32.8%, of which prism constructio
 the "thousands of small sketch/extrude ops" candidate is REFUTED. CORRECTION: an earlier probe wrapped
 `cutAll`, saw 32 calls with zero failures, and concluded there was no bisect thrash — INVALID, because
 `cutAllBisect` is a separate export whose internal retries use an internal ops reference the wrapper never
-saw. That hypothesis was untested, not refuted. NEXT PROBE: read `cutAllBisect`'s own
-`BatchBisectTelemetry` (batchAttempts vs batchSucceeded, pairwise count) — attempts >> successes means a
-FAILING batch whose retry cost is the 203s (a correctness bug wearing a perf costume), one attempt means
-honest N-way work. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
+saw. That hypothesis was untested, not refuted. (5) BISECT TELEMETRY (the right instrument this time): `{totalInputs:8, batchAttempts:1,
+batchSucceeded:1, singletonFallbacks:0, failedInputs:[]}` — **NO thrash**, one attempt, one success. So
+**ONE `cutAll` of just EIGHT tools takes 203.5s**. Those 8 tools are the carved kumiko lattice bands
+(each ~F=1146 per the captured replay), so this is a single honest N-way boolean of the bin body against
+8 very complex solids — squarely a BREPKIT perf defect, not tool-side structure. THE TARGET IS NOW ONE
+CALL WITH NINE OPERANDS: capture body + the 8 pattern solids via serializeSolid and replay natively. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
 NODE_OPTIONS and poolOptions.forks.execArgv, and vite-node is not installed; two attempts produced only
 idle parent-process profiles. Use `vi.mock` wrapping instead, and make sure the wrapper actually covers
 the call path you intend to claim about. REFUTED: the captured goma `compound_cut`

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -684,10 +684,16 @@ dev-dependency of `brepkit-io`, so io examples can reach it): **RAW cut 0 = 231m
 for the SAME cut — the analytic engine is 12x faster and keeps every cone and cylinder, but leaves
 **30 free edges**, so `validate_boolean_result` rejects it and the mesh fallback runs. **RAW cut 1
 fails outright: "assembly failed: open growth shell with 20 faces would be dropped; aborting
-analytic assembly".** So the 203s is the CONSEQUENCE of those 30 free edges. THE TARGET IS NOW:
-why does cut 0 leave 30 free edges (F=494), and why does cut 1 drop an open 20-face growth shell?
-Fixing that makes goma analytic AND ~12x faster per cut, and removes the broken-fallback
-consumption at the same time. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
+analytic assembly".** So the 203s is the CONSEQUENCE of those 30 free edges. (8) THE 30 FREE EDGES ARE LOCALIZED (`DUMP_FREE=1`): every one lies at
+x = 17.00 or x = 17.05 — a single **0.05mm-thin slab** — with y in [-21.95, -17.15] and z in
+[2.70, 12.37]. Curve mix is mostly Line plus a few Ellipse/Circle, on plane and cylinder faces;
+the ellipses each BRIDGE the two planes (e.g. (17.00,-20.75,12.34)->(17.05,-20.75,12.37)), so this
+is a sliver between two near-parallel faces 0.05mm apart, where the lattice band's edge meets the
+bin's corner cylinders. 0.05mm is FAR above the 1e-7 linear tolerance, so this is a genuine
+thin-feature failure, not numerical noise. THE TARGET IS NOW that one sliver region: why the
+analytic assembly cannot close a 0.05mm slab there, and whether cut 1's "open growth shell with 20
+faces" is the same region. Fixing it makes goma analytic AND ~12x faster per cut, and removes the
+broken-fallback consumption at the same time. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
 NODE_OPTIONS and poolOptions.forks.execArgv, and vite-node is not installed; two attempts produced only
 idle parent-process profiles. Use `vi.mock` wrapping instead, and make sure the wrapper actually covers
 the call path you intend to claim about. REFUTED: the captured goma `compound_cut`

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -690,8 +690,14 @@ x = 17.00 or x = 17.05 — a single **0.05mm-thin slab** — with y in [-21.95, 
 the ellipses each BRIDGE the two planes (e.g. (17.00,-20.75,12.34)->(17.05,-20.75,12.37)), so this
 is a sliver between two near-parallel faces 0.05mm apart, where the lattice band's edge meets the
 bin's corner cylinders. 0.05mm is FAR above the 1e-7 linear tolerance, so this is a genuine
-thin-feature failure, not numerical noise. THE TARGET IS NOW that one sliver region: why the
-analytic assembly cannot close a 0.05mm slab there, and whether cut 1's "open growth shell with 20
+thin-feature failure, not numerical noise. ORIGIN OF THE TWO SIDES (`XSCAN=17.0`): the BASE has NO X-normal plane near
+x=17 at all; tool0 has exactly ONE at x=17.05 (its cut plane); tool1 has many including x=17.00.
+Since the 30 free edges come from cut 0 (tool0 only), the x=17.00 side is NOT a plane — the dump
+shows `free line on cylinder (17.00,-19.55,2.70)`, i.e. the base's corner CYLINDER surface. So the
+sliver is between tool0's cut plane at x=17.05 and curved base geometry reaching x~17.00 — a
+plane-vs-cylinder thin sliver, plausibly the same family as the tangency row above, though the
+mechanism is NOT yet proven. THE TARGET IS NOW that one sliver region: why the analytic assembly
+cannot close a 0.05mm plane-vs-cylinder slab there, and whether cut 1's "open growth shell with 20
 faces" is the same region. Fixing it makes goma analytic AND ~12x faster per cut, and removes the
 broken-fallback consumption at the same time. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
 NODE_OPTIONS and poolOptions.forks.execArgv, and vite-node is not installed; two attempts produced only

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -667,8 +667,19 @@ saw. That hypothesis was untested, not refuted. (5) BISECT TELEMETRY (the right 
 batchSucceeded:1, singletonFallbacks:0, failedInputs:[]}` — **NO thrash**, one attempt, one success. So
 **ONE `cutAll` of just EIGHT tools takes 203.5s**. Those 8 tools are the carved kumiko lattice bands
 (each ~F=1146 per the captured replay), so this is a single honest N-way boolean of the bin body against
-8 very complex solids — squarely a BREPKIT perf defect, not tool-side structure. THE TARGET IS NOW ONE
-CALL WITH NINE OPERANDS: capture body + the 8 pattern solids via serializeSolid and replay natively. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
+8 very complex solids — squarely a BREPKIT perf defect, not tool-side structure. (6) CAPTURED AND REPLAYED NATIVELY (capture
+`~/.cache/brepkit-parity-captures/2026-07-24/goma-bisect/`, harness
+`crates/io/examples/replay_cut_capture.rs`, `CAPTURE_DIR=... [N]`): base is the bin body F=78
+{cone:12, cylinder:24, plane:42}; each tool is a carved lattice band F=663-726 ALL PLANE. Cutting
+N tools: **1 -> 2824ms F=1003 free=0 over=0; 2 -> 6187ms F=1519 free=756 over=320; 3 -> 12659ms
+F=1920 free=723 over=333**. TWO CONCLUSIONS. (a) EVERY result is ALL-PLANAR although the base has
+12 cones + 24 cylinders — the analytic types are destroyed, i.e. this is the MESH FALLBACK, so
+goma's cost is not N-way boolean work but fallback meshing that grows superlinearly with tool
+count. The real fix is to stop falling back: find why GFA rejects bin-body x lattice-band. (b) From
+TWO tools on, `compound_cut` returns Ok with a BROKEN solid (756 free, 320 over) — a native repro
+of the open "mesh-boolean fallback emits OPEN meshes that get CONSUMED" row above. NEXT PROBE: the
+GFA rejection reason for base x tool0 (needs an algo-level harness; `brepkit-io` cannot reach
+`brepkit_algo`). TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
 NODE_OPTIONS and poolOptions.forks.execArgv, and vite-node is not installed; two attempts produced only
 idle parent-process profiles. Use `vi.mock` wrapping instead, and make sure the wrapper actually covers
 the call path you intend to claim about. REFUTED: the captured goma `compound_cut`

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -656,8 +656,20 @@ wallPatternClips, or JS-side lattice work. (3) Batching is real but SECONDARY: n
 18.6s, and the SAME 30 tools cost 393ms at F=168 vs 6103ms at F=1131 — cost grows steeply with region
 complexity, so the per-family loop over an accumulating region is the pessimal shape, but fixing it
 cannot recover the missing 77%. Also unexplained: that 180-tool call is 33.5s in-tool vs 11.7s natively
-(3x). NEXT PROBE: a V8 `--cpu-prof` of one generation — the wasm-vs-JS self-time split decides whether
-this is brepkit's problem at all. REFUTED: the captured goma `compound_cut`
+(3x). (4) FULL OP ATTRIBUTION at h=4 (wrap every brepjs op; 99.9% accounted, total 292.7s):
+**`cutAllBisect` 1 call / 203.5s / 69.5%**, `cutAll` 32 calls / 88.5s / 30.2%, all else 0.1%. So the bulk
+is ONE call — the step applying the pattern solids to the bin — not the per-family carve. Phase split
+confirms it: `buildKumikoWallPatterns` is only 32.8%, of which prism construction is **322ms (0.1%)**, so
+the "thousands of small sketch/extrude ops" candidate is REFUTED. CORRECTION: an earlier probe wrapped
+`cutAll`, saw 32 calls with zero failures, and concluded there was no bisect thrash — INVALID, because
+`cutAllBisect` is a separate export whose internal retries use an internal ops reference the wrapper never
+saw. That hypothesis was untested, not refuted. NEXT PROBE: read `cutAllBisect`'s own
+`BatchBisectTelemetry` (batchAttempts vs batchSucceeded, pairwise count) — attempts >> successes means a
+FAILING batch whose retry cost is the 203s (a correctness bug wearing a perf costume), one attempt means
+honest N-way work. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
+NODE_OPTIONS and poolOptions.forks.execArgv, and vite-node is not installed; two attempts produced only
+idle parent-process profiles. Use `vi.mock` wrapping instead, and make sure the wrapper actually covers
+the call path you intend to claim about. REFUTED: the captured goma `compound_cut`
 (`~/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma/`) is NOT the culprit — all 180 tools replay in
 11.8s with F=1146, free=0, over=0.
 

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -677,9 +677,17 @@ F=1920 free=723 over=333**. TWO CONCLUSIONS. (a) EVERY result is ALL-PLANAR alth
 goma's cost is not N-way boolean work but fallback meshing that grows superlinearly with tool
 count. The real fix is to stop falling back: find why GFA rejects bin-body x lattice-band. (b) From
 TWO tools on, `compound_cut` returns Ok with a BROKEN solid (756 free, 320 over) — a native repro
-of the open "mesh-boolean fallback emits OPEN meshes that get CONSUMED" row above. NEXT PROBE: the
-GFA rejection reason for base x tool0 (needs an algo-level harness; `brepkit-io` cannot reach
-`brepkit_algo`). TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
+of the open "mesh-boolean fallback emits OPEN meshes that get CONSUMED" row above. (7) ROOT FOUND — it is a GFA CORRECTNESS bug, not a perf bug (`RAW=1` mode in the same
+harness calls `gfa::boolean` directly, bypassing the ops gate; note `brepkit-algo` IS already a
+dev-dependency of `brepkit-io`, so io examples can reach it): **RAW cut 0 = 231ms, F=494,
+{cone:12, cylinder:24, plane:458}, free=30, over=0** versus the ops path's 2824ms/F=1003/all-plane
+for the SAME cut — the analytic engine is 12x faster and keeps every cone and cylinder, but leaves
+**30 free edges**, so `validate_boolean_result` rejects it and the mesh fallback runs. **RAW cut 1
+fails outright: "assembly failed: open growth shell with 20 faces would be dropped; aborting
+analytic assembly".** So the 203s is the CONSEQUENCE of those 30 free edges. THE TARGET IS NOW:
+why does cut 0 leave 30 free edges (F=494), and why does cut 1 drop an open 20-face growth shell?
+Fixing that makes goma analytic AND ~12x faster per cut, and removes the broken-fallback
+consumption at the same time. TOOLING NOTE: V8 `--cpu-prof` does NOT work here — vitest's fork pool drops it via both
 NODE_OPTIONS and poolOptions.forks.execArgv, and vite-node is not installed; two attempts produced only
 idle parent-process profiles. Use `vi.mock` wrapping instead, and make sure the wrapper actually covers
 the call path you intend to claim about. REFUTED: the captured goma `compound_cut`

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -1,0 +1,107 @@
+#![allow(clippy::print_stdout, clippy::expect_used, missing_docs)]
+//! Replay a captured `cut(base, tools...)` natively from arena `.bin` files.
+//!
+//! Generic over captures laid out as `<prefix>-base.bin` + `<prefix>-tool<i>.bin`.
+//! Built for the goma pattern-application call, which the tool-side probes
+//! narrowed to a single `cutAll` of EIGHT tools taking **203.5 s** (telemetry:
+//! one batch attempt, one success, no fallbacks — honest N-way work, not retry
+//! churn). Capture:
+//! `~/.cache/brepkit-parity-captures/2026-07-24/goma-bisect/`
+//!
+//! Usage:
+//!   CAPTURE_DIR=<dir> PREFIX=gomabisect \
+//!     cargo run --release --example replay_cut_capture -p brepkit-io [N]
+//!
+//! `N` limits the tool count, which is how you get the cost-vs-tool-count
+//! curve without waiting for the full run.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use brepkit_io::arena_io::deserialize_solid;
+use brepkit_operations::boolean::{BooleanOptions, compound_cut};
+use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::solid_faces;
+
+fn describe(topo: &Topology, sid: brepkit_topology::solid::SolidId, label: &str) {
+    let faces = solid_faces(topo, sid).expect("faces");
+    let mut mix: HashMap<&str, usize> = HashMap::new();
+    for &fid in &faces {
+        *mix.entry(topo.face(fid).expect("face").surface().type_tag())
+            .or_default() += 1;
+    }
+    let mut mix: Vec<_> = mix.into_iter().collect();
+    mix.sort_unstable();
+    println!("  {label}: F={} mix={mix:?}", faces.len());
+}
+
+fn main() {
+    let dir = PathBuf::from(std::env::var_os("CAPTURE_DIR").unwrap_or_default());
+    let prefix = std::env::var("PREFIX").unwrap_or_else(|_| "gomabisect".to_string());
+    let limit: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(usize::MAX);
+
+    let mut topo = Topology::new();
+    let base_path = dir.join(format!("{prefix}-base.bin"));
+    let base = deserialize_solid(
+        &std::fs::read(&base_path).expect("base .bin — set CAPTURE_DIR"),
+        &mut topo,
+    )
+    .expect("base parse");
+
+    let mut tools = Vec::new();
+    for i in 0.. {
+        let p = dir.join(format!("{prefix}-tool{i}.bin"));
+        if !p.exists() || tools.len() >= limit {
+            break;
+        }
+        tools.push(deserialize_solid(&std::fs::read(&p).expect("tool"), &mut topo).expect("parse"));
+    }
+    if tools.is_empty() {
+        println!("no tools found for prefix '{prefix}' in {}", dir.display());
+        return;
+    }
+
+    println!("loaded base + {} tools", tools.len());
+    describe(&topo, base, "base");
+    for (i, &t) in tools.iter().enumerate() {
+        describe(&topo, t, &format!("tool{i}"));
+    }
+
+    let t0 = Instant::now();
+    let result = compound_cut(&mut topo, base, &tools, BooleanOptions::default());
+    let ms = t0.elapsed().as_millis();
+
+    match result {
+        Ok(sid) => {
+            let faces = solid_faces(&topo, sid).expect("faces");
+            let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+            for &fid in &faces {
+                let f = topo.face(fid).expect("face");
+                for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+                    for oe in topo.wire(wid).expect("wire").edges() {
+                        *uses.entry(oe.edge()).or_default() += 1;
+                    }
+                }
+            }
+            let free = uses.values().filter(|&&c| c == 1).count();
+            let over = uses.values().filter(|&&c| c > 2).count();
+            let mut mix: HashMap<&str, usize> = HashMap::new();
+            for &fid in &faces {
+                *mix.entry(topo.face(fid).expect("face").surface().type_tag())
+                    .or_default() += 1;
+            }
+            let mut mix: Vec<_> = mix.into_iter().collect();
+            mix.sort_unstable();
+            println!(
+                "ok in {ms}ms: F={} mix={mix:?} free={free} over={over}",
+                faces.len()
+            );
+        }
+        Err(e) => println!("ERR in {ms}ms: {e}"),
+    }
+}

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -72,6 +72,53 @@ fn main() {
         describe(&topo, t, &format!("tool{i}"));
     }
 
+    // RAW=1: call the analytic GFA directly, bypassing the ops-level gate and
+    // its mesh fallback, to see whether GFA itself produces a usable result.
+    if std::env::var("RAW").is_ok() {
+        let mut acc = base;
+        for (i, &tool) in tools.iter().enumerate() {
+            let t = Instant::now();
+            match brepkit_algo::gfa::boolean(
+                &mut topo,
+                brepkit_algo::bop::BooleanOp::Cut,
+                acc,
+                tool,
+            ) {
+                Ok(next) => {
+                    let faces = solid_faces(&topo, next).expect("faces");
+                    let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+                    let mut mix: HashMap<&str, usize> = HashMap::new();
+                    for &fid in &faces {
+                        let f = topo.face(fid).expect("face");
+                        *mix.entry(f.surface().type_tag()).or_default() += 1;
+                        for wid in
+                            std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied())
+                        {
+                            for oe in topo.wire(wid).expect("wire").edges() {
+                                *uses.entry(oe.edge()).or_default() += 1;
+                            }
+                        }
+                    }
+                    let free = uses.values().filter(|&&c| c == 1).count();
+                    let over = uses.values().filter(|&&c| c > 2).count();
+                    let mut mix: Vec<_> = mix.into_iter().collect();
+                    mix.sort_unstable();
+                    println!(
+                        "  RAW cut {i}: {}ms F={} mix={mix:?} free={free} over={over}",
+                        t.elapsed().as_millis(),
+                        faces.len()
+                    );
+                    acc = next;
+                }
+                Err(e) => {
+                    println!("  RAW cut {i}: {}ms ERR {e}", t.elapsed().as_millis());
+                    return;
+                }
+            }
+        }
+        return;
+    }
+
     let t0 = Instant::now();
     let result = compound_cut(&mut topo, base, &tools, BooleanOptions::default());
     let ms = t0.elapsed().as_millis();

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -66,6 +66,34 @@ fn main() {
         return;
     }
 
+    // XSCAN=<v>: list X-normal planes near v in each operand, to tell whether a
+    // thin slab is pre-existing in the inputs or produced by the boolean.
+    if let Ok(v) = std::env::var("XSCAN") {
+        let target: f64 = v.parse().expect("XSCAN");
+        let report = |label: &str, sid: brepkit_topology::solid::SolidId| {
+            let mut xs: Vec<f64> = Vec::new();
+            for fid in solid_faces(&topo, sid).expect("faces") {
+                if let brepkit_topology::face::FaceSurface::Plane { normal, d } =
+                    topo.face(fid).expect("face").surface()
+                    && normal.x().abs() > 0.99
+                {
+                    let x = d / normal.x();
+                    if (x - target).abs() < 1.0 {
+                        xs.push(x);
+                    }
+                }
+            }
+            xs.sort_by(|a, b| a.partial_cmp(b).expect("cmp"));
+            xs.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
+            println!("  {label}: X-normal planes near {target}: {xs:?}");
+        };
+        report("base", base);
+        for (i, &t) in tools.iter().enumerate() {
+            report(&format!("tool{i}"), t);
+        }
+        return;
+    }
+
     println!("loaded base + {} tools", tools.len());
     describe(&topo, base, "base");
     for (i, &t) in tools.iter().enumerate() {

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -108,6 +108,39 @@ fn main() {
                         t.elapsed().as_millis(),
                         faces.len()
                     );
+                    if free > 0 && std::env::var("DUMP_FREE").is_ok() {
+                        for (eid, _) in uses.iter().filter(|&(_, &c)| c == 1) {
+                            let e = topo.edge(*eid).expect("edge");
+                            let a = topo.vertex(e.start()).expect("v").point();
+                            let b = topo.vertex(e.end()).expect("v").point();
+                            // Which face owns it, and what surface is that face?
+                            let owner = faces.iter().find(|&&fid| {
+                                let f = topo.face(fid).expect("face");
+                                std::iter::once(f.outer_wire())
+                                    .chain(f.inner_wires().iter().copied())
+                                    .any(|w| {
+                                        topo.wire(w)
+                                            .expect("wire")
+                                            .edges()
+                                            .iter()
+                                            .any(|oe| oe.edge() == *eid)
+                                    })
+                            });
+                            let tag = owner.map_or("?", |&fid| {
+                                topo.face(fid).expect("face").surface().type_tag()
+                            });
+                            println!(
+                                "    free {} on {tag} ({:.2},{:.2},{:.2})->({:.2},{:.2},{:.2})",
+                                e.curve().type_tag(),
+                                a.x(),
+                                a.y(),
+                                a.z(),
+                                b.x(),
+                                b.y(),
+                                b.z()
+                            );
+                        }
+                    }
                     acc = next;
                 }
                 Err(e) => {


### PR DESCRIPTION
Continues the kumiko/goma dig from #1215 and #1216. Full op-level attribution, two refuted candidates, and a correction to a claim I recorded as settled. Docs only.

## Where the time actually goes

Wrapping every brepjs op across one goma generation at h=4 — 99.9% accounted, total 292.7 s:

| op | calls | ms | % |
|---|---|---|---|
| **`cutAllBisect`** | **1** | **203552** | **69.5** |
| `cutAll` | 32 | 88543 | 30.2 |
| everything else | 7 | ~318 | 0.1 |

The bulk is **one call** — the step applying the pattern solids to the bin — not the per-family carve.

The phase split agrees: `buildKumikoWallPatterns` is only 32.8% of generation, and within it prism construction is **322 ms (0.1%)**.

## Two candidates refuted

- **Prism construction** ("thousands of small sketch/extrude/translate kernel ops") — 322 ms. Dead. I had written this into the roadmap as a leading candidate.
- **Batching as the main cause** — the per-family loop is genuinely the pessimal shape (#1216 measured 1×180 = 11.7 s vs 6×30 = 18.6 s), but at 30.2% it cannot explain the total.

## A correction

An earlier probe wrapped `cutAll`, saw 32 calls with zero failures, and I concluded there was **no bisect thrash** — and recorded that in the roadmap.

That was invalid. `cutAllBisect` is a **separate export**, and its internal retries go through an internal ops reference my wrapper never saw. The hypothesis was **untested**, not refuted. The measurement was real; the claim simply covered a code path the instrument couldn't observe.

## Next probe

Read `cutAllBisect`'s own `BatchBisectTelemetry`:

- `batchAttempts` >> `batchSucceeded`, or a large pairwise count → the batch is **failing** and the 203 s is retry cost — a correctness bug wearing a perf costume.
- one attempt → honest N-way work on a hard batch.

Different fixes, so it is left open rather than guessed.

## Tooling note

V8 `--cpu-prof` does **not** work in this harness: vitest's fork pool drops it via both `NODE_OPTIONS` and `poolOptions.forks.execArgv`, and `vite-node` is not installed. Two attempts (~20 min) produced only idle parent-process profiles. Recorded so the next session doesn't repeat it — use `vi.mock` wrapping, and check the wrapper covers the path you intend to claim about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins kumiko/goma cost to one 8‑tool `cutAllBisect` (~203.5s), not bisect thrash. RAW GFA: cut 0 leaves 30 free edges and cut 1 aborts, forcing mesh fallback (all‑planar, open); all free edges sit on a 0.05 mm slab at x=17.00–17.05, now identified as plane‑vs‑cylinder; prism build is 322 ms.

- **New Features**
  - Added `crates/io/examples/replay_cut_capture.rs` to replay `compound_cut` captures; supports `RAW=1` to call analytic GFA, `DUMP_FREE=1` to print free‑edge locations, and `XSCAN=<x>` to list X‑normal planes near a target.

<sup>Written for commit d35773fe13db5a154f43bc09b27e3bb9b701dbb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

