### PR TITLE
test(algo): trace FF filter stages and curve kinds

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -783,10 +783,23 @@ z[8.185,9.026], ALL are planes and only ONE is base-derived (src=73). INSTRUMENT
 is real and LOCAL. Lump signed volumes are substantial, not slivers: 3.69 / 7.39 / 9.55 / 10.13 mm³
 for bands 1/3/5/7. So the over-selection reading (a spurious tool patch that should never appear) is
 REFUTED; this is a genuine missing-face defect in the same corner and the same family as the
-even-band notch loss, reached by a different mechanism. NEXT: find why the corner-cylinder split
-produces no sub-face covering the diagonal's crossing region — start at the FF/section stage for the
-cylinder × diagonal-plane pairs at those coordinates (`BK_FF_TRACE`), exactly as the even-band dig
-did. Each odd band hits a DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
+even-band notch loss, reached by a different mechanism. **FF STAGE MEASURED (#1228):**
+`BK_FF_TRACE=17.65` with new per-stage `afterF1`/`afterF2` traces (they report curve KINDS, and they
+exist because the old `restrict N -> M` line captures N AFTER both filters, so an earlier loss reads
+as "restrict 0 → 0" and looks like restrict's doing — that misreading cost one iteration in the
+even-band dig). At the lump's x the 127 surviving cylinder×plane pairs split as: **73 dropped at
+filter 1 (lines), 49 ELLIPSES dropped at filter 2's AABB in-both sampling, 3 ellipses surviving, 2
+line pairs.** So the dominant loss is ellipses at filter 2 — the SAME aliasing class as the
+even-band Line bug, on the path #1224 does NOT cover (its exact clip is gated to Lines) and which
+the existing bespoke exact-arc bypass only covers for the faceted-ramp × cylinder configuration.
+**CAUTION, do not overclaim:** most of those 49 are probably CORRECT drops — a tool face's AABB can
+overlap the cylinder while the face itself does not touch it — so the defect is a SUBSET. Treating
+all 49 as wrong would repeat the "12 sections survive intact" false-all-clear. NEXT: identify WHICH
+ellipse should produce the missing corner-cylinder sub-face at the lump bbox
+(x[17.186,18.114] y[−20.745,−19.418] z[8.185,9.026]) and confirm it is among the 49 BEFORE touching
+filter 2. Note filter 2 already refines non-Lines up to 1024 samples, so if aliasing really is the
+root then `n_fine` is under-scaled here — measure that rather than assume it. Each odd band hits a
+DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
 tool3 → (+x,+y) x≈18.6–20.5 y≈+18.3–19.9 z≈6.5–9.8), consistent with one diagonal member per band.
 CORRECTION, filed then retracted within the same session: an initial read called this the
 near-duplicate-vertex/weld-band class and pointed at vertex minting. The near-duplicates ARE present

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -801,10 +801,15 @@ aliasing artifact. So filter 2 is working correctly here and the 49 drops are le
 it would break calibrated fixtures for nothing. Worth recording for a FUTURE case though: `n_fine`
 is clamped at 1024 while `approx_len` reaches ~1173mm on near-axis-parallel planes (1.15mm spacing
 against sub-millimetre boxes), so the clamp IS a real aliasing hazard — just not this bug's cause.
