### PR TITLE
fix(algo): clip straight FF sections to the mutual AABB exactly

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -751,9 +751,23 @@ test also admits lines crossing `bb_a ∩ bb_b` while missing both faces: ungate
 two such plane×plane lines into `dovetail_a1corner_nubfuse_inmem` and took it watertight → bnd=158.
 Plane×plane keeps the sampled test and its `return false`, so it stays theoretically susceptible to
 the same aliasing; no repro exhibits it, and closing it needs a test against true FACE extents
-rather than AABBs. STILL OPEN after that fix: bands
-1/3/5/7 continue to abort with "open growth shell with N faces" (pre-existing, a SEPARATE defect —
-do not assume the line fix addresses it). Secondary lead, the inner/outer asymmetry: the inner
+rather than AABBs. **STILL OPEN after that fix — THE ODD-BAND FAMILY, now the live goma work:** bands
+1/3/5/7 abort with "open growth shell with N faces" (9, 22, 23, 36 respectively). PROVEN INDEPENDENT
+of the line fix — identical counts on pre-fix main, so do NOT assume a shared root. The abort is
+DELIBERATE (`builder_solid.rs` ~1192): an OPEN growth shell of ≥4 faces is a genuine solid lump whose
+selection left unpaired junction edges, and failing beats silently deleting its volume (the lite
+fused-foot lesson). Note the odd tools carry MORE faces than the even ones (726/737/714/764 vs a
+uniform 663) — they are structurally different lattice members (the diagonals), so they meet the
+corner cylinder at an angle rather than square on. LOCALIZED (env-gated `BK_OPEN_SHELL` probe at the
+abort site, stashed not yet committed): tool1's 9 faces are ALL PLANES clustered in the SAME (+x,−y)
+corner as the even-band defect and the SAME 1.2mm wall-thickness band — x≈17.1–18.1, y≈−19.4 to
+−20.75 — but in one narrow z window ≈8.2–9.0. SIGNATURE IS JUNCTION IDENTITY, NOT ALIASING: two face
+pairs share identical start points (Id(2696)/Id(2709) at (17.760,−20.080,8.372), Id(2721)/Id(2730)
+at (17.809,−19.418,8.466)), and the unpaired edges include MICRO-ellipses — (17.809,−19.418,8.466)→
+(17.811,−19.418,8.465) is ~0.002mm, another ~0.022mm. That is the near-duplicate-vertex/weld-band
+class (cf. the intwidth tangency and lite magnet-pad roots), so start from vertex minting in that
+corner (VERTEX_WATCH recipe) rather than from the splitter. Secondary lead, the inner/outer
+asymmetry: the inner
 cylinder Id(6088) forms SEVEN notches and fails only at z 2.700–3.192, while the outer Id(5678)
 forms five and fails at three bands — same tool, same openings, two concentric cylinders 1.2mm
 apart, different outcomes. So the decision is per-face, not per-opening. The two bands where inner

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -729,19 +729,29 @@ outer + 1 inner missing notches and exactly the 4 free components. **So restrict
 generator curves on all 16 geometrically-identical pairs and discards BOTH on 4 of them.** This also
 corrects #1222: its "12 sections survive restrict intact" was a FALSE ALL-CLEAR — the correct
 denominator is 16, and 12 is just the successful-notch count. **ROOT CAUSE, CONFIRMED BY EXPERIMENT:**
