### PR TITLE
test(algo): add an env-gated FF pair trace

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -653,8 +653,12 @@ bands, slow only because the analytic path is rejected for **30 free edges** and
 runs; the analytic path is ~12x faster and keeps all 12 cones + 24 cylinders. Those 30 edges are
 **4 missing faces** in one **0.05mm plane-vs-cylinder sliver** — the tool's deliberate
 `SLAB_OVERLAP = 0.05` past the corner tangent planes (a tangency workaround). Repro is ~230ms per
-tool; all 8 bands fail, evens with free=30, odds aborting on an open growth shell. TARGET: the
-FF/section/split stage — the faces are never created.
+tool; all 8 bands fail, evens with free=30, odds aborting on an open growth shell. TARGET: the FF/section/split stage — the faces are never created. SHARPEST DATUM
+(`FACES_NEAR_X=17.025`): in the result every corner CYLINDER face is trimmed at x=17.000 while
+tool0's cut plane is at x=17.050 — the 0.05mm of cylinder between them has NO face at all, and
+that band is exactly what the 30 free edges bound. Planes do reach 17.050; the cylinders stop
+0.05mm short. So the missing patches are cylinder slivers that should run from 17.000 out to the
+cut plane.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -657,8 +657,15 @@ tool; all 8 bands fail, evens with free=30, odds aborting on an open growth shel
 (`FACES_NEAR_X=17.025`): in the result every corner CYLINDER face is trimmed at x=17.000 while
 tool0's cut plane is at x=17.050 — the 0.05mm of cylinder between them has NO face at all, and
 that band is exactly what the 30 free edges bound. Planes do reach 17.050; the cylinders stop
-0.05mm short. So the missing patches are cylinder slivers that should run from 17.000 out to the
-cut plane.
+0.05mm short. INPUT SCAN (`BASE_FACES_NEAR_X`) shows 17.000 is the BASE's own geometry — the
+tangent point where each corner cylinder (x[17.000,20.750]) meets the flat wall (x[-17.000,17.000])
+— so it is not a trim. tool0's cut plane at x=17.050 therefore lies 0.05mm INSIDE the cylinder's
+range (exactly SLAB_OVERLAP past the tangent), and should split it. The result's cylinders still
+span [17.000,20.750], identical to the base: had they been split with the outer piece kept they
+would read [17.050,20.750]. **So the cut plane appears not to split the corner cylinders at all** —
+that is the defect, and the missing patches are the cylinder pieces it should have produced. NEXT
+STEP needs algo-level instrumentation (black-box probing is exhausted): whether a section is
+emitted for the cylinder x cut-plane pair at all.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -663,9 +663,11 @@ tangent point where each corner cylinder (x[17.000,20.750]) meets the flat wall 
 range (exactly SLAB_OVERLAP past the tangent), and should split it. The result's cylinders still
 span [17.000,20.750], identical to the base: had they been split with the outer piece kept they
 would read [17.050,20.750]. **So the cut plane appears not to split the corner cylinders at all** —
-that is the defect, and the missing patches are the cylinder pieces it should have produced. NEXT
-STEP needs algo-level instrumentation (black-box probing is exhausted): whether a section is
-emitted for the cylinder x cut-plane pair at all.
+that is the defect, and the missing patches are the cylinder pieces it should have produced. ALGO-LEVEL TRACE (`BK_FF_TRACE=<x>` in phase_ff.rs, env-gated, on branch
+perf/goma-ff-trace): sections ARE emitted — **64 cylinder x plane pairs survive the AABB test at
+x=17.05, each returning raw_curves=1** (736 pairs are AABB-rejected, mostly correctly since they do
+not meet). So phase FF is NOT the gap. NEXT STEP: the defect is downstream of section computation —
+restrict/clip, pave-block splitting, or face building. Trace those with the same 230ms repro.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -42,6 +42,19 @@ const NURBS_MARCH_STEP: f64 = 0.01;
 ///
 /// Returns [`AlgoError`] if any topology lookup or intersection computation fails.
 #[allow(clippy::too_many_lines)]