-NEXT: the missing corner-cylinder sub-face at the lump (x[17.186,18.114] y[−20.745,−19.418]
-z[8.185,9.026]) is therefore NOT a dropped FF section. Check the sections that ARE emitted at the
-lump's z and follow them into the face splitter — the sub-face is lost at or after splitting, not at
-section computation. Each odd band hits a
+CONFIRMED, the sections ARE emitted and DO cover the lump: the `FF_TRACE emit` line now carries the
+curve's y/z bbox, and at the lump's x tool1 emits `curve#26` ellipse z[6.128,12.000]
+y[−20.749,−13.251] (the OUTER r=3.75 cylinder) and `curve#241` ellipse z[7.068,11.061]
+y[−19.550,−14.450] (the INNER r=2.55 one) — both spanning the lump's z window [8.185,9.026] and its
+y range — plus `curve#334` line. So FF, restrict, emission and coverage are all CORRECT for this
+lump; **the corner-cylinder sub-face is lost DOWNSTREAM, in the face splitter or in classification,
+not at section computation.** NEXT: dump the corner-cylinder faces' section lists and the sub-faces
+the splitter produces around z 8.2–9.0, and diff against the same corner on a WORKING (even) band —
+the even bands now assemble cleanly, so they are the control. Each odd band hits a
 DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
 tool3 → (+x,+y) x≈18.6–20.5 y≈+18.3–19.9 z≈6.5–9.8), consistent with one diagonal member per band.
 CORRECTION, filed then retracted within the same session: an initial read called this the

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -807,9 +807,24 @@ y[−20.749,−13.251] (the OUTER r=3.75 cylinder) and `curve#241` ellipse z[7.0
 y[−19.550,−14.450] (the INNER r=2.55 one) — both spanning the lump's z window [8.185,9.026] and its
 y range — plus `curve#334` line. So FF, restrict, emission and coverage are all CORRECT for this
 lump; **the corner-cylinder sub-face is lost DOWNSTREAM, in the face splitter or in classification,
-not at section computation.** NEXT: dump the corner-cylinder faces' section lists and the sub-faces
-the splitter produces around z 8.2–9.0, and diff against the same corner on a WORKING (even) band —
-the even bands now assemble cleanly, so they are the control. Each odd band hits a
+not at section computation.** **ROOT FOUND — IT IS A CLASSIFICATION ERROR, NOT A MISSING FACE (#1228).** A new
+`BK_SUBFACE_BOX=x0,x1,y0,y1,z0,z1` probe (in `builder/mod.rs`, reports every sub-face touching the
+box with surface kind, source, `FaceClass`, rank, selection and extent) diffed the SAME corner
+between a working and a broken band. On **tool0 (works)** the inner corner cylinder `Id(72)` yields
+8 tiny **Inside** notch slivers at x[17.000,17.050] — the 0.05mm bands #1224 restored, correctly
+removed — plus ONE big **Outside** remainder x[17.000,19.550] y[−19.550,−17.000] z[1.200,20.300]
+that is SELECTED. On **tool1 (broken)** the identically-extented full remainder
+x[17.000,19.550] y[−19.550,−17.000] z[1.200,20.300] is classified **Inside** and DROPPED, taking the
+whole inner corner wall with it and leaving the tool's cut-surface patch with nothing to pair
+against. So the splitter IS producing the face and #1227's "missing from the selection" stands, but
+the mechanism is misclassification, NOT a failure to create. Prime suspect, and it is a KNOWN class
+here: the sub-face's interior sample point. See the a1corner root ("splitter interior points of
+notched/symmetric pieces land on feature-plane intersections BY CONSTRUCTION; classification must
+survive on-plane sample points", `classifier/ray_cast.rs` per-ray degeneracy re-cast). NEXT: dump
+that remainder's `interior_point` and the classifier's verdict for tool1 vs tool0 — if the point
+lands inside a lattice opening or on a feature plane, that is the bug. CAVEAT on the probe: it tests
+VERTICES against the box, so a large unsplit face whose corners sit outside the box will not
+register — widen the box or add a face-bbox-overlap mode before concluding a face is absent. Each odd band hits a
 DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
 tool3 → (+x,+y) x≈18.6–20.5 y≈+18.3–19.9 z≈6.5–9.8), consistent with one diagonal member per band.
 CORRECTION, filed then retracted within the same session: an initial read called this the

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -792,13 +792,19 @@ filter 1 (lines), 49 ELLIPSES dropped at filter 2's AABB in-both sampling, 3 ell
 line pairs.** So the dominant loss is ellipses at filter 2 — the SAME aliasing class as the
 even-band Line bug, on the path #1224 does NOT cover (its exact clip is gated to Lines) and which
 the existing bespoke exact-arc bypass only covers for the faceted-ramp × cylinder configuration.
-**CAUTION, do not overclaim:** most of those 49 are probably CORRECT drops — a tool face's AABB can
-overlap the cylinder while the face itself does not touch it — so the defect is a SUBSET. Treating
-all 49 as wrong would repeat the "12 sections survive intact" false-all-clear. NEXT: identify WHICH
-ellipse should produce the missing corner-cylinder sub-face at the lump bbox
-(x[17.186,18.114] y[−20.745,−19.418] z[8.185,9.026]) and confirm it is among the 49 BEFORE touching
-filter 2. Note filter 2 already refines non-Lines up to 1024 samples, so if aliasing really is the
-root then `n_fine` is under-scaled here — measure that rather than assume it. Each odd band hits a
+**AND THE ELLIPSE-ALIASING READING OF THOSE 49 IS REFUTED — DO NOT "FIX" FILTER 2.** The caution
+paid off: a temporary min-distance probe (curve samples vs the mutual box `bb_a ∩ bb_b`, since
+removed) shows NONE of the 49 dropped ellipses has a mutual box overlapping the lump's z window
+[8.1,9.1] — they are all elsewhere in z — and the CLOSEST drop anywhere misses by 0.108mm while
+sampled at 0.055mm spacing (n_fine=404 over approx_len=22.261), i.e. a genuine 2× separation, not an
+aliasing artifact. So filter 2 is working correctly here and the 49 drops are legitimate; loosening
+it would break calibrated fixtures for nothing. Worth recording for a FUTURE case though: `n_fine`
+is clamped at 1024 while `approx_len` reaches ~1173mm on near-axis-parallel planes (1.15mm spacing
+against sub-millimetre boxes), so the clamp IS a real aliasing hazard — just not this bug's cause.
+NEXT: the missing corner-cylinder sub-face at the lump (x[17.186,18.114] y[−20.745,−19.418]
+z[8.185,9.026]) is therefore NOT a dropped FF section. Check the sections that ARE emitted at the
+lump's z and follow them into the face splitter — the sub-face is lost at or after splitting, not at
+section computation. Each odd band hits a
 DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;
 tool3 → (+x,+y) x≈18.6–20.5 y≈+18.3–19.9 z≈6.5–9.8), consistent with one diagonal member per band.
 CORRECTION, filed then retracted within the same session: an initial read called this the

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -64,6 +64,76 @@ pub struct SubFace {
     pub interior_point: Option<Point3>,
 }
 