-the AABB pre-filter samples each raw curve 24× and keeps it only if some sample lands in both faces'
-inflated AABBs — but for `EdgeCurve::Line` it then RETURNS FALSE without the adaptive refinement it
+the AABB pre-filter samples each raw curve 16× and keeps it only if some sample lands in both faces'
+inflated AABBs — but for `EdgeCurve::Line` it then RETURNED FALSE without the adaptive refinement it
 applies to every other curve type ("straight lines are exactly represented by their endpoints; a
 uniform scan cannot under-sample them at this granularity in practice"). That reasoning is wrong for
 this geometry: exactness of the LINE says nothing about whether a sample lands in the tiny in-both
-WINDOW. The generator spans the full ~20.3mm cylinder height, 25 uniform samples give a ~0.85mm
+WINDOW. The generator spans the full ~20.3mm cylinder height, 17 uniform samples give a ~1.27mm
 pitch, and each lattice opening band is only ~0.83mm tall — so whether a band is hit is aliasing
-luck, which is exactly why the B,B,B,F,B,F,B,F pattern looked random. Deleting that early-return
-takes tool0 to **free=0** (F=495, 24 cylinders + 12 cones preserved, 232ms — no slowdown), and bands
-2/4/6 likewise; the ready-repro `goma_wall_band_cut_is_closed` PASSES. Note the same mechanism is
+luck, which is exactly why the B,B,B,F,B,F,B,F pattern looked random. Note the same mechanism is
 ALREADY documented one filter above for the faceted-ramp × cylinder ELLIPSE case ("the 16-sample
 AABB pre-filter below and the uniform-t restriction both drop it (no sample lands in the band)"),
-which got a bespoke exact-arc bypass — lines never got one. STILL OPEN after that fix: bands
+which got a bespoke exact-arc bypass — lines never got one. **FIXED (#1224):** a straight section
+never needs sampling at all — the predicate is membership in `bb_a ∩ bb_b`, itself an AABB, so
+`segment_meets_both_boxes` slab-clips the segment against it (exact, O(1), and strictly CHEAPER than
+the 16-sample scan it replaces). tool0 and bands 2/4/6 all go free=30 → **free=0** (F=495, 24
+cylinders + 12 cones preserved, ~230ms unchanged); `goma_wall_band_cut_is_closed` is un-ignored and
+green. **GATED to pairs with a Cylinder/Cone partner, deliberately NOT plane×plane** — the exact and
+sampled tests can only disagree when the in-both window is shorter than the sample pitch, and on
+that difference set the inflated AABB is a gross over-approximation of a PLANAR face, so the exact
+test also admits lines crossing `bb_a ∩ bb_b` while missing both faces: ungated it admitted exactly
+two such plane×plane lines into `dovetail_a1corner_nubfuse_inmem` and took it watertight → bnd=158.
+Plane×plane keeps the sampled test and its `return false`, so it stays theoretically susceptible to
+the same aliasing; no repro exhibits it, and closing it needs a test against true FACE extents
+rather than AABBs. STILL OPEN after that fix: bands
 1/3/5/7 continue to abort with "open growth shell with N faces" (pre-existing, a SEPARATE defect —
 do not assume the line fix addresses it). Secondary lead, the inner/outer asymmetry: the inner
 cylinder Id(6088) forms SEVEN notches and fails only at z 2.700–3.192, while the outer Id(5678)

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -348,13 +348,44 @@ pub fn perform(
                     };
                     let in_both =
                         |p: Point3| -> bool { bb_a.contains_point(p) && bb_b.contains_point(p) };
+                    // A straight section against a BANDED quadric partner
+                    // admits an EXACT answer, so never sample one: the
+                    // predicate is membership in bb_a ∩ bb_b, itself an AABB,
+                    // so slab-clip the segment against it. Sampling is not
+                    // merely wasteful here, it is unsound — the in-both window
+                    // can be far shorter than the sample pitch. A kumiko
+                    // lattice band cuts a bin's corner cylinder in a
+                    // full-height generator (~20mm) whose true in-both span is
+                    // one ~0.8mm opening, well under this filter's ~1.3mm
+                    // pitch, so whether the section survived was aliasing luck:
+                    // 12 of 16 band×cylinder pairs kept their generator and 4
+                    // silently lost both, leaving 30 free edges that sent the
+                    // whole kumiko export family to the mesh fallback.
+                    //
+                    // Deliberately NOT applied to plane×plane. The two tests
+                    // can only disagree when the in-both window is shorter than
+                    // the sample pitch, and on that difference set the inflated
+                    // AABB is a gross over-approximation of a planar face, so
+                    // the exact test also admits lines that cross bb_a ∩ bb_b
+                    // while missing both faces. Widening it there admits two
+                    // such lines into the dovetail A1-corner nub fuse and takes
+                    // it from watertight to bnd=158. Plane×plane keeps the
+                    // sampled test and stays theoretically susceptible to the
+                    // same aliasing; no repro exhibits it, and closing it needs
+                    // a test against true face extents rather than AABBs.
+                    let banded_partner =
+                        matches!(surf_a, FaceSurface::Cylinder(_) | FaceSurface::Cone(_))
+                            || matches!(surf_b, FaceSurface::Cylinder(_) | FaceSurface::Cone(_));
+                    if banded_partner && matches!(raw.curve, EdgeCurve::Line) {
+                        return segment_meets_both_boxes(raw.p_start, raw.p_end, bb_a, bb_b);
+                    }
                     if (0..=N).map(|i| sample(i, N)).any(in_both) {
                         return true;
                     }
-                    // Straight lines are exactly represented by their
-                    // endpoints; a uniform scan cannot under-sample them at
-                    // this granularity in practice, and refining every far
-                    // pair would be pure cost.
+                    // Remaining (plane×plane) lines keep their original
+                    // treatment: no refinement, because refining every far pair
+                    // would be pure cost and the exact test above is the answer
+                    // wherever it is safe to apply.
                     if matches!(raw.curve, EdgeCurve::Line) {
                         return false;
                     }
@@ -911,6 +942,53 @@ fn point_to_polygon_dist(p: brepkit_math::vec::Point2, poly: &[brepkit_math::vec
         best = best.min(((p.x() - cx).powi(2) + (p.y() - cy).powi(2)).sqrt());
     }
     best
+}
+
+/// Exact test: does the segment `p0`→`p1` meet the intersection of two AABBs?
+///
+/// The in-both predicate for a straight section is membership in `a ∩ b`,
+/// itself an AABB, so this is the standard slab clip. It replaces sampling for
+/// lines, which aliases: the overlap window can be orders of magnitude shorter
+/// than the segment, and a missed window silently discards a real section.
+fn segment_meets_both_boxes(p0: Point3, p1: Point3, a: Aabb3, b: Aabb3) -> bool {
+    let lo = [
+        a.min.x().max(b.min.x()),
+        a.min.y().max(b.min.y()),
+        a.min.z().max(b.min.z()),
+    ];
+    let hi = [
+        a.max.x().min(b.max.x()),
+        a.max.y().min(b.max.y()),
+        a.max.z().min(b.max.z()),
+    ];
+    let start = [p0.x(), p0.y(), p0.z()];
+    let dir = [p1.x() - p0.x(), p1.y() - p0.y(), p1.z() - p0.z()];
+    let (mut t0, mut t1) = (0.0_f64, 1.0_f64);
+    for i in 0..3 {
+        if lo[i] > hi[i] {
+            return false;
+        }
+        // Exact zero is the only case that would make the slab ratio NaN; a
+        // merely tiny component divides to a large finite (or infinite) bound,
+        // which the min/max below handle correctly.
+        if dir[i] == 0.0 {
+            if start[i] < lo[i] || start[i] > hi[i] {
+                return false;
+            }
+            continue;
+        }
+        let mut ta = (lo[i] - start[i]) / dir[i];
+        let mut tb = (hi[i] - start[i]) / dir[i];
+        if ta > tb {
+            std::mem::swap(&mut ta, &mut tb);
+        }
+        t0 = t0.max(ta);
+        t1 = t1.min(tb);
+        if t0 > t1 {
+            return false;
+        }
+    }
+    true
 }
 
 /// Restrict surface-surface intersection curves to the region inside BOTH
@@ -4529,6 +4607,89 @@ fn clip_line_to_polygon_general(
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
+
+    fn boxes(
+        a: ([f64; 3], [f64; 3]),
+        b: ([f64; 3], [f64; 3]),
+    ) -> (brepkit_math::aabb::Aabb3, brepkit_math::aabb::Aabb3) {
+        let mk = |(lo, hi): ([f64; 3], [f64; 3])| {
+            brepkit_math::aabb::Aabb3::from_points([
+                Point3::new(lo[0], lo[1], lo[2]),
+                Point3::new(hi[0], hi[1], hi[2]),
+            ])
+        };
+        (mk(a), mk(b))
+    }
+
+    #[test]
+    fn segment_meets_window_far_shorter_than_sample_pitch() {
+        // The goma root: a 20mm generator whose only in-both span is a 0.8mm
+        // window. A 16-sample scan (1.27mm pitch) can step right over it; the
+        // exact slab clip cannot.
+        let (a, b) = boxes(
+            ([-1.0, -1.0, 0.0], [1.0, 1.0, 20.3]),
+            ([-1.0, -1.0, 11.507], [1.0, 1.0, 12.338]),
+        );
+        assert!(segment_meets_both_boxes(
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(0.0, 0.0, 20.3),
+            a,
+            b
+        ));
+    }
+
+    #[test]
+    fn segment_misses_when_boxes_are_disjoint() {
+        let (a, b) = boxes(
+            ([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]),
+            ([5.0, 5.0, 5.0], [6.0, 6.0, 6.0]),
+        );
+        assert!(!segment_meets_both_boxes(
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 1.0, 1.0),
+            a,
+            b
+        ));
+    }
+
+    #[test]
+    fn segment_stopping_short_of_the_window_is_rejected() {
+        // Overlap exists but lies beyond the segment's end: the clip must
+        // respect t in [0,1], not treat the segment as an infinite line.
+        let (a, b) = boxes(
+            ([-1.0, -1.0, 0.0], [1.0, 1.0, 20.0]),
+            ([-1.0, -1.0, 15.0], [1.0, 1.0, 16.0]),
+        );
+        assert!(!segment_meets_both_boxes(
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(0.0, 0.0, 10.0),
+            a,
+            b
+        ));
+    }
+
+    #[test]
+    fn axis_parallel_segment_outside_the_slab_is_rejected() {
+        // Zero direction component: the degenerate axis is decided by
+        // containment alone, and here the segment sits outside the overlap.
+        let (a, b) = boxes(
+            ([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]),
+            ([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]),
+        );
+        assert!(!segment_meets_both_boxes(
+            Point3::new(-5.0, 20.0, 5.0),
+            Point3::new(15.0, 20.0, 5.0),
+            a,
+            b
+        ));
+        // Same segment, inside the slab this time.
+        assert!(segment_meets_both_boxes(
+            Point3::new(-5.0, 5.0, 5.0),
+            Point3::new(15.0, 5.0, 5.0),
+            a,
+            b
+        ));
+    }
 
     #[test]
     fn longest_run_open_middle() {

--- a/crates/io/tests/goma_wall_band_cut_inmem.rs
+++ b/crates/io/tests/goma_wall_band_cut_inmem.rs
@@ -1,6 +1,18 @@
-//! Ready-repro: cutting a gridfinity bin wall by one kumiko lattice band
-//! leaves 30 free edges, so the analytic result is rejected and the whole
-//! kumiko family falls back to the mesh boolean.
+//! Regression: cutting a gridfinity bin wall by one kumiko lattice band used
+//! to leave 30 free edges, so the analytic result was rejected and the whole
+//! kumiko family fell back to the mesh boolean.
+//!
+//! Root cause (#1224): phase FF's AABB in-both pre-filter sampled each raw
+//! curve 16× and, for a `Line`, gave up without the adaptive refinement it
+//! applies to every other curve type — on the stated reasoning that a straight
+//! line cannot be under-sampled. But exactness of the LINE says nothing about
+//! whether a sample lands in the tiny in-both WINDOW: the section here is a
+//! full-height (~20.3mm) cylinder generator whose true in-both span is one
+//! ~0.83mm lattice opening, under the filter's ~1.27mm pitch. Whether a band
+//! survived was aliasing luck — 12 of the 16 band×cylinder pairs kept their
+//! generator and 4 silently lost both. A straight section needs no sampling at
+//! all: the predicate is membership in `bb_a ∩ bb_b`, itself an AABB, so the
+//! segment is now slab-clipped against it exactly.
 //!
 //! This one boolean is the root of the kumiko export-integrity family. The
 //! chain, measured (see the roadmap's goma entry): the tool's
@@ -11,19 +23,23 @@
 //! analytic path is rejected and the mesh fallback runs instead. The analytic
 //! path is ~12x faster and keeps all 12 cones and 24 cylinders.
 //!
-//! What the analytic result gets wrong is small and precise: **30 free edges**,
-//! which chain into **4 components whose every vertex has degree exactly 2** —
-//! four simple closed outlines, i.e. four missing faces. They all sit in one
-//! 0.05mm slab: every vertex is at x=17.00 or x=17.05. The x=17.05 side is this
-//! tool's cut plane; the x=17.00 side is NOT a plane but the base's corner
-//! cylinder, so it is a plane-vs-cylinder sliver. Each outline mixes lines in
-//! the cut plane with one line at x=17.00 and two ellipse arcs bridging the
-//! gap, so the missing faces are non-planar patches, not flat slivers.
+//! What the analytic result got wrong was small and precise: **30 free edges**,
+//! chaining into **4 components whose every vertex has degree exactly 2**. Each
+//! was an un-notched span of a corner cylinder's tangent generator at x=17.00,
+//! left unpaired because the flat wall at y=−20.750 does have its opening
+//! there. The notch — the quarter-cylinder trimmed from θ=90 back to θ=89.24
+//! across the tool's 0.05mm `SLAB_OVERLAP` — formed in 5 of 8 z-bands on the
+//! outer (r=3.75) cylinder and 7 of 8 on the inner (r=2.55) one.
 //!
-//! The defect is op-independent (Cut/Fuse both leave ~30 free edges, Intersect
-//! aborts assembly), which points at the splitter/section stage rather than
-//! classification. It also hits every band: tools 0/2/4/6 all give this exact
-//! signature, tools 1/3/5/7 abort with "open growth shell with N faces".
+//! Diagnostic notes worth keeping: the failing bands are NOT distinguished by
+//! the bridging ellipse's slope, band width, or band spacing (all three were
+//! checked and refuted — the working bay at z 9.291–10.122 slopes the same way
+//! as all three failures). And "only 2 of 24 cylinders carry sections" is
+//! CORRECT, not short: localizing by the free loops' y/z rather than x puts
+//! every outline in the single (+x,−y) corner.
+//!
+//! Bands 1/3/5/7 still abort with "open growth shell with N faces" — a
+//! SEPARATE, pre-existing defect that this fix does not address.
 //!
 //! Operands captured from the live tool on published 2.128.2; the other seven
 //! bands live in `~/.cache/brepkit-parity-captures/2026-07-24/goma-bisect/`
@@ -50,7 +66,6 @@ fn load(name: &str, topo: &mut Topology) -> brepkit_topology::solid::SolidId {
 }
 
 #[test]
-#[ignore = "ready-repro — kumiko band cut leaves 30 free edges; see doc comment"]
 fn goma_wall_band_cut_is_closed() {
     let mut topo = Topology::new();
     let base = load("goma_wall_base.bin", &mut topo);

--- a/crates/io/tests/goma_wall_band_cut_inmem.rs
+++ b/crates/io/tests/goma_wall_band_cut_inmem.rs
@@ -2,10 +2,11 @@
 //! to leave 30 free edges, so the analytic result was rejected and the whole
 //! kumiko family fell back to the mesh boolean.
 //!
-//! Root cause (#1224): phase FF's AABB in-both pre-filter sampled each raw
-//! curve 16× and, for a `Line`, gave up without the adaptive refinement it
-//! applies to every other curve type — on the stated reasoning that a straight
-//! line cannot be under-sampled. But exactness of the LINE says nothing about
+//! Root cause (diagnosed in #1223, fixed in #1224): phase FF's AABB in-both
+//! pre-filter sampled each raw curve 16× and, for a `Line`, gave up without
+//! the adaptive refinement it applies to every other curve type — on the
+//! stated reasoning that a straight line cannot be under-sampled at that
+//! granularity. But exactness of the LINE says nothing about
 //! whether a sample lands in the tiny in-both WINDOW: the section here is a
 //! full-height (~20.3mm) cylinder generator whose true in-both span is one
 //! ~0.83mm lattice opening, under the filter's ~1.27mm pitch. Whether a band


### PR DESCRIPTION
Closes the goma/kumiko wall-band cut root diagnosed in #1223. Un-ignores `goma_wall_band_cut_is_closed`.

## The bug

Phase FF's AABB in-both pre-filter samples each raw curve 16× and keeps it only if a sample lands in both faces' inflated AABBs. For an `EdgeCurve::Line` it then gave up **without** the adaptive refinement it applies to every other curve type:

```rust
// Straight lines are exactly represented by their endpoints; a uniform scan
// cannot under-sample them at this granularity in practice, and refining
// every far pair would be pure cost.
if matches!(raw.curve, EdgeCurve::Line) {
    return false;
}
```

That reasoning is wrong. Exactness of the *line* says nothing about whether a sample lands in the tiny in-both **window**. A kumiko lattice band cuts a gridfinity bin's corner cylinder in a full-height (~20.3 mm) generator whose true in-both span is one ~0.83 mm opening — under the filter's ~1.27 mm pitch. Whether a section survived was aliasing luck: **12 of 16** band×cylinder pairs kept their generator and **4 silently lost both**, leaving 30 free edges that failed the manifold gate and sent the whole kumiko export family to the mesh fallback.

The same mechanism is already documented one filter above for the faceted-ramp × cylinder *ellipse* case, which got a bespoke exact-arc bypass. Lines never got one.

## The fix

A straight section needs no sampling at all. The predicate is membership in `bb_a ∩ bb_b`, itself an AABB, so `segment_meets_both_boxes` slab-clips the segment against it — **exact, O(1), and strictly cheaper than the 16-sample scan it replaces.**

**Gated to pairs with a Cylinder/Cone partner, deliberately not plane×plane.** The exact and sampled tests can only disagree when the in-both window is shorter than the sample pitch, and on that difference set the inflated AABB is a gross over-approximation of a *planar* face — so the exact test also admits lines crossing `bb_a ∩ bb_b` while missing both faces. Ungated, it admitted exactly two such plane×plane lines into `dovetail_a1corner_nubfuse_inmem` and took it from watertight to `bnd=158`.

**Known limitation, stated plainly:** plane×plane keeps the sampled test and its early return, so it remains theoretically susceptible to the same aliasing. No repro exhibits it, and closing it properly needs a test against true face extents rather than AABBs. Recorded in the roadmap.

## Results

| Band | Before | After |
|---|---|---|
| tool0 | free=30 | **free=0** |
| tool2 / 4 / 6 | free=30 | **free=0** |
| tool1 / 3 / 5 / 7 | open growth shell | open growth shell (unchanged) |

tool0: F=495, 24 cylinders + 12 cones preserved, ~230 ms (unchanged). `goma_wall_band_cut_is_closed` un-ignored and green.

**Not closed by this PR:** bands 1/3/5/7 still abort with "open growth shell with N faces" — a separate, pre-existing defect. The kumiko family is half addressed, not finished.

## Verification

- **1419** tests across `brepkit-algo` + `brepkit-io` + `brepkit-operations`, all passing — including the full calibrated foil set (d4, honeycomb pcut3, divider-lip, cylinder-slot, groove-mouth, junction-disc, a1corner/dblcorner nub fixtures).
- `cargo test -p brepkit-wasm --lib gridfinity`: 27 passed.
- `cargo clippy --all-targets --all-features`: clean.
- Census unchanged — `cone ∪ box` remains the only primitive-boolean fallback; no new fallbacks.
- Four unit tests on `segment_meets_both_boxes` cover the sub-pitch window, disjoint boxes, a segment stopping short of the overlap, and the axis-parallel/zero-direction branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes aliasing in FF’s AABB pre-filter by replacing sampled checks for straight intersection lines with an exact slab clip against the mutual AABB when paired with a cylinder or cone. This restores watertight analytic results in kumiko band cuts (free edges 30 → 0).

- **Bug Fixes**
  - Added `segment_meets_both_boxes` and used it for `EdgeCurve::Line` when either face is a cylinder or cone; exact O(1) slab clip replaces the 16-sample scan.
  - Left plane×plane pairs on the sampled path to avoid admitting lines that only cross the AABB overlap; limitation documented.
  - Un-ignored `goma_wall_band_cut_is_closed` (now green). Tools 0/2/4/6 fixed; 1/3/5/7 still fail with open growth shell (separate issue). Added unit tests for narrow window, disjoint boxes, truncated segment, and axis-parallel cases.
  - Clarified test docs to attribute the diagnosis to #1223 and this fix to #1224; roadmap updated to localize the odd-band open growth shell as a separate, independent work item.

<sup>Written for commit b945261eaf973681b6a791fa130a4c83015b8f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

