### PR TITLE
test(io): report operand watertightness — the odd-band replay was GIGO

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -820,7 +820,22 @@ against. So the splitter IS producing the face and #1227's "missing from the sel
 the mechanism is misclassification, NOT a failure to create. Prime suspect, and it is a KNOWN class
 here: the sub-face's interior sample point. See the a1corner root ("splitter interior points of
 notched/symmetric pieces land on feature-plane intersections BY CONSTRUCTION; classification must
-survive on-plane sample points", `classifier/ray_cast.rs` per-ray degeneracy re-cast). **CONFIRMED A GFA CLASSIFIER MISJUDGEMENT, NOT AN INCOMPLETE SPLIT (#1229).** The probe now prints
+survive on-plane sample points", `classifier/ray_cast.rs` per-ray degeneracy re-cast). **STOP — THE WHOLE ODD-BAND LINE OF INVESTIGATION WAS GIGO. THE ODD TOOL OPERANDS ARE NOT
+WATERTIGHT.** Adding free/over-edge counts to the replay's operand `describe()` shows the failure
+split IS the watertightness split: tool0/2/4/6 (the bands that work) are `free=0 over=0`; tool1/3/5/7
+(every failing band) are `free=405 over=38`, `free=383 over=34`, `free=367 over=42`, `free=392
+over=29`. Ray-cast parity against a non-closed solid is UNDEFINED, which fully explains the chain
+below — the "1 crossing" rays, the misclassified corner cylinder, the dropped inner wall and the open
+growth shell are all downstream of a malformed operand. This is exactly the documented trap
+("captured operands are fallback-poisoned, never replay them directly", the snapClip note) and a
+whole iteration was spent inside it. **ALWAYS print operand free/over counts before diagnosing a
+replayed capture; the harness now does this unconditionally.** OPEN QUESTION, and the real next
+step: is the breakage in the CAPTURE or does the tool genuinely build open lattice bands? If the
+latter it is a real defect, but upstream of GFA — re-capture the odd bands from a current build
+before spending anything further. Everything below this line about the odd bands describes behaviour
+observed on BROKEN INPUT and must not be treated as an engine defect: **RETRACTED — the "GFA
+classifier misjudgement" reading (#1229) is NOT established; the classifier was fed a non-closed
+solid.** The probe now prints
 each sub-face's `interior_point`, and a new `POINT_IN=x,y,z` knob on the replay classifies a point
 against the base and every tool with the independent operations-level `classify_point`. The two
 remainders' points differ: tool0 uses (17.244,−19.538,10.771) → GFA Outside, SELECTED; tool1 uses

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -820,9 +820,20 @@ against. So the splitter IS producing the face and #1227's "missing from the sel
 the mechanism is misclassification, NOT a failure to create. Prime suspect, and it is a KNOWN class
 here: the sub-face's interior sample point. See the a1corner root ("splitter interior points of
 notched/symmetric pieces land on feature-plane intersections BY CONSTRUCTION; classification must
