### PR TITLE
test(io): show cylinders stop 0.05mm short of the cut plane

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -653,8 +653,12 @@ bands, slow only because the analytic path is rejected for **30 free edges** and
 runs; the analytic path is ~12x faster and keeps all 12 cones + 24 cylinders. Those 30 edges are
 **4 missing faces** in one **0.05mm plane-vs-cylinder sliver** — the tool's deliberate
 `SLAB_OVERLAP = 0.05` past the corner tangent planes (a tangency workaround). Repro is ~230ms per
-tool; all 8 bands fail, evens with free=30, odds aborting on an open growth shell. TARGET: the
-FF/section/split stage — the faces are never created.
+tool; all 8 bands fail, evens with free=30, odds aborting on an open growth shell. TARGET: the FF/section/split stage — the faces are never created. SHARPEST DATUM
+(`FACES_NEAR_X=17.025`): in the result every corner CYLINDER face is trimmed at x=17.000 while
+tool0's cut plane is at x=17.050 — the 0.05mm of cylinder between them has NO face at all, and
+that band is exactly what the 30 free edges bound. Planes do reach 17.050; the cylinders stop
+0.05mm short. So the missing patches are cylinder slivers that should run from 17.000 out to the
+cut plane.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -657,8 +657,15 @@ tool; all 8 bands fail, evens with free=30, odds aborting on an open growth shel
 (`FACES_NEAR_X=17.025`): in the result every corner CYLINDER face is trimmed at x=17.000 while
 tool0's cut plane is at x=17.050 — the 0.05mm of cylinder between them has NO face at all, and
 that band is exactly what the 30 free edges bound. Planes do reach 17.050; the cylinders stop
-0.05mm short. So the missing patches are cylinder slivers that should run from 17.000 out to the
-cut plane.
+0.05mm short. INPUT SCAN (`BASE_FACES_NEAR_X`) shows 17.000 is the BASE's own geometry — the
+tangent point where each corner cylinder (x[17.000,20.750]) meets the flat wall (x[-17.000,17.000])
+— so it is not a trim. tool0's cut plane at x=17.050 therefore lies 0.05mm INSIDE the cylinder's
+range (exactly SLAB_OVERLAP past the tangent), and should split it. The result's cylinders still
+span [17.000,20.750], identical to the base: had they been split with the outer piece kept they
+would read [17.050,20.750]. **So the cut plane appears not to split the corner cylinders at all** —
+that is the defect, and the missing patches are the cylinder pieces it should have produced. NEXT
+STEP needs algo-level instrumentation (black-box probing is exhausted): whether a section is
+emitted for the cylinder x cut-plane pair at all.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -175,6 +175,38 @@ fn main() {
                         t.elapsed().as_millis(),
                         faces.len()
                     );
