### PR TITLE
test(io): root-cause the goma notch loss to phase FF's AABB pre-filter

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -713,7 +713,12 @@ B 16.093–16.923 down, B 13.723–14.707 down, **F 11.507–12.338 up**, B 9.29
 **F 6.794–7.624 up**, B 4.578–5.408 down, **F 2.700–3.192 up**. Also REFUTED as discriminants: band
 width (working and failing bands are both ≈0.831, except one working band at 0.984 and one failing
 at 0.492) and band spacing (centres are a near-uniform ≈2.2 lattice pitch). START THE NEXT SESSION
-HERE — **THE DEFECT IS IN `restrict_curves_to_faces`, NOT THE FACE SPLITTER.** Aggregating the
+HERE — **THE DEFECT IS IN PHASE FF'S AABB IN-BOTH PRE-FILTER, NOT THE FACE SPLITTER AND NOT
+`restrict_curves_to_faces`.** (An intermediate commit on this branch pinned it on
+`restrict_curves_to_faces`; that was a MISREAD of the trace — `before_restrict` is captured after two
+shadowing filters, so "restrict 0 → 0" means the curves were ALREADY gone. Stage traces afterF1 /
+afterF2 show filter 1 keeps 2 of 2 on all 16 pairs and the AABB pre-filter at phase_ff.rs ~333–383
+drops 2→1 on the 12 successes and 2→0 on the 4 failures.) Aggregating the
 `BK_FF_TRACE=17.05` pair/restrict lines by partner face closes the accounting exactly. Isolating the
 true cut-plane partners (`bx[17.050,17.050]`; the `bx[15.437,17.050]`/`[16.037,17.050]`/
 `[16.756,17.050]` partners are the slanted lattice walls and all restrict 0→0): outer cylinder
@@ -723,12 +728,22 @@ i.e. ALL 16 band×cylinder pairs accounted for, and the 3 outer + 1 inner failur
 outer + 1 inner missing notches and exactly the 4 free components. **So restrict is handed TWO raw
 generator curves on all 16 geometrically-identical pairs and discards BOTH on 4 of them.** This also
 corrects #1222: its "12 sections survive restrict intact" was a FALSE ALL-CLEAR — the correct
