### PR TITLE
docs(roadmap): the goma odd bands are malformed at construction, not by the cut

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -839,12 +839,15 @@ geometry would be a triangle soup in the thousands. So the "fallback-poisoned ca
 does not fit and should not be assumed. (2) they are non-manifold as well as open (`over` 29–42
 alongside `free` 367–405), which reads as overlapping or duplicated faces — a mis-assembled analytic
 shell, not a truncated or lossy capture. Note also that serialization is unlikely to be the culprit:
-the SAME arena_io round-trip produced perfectly watertight even bands in the same capture directory.
-Captures are dated 2026-07-24 from published 2.128.2, i.e. BEFORE the #1224 fix; the tool is present
-at `~/Git/gridfinity-layout-tool`, so a re-capture on ≥2.128.5 is the decisive test. Everything below this line about the odd bands describes behaviour
-observed on BROKEN INPUT and must not be treated as an engine defect: **RETRACTED — the "GFA
-classifier misjudgement" reading (#1229) is NOT established; the classifier was fed a non-closed
-solid.** The probe now prints
+the SAME `arena_io` round-trip produced perfectly watertight even bands in the same capture
+directory. Captures are dated 2026-07-24 from published 2.128.2, i.e. BEFORE the #1224 fix; the tool
+is present at `~/Git/gridfinity-layout-tool`, so a re-capture on ≥2.128.5 is the decisive test.
+
+Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
+not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)
+is NOT established; the classifier was fed a non-closed solid.**
+
+The probe now prints
 each sub-face's `interior_point`, and a new `POINT_IN=x,y,z` knob on the replay classifies a point
 against the base and every tool with the independent operations-level `classify_point`. The two
 remainders' points differ: tool0 uses (17.244,−19.538,10.771) → GFA Outside, SELECTED; tool1 uses

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -832,7 +832,16 @@ whole iteration was spent inside it. **ALWAYS print operand free/over counts bef
 replayed capture; the harness now does this unconditionally.** OPEN QUESTION, and the real next
 step: is the breakage in the CAPTURE or does the tool genuinely build open lattice bands? If the
 latter it is a real defect, but upstream of GFA — re-capture the odd bands from a current build
-before spending anything further. Everything below this line about the odd bands describes behaviour
+before spending anything further. TWO FACTS THAT NARROW IT ALREADY, both cheap and already measured:
+(1) **they are NOT mesh-fallback output** — the odd tools carry 726/737/714/764 PLANAR faces against
+663 for the working ones, comparable magnitude, whereas a mesh co-refinement fallback on this
+geometry would be a triangle soup in the thousands. So the "fallback-poisoned capture" explanation
+does not fit and should not be assumed. (2) they are non-manifold as well as open (`over` 29–42
+alongside `free` 367–405), which reads as overlapping or duplicated faces — a mis-assembled analytic
+shell, not a truncated or lossy capture. Note also that serialization is unlikely to be the culprit:
+the SAME arena_io round-trip produced perfectly watertight even bands in the same capture directory.
+Captures are dated 2026-07-24 from published 2.128.2, i.e. BEFORE the #1224 fix; the tool is present
+at `~/Git/gridfinity-layout-tool`, so a re-capture on ≥2.128.5 is the decisive test. Everything below this line about the odd bands describes behaviour
 observed on BROKEN INPUT and must not be treated as an engine defect: **RETRACTED — the "GFA
 classifier misjudgement" reading (#1229) is NOT established; the classifier was fed a non-closed
 solid.** The probe now prints

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -840,8 +840,22 @@ does not fit and should not be assumed. (2) they are non-manifold as well as ope
 alongside `free` 367–405), which reads as overlapping or duplicated faces — a mis-assembled analytic
 shell, not a truncated or lossy capture. Note also that serialization is unlikely to be the culprit:
 the SAME `arena_io` round-trip produced perfectly watertight even bands in the same capture