+                    if let Ok(v) = std::env::var("FACES_NEAR_X") {
+                        // Which faces actually exist in the sliver slab? If the
+                        // splitter never made the missing patches, nothing here
+                        // will span the gap.
+                        let target: f64 = v.parse().expect("FACES_NEAR_X");
+                        for &fid in &faces {
+                            let f = topo.face(fid).expect("face");
+                            let mut lo = f64::MAX;
+                            let mut hi = f64::MIN;
+                            let mut n = 0;
+                            for wid in std::iter::once(f.outer_wire())
+                                .chain(f.inner_wires().iter().copied())
+                            {
+                                for oe in topo.wire(wid).expect("wire").edges() {
+                                    let e = topo.edge(oe.edge()).expect("edge");
+                                    for v in [e.start(), e.end()] {
+                                        let x = topo.vertex(v).expect("v").point().x();
+                                        lo = lo.min(x);
+                                        hi = hi.max(x);
+                                        n += 1;
+                                    }
+                                }
+                            }
+                            if n > 0 && lo < target + 0.1 && hi > target - 0.1 {
+                                println!(
+                                    "    face {fid:?} {} x[{lo:.3},{hi:.3}] edges={}",
+                                    f.surface().type_tag(),
+                                    n / 2
+                                );
+                            }
+                        }
+                    }
                     if free > 0 && std::env::var("FREE_LOOPS").is_ok() {
                         // Free edges bound the hole(s) left by dropped faces.
                         // Chain them by shared vertex: each closed chain is one

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -119,6 +119,39 @@ fn main() {
         return;
     }
 
+    // BASE_FACES_NEAR_X=<v>: same slab scan, but on the INPUT operands, to tell
+    // whether a trim boundary pre-exists or is produced by the boolean.
+    if let Ok(v) = std::env::var("BASE_FACES_NEAR_X") {
+        let target: f64 = v.parse().expect("BASE_FACES_NEAR_X");
+        let scan = |label: &str, sid: brepkit_topology::solid::SolidId| {
+            for fid in solid_faces(&topo, sid).expect("faces") {
+                let f = topo.face(fid).expect("face");
+                let (mut lo, mut hi) = (f64::MAX, f64::MIN);
+                for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+                    for oe in topo.wire(wid).expect("wire").edges() {
+                        let e = topo.edge(oe.edge()).expect("edge");
+                        for v in [e.start(), e.end()] {
+                            let x = topo.vertex(v).expect("v").point().x();
+                            lo = lo.min(x);
+                            hi = hi.max(x);
+                        }
+                    }
+                }
+                if lo <= hi && lo < target + 0.1 && hi > target - 0.1 {
+                    println!(
+                        "    {label} {fid:?} {} x[{lo:.3},{hi:.3}]",
+                        f.surface().type_tag()
+                    );
+                }
+            }
+        };
+        scan("base", base);
+        if let Some(&t0) = tools.first() {
+            scan("tool0", t0);
+        }
+        return;
+    }
+
     println!("loaded base + {} tools", tools.len());
     describe(&topo, base, "base");
     for (i, &t) in tools.iter().enumerate() {

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -130,8 +130,8 @@ fn main() {
                 for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
                     for oe in topo.wire(wid).expect("wire").edges() {
                         let e = topo.edge(oe.edge()).expect("edge");
-                        for v in [e.start(), e.end()] {
-                            let x = topo.vertex(v).expect("v").point().x();
+                        for vid in [e.start(), e.end()] {
+                            let x = topo.vertex(vid).expect("vertex").point().x();
                             lo = lo.min(x);
                             hi = hi.max(x);
                         }
@@ -223,8 +223,8 @@ fn main() {
                             {
                                 for oe in topo.wire(wid).expect("wire").edges() {
                                     let e = topo.edge(oe.edge()).expect("edge");
-                                    for v in [e.start(), e.end()] {
-                                        let x = topo.vertex(v).expect("v").point().x();
+                                    for vid in [e.start(), e.end()] {
+                                        let x = topo.vertex(vid).expect("vertex").point().x();
                                         lo = lo.min(x);
                                         hi = hi.max(x);
                                         n += 1;


### PR DESCRIPTION
Follow-on to #1219. Adds `FACES_NEAR_X=<v>` to list result faces spanning a slab, which produces the sharpest datum yet on the goma root. Diagnostic only.

## The gap, stated exactly

```
face Id(5676) cylinder x[17.000, 20.750]     ← every corner cylinder stops at 17.000
face Id(5678) cylinder x[17.000, 20.750]
face Id(5688) plane    x[17.050, 17.050]     ← tool0's cut plane
face Id(5687) plane    x[16.756, 17.050]     ← planes do reach it
```

Every corner **cylinder** face in the result is trimmed at **x = 17.000**, while tool0's cut plane sits at **x = 17.050**. The 0.05 mm of cylinder between those values has **no face at all** — and that band is precisely what the 30 free edges bound.

The planes reach 17.050 correctly. The cylinders stop 0.05 mm short.

So the four missing patches are **cylinder slivers that should run from x=17.000 out to the cut plane**, and the free-edge loops are the holes they leave behind. That matches everything upstream: the loops are non-planar (#1218), the defect is op-independent (#1218), and nothing is dropped at assembly (#1219) — the splitter simply never extends those cylinder faces to the cut plane.

## Where this leaves the fix

The question is now specific enough to act on: **why the cylinder faces are trimmed at 17.000 rather than at tool0's cut plane 0.05 mm further out.** Candidates worth checking first are the section emitted for the cylinder × cut-plane pair, and whether the cylinder's own trim boundary is being taken from the wrong partner.

Repro is unchanged and cheap: `goma_wall_band_cut_inmem.rs` (~230 ms), or `TOOL=0 FACES_NEAR_X=17.025` through `replay_cut_capture`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `BASE_FACES_NEAR_X=<v>` and `FACES_NEAR_X=<v>` to `replay_cut_capture` to show the cut plane at x=17.050 does not split the corner cylinders, which stop at x=17.000. Confirms a 0.05 mm band with no cylinder face and narrows the defect to the FF/section/split stage; investigation notes updated.

- **New Features**
  - `BASE_FACES_NEAR_X=<v>` scans input operands to confirm 17.000 is the base cylinder tangent (not a trim).
  - `FACES_NEAR_X=<v>` slab scan prints face type and edge count to show cylinders span [17.000, 20.750] while the cut plane is at 17.050.

- **Refactors**
  - Renamed a loop vertex variable to avoid shadowing; no behavior change.

<sup>Written for commit 0020b3146a16cf3ad96ba6db12f52f5c7a817099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

