### PR TITLE
test(algo): add an env-gated FF pair trace

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -663,9 +663,11 @@ tangent point where each corner cylinder (x[17.000,20.750]) meets the flat wall 
 range (exactly SLAB_OVERLAP past the tangent), and should split it. The result's cylinders still
 span [17.000,20.750], identical to the base: had they been split with the outer piece kept they
 would read [17.050,20.750]. **So the cut plane appears not to split the corner cylinders at all** —
-that is the defect, and the missing patches are the cylinder pieces it should have produced. NEXT
-STEP needs algo-level instrumentation (black-box probing is exhausted): whether a section is
-emitted for the cylinder x cut-plane pair at all.
+that is the defect, and the missing patches are the cylinder pieces it should have produced. ALGO TRACE (`BK_FF_TRACE=<x>` in phase_ff.rs, env-gated): sections ARE
+emitted and DO survive clipping — at x=17.05, 64 cylinder x plane pairs pass the AABB test (736
+rejected, mostly correctly) and **12 sections survive `restrict_curves_to_faces` intact**. So
+phase FF and restrict both do their job; curves reach the splitter. NEXT STEP: pave-block splitting
+or face building, same 230ms repro.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -673,8 +673,14 @@ BETWEEN ARENA EMISSION AND THE PER-FACE SECTION LISTS (`BK_SPLIT_TRACE=1`, eprin
 `fill_images_faces` face loop): that loop DOES run, over 741 faces, and reports **only 2 of 24
 CYLINDER faces with has_sections=true** (22 without; planes are 420 true / 285 false) — although FF
 emitted 12 cylinder x plane curves. So ~10 emitted sections never reach their cylinder face's
