### PR TITLE
test(algo): describe open growth shells before the assembly aborts

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -761,12 +761,20 @@ uniform 663) — they are structurally different lattice members (the diagonals)
 corner cylinder at an angle rather than square on. LOCALIZED (env-gated `BK_OPEN_SHELL` probe at the
 abort site, stashed not yet committed): tool1's 9 faces are ALL PLANES clustered in the SAME (+x,−y)
 corner as the even-band defect and the SAME 1.2mm wall-thickness band — x≈17.1–18.1, y≈−19.4 to
-−20.75 — but in one narrow z window ≈8.2–9.0. SIGNATURE IS JUNCTION IDENTITY, NOT ALIASING: two face
-pairs share identical start points (Id(2696)/Id(2709) at (17.760,−20.080,8.372), Id(2721)/Id(2730)
-at (17.809,−19.418,8.466)), and the unpaired edges include MICRO-ellipses — (17.809,−19.418,8.466)→
-(17.811,−19.418,8.465) is ~0.002mm, another ~0.022mm. That is the near-duplicate-vertex/weld-band
-class (cf. the intwidth tangency and lite magnet-pad roots), so start from vertex minting in that
-corner (VERTEX_WATCH recipe) rather than from the splitter. Secondary lead, the inner/outer
+−20.75 — but in one narrow z window ≈8.2–9.0. **THE STRONGEST DATUM: BOTH LUMPS ARE ALL PLANES,
+zero cylinder or cone faces.** A genuine chunk of bin WALL at a corner would necessarily include
+corner-cylinder faces; the lattice tool is 100% planes. So these lumps are clusters of TOOL faces
+(the cut surfaces) that formed a disjoint growth shell instead of joining the main body — i.e. the
+junction between the tool's cut surface and the bin's corner cylinder never connects. Start there,
+not at a stray-sliver theory. Each odd band hits a DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
+tool3 → (+x,+y) x≈18.6–20.5 y≈+18.3–19.9 z≈6.5–9.8), consistent with one diagonal member per band.
+CORRECTION, filed then retracted within the same session: an initial read called this the
+near-duplicate-vertex/weld-band class and pointed at vertex minting. The near-duplicates ARE present
+(Id(2721)/Id(2730) start at (17.809,−19.418,8.466) with a ~0.002mm unpaired ellipse to
+(17.811,−19.418,8.465)), but the surrounding junction gaps run ~0.019–0.06mm — three to four orders
+above the ~1e-6 marched-fit error that defines the weld-band class, so that filing is NOT supported.
+Treat the micro-edges as a symptom of the unconnected tool/cylinder junction, not the root.
+Secondary lead, the inner/outer
 asymmetry: the inner
 cylinder Id(6088) forms SEVEN notches and fails only at z 2.700–3.192, while the outer Id(5678)
 forms five and fails at three bands — same tool, same openings, two concentric cylinders 1.2mm

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeId;
 use brepkit_topology::face::{Face, FaceId, FaceSurface};
 use brepkit_topology::shell::Shell;
 use brepkit_topology::solid::{Solid, SolidId};
@@ -1132,6 +1133,70 @@ fn normalize_face_wires(topo: &mut Topology, fid: FaceId) {
 }
 
 /// Final assembly: build Solid from growth + hole shells.