-directory. Captures are dated 2026-07-24 from published 2.128.2, i.e. BEFORE the #1224 fix; the tool
-is present at `~/Git/gridfinity-layout-tool`, so a re-capture on ≥2.128.5 is the decisive test.
+directory. **THE DECISIVE TEST IS DONE AND THE ANSWER IS: A REAL DEFECT, UPSTREAM OF THE GFA CUT.** The old
+captures were 2026-07-24 from published 2.128.2 (pre-#1224), so the odd bands were re-captured on a
+local 2.128.5 build carrying the fix (overlay md5-verified in BOTH tool `node_modules` locations;
+`gomaCaptureBisect.test.ts` in the tool's `__kernel-tests__/`, 294s; fresh operands in
+`~/.cache/brepkit-parity-captures/2026-07-25/goma-bisect/`). **The odd bands are STILL open and
+non-manifold**: tool1 free=405 over=38 (identical to the old capture), tool3 393/33, tool5 386/36,
+tool7 428/40 — while tool0/2/4/6 stay a clean 0/0. Face counts shifted slightly between captures
+(tool5 714→690, tool7 764→792) so construction is not bit-identical, yet the brokenness reproduces
+every time. That kills BOTH remaining benign explanations: not a stale/bad fixture, and not a
+nondeterministic flake. So the tool's DIAGONAL kumiko lattice bands are genuinely built as malformed
+solids, and the goma odd-band failures were never a defect in the boolean engine — the cut is being
+handed garbage. NEXT: find which operation builds those bands and whether it is a brepkit op
+returning an open solid (which WOULD be a real engine bug, just not in GFA — cf. the open roadmap
+item "Mesh-boolean fallback emits OPEN meshes that get CONSUMED") or tool-side construction. Start
+from the kumiko pattern generator in `~/Git/gridfinity-layout-tool` (`patterns/kumiko/`) and the
+tool's existing probes (`__kernel-tests__/goma*`, `kumiko*`).
 
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)


### PR DESCRIPTION
Follow-up to #1229, which found the goma odd-band replay was GIGO. This **answers** the question that left open: the odd lattice bands are genuinely built as malformed solids, so the failures were never a defect in the boolean engine.

Docs only; no code change.

## The decisive test

The old captures were 2026-07-24 from published **2.128.2** — before the #1224 fix. So I re-captured on a local **2.128.5** build carrying it (overlay md5-verified in *both* tool `node_modules` locations, via the tool's own `gomaCaptureBisect` probe, 294 s).

| Tool | old capture (2.128.2) | fresh capture (2.128.5) |
|---|---|---|
| tool0 / 2 / 4 / 6 | free=0 over=0 | **free=0 over=0** |
| tool1 | free=405 over=38 | **free=405 over=38** |
| tool3 | free=383 over=34 | **free=393 over=33** |
| tool5 | free=367 over=42 | **free=386 over=36** |
| tool7 | free=392 over=29 | **free=428 over=40** |

Still open, still non-manifold, on a current kernel.

## What that rules out

Face counts shifted slightly between captures (tool5 714→690, tool7 764→792), so construction is **not** bit-identical — yet the brokenness reproduces every time. That kills both remaining benign explanations at once:

- **not a stale/bad fixture** — a fresh capture on the fixed kernel behaves the same;
- **not a nondeterministic flake** — it varies in detail and fails regardless.

Combined with the earlier forensics (not mesh-fallback output, not a serialization artifact), the conclusion is that the tool's **diagonal** kumiko lattice bands are genuinely malformed solids, and the GFA cut was being handed garbage.

## Why this matters for the campaign

The goma odd-band work consumed several iterations diagnosing the boolean engine — classifier verdicts, sub-face splitting, FF section filters — all downstream of a broken operand. Those readings are retracted in the roadmap. The engine-side half of this family (the even bands) was a real bug and is fixed and shipped in #1224.

## Next

Find which operation builds those bands, and whether it is a brepkit op returning an open solid — which **would** be a real engine bug, just not in GFA (compare the open roadmap item "Mesh-boolean fallback emits OPEN meshes that get CONSUMED") — or tool-side construction. Start from `patterns/kumiko/` in the tool and its existing `__kernel-tests__/goma*` / `kumiko*` probes.

## Also in this PR

The earlier operand forensics that narrowed the question before the re-capture: the odd tools are not mesh-fallback output (726/737/714/764 planar faces vs 663 for working bands — a fallback would be thousands of triangles), and not a serialization artifact (the same `arena_io` round-trip produced watertight even bands from the same directory). Plus two doc-style review fixes.