-denominator is 16, and 12 is just the successful-notch count. NEXT: instrument inside
-`restrict_curves_to_faces` (phase_ff.rs) for those 4 pairs — which rejection branch fires, and on
-which of the two generators — rather than anything in the splitter. Its graze/extent-scaled
-refinement is the prime suspect given the 0.05mm in-both run (same class as the lite magnet-pad
-`rescue_corner_crossing` root), but that is NOT yet confirmed. Secondary lead, the inner/outer
-asymmetry: the inner
+denominator is 16, and 12 is just the successful-notch count. **ROOT CAUSE, CONFIRMED BY EXPERIMENT:**
+the AABB pre-filter samples each raw curve 24× and keeps it only if some sample lands in both faces'
+inflated AABBs — but for `EdgeCurve::Line` it then RETURNS FALSE without the adaptive refinement it
+applies to every other curve type ("straight lines are exactly represented by their endpoints; a
+uniform scan cannot under-sample them at this granularity in practice"). That reasoning is wrong for
+this geometry: exactness of the LINE says nothing about whether a sample lands in the tiny in-both
+WINDOW. The generator spans the full ~20.3mm cylinder height, 25 uniform samples give a ~0.85mm
+pitch, and each lattice opening band is only ~0.83mm tall — so whether a band is hit is aliasing
+luck, which is exactly why the B,B,B,F,B,F,B,F pattern looked random. Deleting that early-return
+takes tool0 to **free=0** (F=495, 24 cylinders + 12 cones preserved, 232ms — no slowdown), and bands
+2/4/6 likewise; the ready-repro `goma_wall_band_cut_is_closed` PASSES. Note the same mechanism is
+ALREADY documented one filter above for the faceted-ramp × cylinder ELLIPSE case ("the 16-sample
+AABB pre-filter below and the uniform-t restriction both drop it (no sample lands in the band)"),
+which got a bespoke exact-arc bypass — lines never got one. STILL OPEN after that fix: bands
+1/3/5/7 continue to abort with "open growth shell with N faces" (pre-existing, a SEPARATE defect —
+do not assume the line fix addresses it). Secondary lead, the inner/outer asymmetry: the inner
 cylinder Id(6088) forms SEVEN notches and fails only at z 2.700–3.192, while the outer Id(5678)
 forms five and fails at three bands — same tool, same openings, two concentric cylinders 1.2mm
 apart, different outcomes. So the decision is per-face, not per-opening. The two bands where inner

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -713,9 +713,22 @@ B 16.093–16.923 down, B 13.723–14.707 down, **F 11.507–12.338 up**, B 9.29
 **F 6.794–7.624 up**, B 4.578–5.408 down, **F 2.700–3.192 up**. Also REFUTED as discriminants: band
 width (working and failing bands are both ≈0.831, except one working band at 0.984 and one failing
 at 0.492) and band spacing (centres are a near-uniform ≈2.2 lattice pitch). START THE NEXT SESSION
-HERE: the pattern B,B,B,F,B,F,B,F is not periodic and not slope-keyed, so stop pattern-matching the
-OUTPUT and instrument the notch split itself — find where the θ=90→89.24 trim is decided per band
-and log why it declines for those three. THE SHARPEST LEAD IS THE INNER/OUTER ASYMMETRY: the inner
+HERE — **THE DEFECT IS IN `restrict_curves_to_faces`, NOT THE FACE SPLITTER.** Aggregating the
+`BK_FF_TRACE=17.05` pair/restrict lines by partner face closes the accounting exactly. Isolating the
+true cut-plane partners (`bx[17.050,17.050]`; the `bx[15.437,17.050]`/`[16.037,17.050]`/
+`[16.756,17.050]` partners are the slanted lattice walls and all restrict 0→0): outer cylinder
+`ax[17.000,20.750]` × cut plane gives raw_curves=2 restrict **1→1 on 5** pairs and **0→0 on 3**;
+inner `ax[17.000,19.550]` × cut plane gives **1→1 on 7** and **0→0 on 1**. That is 5+3=8 and 7+1=8,
+i.e. ALL 16 band×cylinder pairs accounted for, and the 3 outer + 1 inner failures are exactly the 3
+outer + 1 inner missing notches and exactly the 4 free components. **So restrict is handed TWO raw
+generator curves on all 16 geometrically-identical pairs and discards BOTH on 4 of them.** This also
+corrects #1222: its "12 sections survive restrict intact" was a FALSE ALL-CLEAR — the correct
+denominator is 16, and 12 is just the successful-notch count. NEXT: instrument inside
+`restrict_curves_to_faces` (phase_ff.rs) for those 4 pairs — which rejection branch fires, and on
+which of the two generators — rather than anything in the splitter. Its graze/extent-scaled
+refinement is the prime suspect given the 0.05mm in-both run (same class as the lite magnet-pad
+`rescue_corner_crossing` root), but that is NOT yet confirmed. Secondary lead, the inner/outer
+asymmetry: the inner
 cylinder Id(6088) forms SEVEN notches and fails only at z 2.700–3.192, while the outer Id(5678)
 forms five and fails at three bands — same tool, same openings, two concentric cylinders 1.2mm
 apart, different outcomes. So the decision is per-face, not per-opening. The two bands where inner

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -681,11 +681,24 @@ deepened-notch pave-bypass root. Nor is it the `section_map` lookup: that map ha
 nothing is lost in the lookup. CAUTION — do NOT read "only 2 of 24 cylinders sectioned" as the
 defect. The `FACES_NEAR_X` filter tests only the X range, and EVERY corner cylinder spans
 [17.000,20.750], so all four corners pass it regardless of y/z; most of those 22 are on other
-corners and SHOULD be untouched by tool0's single-wall slab. START THE NEXT SESSION HERE: identify
-which cylinder faces tool0 actually reaches (using y and z, not just x), and only then decide
-whether 2 sectioned is right or short. Everything else in this chain is measured and solid — FF
-pairing, restrict, emission and the section map are all confirmed working; two hypotheses (the
-empty-`pave_blocks` skip and a face-id mismatch) are REFUTED. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
+corners and SHOULD be untouched by tool0's single-wall slab. **RESOLVED: 2 sectioned cylinders is
+RIGHT, not short** — localizing by the free loops' y/z (not x) puts all four missing outlines in the
+SINGLE (+x,−y) corner, whose two full-height wall cylinders are exactly the outer r=3.75
+(x[17.000,20.750], 30 edges) and inner r=2.55 (x[17.000,19.550], 34 edges); the other 22 are other
+corners or low-z base profile that tool0 never reaches. **AND THE QUADRIC SIDE IS PROBABLY NOT THE
+DEFECT AT ALL.** `FACE_WIRES=1` (new knob on the replay example) shows both cylinders carry ONE
+plain outer wire and ZERO inner wires — so the cone-box row's predicted "inner wire duplicating the
+outer" fix-shape does NOT transfer here, and a bayed single outer wire is the CORRECT shape for a
+quarter-cylinder bitten at its θ=90 edge. Re-reading the free-loop geometry accordingly: each
+missing outline spans y∈[−19.550,−20.750] — exactly the 1.2mm wall thickness between the inner and
+outer corner cylinders — and is bounded by TWO ELLIPSE ARCS plus lines. A plane×cylinder section is
+an ellipse and tool0 is 663 PLANES, so **the missing patches are planar TOOL-side faces (the lattice
+opening's slanted walls) trimmed by the two corner cylinders, not cylinder pieces**. Confirmed
+absent: no face in the result spans x[17.000,17.050]. START THE NEXT SESSION HERE: identify which
+tool0 plane face each of the 4 outlines belongs to, and whether that plane face is split-but-missing
+a sliver sub-face or dropped whole. Everything else in this chain is measured and solid — FF
+pairing, restrict, emission and the section map are all confirmed working; three hypotheses (the
+empty-`pave_blocks` skip, a face-id mismatch, and cylinder mis-wiring) are REFUTED. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
 adjacent `log::debug!` and `eprintln!` on the same line gave **0 vs 890** records, while
 `builder_solid`'s `log::debug!` reaches the same logger fine. Log-based probes in that file read as
 a FALSE ZERO. Use a temporary `eprintln!` gated on an env var (it trips `clippy::print_stderr`, so

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -691,14 +691,27 @@ plain outer wire and ZERO inner wires — so the cone-box row's predicted "inner
 outer" fix-shape does NOT transfer here, and a bayed single outer wire is the CORRECT shape for a
 quarter-cylinder bitten at its θ=90 edge. Re-reading the free-loop geometry accordingly: each
 missing outline spans y∈[−19.550,−20.750] — exactly the 1.2mm wall thickness between the inner and
-outer corner cylinders — and is bounded by TWO ELLIPSE ARCS plus lines. A plane×cylinder section is
-an ellipse and tool0 is 663 PLANES, so **the missing patches are planar TOOL-side faces (the lattice
-opening's slanted walls) trimmed by the two corner cylinders, not cylinder pieces**. Confirmed
-absent: no face in the result spans x[17.000,17.050]. START THE NEXT SESSION HERE: identify which
-tool0 plane face each of the 4 outlines belongs to, and whether that plane face is split-but-missing
-a sliver sub-face or dropped whole. Everything else in this chain is measured and solid — FF
-pairing, restrict, emission and the section map are all confirmed working; three hypotheses (the
-empty-`pave_blocks` skip, a face-id mismatch, and cylinder mis-wiring) are REFUTED. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
+outer corner cylinders. An intermediate read of that — "the missing patches are planar TOOL-side
+faces, not cylinder pieces" — was WRONG and is retracted; it inferred the surface from the rim's
+ellipse arcs without checking whether the cylinder boundary itself was notched. **THE REAL
+SIGNATURE, and the sharpest datum in this whole dig: the notch forms in 5 of 8 z-bands and is simply
+ABSENT in 3.** Dumping face 5678's 30-edge outer wire (`FACE_WIRES=1` prints per-edge geometry and
+flags free edges) shows a clean repeating bay wherever the cut worked — `line` along the tangent
+generator at x=17.000, `ellipse` out to x=17.050, `line` down the cut plane, `ellipse` back — i.e.
+the quarter-cylinder trimmed from θ=90 back to θ=89.24 across the tool's 0.05mm overshoot. In the
+three failing bands (z 11.507–12.338, 6.794–7.624, 2.700–3.192) the wire instead runs STRAIGHT along
+x=17.000 with no bay, and **those un-notched generator segments ARE the free edges** (e17959, e17965,
+e17971), free because the flat wall at y=−20.750 does have its opening there so nothing pairs.
+`FREE_OWNERS=1` confirms the whole rim: 10 faces carry all 30 free edges — the two corner cylinders
+(3 + 2) and eight planes, dominated by the cut-plane faces Id(6090) 10-of-12 and Id(6091) 4-of-9.
+CANDIDATE DISCRIMINANT (not yet confirmed): in every WORKING bay the bridging ellipse's z DECREASES
+outward (19.140→19.111), in every FAILING one it INCREASES (12.338→12.367) — kumiko diagonals slope
+alternately, so this points at a direction/orientation assumption in the notch split rather than a
+tolerance. START THE NEXT SESSION HERE: confirm or refute that slope discriminant across all 8 bands
+and both cylinders, then find the split site that declines the notch for one slope sign. Everything
+else in this chain is measured and solid — FF pairing, restrict, emission and the section map are
+all confirmed working; three hypotheses (the empty-`pave_blocks` skip, a face-id mismatch, and
+cylinder mis-wiring via a duplicated inner wire) are REFUTED. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an
 adjacent `log::debug!` and `eprintln!` on the same line gave **0 vs 890** records, while
 `builder_solid`'s `log::debug!` reaches the same logger fine. Log-based probes in that file read as
 a FALSE ZERO. Use a temporary `eprintln!` gated on an env var (it trips `clippy::print_stderr`, so

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -704,11 +704,27 @@ x=17.000 with no bay, and **those un-notched generator segments ARE the free edg
 e17971), free because the flat wall at y=−20.750 does have its opening there so nothing pairs.
 `FREE_OWNERS=1` confirms the whole rim: 10 faces carry all 30 free edges — the two corner cylinders
 (3 + 2) and eight planes, dominated by the cut-plane faces Id(6090) 10-of-12 and Id(6091) 4-of-9.
-CANDIDATE DISCRIMINANT (not yet confirmed): in every WORKING bay the bridging ellipse's z DECREASES
-outward (19.140→19.111), in every FAILING one it INCREASES (12.338→12.367) — kumiko diagonals slope
-alternately, so this points at a direction/orientation assumption in the notch split rather than a
-tolerance. START THE NEXT SESSION HERE: confirm or refute that slope discriminant across all 8 bands
-and both cylinders, then find the split site that declines the notch for one slope sign. Everything
+SLOPE DISCRIMINANT — PROPOSED AND REFUTED IN THE SAME SESSION, do not re-chase: the bridging
+ellipse's z direction looked like the split (working bays DECREASE outward 19.140→19.111, the three
+failures INCREASE 12.338→12.367), but enumerating all 8 bands kills it — the working bay at
+z 9.291–10.122 goes 10.122→10.151, i.e. UP-outward exactly like all three failures, and its notch
+forms fine. Full band table, top to bottom (B=notch formed, F=free): B 18.309–19.140 down,
+B 16.093–16.923 down, B 13.723–14.707 down, **F 11.507–12.338 up**, B 9.291–10.122 up,
+**F 6.794–7.624 up**, B 4.578–5.408 down, **F 2.700–3.192 up**. Also REFUTED as discriminants: band
+width (working and failing bands are both ≈0.831, except one working band at 0.984 and one failing
+at 0.492) and band spacing (centres are a near-uniform ≈2.2 lattice pitch). START THE NEXT SESSION
+HERE: the pattern B,B,B,F,B,F,B,F is not periodic and not slope-keyed, so stop pattern-matching the
+OUTPUT and instrument the notch split itself — find where the θ=90→89.24 trim is decided per band
+and log why it declines for those three. THE SHARPEST LEAD IS THE INNER/OUTER ASYMMETRY: the inner
+cylinder Id(6088) forms SEVEN notches and fails only at z 2.700–3.192, while the outer Id(5678)
+forms five and fails at three bands — same tool, same openings, two concentric cylinders 1.2mm
+apart, different outcomes. So the decision is per-face, not per-opening. The two bands where inner
+succeeds but outer fails also show the cascade: at z 11.536–12.367 the inner notch IS built but its
+x=17.050 line (e19454) is left FREE because the outer side never produced the partner patch. Also
+worth explaining: every outer-cylinder edge sits in one fresh contiguous id block (e17930–e17972)
+while the inner mixes a shared lower block (e18387–e18485, its formed notch ellipses) with fresh
+e19445–e19459 — the outer's notch ellipses appear NOT to be the shared section edges the inner's
+are, which may be the provenance difference behind the whole asymmetry. Everything
 else in this chain is measured and solid — FF pairing, restrict, emission and the section map are
 all confirmed working; three hypotheses (the empty-`pave_blocks` skip, a face-id mismatch, and
 cylinder mis-wiring via a duplicated inner wire) are REFUTED. WARNING: `log::debug!` inside `fill_images_faces.rs` does NOT emit — an

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -287,7 +287,7 @@ fn main() {
                         // than an untouched quarter-cylinder's four.
                         for &fid in &faces {
                             let f = topo.face(fid).expect("face");
-                            if f.surface().type_tag() == "plane" {
+                            if f.surface().is_planar() {
                                 continue;
                             }
                             let wires: Vec<_> = std::iter::once(f.outer_wire())

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -241,6 +241,45 @@ fn main() {
                             }
                         }
                     }
+                    if std::env::var("FACE_WIRES").is_ok() {
+                        // Sections reach the two corner cylinders but no sliver
+                        // sub-faces come out. Either the splitter declined the
+                        // split (one plain outer wire) or it mis-wired the face
+                        // (an inner wire duplicating the outer). Print the wire
+                        // structure of every curved face carrying more edges
+                        // than an untouched quarter-cylinder's four.
+                        for &fid in &faces {
+                            let f = topo.face(fid).expect("face");
+                            if f.surface().type_tag() == "plane" {
+                                continue;
+                            }
+                            let wires: Vec<_> = std::iter::once(f.outer_wire())
+                                .chain(f.inner_wires().iter().copied())
+                                .collect();
+                            let total: usize = wires
+                                .iter()
+                                .map(|&w| topo.wire(w).expect("wire").edges().len())
+                                .sum();
+                            if total <= 4 {
+                                continue;
+                            }
+                            println!(
+                                "    face {fid:?} {} wires={} edges={total}",
+                                f.surface().type_tag(),
+                                wires.len()
+                            );
+                            for (k, &wid) in wires.iter().enumerate() {
+                                let w = topo.wire(wid).expect("wire");
+                                let kind = if k == 0 { "outer" } else { "inner" };
+                                let ids: Vec<usize> =
+                                    w.edges().iter().map(|oe| oe.edge().index()).collect();
+                                println!(
+                                    "      {kind} wire {wid:?} n={} edges={ids:?}",
+                                    w.edges().len()
+                                );
+                            }
+                        }
+                    }
                     if free > 0 && std::env::var("FREE_LOOPS").is_ok() {
                         // Free edges bound the hole(s) left by dropped faces.
                         // Chain them by shared vertex: each closed chain is one

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -241,6 +241,43 @@ fn main() {
                             }
                         }
                     }
+                    if free > 0 && std::env::var("FREE_OWNERS").is_ok() {
+                        // Each free edge is used by exactly one face. Those
+                        // faces are the rim around the hole, so their surfaces
+                        // say which input face should have owned the missing
+                        // patch.
+                        let mut rows: Vec<(usize, String, usize, [f64; 3])> = Vec::new();
+                        for &fid in &faces {
+                            let f = topo.face(fid).expect("face");
+                            let n = std::iter::once(f.outer_wire())
+                                .chain(f.inner_wires().iter().copied())
+                                .flat_map(|wid| topo.wire(wid).expect("wire").edges())
+                                .filter(|oe| uses.get(&oe.edge()).copied() == Some(1))
+                                .count();
+                            if n == 0 {
+                                continue;
+                            }
+                            let w = topo.wire(f.outer_wire()).expect("w");
+                            let p = topo
+                                .vertex(topo.edge(w.edges()[0].edge()).expect("e").start())
+                                .expect("v")
+                                .point();
+                            rows.push((
+                                fid.index(),
+                                f.surface().type_tag().to_string(),
+                                n,
+                                [p.x(), p.y(), p.z()],
+                            ));
+                        }
+                        rows.sort_unstable_by_key(|r| r.0);
+                        println!("    free-edge rim faces: {}", rows.len());
+                        for (fid, tag, n, p) in rows {
+                            println!(
+                                "      face Id({fid}) {tag} free={n} at ({:.3},{:.3},{:.3})",
+                                p[0], p[1], p[2]
+                            );
+                        }
+                    }
                     if std::env::var("FACE_WIRES").is_ok() {
                         // Sections reach the two corner cylinders but no sliver
                         // sub-faces come out. Either the splitter declined the
@@ -271,12 +308,28 @@ fn main() {
                             for (k, &wid) in wires.iter().enumerate() {
                                 let w = topo.wire(wid).expect("wire");
                                 let kind = if k == 0 { "outer" } else { "inner" };
-                                let ids: Vec<usize> =
-                                    w.edges().iter().map(|oe| oe.edge().index()).collect();
-                                println!(
-                                    "      {kind} wire {wid:?} n={} edges={ids:?}",
-                                    w.edges().len()
-                                );
+                                println!("      {kind} wire {wid:?} n={}", w.edges().len());
+                                for oe in w.edges() {
+                                    let e = topo.edge(oe.edge()).expect("edge");
+                                    let a = topo.vertex(e.start()).expect("v").point();
+                                    let b = topo.vertex(e.end()).expect("v").point();
+                                    let f = if uses.get(&oe.edge()).copied() == Some(1) {
+                                        " FREE"
+                                    } else {
+                                        ""
+                                    };
+                                    println!(
+                                        "        e{} {} ({:.3},{:.3},{:.3})->({:.3},{:.3},{:.3}){f}",
+                                        oe.edge().index(),
+                                        e.curve().type_tag(),
+                                        a.x(),
+                                        a.y(),
+                                        a.z(),
+                                        b.x(),
+                                        b.y(),
+                                        b.z()
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Continues the goma dig past #1222 and **root-causes it**. Diagnostics + roadmap only; the one-line fix lands in a follow-up PR so it can be reviewed on its own.

Six commits, three of which retract or refute an earlier hypothesis of mine. All kept on the record so the dead ends aren't rediscovered.

## Root cause

Phase FF's AABB in-both pre-filter (`phase_ff.rs` ~333–383) samples each raw curve 24× and keeps it only if some sample lands in both faces' inflated AABBs — but for `EdgeCurve::Line` it returns `false` **without** the adaptive refinement it applies to every other curve type:

```rust
// Straight lines are exactly represented by their endpoints; a uniform scan
// cannot under-sample them at this granularity in practice, and refining
// every far pair would be pure cost.
if matches!(raw.curve, EdgeCurve::Line) {
    return false;
}
```

That reasoning is wrong for this geometry. Exactness of the *line* says nothing about whether a sample lands in the tiny in-both **window**. The generator spans the full ~20.3 mm cylinder height; 25 uniform samples give a ~0.85 mm pitch; each lattice opening band is ~0.83 mm tall. Whether a band gets hit is aliasing luck — which is exactly why the failure pattern looked random.

The same mechanism is **already documented one filter above** for the faceted-ramp × cylinder *ellipse* case ("the 16-sample AABB pre-filter below and the uniform-t restriction both drop it (no sample lands in the band)"), which got a bespoke exact-arc bypass. Lines never got one.

## The accounting, closed exactly

Stage traces (`afterF1`/`afterF2`) show filter 1 keeps 2 of 2 on all 16 pairs, and the AABB pre-filter drops:

| Cylinder | raw | after pre-filter | count |
|---|---|---|---|
| outer `ax[17.000,20.750]` | 2 | **1** | **5** |
| outer `ax[17.000,20.750]` | 2 | **0** | **3** |
| inner `ax[17.000,19.550]` | 2 | **1** | **7** |
| inner `ax[17.000,19.550]` | 2 | **0** | **1** |

5+3 = 8 and 7+1 = 8 — all 16 band×cylinder pairs, and the 3+1 failures are exactly the 3+1 missing notches and exactly the 4 free components.

This corrects #1222: "12 sections survive restrict intact" was a **false all-clear**. The correct denominator is 16; 12 is just the successful-notch count.

## Experimental confirmation

Deleting the early-return takes tool0 to **`free=0`** (F=495, 24 cylinders + 12 cones preserved, 232 ms — no slowdown). Bands 2/4/6 likewise, and the ready-repro `goma_wall_band_cut_is_closed` **passes**. Full gate green: 425 algo+io, 989 operations, 27 wasm gridfinity.

**Still open, separate defect:** bands 1/3/5/7 continue to abort with "open growth shell with N faces" — pre-existing, not addressed by the line fix.

## Retracted / refuted along the way

- **Retracted:** the missing patches are planar tool-side faces (inferred from rim ellipse arcs without checking the cylinder boundary).
- **Retracted:** the defect is in `restrict_curves_to_faces` — a misread, since `before_restrict` is captured *after* two shadowing filters.
- **Refuted:** the ellipse-slope discriminant (working bay z 9.291–10.122 is up-outward like all three failures and forms fine), band width (~0.831 both sides), band spacing (uniform ~2.2 pitch).
- **Refuted:** cylinder mis-wiring — both carry one plain outer wire, zero inner wires.
- **Settled:** "only 2 of 24 cylinders sectioned" is right, not short.

## Verification

- Probes are env-gated and off by default; no behavior change in this PR.
- `cargo nextest run -p brepkit-io`: 223 passed, 1 skipped.
- `cargo fmt` + `cargo clippy` clean.
- Review finding addressed: `is_planar()` replaces the type-tag string compare.