-section list, which is why those faces are never split. NEXT STEP: `build_section_edges` / how
-arena curves are attached to faces. WARNING: `log::debug!` markers added inside
+section list, which is why those faces are never split. NEXT STEP: `build_section_map` in fill_images_faces.rs, which SKIPS any
+`arena.curves` entry whose `pave_blocks` is empty (`continue`). HYPOTHESIS, EXPLICITLY UNVERIFIED:
+those 10 cylinder sections carry no pave blocks and are skipped there — which would make this the
+SAME root as the snapClip deepened-notch row ("marched FF sections on curved faces carry
+pave_block_id=None, bypassing the pave machinery", canonical fix at phase-FF/make_blocks altitude).
+Could NOT be confirmed: `log::debug!` inside fill_images_faces.rs does not emit (see warning below),
+and `eprintln!` is denied there by `clippy::print_stderr`, so both probes read as a false zero.
+Confirm it by counting empty-`pave_blocks` curves some other way before acting on it. WARNING: `log::debug!` markers added inside
 `fill_images_faces` did NOT reach a custom logger that WAS receiving `builder_solid`'s debug lines,
 so log-based probes there read as a false ZERO — use `eprintln!` gated on the env var instead.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -674,15 +674,15 @@ BETWEEN ARENA EMISSION AND THE PER-FACE SECTION LISTS (`BK_SPLIT_TRACE=1`, eprin
 CYLINDER faces with has_sections=true** (22 without; planes are 420 true / 285 false) — although FF
 emitted 12 cylinder x plane curves. So ~10 emitted sections never reach their cylinder face's
 section list, which is why those faces are never split. NEXT STEP: `build_section_map` in fill_images_faces.rs, which SKIPS any
-`arena.curves` entry whose `pave_blocks` is empty (`continue`). HYPOTHESIS, EXPLICITLY UNVERIFIED:
-those 10 cylinder sections carry no pave blocks and are skipped there — which would make this the
-SAME root as the snapClip deepened-notch row ("marched FF sections on curved faces carry
-pave_block_id=None, bypassing the pave machinery", canonical fix at phase-FF/make_blocks altitude).
-Could NOT be confirmed: `log::debug!` inside fill_images_faces.rs does not emit (see warning below),
-and `eprintln!` is denied there by `clippy::print_stderr`, so both probes read as a false zero.
-Confirm it by counting empty-`pave_blocks` curves some other way before acting on it. WARNING: `log::debug!` markers added inside
-`fill_images_faces` did NOT reach a custom logger that WAS receiving `builder_solid`'s debug lines,
-so log-based probes there read as a false ZERO — use `eprintln!` gated on the env var instead.
+`arena.curves` entry whose `pave_blocks` is empty (`continue`). REFUTED: that skip never fires — all
+**890 curves carry exactly ONE pave block, none are empty**, so this is NOT the snapClip
+deepened-notch pave-bypass root. The loss is in the `section_map` -> face lookup instead: curves are
+keyed by `curve.face_a`/`face_b`, yet 22 of 24 cylinder faces find no sections, so suspect a face-id
+mismatch between the arena's recorded faces and the faces the split loop iterates. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
+adjacent `log::debug!` and `eprintln!` on the same line gave **0 vs 890** records, while
+`builder_solid`'s `log::debug!` reaches the same logger fine. Log-based probes in that file read as
+a FALSE ZERO. Use a temporary `eprintln!` gated on an env var (it trips `clippy::print_stderr`, so
+do not commit it). Cause not diagnosed.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -668,9 +668,15 @@ emitted and DO survive clipping — at x=17.05, 64 cylinder x plane pairs pass t
 rejected, mostly correctly) and **12 sections survive `restrict_curves_to_faces` intact**. and all 12 are then EMITTED into the arena as `line` curves —
 correct geometry, since the cut plane's normal is along X while the corner cylinders' axes are
 along Z, so the plane is parallel to the axis and meets them in generators, not ellipses (and only
-one of the two generators lies on each quarter-arc face). So FF, restrict and emission all do their
-job: **the splitter has correct sections and still does not split the cylinder faces**. NEXT STEP:
-pave-block splitting / face building, same 230ms repro.
+one of the two generators lies on each quarter-arc face). So FF, restrict and emission all do their job. THE GAP IS
+BETWEEN ARENA EMISSION AND THE PER-FACE SECTION LISTS (`BK_SPLIT_TRACE=1`, eprintln at the
+`fill_images_faces` face loop): that loop DOES run, over 741 faces, and reports **only 2 of 24
+CYLINDER faces with has_sections=true** (22 without; planes are 420 true / 285 false) — although FF
+emitted 12 cylinder x plane curves. So ~10 emitted sections never reach their cylinder face's
+section list, which is why those faces are never split. NEXT STEP: `build_section_edges` / how
+arena curves are attached to faces. WARNING: `log::debug!` markers added inside
+`fill_images_faces` did NOT reach a custom logger that WAS receiving `builder_solid`'s debug lines,
+so log-based probes there read as a false ZERO — use `eprintln!` gated on the env var instead.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -665,9 +665,12 @@ span [17.000,20.750], identical to the base: had they been split with the outer 
 would read [17.050,20.750]. **So the cut plane appears not to split the corner cylinders at all** —
 that is the defect, and the missing patches are the cylinder pieces it should have produced. ALGO TRACE (`BK_FF_TRACE=<x>` in phase_ff.rs, env-gated): sections ARE
 emitted and DO survive clipping — at x=17.05, 64 cylinder x plane pairs pass the AABB test (736
-rejected, mostly correctly) and **12 sections survive `restrict_curves_to_faces` intact**. So
-phase FF and restrict both do their job; curves reach the splitter. NEXT STEP: pave-block splitting
-or face building, same 230ms repro.
+rejected, mostly correctly) and **12 sections survive `restrict_curves_to_faces` intact**. and all 12 are then EMITTED into the arena as `line` curves —
+correct geometry, since the cut plane's normal is along X while the corner cylinders' axes are
+along Z, so the plane is parallel to the axis and meets them in generators, not ellipses (and only
+one of the two generators lies on each quarter-arc face). So FF, restrict and emission all do their
+job: **the splitter has correct sections and still does not split the cylinder faces**. NEXT STEP:
+pave-block splitting / face building, same 230ms repro.
 REFUTED, do not re-attempt: a panic (none; `lastPanicMessage()` is empty), bisect thrash
 (telemetry: 1 attempt, 1 success), prism construction (322ms, 0.1%), boolean batching as the main
 cost (30%), classification (defect is op-independent), and the assembly sliver-drop guard (tool0

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -676,14 +676,16 @@ emitted 12 cylinder x plane curves. So ~10 emitted sections never reach their cy
 section list, which is why those faces are never split. NEXT STEP: `build_section_map` in fill_images_faces.rs, which SKIPS any
 `arena.curves` entry whose `pave_blocks` is empty (`continue`). REFUTED: that skip never fires — all
 **890 curves carry exactly ONE pave block, none are empty**, so this is NOT the snapClip
-deepened-notch pave-bypass root. Nor is it the `section_map` lookup — that map has
-**only 2 cylinder keys** (total 422: cylinder 2, plane 420), and the 22 unsplit cylinder faces are
-simply ABSENT from it (`in_map=false`), so nothing is being lost in the lookup either. Only 2 of 24
-cylinder faces ever had a section emitted for them. That sends it back UPSTREAM and reframes the
-restrict numbers: the "52 pairs 0 -> 0" had zero curves BEFORE restrict as well, i.e.
-**`compute_raw_curves` returns nothing for 52 of the 64 cylinder x plane pairs** — that is where the
-22 cylinders lose their sections. TARGET: why plane x cylinder section computation yields no curve
-for those pairs (they are generator-line cases; the 12 that do work prove the path exists). WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
+deepened-notch pave-bypass root. Nor is it the `section_map` lookup: that map has 2 cylinder keys
+(total 422; plane 420) and the other 22 cylinder faces are simply ABSENT (`in_map=false`), so
+nothing is lost in the lookup. CAUTION — do NOT read "only 2 of 24 cylinders sectioned" as the
+defect. The `FACES_NEAR_X` filter tests only the X range, and EVERY corner cylinder spans
+[17.000,20.750], so all four corners pass it regardless of y/z; most of those 22 are on other
+corners and SHOULD be untouched by tool0's single-wall slab. START THE NEXT SESSION HERE: identify
+which cylinder faces tool0 actually reaches (using y and z, not just x), and only then decide
+whether 2 sectioned is right or short. Everything else in this chain is measured and solid — FF
+pairing, restrict, emission and the section map are all confirmed working; two hypotheses (the
+empty-`pave_blocks` skip and a face-id mismatch) are REFUTED. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
 adjacent `log::debug!` and `eprintln!` on the same line gave **0 vs 890** records, while
 `builder_solid`'s `log::debug!` reaches the same logger fine. Log-based probes in that file read as
 a FALSE ZERO. Use a temporary `eprintln!` gated on an env var (it trips `clippy::print_stderr`, so

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -676,9 +676,14 @@ emitted 12 cylinder x plane curves. So ~10 emitted sections never reach their cy
 section list, which is why those faces are never split. NEXT STEP: `build_section_map` in fill_images_faces.rs, which SKIPS any
 `arena.curves` entry whose `pave_blocks` is empty (`continue`). REFUTED: that skip never fires — all
 **890 curves carry exactly ONE pave block, none are empty**, so this is NOT the snapClip
-deepened-notch pave-bypass root. The loss is in the `section_map` -> face lookup instead: curves are
-keyed by `curve.face_a`/`face_b`, yet 22 of 24 cylinder faces find no sections, so suspect a face-id
-mismatch between the arena's recorded faces and the faces the split loop iterates. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
+deepened-notch pave-bypass root. Nor is it the `section_map` lookup — that map has
+**only 2 cylinder keys** (total 422: cylinder 2, plane 420), and the 22 unsplit cylinder faces are
+simply ABSENT from it (`in_map=false`), so nothing is being lost in the lookup either. Only 2 of 24
+cylinder faces ever had a section emitted for them. That sends it back UPSTREAM and reframes the
+restrict numbers: the "52 pairs 0 -> 0" had zero curves BEFORE restrict as well, i.e.
+**`compute_raw_curves` returns nothing for 52 of the 64 cylinder x plane pairs** — that is where the
+22 cylinders lose their sections. TARGET: why plane x cylinder section computation yields no curve
+for those pairs (they are generator-line cases; the 12 that do work prove the path exists). WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
 adjacent `log::debug!` and `eprintln!` on the same line gave **0 vs 890** records, while
 `builder_solid`'s `log::debug!` reaches the same logger fine. Log-based probes in that file read as
 a FALSE ZERO. Use a temporary `eprintln!` gated on an env var (it trips `clippy::print_stderr`, so

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -508,6 +508,14 @@ pub fn perform(
                 let pb_id = arena.pave_blocks.alloc(pb);
 
                 let curve_index = arena.curves.len();
+                if traced {
+                    log::debug!(
+                        "FF_TRACE emit a={} b={} curve#{curve_index} {}",
+                        surf_a.type_tag(),
+                        surf_b.type_tag(),
+                        raw.curve.type_tag()
+                    );
+                }
                 arena.curves.push(IntersectionCurveDS {
                     curve: raw.curve,
                     face_a: fa,

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -390,9 +390,19 @@ pub fn perform(
             // cylinder/tilted-plane ellipse that meets the other face only
             // along a shared cap then reaches far past it and slits the
             // partner face's wire. Keep only the in-both span (curves only).
+            let before_restrict = raw_curves.len();
             let raw_curves = restrict_curves_to_faces(
                 topo, fa, fb, surf_a, surf_b, v_range_a, v_range_b, raw_curves, tol,
             );
+            if traced {
+                log::debug!(
+                    "FF_TRACE restrict a={} b={} {} -> {}",
+                    surf_a.type_tag(),
+                    surf_b.type_tag(),
+                    before_restrict,
+                    raw_curves.len()
+                );
+            }
             // Emit the EXACT faceted-ramp arcs with registry-aware endpoint
             // resolution: each arc's endpoints are bit-identical to the shared
             // boundary-line crossing of the adjacent tread's arc, so consult

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -28,6 +28,19 @@ const NURBS_SAMPLES: usize = 32;
 /// Default march step for NURBS-NURBS intersection.
 const NURBS_MARCH_STEP: f64 = 0.01;
 
+/// `BK_FF_TRACE=<x>`: report every face pair whose AABBs straddle that x, and
+/// whether the pair was AABB-rejected. Diagnostic only, and resolved ONCE per
+/// process — the pair loop runs hundreds of times per boolean and must not pay
+/// an env lookup and allocation each iteration.
+fn ff_trace_x() -> Option<f64> {
+    static FF_TRACE: std::sync::OnceLock<Option<f64>> = std::sync::OnceLock::new();
+    *FF_TRACE.get_or_init(|| {
+        std::env::var("BK_FF_TRACE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+    })
+}
+
 /// Detect face-face intersections between the two solids.
 ///
 /// For each face pair (one from each solid), computes intersection
@@ -90,6 +103,8 @@ pub fn perform(
         brepkit_topology::vertex::VertexId,
     > = std::collections::HashMap::new();
 
+    let ff_trace = ff_trace_x();
+
     for (idx_a, &fa) in faces_a.iter().enumerate() {
         let bbox_a = &bboxes_a[idx_a];
         let surf_a = &surfs_a[idx_a];
@@ -97,11 +112,37 @@ pub fn perform(
         for (idx_b, &fb) in faces_b.iter().enumerate() {
             let bbox_b = &bboxes_b[idx_b];
 
+            let traced = ff_trace.is_some_and(|x| {
+                bbox_a.min.x() - tol.linear <= x
+                    && x <= bbox_a.max.x() + tol.linear
+                    && bbox_b.min.x() - tol.linear <= x
+                    && x <= bbox_b.max.x() + tol.linear
+            });
+
             // AABB rejection
             if !bbox_a
                 .expanded(tol.linear)
                 .intersects(bbox_b.expanded(tol.linear))
             {
+                if traced {
+                    log::debug!(
+                        "FF_TRACE reject-aabb a={} b={} A[{:.2},{:.2},{:.2}..{:.2},{:.2},{:.2}] B[{:.2},{:.2},{:.2}..{:.2},{:.2},{:.2}]",
+                        surfs_a[idx_a].type_tag(),
+                        surfs_b[idx_b].type_tag(),
+                        bbox_a.min.x(),
+                        bbox_a.min.y(),
+                        bbox_a.min.z(),
+                        bbox_a.max.x(),
+                        bbox_a.max.y(),
+                        bbox_a.max.z(),
+                        bbox_b.min.x(),
+                        bbox_b.min.y(),
+                        bbox_b.min.z(),
+                        bbox_b.max.x(),
+                        bbox_b.max.y(),
+                        bbox_b.max.z()
+                    );
+                }
                 continue;
             }
 
@@ -111,6 +152,18 @@ pub fn perform(
             let v_range_b = v_ranges_b[idx_b];
             let raw_curves =
                 compute_raw_curves(surf_a, surf_b, bbox_a, bbox_b, v_range_a, v_range_b)?;
+            if traced {
+                log::debug!(
+                    "FF_TRACE pair a={} b={} raw_curves={} ax[{:.3},{:.3}] bx[{:.3},{:.3}]",
+                    surf_a.type_tag(),
+                    surf_b.type_tag(),
+                    raw_curves.len(),
+                    bbox_a.min.x(),
+                    bbox_a.max.x(),
+                    bbox_b.min.x(),
+                    bbox_b.max.x()
+                );
+            }
 
             // For plane-plane Line curves with all-straight-edge faces, trim
             // each curve to the mutual overlap of the two faces' clipped

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -49,7 +49,8 @@ impl log::Log for DropLogger {
             return;
         }
         let msg = format!("{}", r.args());
-        if msg.contains("growth sliver") || msg.contains("growth shell") {
+        if msg.contains("growth sliver") || msg.contains("growth shell") || msg.contains("FF_TRACE")
+        {
             println!("    [algo] {msg}");
         }
     }


### PR DESCRIPTION
Replaces #1221, which went CONFLICTING after picking up #1220's commits. Single commit off current main, with both review findings from there fixed.

Continues the goma dig past where black-box probing ran out (#1220). Adds `BK_FF_TRACE=<x>`, an env-gated diagnostic in `phase_ff`, and uses it to **rule out phase FF as the gap**.

## What it showed

At the sliver's x=17.05 on the `TOOL=0` repro:

```
 64 FF_TRACE pair          (all cylinder × plane, raw_curves=1 each)
736 FF_TRACE reject-aabb   (416 cylinder × plane)
```

**Sections are emitted.** 64 cylinder × plane pairs survive the AABB test and each returns a curve; the rejections are mostly correct, since most face pairs genuinely do not meet.

So phase FF is not where the four missing cylinder patches are lost. The defect is **downstream of section computation** — restrict/clip, pave-block splitting, or face building — traceable with the same ~230 ms repro.

## Fixed from #1221

- **Misattached attribute** (Copilot). My splice landed between `perform`'s doc block and its `#[allow(clippy::too_many_lines)]`, so both attached to the new helper and `perform` silently lost its allow. The helper now sits above the doc block; verified `#[allow(clippy::too_many_lines)]` is immediately followed by `pub fn perform`.
- **Formatting churn** (Copilot) — `cargo fmt` applied.

## Diagnostic hygiene

The first version resolved `std::env::var` **inside the face-pair loop** — 800 iterations on this small case, far more on real geometry, so an env lookup and allocation per pair in the boolean hot path. Now resolved once per process behind a module-level `OnceLock`. Trace output unchanged; untraced path measures 229–260 ms as before.

Verified: `clippy --all-targets` clean, 425 tests green across `brepkit-algo` and `brepkit-io`.

One correction carried over: my first read of this trace was "zero pair lines, everything rejected." That came from a frequency-sorted top-10 that happened to contain only rejects. The counts above are what the trace actually says.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an env-gated FF pair trace in `phase_ff` via `BK_FF_TRACE=<x>` to log face-pair behavior at a chosen x. Roadmap updated: sections survive FF/restrict/emission; only two cylinder faces report sections, and the x-only filter is non-localizing — next step is to check y/z-local faces.

- **New Features**
  - `BK_FF_TRACE=<x>` logs: "reject-aabb", `raw_curves` count, "restrict N -> M", and "emit curve#k type".
  - Resolves the env var once via a module `OnceLock`; untraced path performance unchanged.
  - `replay_cut_capture` prints `FF_TRACE` lines for easier inspection.

- **Bug Fixes**
  - Corrected placement of `#[allow(clippy::too_many_lines)]` on `perform`.
  - Formatting cleanup.

<sup>Written for commit 7573772b2b9c44c401e39815e0e6edfbb3918c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