+/// `BK_FF_TRACE=<x>`: report every face pair whose AABBs straddle that x, and
+/// whether the pair was AABB-rejected. Diagnostic only, and resolved ONCE per
+/// process — the pair loop runs hundreds of times per boolean and must not pay
+/// an env lookup and allocation each iteration.
+fn ff_trace_x() -> Option<f64> {
+    static FF_TRACE: std::sync::OnceLock<Option<f64>> = std::sync::OnceLock::new();
+    *FF_TRACE.get_or_init(|| {
+        std::env::var("BK_FF_TRACE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+    })
+}
+
 pub fn perform(
     topo: &mut Topology,
     solid_a: SolidId,
@@ -90,6 +103,8 @@ pub fn perform(
         brepkit_topology::vertex::VertexId,
     > = std::collections::HashMap::new();
 
+    let ff_trace = ff_trace_x();
+
     for (idx_a, &fa) in faces_a.iter().enumerate() {
         let bbox_a = &bboxes_a[idx_a];
         let surf_a = &surfs_a[idx_a];
@@ -97,11 +112,6 @@ pub fn perform(
         for (idx_b, &fb) in faces_b.iter().enumerate() {
             let bbox_b = &bboxes_b[idx_b];
 
-            // BK_FF_TRACE=<x>: report every face pair whose AABBs straddle that
-            // x, and whether the pair was AABB-rejected. Diagnostic only.
-            let ff_trace: Option<f64> = std::env::var("BK_FF_TRACE")
-                .ok()
-                .and_then(|v| v.parse().ok());
             let traced = ff_trace.is_some_and(|x| {
                 bbox_a.min.x() - tol.linear <= x
                     && x <= bbox_a.max.x() + tol.linear

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -97,11 +97,42 @@ pub fn perform(
         for (idx_b, &fb) in faces_b.iter().enumerate() {
             let bbox_b = &bboxes_b[idx_b];
 
+            // BK_FF_TRACE=<x>: report every face pair whose AABBs straddle that
+            // x, and whether the pair was AABB-rejected. Diagnostic only.
+            let ff_trace: Option<f64> = std::env::var("BK_FF_TRACE")
+                .ok()
+                .and_then(|v| v.parse().ok());
+            let traced = ff_trace.is_some_and(|x| {
+                bbox_a.min.x() - tol.linear <= x
+                    && x <= bbox_a.max.x() + tol.linear
+                    && bbox_b.min.x() - tol.linear <= x
+                    && x <= bbox_b.max.x() + tol.linear
+            });
+
             // AABB rejection
             if !bbox_a
                 .expanded(tol.linear)
                 .intersects(bbox_b.expanded(tol.linear))
             {
+                if traced {
+                    log::debug!(
+                        "FF_TRACE reject-aabb a={} b={} A[{:.2},{:.2},{:.2}..{:.2},{:.2},{:.2}] B[{:.2},{:.2},{:.2}..{:.2},{:.2},{:.2}]",
+                        surfs_a[idx_a].type_tag(),
+                        surfs_b[idx_b].type_tag(),
+                        bbox_a.min.x(),
+                        bbox_a.min.y(),
+                        bbox_a.min.z(),
+                        bbox_a.max.x(),
+                        bbox_a.max.y(),
+                        bbox_a.max.z(),
+                        bbox_b.min.x(),
+                        bbox_b.min.y(),
+                        bbox_b.min.z(),
+                        bbox_b.max.x(),
+                        bbox_b.max.y(),
+                        bbox_b.max.z()
+                    );
+                }
                 continue;
             }
 
@@ -111,6 +142,18 @@ pub fn perform(
             let v_range_b = v_ranges_b[idx_b];
             let raw_curves =
                 compute_raw_curves(surf_a, surf_b, bbox_a, bbox_b, v_range_a, v_range_b)?;
+            if traced {
+                log::debug!(
+                    "FF_TRACE pair a={} b={} raw_curves={} ax[{:.3},{:.3}] bx[{:.3},{:.3}]",
+                    surf_a.type_tag(),
+                    surf_b.type_tag(),
+                    raw_curves.len(),
+                    bbox_a.min.x(),
+                    bbox_a.max.x(),
+                    bbox_b.min.x(),
+                    bbox_b.max.x()
+                );
+            }
 
             // For plane-plane Line curves with all-straight-edge faces, trim
             // each curve to the mutual overlap of the two faces' clipped

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -49,7 +49,8 @@ impl log::Log for DropLogger {
             return;
         }
         let msg = format!("{}", r.args());
-        if msg.contains("growth sliver") || msg.contains("growth shell") {
+        if msg.contains("growth sliver") || msg.contains("growth shell") || msg.contains("FF_TRACE")
+        {
             println!("    [algo] {msg}");
         }
     }

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -175,6 +175,38 @@ fn main() {
                         t.elapsed().as_millis(),
                         faces.len()
                     );
+                    if let Ok(v) = std::env::var("FACES_NEAR_X") {
+                        // Which faces actually exist in the sliver slab? If the
+                        // splitter never made the missing patches, nothing here
+                        // will span the gap.
+                        let target: f64 = v.parse().expect("FACES_NEAR_X");
+                        for &fid in &faces {
+                            let f = topo.face(fid).expect("face");
+                            let mut lo = f64::MAX;
+                            let mut hi = f64::MIN;
+                            let mut n = 0;
+                            for wid in std::iter::once(f.outer_wire())
+                                .chain(f.inner_wires().iter().copied())
+                            {
+                                for oe in topo.wire(wid).expect("wire").edges() {
+                                    let e = topo.edge(oe.edge()).expect("edge");
+                                    for v in [e.start(), e.end()] {
+                                        let x = topo.vertex(v).expect("v").point().x();
+                                        lo = lo.min(x);
+                                        hi = hi.max(x);
+                                        n += 1;
+                                    }
+                                }
+                            }
+                            if n > 0 && lo < target + 0.1 && hi > target - 0.1 {
+                                println!(
+                                    "    face {fid:?} {} x[{lo:.3},{hi:.3}] edges={}",
+                                    f.surface().type_tag(),
+                                    n / 2
+                                );
+                            }
+                        }
+                    }
                     if free > 0 && std::env::var("FREE_LOOPS").is_ok() {
                         // Free edges bound the hole(s) left by dropped faces.
                         // Chain them by shared vertex: each closed chain is one

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -119,6 +119,39 @@ fn main() {
         return;
     }
 
+    // BASE_FACES_NEAR_X=<v>: same slab scan, but on the INPUT operands, to tell
+    // whether a trim boundary pre-exists or is produced by the boolean.
+    if let Ok(v) = std::env::var("BASE_FACES_NEAR_X") {
+        let target: f64 = v.parse().expect("BASE_FACES_NEAR_X");
+        let scan = |label: &str, sid: brepkit_topology::solid::SolidId| {
+            for fid in solid_faces(&topo, sid).expect("faces") {
+                let f = topo.face(fid).expect("face");
+                let (mut lo, mut hi) = (f64::MAX, f64::MIN);
+                for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+                    for oe in topo.wire(wid).expect("wire").edges() {
+                        let e = topo.edge(oe.edge()).expect("edge");
+                        for v in [e.start(), e.end()] {
+                            let x = topo.vertex(v).expect("v").point().x();
+                            lo = lo.min(x);
+                            hi = hi.max(x);
+                        }
+                    }
+                }
+                if lo <= hi && lo < target + 0.1 && hi > target - 0.1 {
+                    println!(
+                        "    {label} {fid:?} {} x[{lo:.3},{hi:.3}]",
+                        f.surface().type_tag()
+                    );
+                }
+            }
+        };
+        scan("base", base);
+        if let Some(&t0) = tools.first() {
+            scan("tool0", t0);
+        }
+        return;
+    }
+
     println!("loaded base + {} tools", tools.len());
     describe(&topo, base, "base");
     for (i, &t) in tools.iter().enumerate() {

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -130,8 +130,8 @@ fn main() {
                 for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
                     for oe in topo.wire(wid).expect("wire").edges() {
                         let e = topo.edge(oe.edge()).expect("edge");
-                        for v in [e.start(), e.end()] {
-                            let x = topo.vertex(v).expect("v").point().x();
+                        for vid in [e.start(), e.end()] {
+                            let x = topo.vertex(vid).expect("vertex").point().x();
                             lo = lo.min(x);
                             hi = hi.max(x);
                         }
@@ -223,8 +223,8 @@ fn main() {
                             {
                                 for oe in topo.wire(wid).expect("wire").edges() {
                                     let e = topo.edge(oe.edge()).expect("edge");
-                                    for v in [e.start(), e.end()] {
-                                        let x = topo.vertex(v).expect("v").point().x();
+                                    for vid in [e.start(), e.end()] {
+                                        let x = topo.vertex(vid).expect("vertex").point().x();
                                         lo = lo.min(x);
                                         hi = hi.max(x);
                                         n += 1;


### PR DESCRIPTION
Continues the goma dig past the point where black-box probing ran out (#1220). Adds `BK_FF_TRACE=<x>`, an env-gated diagnostic in `phase_ff::perform`, and uses it to **rule out phase FF as the gap**.

## What it showed

At the sliver's x=17.05, on the `TOOL=0` repro:

```
 64 FF_TRACE pair          (all cylinder × plane, raw_curves=1 each)
736 FF_TRACE reject-aabb   (416 cylinder × plane)
```

**Sections are emitted.** 64 cylinder × plane pairs survive the AABB test and each returns a curve. The rejections are mostly correct — most face pairs genuinely do not meet.

So phase FF is not where the four missing cylinder patches are lost. The defect is **downstream of section computation**: restrict/clip, pave-block splitting, or face building. That is the next target, traceable with the same ~230 ms repro.

I want to flag a wrong turn honestly: my first read of this output was "zero pair lines, everything rejected — found it." That came from a frequency-sorted top-10 that happened to contain only rejects. The `pair` lines were there, just less frequent. The corrected counts above are what the trace actually says.

## On the diagnostic itself

The first version resolved `std::env::var` **inside the face-pair loop** — 800 iterations on this small case and far more on real geometry, so an env lookup plus allocation per pair in the boolean hot path. That is a perf regression introduced by a diagnostic, which would have been a poor trade.

Now resolved once per process behind a module-level `OnceLock` (`ff_trace_x()`). Trace output is unchanged, and the untraced path measures 229–260 ms as before.

Verified: `cargo clippy --all-targets` clean, 425 tests green across `brepkit-algo` and `brepkit-io`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an env-gated FF pair trace to `phase_ff::perform` and extends the replay tool to inspect faces near a target X, helping rule out phase FF as the source of the missing cylinder patches.

- **New Features**
  - `BK_FF_TRACE=<x>`: logs each face pair that straddles x and AABB rejections.
  - `FACES_NEAR_X` and `BASE_FACES_NEAR_X` in `replay_cut_capture`: print face x-spans for result and input solids.
  - Logger prints `FF_TRACE` lines to stdout for easy scanning.

- **Refactors**
  - Resolve `BK_FF_TRACE` once via `OnceLock` instead of per face pair to avoid hot-path overhead.

<sup>Written for commit c5cebd92592699309dc79c95dd4ec12bdcb365e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

