### PR TITLE
test(operations): pin helical sweep watertightness, refuting it as the goma cause

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -858,13 +858,21 @@ left-handed helix is unsupported). The odd/even split maps onto that: revolve-bu
 diagonal-bearing bands are open. **HELIX SWEEP REFUTED as the direct cause** — `helical_sweep` is
 watertight (free=0 over=0) at every turn count 0.25–2.0 and segment density 4/8/16 at the bin's
 r=3.75; now pinned by `helical_sweep_is_watertight_across_turns_and_segments` in `helix.rs`. So a
-single strut is not the problem. NEXT, and the prime suspect: the band is ASSEMBLED by fusing those
-struts, so chase the FUSE, not the sweep — and note there is an already-open roadmap item that fits
-exactly, "Mesh-boolean fallback emits OPEN meshes that get CONSUMED" (discovered 2026-07-16). If a
-strut fuse falls back to the mesh boolean and that output is open, it is consumed and the band comes
-out open — which would make this a KNOWN engine bug rather than a new one. Probe by checking
-free/over on the partial band after each strut fuse; use a SMALL repro (one diagonal band), since
-the full export is 844s and blows the 600s vitest timeout before reporting.
+single strut is not the problem. NEXT: the band is ASSEMBLED by fusing those struts, so chase the FUSE, not the sweep. **The obvious
+candidate is ALREADY PARTLY REFUTED, so do not start there.** The mechanism of the open roadmap item
+"Mesh-boolean fallback emits OPEN meshes that get CONSUMED" is confirmed present in code —
+`mesh_boolean_fallback` (`boolean/mod.rs` ~2327) checks `boundary_edge_count`/`non_manifold_edge_count`,
+`log::warn!`s that the output is not a closed 2-manifold, and then falls straight through to
+`mesh_result_to_face_specs` and uses it anyway. BUT the odd bands are almost certainly NOT that
+path's output: a mesh fallback on this geometry is a triangle soup in the thousands, and the bands
+are 726/737/690/792 PLANAR faces, comparable to the 663 of the clean ones. So the open band most
+likely comes from an ANALYTIC fuse result accepted despite being open — which is surprising, because
+#1192 made `validate_boolean_result` hard-fail on `free_edges > 0`. FIRST QUESTION FOR THE NEXT
+SESSION: which gate does the band-assembly path actually run (the tool builds bands with `cutAll`
+and repeated fuses through brepjs), and is the #1192 free-edge check reached at all on that route?
+Probe by checking free/over on the partial band after each strut fuse; use a SMALL repro (one
+diagonal band, or a native Rust fuse of a few revolve + helix-sweep struts at the tool's
+parameters), since the full export is 844s and blows the 600s vitest timeout before reporting.
 
 **MANDATORY POST-GFA RE-PROBE DONE, AND THE ANSWER IS THAT #1224 MOVED THE SCENARIO NOT AT ALL.**
 `gomaBoundaryProbe` (goma 1×1×6 export + STL edge-use oracle) on the overlaid 2.128.5 build:

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -851,11 +851,20 @@ tool7 428/40 — while tool0/2/4/6 stay a clean 0/0. Face counts shifted slightl
 every time. That kills BOTH remaining benign explanations: not a stale/bad fixture, and not a
 nondeterministic flake. So the tool's DIAGONAL kumiko lattice bands are genuinely built as malformed
 solids, and the goma odd-band failures were never a defect in the boolean engine — the cut is being
-handed garbage. NEXT: find which operation builds those bands and whether it is a brepkit op
-returning an open solid (which WOULD be a real engine bug, just not in GFA — cf. the open roadmap
-item "Mesh-boolean fallback emits OPEN meshes that get CONSUMED") or tool-side construction. Start
-from the kumiko pattern generator in `~/Git/gridfinity-layout-tool` (`patterns/kumiko/`) and the
-tool's existing probes (`__kernel-tests__/goma*`, `kumiko*`).
+handed garbage. CONSTRUCTION TRACED (`kumikoWrapBuilder.ts` in the tool): a band is the FUSE of dozens of struts —
+vertical struts as small-angle revolves, near-horizontal as thin partial revolves, **rising diagonals
+as `sketchHelix(...).sweepSketch(rect, {frenet:true})`**, and falling diagonals as chord boxes (a
+left-handed helix is unsupported). The odd/even split maps onto that: revolve-built bands are clean,
+diagonal-bearing bands are open. **HELIX SWEEP REFUTED as the direct cause** — `helical_sweep` is
+watertight (free=0 over=0) at every turn count 0.25–2.0 and segment density 4/8/16 at the bin's
+r=3.75; now pinned by `helical_sweep_is_watertight_across_turns_and_segments` in `helix.rs`. So a
+single strut is not the problem. NEXT, and the prime suspect: the band is ASSEMBLED by fusing those
+struts, so chase the FUSE, not the sweep — and note there is an already-open roadmap item that fits
+exactly, "Mesh-boolean fallback emits OPEN meshes that get CONSUMED" (discovered 2026-07-16). If a
+strut fuse falls back to the mesh boolean and that output is open, it is consumed and the band comes
+out open — which would make this a KNOWN engine bug rather than a new one. Probe by checking
+free/over on the partial band after each strut fuse; use a SMALL repro (one diagonal band), since
+the full export is 844s and blows the 600s vitest timeout before reporting.
 
 **MANDATORY POST-GFA RE-PROBE DONE, AND THE ANSWER IS THAT #1224 MOVED THE SCENARIO NOT AT ALL.**
 `gomaBoundaryProbe` (goma 1×1×6 export + STL edge-use oracle) on the overlaid 2.128.5 build:

--- a/crates/operations/src/helix.rs
+++ b/crates/operations/src/helix.rs
@@ -284,6 +284,57 @@ mod tests {
         );
     }
 
+    /// A helical sweep must be closed at every turn count and segment density.
+    ///
+    /// The kumiko wall builder sweeps rising diagonal struts along a helix, and
+    /// the lattice bands made of them come back open while revolve-built bands
+    /// do not — so the sweep itself was the natural suspect. It is not: this
+    /// pins that down, and keeps it pinned.
+    #[test]
+    fn helical_sweep_is_watertight_across_turns_and_segments() {
+        use std::collections::HashMap;
+
+        use brepkit_topology::edge::EdgeId;
+        use brepkit_topology::explorer::solid_faces;
+
+        for turns in [0.25_f64, 0.3, 0.5, 0.75, 1.0, 2.0] {
+            for segs in [4_usize, 8, 16] {
+                let mut topo = Topology::new();
+                let profile = make_unit_square_face(&mut topo);
+                let sid = helical_sweep(
+                    &mut topo,
+                    profile,
+                    Point3::new(0.0, 0.0, 0.0),
+                    Vec3::new(0.0, 0.0, 1.0),
+                    3.75,
+                    12.0,
+                    turns,
+                    segs,
+                )
+                .unwrap();
+
+                let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+                for fid in solid_faces(&topo, sid).unwrap() {
+                    let f = topo.face(fid).unwrap();
+                    for wid in
+                        std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied())
+                    {
+                        for oe in topo.wire(wid).unwrap().edges() {
+                            *uses.entry(oe.edge()).or_default() += 1;
+                        }
+                    }
+                }
+                let free = uses.values().filter(|&&c| c == 1).count();
+                let over = uses.values().filter(|&&c| c > 2).count();
+                assert_eq!(
+                    (free, over),
+                    (0, 0),
+                    "helical sweep turns={turns} segs={segs} must be closed and manifold"
+                );
+            }
+        }
+    }
+
     #[test]
     fn helical_sweep_creates_solid() {
         let mut topo = Topology::new();

--- a/crates/operations/src/helix.rs
+++ b/crates/operations/src/helix.rs
@@ -331,6 +331,15 @@ mod tests {
                     (0, 0),
                     "helical sweep turns={turns} segs={segs} must be closed and manifold"
                 );
+                // The two checks are complementary, not redundant: edge-use
+                // counts catch position-duplicate faces that `validate_solid`
+                // is blind to, and it catches Euler and wire-closure faults
+                // that leave every edge used exactly twice.
+                let report = crate::validate::validate_solid(&topo, sid).unwrap();
+                assert!(
+                    report.is_valid(),
+                    "helical sweep turns={turns} segs={segs} must pass validation: {report:?}"
+                );
             }
         }
     }


### PR DESCRIPTION
Follow-up to #1230/#1231. Traces how the goma bands are actually built, and eliminates the most obvious suspect with a test that keeps it eliminated.

## The construction

`kumikoWrapBuilder.ts` in the tool builds a lattice band as the **fuse of dozens of struts**:

- vertical struts → small-angle revolves
- near-horizontal struts → thin partial revolves
- **rising diagonals → `sketchHelix(...).sweepSketch(rect, {frenet: true})`**
- falling diagonals → chord boxes (a left-handed helix is unsupported)

The odd/even split maps neatly onto that: revolve-built bands come out clean (`free=0 over=0`), diagonal-bearing bands come out open. So the helix sweep was the natural suspect.

## It is not the cause

`helical_sweep` is watertight — `free=0 over=0` — at every turn count from 0.25 to 2.0 and segment density 4/8/16, at the bin's r=3.75 corner radius:

```
turns=0.25 segs=4:  F=26  free=0 over=0
turns=0.5  segs=16: F=138 free=0 over=0
turns=2.0  segs=16: F=522 free=0 over=0
```

This PR adds `helical_sweep_is_watertight_across_turns_and_segments` so the result is pinned and the next session doesn't re-suspect it.

## Where that points instead

A band is *assembled*, so chase the **fuse**, not the sweep. And there is an already-open roadmap item that fits exactly: **"Mesh-boolean fallback emits OPEN meshes that get CONSUMED"** (discovered 2026-07-16). If a strut fuse falls back to the mesh boolean and that output is open, it gets consumed and the band comes out open — which would make the odd-band defect a **known** engine bug rather than a new one.

Suggested probe: check `free`/`over` on the partial band after each strut fuse. Use a small repro (one diagonal band) — the full export is 844 s and blows the 600 s vitest timeout before it can report.

## Verification

- `cargo nextest run -p brepkit-operations`: **990 passed**, 12 skipped.
- `cargo clippy -p brepkit-operations --all-targets`: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `helical_sweep_is_watertight_across_turns_and_segments` proving `helical_sweep` is closed and valid across turns 0.25–2.0 and segments 4/8/16 at r=3.75. The test also runs `validate_solid`, all combos pass, refuting the helix sweep as the goma cause; the roadmap is updated to partly refute the mesh-boolean fallback hypothesis and point instead to an analytic fuse accepted despite being open, with a follow-up to check which gate runs and whether the #1192 free‑edge check is reached.

<sup>Written for commit 272e33975c423a646adefe9df6a6a48c83797ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