+/// `BK_OPEN_SHELL=1`: describe an open growth shell before the assembly aborts.
+///
+/// The abort message carries only a face count, which says nothing about WHY
+/// the lump failed to pair. This prints each face's surface kind and a
+/// representative point, then every unpaired edge with its curve kind and
+/// endpoints — enough to tell a stray sliver from a real chunk, and to spot
+/// near-duplicate junction vertices.
+fn log_open_growth_shell(topo: &Topology, gs: &[FaceId]) {
+    if std::env::var("BK_OPEN_SHELL").is_err() {
+        return;
+    }
+    let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+    for &fid in gs {
+        let Ok(f) = topo.face(fid) else { continue };
+        for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+            let Ok(w) = topo.wire(wid) else { continue };
+            for oe in w.edges() {
+                *uses.entry(oe.edge()).or_default() += 1;
+            }
+        }
+    }
+    log::debug!("growth shell OPENSHELL faces={}", gs.len());
+    for &fid in gs {
+        let Ok(f) = topo.face(fid) else { continue };
+        let p = topo.wire(f.outer_wire()).ok().and_then(|w| {
+            let e = topo.edge(w.edges().first()?.edge()).ok()?;
+            Some(topo.vertex(e.start()).ok()?.point())
+        });
+        match p {
+            Some(p) => log::debug!(
+                "growth shell OPENSHELL face {fid:?} {} at ({:.3},{:.3},{:.3})",
+                f.surface().type_tag(),
+                p.x(),
+                p.y(),
+                p.z()
+            ),
+            None => log::debug!(
+                "growth shell OPENSHELL face {fid:?} {} at ?",
+                f.surface().type_tag()
+            ),
+        }
+    }
+    for (eid, count) in &uses {
+        if *count != 1 {
+            continue;
+        }
+        let Ok(e) = topo.edge(*eid) else { continue };
+        let (Ok(a), Ok(b)) = (topo.vertex(e.start()), topo.vertex(e.end())) else {
+            continue;
+        };
+        let (a, b) = (a.point(), b.point());
+        log::debug!(
+            "growth shell OPENSHELL free {} ({:.3},{:.3},{:.3})->({:.3},{:.3},{:.3})",
+            e.curve().type_tag(),
+            a.x(),
+            a.y(),
+            a.z(),
+            b.x(),
+            b.y(),
+            b.z()
+        );
+    }
+}
+
 fn assemble(
     topo: &mut Topology,
     growth_shells: Vec<Vec<FaceId>>,
@@ -1188,6 +1253,7 @@ fn assemble(
             // boolean falls back to the volume-correct mesh path. Note the
             // OUTER shell is never subjected to this test, so which lump
             // dodges it historically depended on volume-ordering luck.
+            log_open_growth_shell(topo, gs);
             return Err(AlgoError::AssemblyFailed(format!(
                 "open growth shell with {} faces would be dropped; aborting analytic assembly",
                 gs.len()


### PR DESCRIPTION
Follow-up to #1224, which closed the goma **even** bands. This characterises the remaining half — bands 1/3/5/7, which abort with "open growth shell with N faces" (9, 22, 23, 36).

Diagnostics only; no behavior change.

## The probe

`BK_OPEN_SHELL=1` at the abort site in `builder_solid`. The abort message carries only a face count, which says nothing about *why* the lump failed to pair. This prints each face's surface kind and a representative point, then every unpaired edge with its curve kind and endpoints — enough to tell a stray sliver from a real chunk and to spot near-duplicate junction vertices.

The abort itself is deliberate and correct: an open growth shell of ≥4 faces is a genuine solid lump whose selection left unpaired junction edges, and failing beats silently deleting its volume (the lite fused-foot lesson — 72 faces and ~2700 units³ invisible to every edge-pairing gate).

## What it shows

**Strongest datum: both inspected lumps are ALL PLANES — zero cylinder or cone faces.** A genuine chunk of bin *wall* at a corner would necessarily include corner-cylinder faces, and the lattice tool is 100% planes. So these lumps are clusters of **tool** faces (the cut surfaces) that formed a disjoint growth shell instead of joining the main body — the junction between the tool's cut surface and the bin's corner cylinder never connects.

Each odd band hits a **different corner**, consistent with one diagonal lattice member per band:

| Band | Faces | Location |
|---|---|---|
| tool1 | 9 | (+x,−y), z ≈ 8.2–9.0 |
| tool3 | 22 | (+x,+y), x ≈ 18.6–20.5, y ≈ +18.3–19.9, z ≈ 6.5–9.8 |

Also confirmed: this defect is **independent of #1224** — identical face counts on pre-fix main.

## A correction, filed and retracted in the same session

An initial read called this the near-duplicate-vertex / weld-band class and pointed the next dig at vertex minting. The near-duplicates *are* present — `Id(2721)`/`Id(2730)` start at `(17.809,−19.418,8.466)` with a ~0.002 mm unpaired ellipse to `(17.811,−19.418,8.465)` — but the surrounding junction gaps run **~0.019–0.06 mm**, three to four orders above the ~1e-6 marched-fit error that defines that class. So the filing is not supported, and the micro-edges are a symptom of the unconnected tool/cylinder junction rather than the root. Both the claim and its retraction are in the roadmap so the next session doesn't re-derive either.

## Verification

- `cargo nextest run -p brepkit-algo -p brepkit-io`: **430 passed**, 0 skipped (includes the full calibrated foil set).
- `cargo clippy -p brepkit-algo --all-targets`: clean.
- Diagnostic is env-gated and off by default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an env-gated diagnostic to describe open growth shells just before the assembly abort. Helps debug the remaining goma odd-band failures; no behavior change and logging is off by default.

- New Features
  - `BK_OPEN_SHELL=1` in `builder_solid` logs each face’s surface type and a sample point, plus every unpaired edge with its curve type and endpoints.
  - Default behavior unchanged; runs only when the env var is set.

<sup>Written for commit e038e322c7599c1f06e08b7644d6d82ccba49e53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