+/// `BK_SUBFACE_BOX=x0,x1,y0,y1,z0,z1`: report every sub-face whose vertices
+/// touch that box, with its surface kind, classification and selection.
+///
+/// The decisive probe for a missing result face: it separates "the splitter
+/// never produced a sub-face here" from "it did, and selection dropped it".
+/// Those need opposite fixes, so guessing between them wastes a whole dig.
+fn log_subfaces_in_box(topo: &Topology, subs: &[SubFace], selected: &[bop::SelectedFace]) {
+    let Ok(spec) = std::env::var("BK_SUBFACE_BOX") else {
+        return;
+    };
+    let v: Vec<f64> = spec
+        .split(',')
+        .filter_map(|t| t.trim().parse().ok())
+        .collect();
+    if v.len() != 6 {
+        log::debug!("BK_SUBFACE_BOX needs x0,x1,y0,y1,z0,z1");
+        return;
+    }
+    let (lo, hi) = ([v[0], v[2], v[4]], [v[1], v[3], v[5]]);
+    let chosen: std::collections::HashSet<FaceId> = selected.iter().map(|s| s.face_id).collect();
+    for sf in subs {
+        let Ok(f) = topo.face(sf.face_id) else {
+            continue;
+        };
+        let mut touches = false;
+        let mut flo = [f64::MAX; 3];
+        let mut fhi = [f64::MIN; 3];
+        for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+            let Ok(w) = topo.wire(wid) else { continue };
+            for oe in w.edges() {
+                let Ok(e) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                for vid in [e.start(), e.end()] {
+                    let Ok(vtx) = topo.vertex(vid) else { continue };
+                    let p = vtx.point();
+                    let c = [p.x(), p.y(), p.z()];
+                    for k in 0..3 {
+                        flo[k] = flo[k].min(c[k]);
+                        fhi[k] = fhi[k].max(c[k]);
+                    }
+                    if c.into_iter()
+                        .enumerate()
+                        .all(|(k, v)| v >= lo[k] && v <= hi[k])
+                    {
+                        touches = true;
+                    }
+                }
+            }
+        }
+        if touches {
+            log::debug!(
+                "SUBFACE {:?} {} src={:?} class={:?} rank={:?} selected={} x[{:.3},{:.3}] y[{:.3},{:.3}] z[{:.3},{:.3}]",
+                sf.face_id,
+                f.surface().type_tag(),
+                sf.source_face,
+                sf.classification,
+                sf.rank,
+                chosen.contains(&sf.face_id),
+                flo[0],
+                fhi[0],
+                flo[1],
+                fhi[1],
+                flo[2],
+                fhi[2]
+            );
+        }
+    }
+}
+
 /// Builder — orchestrates face splitting and classification.
 ///
 /// Owns both the `Topology` and `GfaArena`, mutating them as needed.
