### PR TITLE
test(algo): narrow the goma odd-band defect to missing corner-cylinder faces

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -766,7 +766,27 @@ zero cylinder or cone faces.** A genuine chunk of bin WALL at a corner would nec
 corner-cylinder faces; the lattice tool is 100% planes. So these lumps are clusters of TOOL faces
 (the cut surfaces) that formed a disjoint growth shell instead of joining the main body — i.e. the
 junction between the tool's cut surface and the bin's corner cylinder never connects. Start there,
-not at a stray-sliver theory. Each odd band hits a DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
+not at a stray-sliver theory. **ROOT NARROWED (2026-07-25, #1227): THE CORNER-CYLINDER SUB-FACES
+THAT SHOULD CLOSE THE CHUNK ARE MISSING FROM THE SELECTION.** Four measurements, each ruling
+something out. (1) Every one of tool1's 14 unpaired edges has `same_id_outside=0` AND
+`coincident_other_id=0` — the partner exists nowhere in the selected set under ANY identity, so this
+is neither "the lump was not walked into the main shell" nor a double-minted junction. (2) All 9
+lump faces carry `src` ids 226–348; the base holds only 78 faces (ids 0–77, deserialized first), so
+EVERY lump face is tool-derived and the missing partners must be BASE faces. (3) The lump's boundary
+vertices lie EXACTLY on the two corner cylinders — (17.186,−20.745) and (18.114,−20.581) are at
+r=3.750 from axis (17,−17), and (17.809,−19.418) is at r=2.550 — so the chunk is the wall segment
+between the inner and outer corner cylinders, and those cylinders are what should close it. (4) Of
+the 11 selected faces within 0.5mm of the lump bbox x[17.186,18.114] y[−20.745,−19.418]
+z[8.185,9.026], ALL are planes and only ONE is base-derived (src=73). INSTRUMENT VERIFIED (the
+"probe that misses the path looks like a null result" trap): the same run reports selected-total
+`[cone 12, cylinder 26, plane 378]`, so cylinders ARE selected globally — their absence at the lump
+is real and LOCAL. Lump signed volumes are substantial, not slivers: 3.69 / 7.39 / 9.55 / 10.13 mm³
+for bands 1/3/5/7. So the over-selection reading (a spurious tool patch that should never appear) is
+REFUTED; this is a genuine missing-face defect in the same corner and the same family as the
+even-band notch loss, reached by a different mechanism. NEXT: find why the corner-cylinder split
+produces no sub-face covering the diagonal's crossing region — start at the FF/section stage for the
+cylinder × diagonal-plane pairs at those coordinates (`BK_FF_TRACE`), exactly as the even-band dig
+did. Each odd band hits a DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
 tool3 → (+x,+y) x≈18.6–20.5 y≈+18.3–19.9 z≈6.5–9.8), consistent with one diagonal member per band.
 CORRECTION, filed then retracted within the same session: an initial read called this the
 near-duplicate-vertex/weld-band class and pointed at vertex minting. The near-duplicates ARE present

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -202,7 +202,7 @@ pub fn build_solid_with_origins(
     }
 
     // Phase 4: Assemble
-    let solid_id = assemble(topo, growth, holes)?;
+    let solid_id = assemble(topo, growth, holes, &face_source)?;
     let origins = brepkit_topology::explorer::solid_faces(topo, solid_id)?
         .into_iter()
         .map(|f| (f, face_source.get(&f).copied().flatten()))