-survive on-plane sample points", `classifier/ray_cast.rs` per-ray degeneracy re-cast). NEXT: dump
-that remainder's `interior_point` and the classifier's verdict for tool1 vs tool0 — if the point
-lands inside a lattice opening or on a feature plane, that is the bug. CAVEAT on the probe: it tests
+survive on-plane sample points", `classifier/ray_cast.rs` per-ray degeneracy re-cast). **CONFIRMED A GFA CLASSIFIER MISJUDGEMENT, NOT AN INCOMPLETE SPLIT (#1229).** The probe now prints
+each sub-face's `interior_point`, and a new `POINT_IN=x,y,z` knob on the replay classifies a point
+against the base and every tool with the independent operations-level `classify_point`. The two
+remainders' points differ: tool0 uses (17.244,−19.538,10.771) → GFA Outside, SELECTED; tool1 uses
+(17.816,−19.416,8.070) → GFA Inside, DROPPED. But the oracle says that tool1 point is **Outside
+tool1**, and the geometry agrees — z=8.070 sits BELOW the lattice opening at z[8.185,9.026]. So GFA's
+classifier is wrong on this point; the face is correctly split and correctly sampled. This is the
+a1corner degenerate-ray class (`classifier/ray_cast.rs`, per-ray degeneracy re-cast): the point lies
+exactly ON the inner corner cylinder in a corner crowded with coincident feature planes. NEXT:
+instrument GFA's ray-cast for that exact point on tool1 — which rays are cast, which hits are
+counted, and whether the existing degeneracy re-cast fires. CAVEAT on the new knob: both interior
+points classify oddly against the BASE (Inside vs Outside) when both lie exactly ON the inner
+cylinder and should read OnBoundary — a tolerance artifact in `is_on_boundary`, harmless for the
+tool verdict but the base column of `POINT_IN` is not trustworthy. CAVEAT on the probe: it tests
 VERTICES against the box, so a large unsplit face whose corners sit outside the box will not
 register — widen the box or add a face-bbox-overlap mode before concluding a face is absent. Each odd band hits a
 DIFFERENT corner (tool1 → (+x,−y) z≈8.2–9.0;

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -116,13 +116,17 @@ fn log_subfaces_in_box(topo: &Topology, subs: &[SubFace], selected: &[bop::Selec
         }
         if touches {
             log::debug!(
-                "SUBFACE {:?} {} src={:?} class={:?} rank={:?} selected={} x[{:.3},{:.3}] y[{:.3},{:.3}] z[{:.3},{:.3}]",
+                "SUBFACE {:?} {} src={:?} class={:?} rank={:?} selected={} ip={} x[{:.3},{:.3}] y[{:.3},{:.3}] z[{:.3},{:.3}]",
                 sf.face_id,
                 f.surface().type_tag(),
                 sf.source_face,
                 sf.classification,
                 sf.rank,
                 chosen.contains(&sf.face_id),
+                sf.interior_point.map_or_else(
+                    || "none".to_string(),
+                    |p| format!("({:.3},{:.3},{:.3})", p.x(), p.y(), p.z())
+                ),
                 flo[0],
                 fhi[0],
                 flo[1],

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -151,6 +151,26 @@ pub fn classify_ray_cast_cached(
         Ok(FaceClass::Outside)
     }
 }
+/// `BK_RAY_POINT=x,y,z[,radius]` — the point (and match radius) for `RAYTRACE`.
+///
+/// Resolved once: the classifier runs this per sub-face, so an env lookup here
+/// would land in a hot path.
+fn ray_trace_target() -> Option<(Point3, f64)> {
+    static TARGET: std::sync::OnceLock<Option<(Point3, f64)>> = std::sync::OnceLock::new();
+    *TARGET.get_or_init(|| {
+        let spec = std::env::var("BK_RAY_POINT").ok()?;
+        let v: Vec<f64> = spec
+            .split(',')
+            .map(|t| t.trim().parse::<f64>())
+            .collect::<Result<_, _>>()
+            .ok()?;
+        match v.len() {
+            3 => Some((Point3::new(v[0], v[1], v[2]), 1e-6)),
+            4 => Some((Point3::new(v[0], v[1], v[2]), v[3])),
+            _ => None,
+        }
+    })
+}
 
 /// Count the inside votes (of three rays) for a point against pre-collected
 /// face geometry: cardinal rays first, re-cast with fixed generic directions
@@ -194,7 +214,14 @@ fn votes_from_geoms(face_data: &[FaceGeom], point: Point3) -> Result<u8, AlgoErr
         ),
     ];
 
-    let vote = |dirs: &[Vec3; 3]| -> (u8, u8) {
+    // `BK_RAY_POINT=x,y,z[,radius]`: dump this vote when the classified point is
+    // near the given one. The verdict alone cannot say WHY a point classified
+    // wrongly — the useful facts are the per-ray crossing parity and which rays
+    // reported grazing degenerate structure, since the generic re-cast only
+    // fires when ALL THREE cardinal rays are suspicious.
+    let traced = ray_trace_target().is_some_and(|(t, r)| (point - t).length() <= r);
+
+    let vote = |dirs: &[Vec3; 3], label: &str| -> (u8, u8) {
         let mut inside_votes = 0u8;
         let mut suspicious_rays = 0u8;
         for ray_dir in dirs {
@@ -211,11 +238,30 @@ fn votes_from_geoms(face_data: &[FaceGeom], point: Point3) -> Result<u8, AlgoErr
             if suspicious {
                 suspicious_rays += 1;
             }
+            if traced {
+                log::debug!(
+                    "RAYTRACE {label} dir=({:.3},{:.3},{:.3}) crossings={crossings} parity={} suspicious={suspicious}",
+                    ray_dir.x(),
+                    ray_dir.y(),
+                    ray_dir.z(),
+                    crossings % 2
+                );
+            }
         }
         (inside_votes, suspicious_rays)
     };
 
-    let (cardinal, suspicious) = vote(&cardinal_dirs);
+    let (cardinal, suspicious) = vote(&cardinal_dirs, "cardinal");
+    if traced {
+        log::debug!(
+            "RAYTRACE point=({:.3},{:.3},{:.3}) faces={} cardinal_inside={cardinal} suspicious={suspicious} recast={}",
+            point.x(),
+            point.y(),
+            point.z(),
+            face_data.len(),
+            suspicious >= 3
+        );
+    }
     if suspicious < 3 {
         return Ok(cardinal);
     }
@@ -223,7 +269,7 @@ fn votes_from_geoms(face_data: &[FaceGeom], point: Point3) -> Result<u8, AlgoErr
     // when both instruments graze degenerate structure there is no cleaner
     // signal left, and the generic directions are still the less-aligned,
     // better-conditioned of the two.
-    let (generic, _) = vote(&generic_dirs);
+    let (generic, _) = vote(&generic_dirs, "generic");
     Ok(generic)
 }
 

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -99,11 +99,22 @@ fn main() {
     // Answers "is this splitter interior point genuinely inside the cutter?",
     // which separates an incomplete face split from a classifier misjudgement.
     if let Ok(spec) = std::env::var("POINT_IN") {
-        let v: Vec<f64> = spec
-            .split(',')
-            .filter_map(|t| t.trim().parse().ok())
+        // Parse exactly three floats. Discarding unparseable tokens would let
+        // POINT_IN=1,2,foo,3 run silently as (1,2,3) — a probe answering about
+        // a different point than asked is worse than no probe.
+        let tokens: Vec<&str> = spec.split(',').map(str::trim).collect();
+        let v: Vec<f64> = tokens
+            .iter()
+            .map(|t| {
+                t.parse::<f64>()
+                    .expect("POINT_IN component must be a float")
+            })
             .collect();
-        assert!(v.len() == 3, "POINT_IN needs x,y,z");
+        assert!(
+            v.len() == 3,
+            "POINT_IN needs exactly x,y,z — got {} component(s)",
+            v.len()
+        );
         let p = brepkit_math::vec::Point3::new(v[0], v[1], v[2]);
         let labelled = std::iter::once(("base".to_string(), base)).chain(
             tools

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -95,6 +95,30 @@ fn main() {
         return;
     }
 
+    // POINT_IN=x,y,z: classify that point against the base and every tool.
+    // Answers "is this splitter interior point genuinely inside the cutter?",
+    // which separates an incomplete face split from a classifier misjudgement.
+    if let Ok(spec) = std::env::var("POINT_IN") {
+        let v: Vec<f64> = spec
+            .split(',')
+            .filter_map(|t| t.trim().parse().ok())
+            .collect();
+        assert!(v.len() == 3, "POINT_IN needs x,y,z");
+        let p = brepkit_math::vec::Point3::new(v[0], v[1], v[2]);
+        let labelled = std::iter::once(("base".to_string(), base)).chain(
+            tools
+                .iter()
+                .enumerate()
+                .map(|(i, &t)| (format!("tool{i}"), t)),
+        );
+        for (label, sid) in labelled {
+            match brepkit_operations::classify::classify_point(&topo, sid, p, 0.01, 1e-7) {
+                Ok(c) => println!("  POINT_IN {label} {sid:?}: {c:?}"),
+                Err(e) => println!("  POINT_IN {label} {sid:?}: ERR {e}"),
+            }
+        }
+    }
+
     // XSCAN=<v>: list X-normal planes near v in each operand, to tell whether a
     // thin slab is pre-existing in the inputs or produced by the boolean.
     if let Ok(v) = std::env::var("XSCAN") {

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -28,13 +28,27 @@ use brepkit_topology::explorer::solid_faces;
 fn describe(topo: &Topology, sid: brepkit_topology::solid::SolidId, label: &str) {
     let faces = solid_faces(topo, sid).expect("faces");
     let mut mix: HashMap<&str, usize> = HashMap::new();
+    let mut uses: HashMap<EdgeId, usize> = HashMap::new();
     for &fid in &faces {
-        *mix.entry(topo.face(fid).expect("face").surface().type_tag())
-            .or_default() += 1;
+        let f = topo.face(fid).expect("face");
+        *mix.entry(f.surface().type_tag()).or_default() += 1;
+        for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).expect("wire").edges() {
+                *uses.entry(oe.edge()).or_default() += 1;
+            }
+        }
     }
     let mut mix: Vec<_> = mix.into_iter().collect();
     mix.sort_unstable();
-    println!("  {label}: F={} mix={mix:?}", faces.len());
+    // Ray-cast parity is only meaningful against a CLOSED operand: a point
+    // outside a watertight solid must cross it an even number of times. An
+    // operand with free edges silently poisons every classification.
+    let free = uses.values().filter(|&&c| c == 1).count();
+    let over = uses.values().filter(|&&c| c > 2).count();
+    println!(
+        "  {label}: F={} mix={mix:?} free={free} over={over}",
+        faces.len()
+    );
 }
 
 struct DropLogger;
@@ -53,6 +67,7 @@ impl log::Log for DropLogger {
             || msg.contains("growth shell")
             || msg.contains("FF_TRACE")
             || msg.contains("SUBFACE")
+            || msg.contains("RAYTRACE")
         {
             println!("    [algo] {msg}");
         }


### PR DESCRIPTION
Follow-up to #1228. Ends the odd-band investigation with a result I did not expect: **the odd tool operands are not watertight, so everything diagnosed from them was garbage-in.** Diagnostics only; no behavior change.

## The finding

Adding free/over-edge counts to the replay's operand `describe()` shows the failure split **is** the watertightness split:

| Tool | free | over | band |
|---|---|---|---|
| tool0 / 2 / 4 / 6 | 0 | 0 | all work ✅ |
| tool1 | **405** | 38 | fails |
| tool3 | **383** | 34 | fails |
| tool5 | **367** | 42 | fails |
| tool7 | **392** | 29 | fails |

Ray-cast parity against a non-closed solid is undefined. That single fact explains the entire chain: rays reporting **1** crossing from a point provably outside, the misclassified corner cylinder, the dropped inner wall, and the open growth shell.

## What this retracts

The earlier commits on this branch concluded the odd-band root was a **GFA classifier misjudgement**. That is **not established** — the classifier was fed a malformed solid, so its verdict is meaningless rather than wrong. I have retracted it in the roadmap and in the commit history rather than quietly dropping it.

The evidence that led there was real and reproducible (tool0 and tool1 sample the same face at different points; the oracle disagrees with GFA on tool1's point). It was simply downstream of the actual problem.

## How it was found

`BK_RAY_POINT=x,y,z[,radius]` dumps the per-ray crossing parity and suspicion flags behind a vote:

```
cardinal dir=(0,0,1) crossings=4 parity=0 suspicious=false
cardinal dir=(1,0,0) crossings=1 parity=1 suspicious=false
cardinal dir=(0,1,0) crossings=1 parity=1 suspicious=false
point=(17.816,-19.416,8.070) faces=726 cardinal_inside=2 suspicious=0 recast=false
```

`suspicious=0` ruled out the a1corner degenerate-ray class immediately. A point outside a **closed** solid must cross it an even number of times; two rays reported 1. That parity violation pointed at the operand, not the vote.

## Guard against a repeat

The harness now prints operand free/over counts **unconditionally**, so no future replay of any capture can start from a broken operand unnoticed. This is the documented trap — *"captured operands are fallback-poisoned, never replay them directly"* — and a full iteration was spent inside it.

## The real next step

Is the breakage in the **capture**, or does the tool genuinely build open lattice bands? The latter would be a real defect, but upstream of GFA. Re-capture the odd bands from a current build before spending anything further on them.

## Verification

- `cargo nextest run -p brepkit-algo -p brepkit-io`: **430 passed**, 0 skipped.
- `cargo clippy -p brepkit-algo -p brepkit-io --all-targets`: clean.
- All probes env-gated except the operand summary, which is one line per operand.
- Review finding addressed: `POINT_IN` now parses strictly instead of silently dropping malformed tokens.