@@ -142,6 +212,7 @@ impl Builder {
             &self.sd_pairs,
             &self.sd_within_rank_dups,
         );
+        log_subfaces_in_box(&self.topo, &self.sub_faces, &selected);
         let cap_planes = self.partial_overlap_cap_planes(&selected);
         let solid_id = assemble::assemble_solid(&mut self.topo, &selected, &cap_planes)?;
         Ok((self.topo, solid_id))
@@ -161,6 +232,7 @@ impl Builder {
             &self.sd_pairs,
             &self.sd_within_rank_dups,
         );
+        log_subfaces_in_box(&self.topo, &self.sub_faces, &selected);
         let cap_planes = self.partial_overlap_cap_planes(&selected);
         let (solid_id, origins) =
             assemble::assemble_solid_with_origins(&mut self.topo, &selected, &cap_planes)?;

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -330,6 +330,18 @@ pub fn perform(
             // restriction below applies to grazes.
             let bb_a = bbox_a.expanded(tol.linear * 10.0);
             let bb_b = bbox_b.expanded(tol.linear * 10.0);
+            if traced {
+                log::debug!(
+                    "FF_TRACE afterF1 a={} b={} n={} kinds={:?}",
+                    surf_a.type_tag(),
+                    surf_b.type_tag(),
+                    raw_curves.len(),
+                    raw_curves
+                        .iter()
+                        .map(|r| r.curve.type_tag())
+                        .collect::<Vec<_>>()
+                );
+            }
             let raw_curves: Vec<RawCurve> = raw_curves
                 .into_iter()
                 .filter(|raw| {
@@ -412,6 +424,18 @@ pub fn perform(
                     n_fine > N && (0..=n_fine).map(|i| sample(i, n_fine)).any(in_both)
                 })
                 .collect();
+            if traced {
+                log::debug!(
+                    "FF_TRACE afterF2 a={} b={} n={} kinds={:?}",
+                    surf_a.type_tag(),
+                    surf_b.type_tag(),
+                    raw_curves.len(),
+                    raw_curves
+                        .iter()
+                        .map(|r| r.curve.type_tag())
+                        .collect::<Vec<_>>()
+                );
+            }
 
             // Restrict surface-surface intersection curves to the region that
             // lies inside BOTH faces. `compute_raw_curves` works on the

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -559,10 +559,14 @@ pub fn perform(
                 let curve_index = arena.curves.len();
                 if traced {
                     log::debug!(
-                        "FF_TRACE emit a={} b={} curve#{curve_index} {}",
+                        "FF_TRACE emit a={} b={} curve#{curve_index} {} z[{:.3},{:.3}] y[{:.3},{:.3}]",
                         surf_a.type_tag(),
                         surf_b.type_tag(),
-                        raw.curve.type_tag()
+                        raw.curve.type_tag(),
+                        raw.bbox.min.z(),
+                        raw.bbox.max.z(),
+                        raw.bbox.min.y(),
+                        raw.bbox.max.y()
                     );
                 }
                 arena.curves.push(IntersectionCurveDS {

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -331,15 +331,12 @@ pub fn perform(
             let bb_a = bbox_a.expanded(tol.linear * 10.0);
             let bb_b = bbox_b.expanded(tol.linear * 10.0);
             if traced {
+                let [ln, ci, el, nu] = kind_counts(&raw_curves);
                 log::debug!(
-                    "FF_TRACE afterF1 a={} b={} n={} kinds={:?}",
+                    "FF_TRACE afterF1 a={} b={} n={} line={ln} circle={ci} ellipse={el} nurbs={nu}",
                     surf_a.type_tag(),
                     surf_b.type_tag(),
-                    raw_curves.len(),
-                    raw_curves
-                        .iter()
-                        .map(|r| r.curve.type_tag())
-                        .collect::<Vec<_>>()
+                    raw_curves.len()
                 );
             }
             let raw_curves: Vec<RawCurve> = raw_curves
@@ -425,15 +422,12 @@ pub fn perform(
                 })
                 .collect();
             if traced {
+                let [ln, ci, el, nu] = kind_counts(&raw_curves);
                 log::debug!(
-                    "FF_TRACE afterF2 a={} b={} n={} kinds={:?}",
+                    "FF_TRACE afterF2 a={} b={} n={} line={ln} circle={ci} ellipse={el} nurbs={nu}",
                     surf_a.type_tag(),
                     surf_b.type_tag(),
-                    raw_curves.len(),
-                    raw_curves
-                        .iter()
-                        .map(|r| r.curve.type_tag())
-                        .collect::<Vec<_>>()
+                    raw_curves.len()
                 );
             }
 
@@ -966,6 +960,26 @@ fn point_to_polygon_dist(p: brepkit_math::vec::Point2, poly: &[brepkit_math::vec
         best = best.min(((p.x() - cx).powi(2) + (p.y() - cy).powi(2)).sqrt());
     }
     best
+}
+
+/// Per-kind counts of raw section curves, for the `BK_FF_TRACE` diagnostics.
+///
+/// Returns `[line, circle, ellipse, nurbs]`. A fixed histogram keeps the trace
+/// line short and allocation-free even when a pair yields many curves, and it
+/// is what the reader actually wants — which KINDS survived a filter, not the
+/// order they happened to be in.
+fn kind_counts(curves: &[RawCurve]) -> [usize; 4] {
+    let mut n = [0usize; 4];
+    for c in curves {
+        let i = match c.curve {
+            EdgeCurve::Line => 0,
+            EdgeCurve::Circle(_) => 1,
+            EdgeCurve::Ellipse(_) => 2,
+            EdgeCurve::NurbsCurve(_) => 3,
+        };
+        n[i] += 1;
+    }
+    n
 }
 
 /// Exact test: does the segment `p0`→`p1` meet the intersection of two AABBs?

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -49,7 +49,10 @@ impl log::Log for DropLogger {
             return;
         }
         let msg = format!("{}", r.args());
-        if msg.contains("growth sliver") || msg.contains("growth shell") || msg.contains("FF_TRACE")
+        if msg.contains("growth sliver")
+            || msg.contains("growth shell")
+            || msg.contains("FF_TRACE")
+            || msg.contains("SUBFACE")
         {
             println!("    [algo] {msg}");
         }


### PR DESCRIPTION
Follow-up to #1227. Measures where the goma odd-band sections are lost — and **refutes** the hypothesis that measurement first suggested. Diagnostics only; no behavior change.

## Why these traces

The existing trace prints `restrict N -> M`, but `N` is captured **after** two shadowing filters — so a curve lost earlier reads as `restrict 0 -> 0` and looks like restrict's doing. That misreading cost an iteration during the even-band dig. These traces report the surviving count and a per-kind histogram after each filter.

## What it shows

`BK_FF_TRACE=17.65` on tool1. The 127 surviving cylinder×plane pairs split as:

| Stage | Kinds | Count |
|---|---|---|
| dropped at filter 1 | lines | **73** |
| survives F1, dropped at F2 | ellipse | **49** |
| survives both | ellipse | 3 |
| line pairs | line | 2 |

By count, filter 2's ellipse drops dominate — and "same aliasing class as the even-band Line bug, on the path #1224 doesn't cover" is a tempting story.

## It is wrong, and that is the point of this PR

A temporary min-distance probe (curve samples vs the mutual box `bb_a ∩ bb_b`, since removed) shows:

- **None** of the 49 dropped ellipses has a mutual box overlapping the lump's z window [8.1, 9.1]. They are all elsewhere in z.
- The **closest** drop anywhere misses by **0.108 mm** while sampled at **0.055 mm** spacing (`n_fine=404` over `approx_len=22.261`) — a genuine 2× separation, not an aliasing artifact.

So filter 2 is working correctly here, the 49 drops are legitimate, and loosening it would break calibrated fixtures for no gain. Acting on the count alone would have repeated the "12 sections survive restrict intact" false all-clear that #1223 had to undo.

## One hazard worth recording for a future case

`n_fine` is clamped at **1024** while `approx_len` reaches **~1173 mm** on near-axis-parallel planes — a 1.15 mm sample spacing against sub-millimetre mutual boxes. That clamp is a real aliasing hazard. It is simply not the cause of this bug.

## Where the odd-band defect actually is

Not a dropped FF section. The next step is to follow the sections that **are** emitted at the lump's z into the face splitter — the sub-face is lost at or after splitting, not at section computation.

## Verification

- `cargo nextest run -p brepkit-algo -p brepkit-io`: **430 passed**, 0 skipped.
- `cargo clippy -p brepkit-algo --all-targets`: clean.
- Traces gated on the existing `BK_FF_TRACE`; kinds logged as a fixed `[line, circle, ellipse, nurbs]` histogram (review finding — no per-curve `Vec` allocation, short lines).