@@ -1140,10 +1140,16 @@ fn normalize_face_wires(topo: &mut Topology, fid: FaceId) {
 /// representative point, then every unpaired edge with its curve kind and
 /// endpoints — enough to tell a stray sliver from a real chunk, and to spot
 /// near-duplicate junction vertices.
-fn log_open_growth_shell(topo: &Topology, gs: &[FaceId]) {
+fn log_open_growth_shell(
+    topo: &Topology,
+    gs: &[FaceId],
+    all: &[FaceId],
+    face_source: &HashMap<FaceId, Option<FaceId>>,
+) {
     if std::env::var("BK_OPEN_SHELL").is_err() {
         return;
     }
+    let in_lump: HashSet<FaceId> = gs.iter().copied().collect();
     let mut uses: HashMap<EdgeId, usize> = HashMap::new();
     for &fid in gs {
         let Ok(f) = topo.face(fid) else { continue };
@@ -1154,16 +1160,21 @@ fn log_open_growth_shell(topo: &Topology, gs: &[FaceId]) {
             }
         }
     }
-    log::debug!("growth shell OPENSHELL faces={}", gs.len());
+    log::debug!(
+        "growth shell OPENSHELL faces={} signed_volume={:.6}",
+        gs.len(),
+        signed_volume_of_shell(topo, gs)
+    );
     for &fid in gs {
         let Ok(f) = topo.face(fid) else { continue };
         let p = topo.wire(f.outer_wire()).ok().and_then(|w| {
             let e = topo.edge(w.edges().first()?.edge()).ok()?;
             Some(topo.vertex(e.start()).ok()?.point())
         });
+        let src = face_source.get(&fid).copied().flatten();
         match p {
             Some(p) => log::debug!(
-                "growth shell OPENSHELL face {fid:?} {} at ({:.3},{:.3},{:.3})",
+                "growth shell OPENSHELL face {fid:?} {} src={src:?} at ({:.3},{:.3},{:.3})",
                 f.surface().type_tag(),
                 p.x(),
                 p.y(),
@@ -1175,6 +1186,79 @@ fn log_open_growth_shell(topo: &Topology, gs: &[FaceId]) {
             ),
         }
     }
+    // What else was SELECTED near the lump? If the missing partners are base
+    // faces that were never created, nothing of the base appears here; if they
+    // exist but were not walked in, they show up.
+    let mut lo = [f64::MAX; 3];
+    let mut hi = [f64::MIN; 3];
+    for &fid in gs {
+        let Ok(f) = topo.face(fid) else { continue };
+        for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+            let Ok(w) = topo.wire(wid) else { continue };
+            for oe in w.edges() {
+                let Ok(e) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                for vid in [e.start(), e.end()] {
+                    let Ok(v) = topo.vertex(vid) else { continue };
+                    let p = v.point();
+                    for (k, c) in [p.x(), p.y(), p.z()].into_iter().enumerate() {
+                        lo[k] = lo[k].min(c);
+                        hi[k] = hi[k].max(c);
+                    }
+                }
+            }
+        }
+    }
+    log::debug!(
+        "growth shell OPENSHELL bbox x[{:.3},{:.3}] y[{:.3},{:.3}] z[{:.3},{:.3}]",
+        lo[0],
+        hi[0],
+        lo[1],
+        hi[1],
+        lo[2],
+        hi[2]
+    );
+    let mut allmix: HashMap<&str, usize> = HashMap::new();
+    for &ofid in all {
+        if let Ok(f) = topo.face(ofid) {
+            *allmix.entry(f.surface().type_tag()).or_default() += 1;
+        }
+    }
+    let mut allmix: Vec<_> = allmix.into_iter().collect();
+    allmix.sort_unstable();
+    log::debug!("growth shell OPENSHELL selected-total {allmix:?}");
+    let pad = 0.5;
+    for &ofid in all {
+        if in_lump.contains(&ofid) {
+            continue;
+        }
+        let Ok(of) = topo.face(ofid) else { continue };
+        let Ok(w) = topo.wire(of.outer_wire()) else {
+            continue;
+        };
+        let inside = w.edges().iter().any(|oe| {
+            let Ok(e) = topo.edge(oe.edge()) else {
+                return false;
+            };
+            [e.start(), e.end()].into_iter().any(|vid| {
+                topo.vertex(vid).is_ok_and(|v| {
+                    let p = v.point();
+                    [p.x(), p.y(), p.z()]
+                        .into_iter()
+                        .enumerate()
+                        .all(|(k, c)| c >= lo[k] - pad && c <= hi[k] + pad)
+                })
+            })
+        });
+        if inside {
+            let src = face_source.get(&ofid).copied().flatten();
+            log::debug!(
+                "growth shell OPENSHELL near {ofid:?} {} src={src:?}",
+                of.surface().type_tag()
+            );
+        }
+    }
     for (eid, count) in &uses {
         if *count != 1 {
             continue;
@@ -1184,8 +1268,41 @@ fn log_open_growth_shell(topo: &Topology, gs: &[FaceId]) {
             continue;
         };
         let (a, b) = (a.point(), b.point());
+        // Is the partner MISSING, or does it exist under a different edge id?
+        // "same id elsewhere" means the lump simply was not walked into the
+        // main shell; a position-coincident DIFFERENT id means the junction was
+        // minted twice and the two copies never merged. Those need opposite
+        // fixes, so the distinction is the whole point of this probe.
+        let mut same_id_outside = 0usize;
+        let mut coincident_other_id = 0usize;
+        let near = |p: Point3, q: Point3| (p - q).length() < 1e-4;
+        for &ofid in all {
+            if in_lump.contains(&ofid) {
+                continue;
+            }
+            let Ok(of) = topo.face(ofid) else { continue };
+            for wid in std::iter::once(of.outer_wire()).chain(of.inner_wires().iter().copied()) {
+                let Ok(w) = topo.wire(wid) else { continue };
+                for oe in w.edges() {
+                    if oe.edge() == *eid {
+                        same_id_outside += 1;
+                        continue;
+                    }
+                    let Ok(oe2) = topo.edge(oe.edge()) else {
+                        continue;
+                    };
+                    let (Ok(c), Ok(d)) = (topo.vertex(oe2.start()), topo.vertex(oe2.end())) else {
+                        continue;
+                    };
+                    let (c, d) = (c.point(), d.point());
+                    if (near(a, c) && near(b, d)) || (near(a, d) && near(b, c)) {
+                        coincident_other_id += 1;
+                    }
+                }
+            }
+        }
         log::debug!(
-            "growth shell OPENSHELL free {} ({:.3},{:.3},{:.3})->({:.3},{:.3},{:.3})",
+            "growth shell OPENSHELL free {} ({:.3},{:.3},{:.3})->({:.3},{:.3},{:.3}) same_id_outside={same_id_outside} coincident_other_id={coincident_other_id}",
             e.curve().type_tag(),
             a.x(),
             a.y(),
@@ -1201,6 +1318,7 @@ fn assemble(
     topo: &mut Topology,
     growth_shells: Vec<Vec<FaceId>>,
     hole_shells: Vec<Vec<FaceId>>,
+    face_source: &HashMap<FaceId, Option<FaceId>>,
 ) -> Result<SolidId, AlgoError> {
     let all_faces: Vec<FaceId> = growth_shells
         .iter()
@@ -1208,7 +1326,7 @@ fn assemble(
         .flatten()
         .copied()
         .collect();
-    for fid in all_faces {
+    for &fid in &all_faces {
         normalize_face_wires(topo, fid);
     }
 
@@ -1253,7 +1371,7 @@ fn assemble(
             // boolean falls back to the volume-correct mesh path. Note the
             // OUTER shell is never subjected to this test, so which lump
             // dodges it historically depended on volume-ordering luck.
-            log_open_growth_shell(topo, gs);
+            log_open_growth_shell(topo, gs, &all_faces, face_source);
             return Err(AlgoError::AssemblyFailed(format!(
                 "open growth shell with {} faces would be dropped; aborting analytic assembly",
                 gs.len()


### PR DESCRIPTION
Follow-up to #1226. Narrows the remaining goma defect (bands 1/3/5/7) from "a lump failed to pair" to a specific missing-face claim. Diagnostics only; no behavior change.

Extends `BK_OPEN_SHELL` to classify each unpaired edge, report face provenance, list what else was selected near the lump, and print the lump's signed volume plus a global surface-type histogram.

## Four measurements, each ruling something out

**1. The partner faces do not exist.** Every one of tool1's 14 unpaired edges reports `same_id_outside=0` **and** `coincident_other_id=0` — no face outside the lump uses that edge id, and none has a position-coincident edge under a different id. That rules out both "the lump was never walked into the main shell" and "the junction was minted twice and the copies never merged."

**2. The lump is entirely tool-derived.** All 9 faces carry `src` ids 226–348. The base holds only 78 faces (ids 0–77, deserialized first), so every lump face comes from the tool and the missing partners must be **base** faces.

**3. The missing partners are the corner cylinders.** The lump's boundary vertices lie exactly on them — `(17.186,−20.745)` and `(18.114,−20.581)` are at r=3.750 from axis (17,−17), and `(17.809,−19.418)` is at r=2.550. So the chunk is the wall segment between the inner and outer corner cylinders, and those cylinders are what should close it.

**4. Nothing curved was selected nearby.** Of the 11 selected faces within 0.5 mm of the lump bbox `x[17.186,18.114] y[−20.745,−19.418] z[8.185,9.026]`, all are planes and only one is base-derived (`src=73`).

## Instrument verified, not assumed

The same run reports `selected-total [cone 12, cylinder 26, plane 378]`. Cylinders **are** selected globally, so their absence at the lump is real and local — not a probe that quietly missed the path it claims to test.

## What this refutes

Lump signed volumes are substantial, not degenerate slivers: **3.69 / 7.39 / 9.55 / 10.13 mm³** for bands 1/3/5/7. Combined with (3), the over-selection reading — a spurious tool patch that should never have appeared, which the ≥4-face guard is merely refusing to drop — is **refuted**. This is a genuine missing-face defect, in the same corner and the same family as the even-band notch loss closed by #1224, reached by a different mechanism.

## Next

Find why the corner-cylinder split produces no sub-face covering the diagonal's crossing region — start at the FF/section stage for the cylinder × diagonal-plane pairs at those coordinates (`BK_FF_TRACE`), exactly as the even-band dig did.

## Verification

- `cargo nextest run -p brepkit-algo -p brepkit-io`: **430 passed**, 0 skipped (full calibrated foil set included).
- `cargo clippy -p brepkit-algo --all-targets`: clean.
- Diagnostic is env-gated and off by default; the lump-membership tests use a `HashSet` rather than repeated linear scans.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend `BK_OPEN_SHELL` diagnostics to trace open growth shells and confirm the odd‑band goma defect comes from missing corner‑cylinder faces. Env‑gated only; no behavior change.

- **New Features**
  - Log lump signed volume and a global surface-type histogram; compute lump bbox and list nearby selected faces with `src` provenance.
  - For each unpaired edge, log curve kind, endpoints, and counts for `same_id_outside` and `coincident_other_id`.
  - Include face `src` in shell logs; pass `face_source` through `assemble` to `log_open_growth_shell`.
  - Behind `BK_OPEN_SHELL` (off by default); `cargo nextest` (430 passed) and `cargo clippy` are clean.

<sup>Written for commit ed168035cc778a369e67dfe7e0baf7df81928055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

