### PR TITLE
docs(roadmap): the goma scenario re-probe shows #1224 moved it not at all

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -857,6 +857,18 @@ item "Mesh-boolean fallback emits OPEN meshes that get CONSUMED") or tool-side c
 from the kumiko pattern generator in `~/Git/gridfinity-layout-tool` (`patterns/kumiko/`) and the
 tool's existing probes (`__kernel-tests__/goma*`, `kumiko*`).
 
+**MANDATORY POST-GFA RE-PROBE DONE, AND THE ANSWER IS THAT #1224 MOVED THE SCENARIO NOT AT ALL.**
+`gomaBoundaryProbe` (goma 1×1×6 export + STL edge-use oracle) on the overlaid 2.128.5 build:
+**844s wall-clock** (pre-fix baseline 849s — unchanged, still blows the 600s vitest timeout) and
+**2567 boundary edges** on the exported STL (still not watertight). So the even-band fix, though
+real and verified free=30→0 on tools 0/2/4/6 in isolation, buys NOTHING at scenario level, because
+goma's cost and brokenness are dominated by the four malformed diagonal bands — an upstream
+construction defect #1224 does not touch. **Do not quote #1224 as progress on the kumiko
+export-integrity family; it is not.** The 14 kumiko failures, the 850s export and its
+timeout-poisoning of later tests are ALL still open, and they will stay open until the diagonal
+lattice bands are built as closed solids. That is now the single blocking item for this whole
+family.
+
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)
 is NOT established; the classifier was fed a non-closed solid.**


### PR DESCRIPTION
The mandatory post-GFA re-probe for #1224 is done. The result is negative and worth recording plainly rather than leaving the fix to imply progress it did not deliver.

Docs only; no code change.

## Measurement

`gomaBoundaryProbe` — the goma 1×1×6 export plus the STL edge-use oracle — run against an overlaid local **2.128.5** build (md5-verified in both tool `node_modules` locations):

| | pre-fix baseline | on #1224 |
|---|---|---|
| wall-clock | 849 s | **844 s** |
| vitest 600 s timeout | blown | **still blown** |
| exported STL boundary edges | — | **2567** (not watertight) |

## What that means

The even-band fix is **real** — verified `free=30 → 0` on tools 0/2/4/6 in isolation, with all analytic surfaces preserved and the ready-repro un-ignored as a passing regression test. But it buys **nothing at scenario level**, because goma's cost and brokenness are dominated by the four *malformed diagonal bands* — the upstream construction defect established in #1230, which #1224 does not touch.

So: **#1224 should not be quoted as progress on the kumiko export-integrity family.** The 14 kumiko failures, the 850 s export, and its timeout-poisoning of the tests that follow are all still open. They stay open until the diagonal lattice bands are built as closed solids, which is now the single blocking item for this family.

## Why record a null result

The native repro said "fixed" — 30 free edges to 0, four times over. Only the end-to-end scenario shows that the user-visible symptom did not move at all. Without this measurement the roadmap would carry a fix that reads like it advanced the campaign when it did not, which is exactly the kind of stale scorecard the parity doctrine warns about.

## Housekeeping

The tool overlay has been restored to its exact prior state (2.128.2 in both `node_modules` locations, md5-verified against a backup taken before the change — note `pnpm install --force` would *not* have restored it, since the pre-existing state was itself an overlay rather than the pinned 2.126.15).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update roadmap docs to record the mandatory re-probe: #1224 fixed the even bands in isolation, but the goma scenario didn’t improve.

`gomaBoundaryProbe` on 2.128.5 still runs ~844s (600s timeout blown) and reports 2567 STL boundary edges (not watertight); kumiko export-integrity remains blocked by malformed diagonal bands.

<sup>Written for commit 61108334136244f4f24b690a4d819eb38ba1a95c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

