### PR TITLE
docs(roadmap): qualify the all-planar fallback tell for the goma bands

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -891,7 +891,26 @@ NOT try to confirm this with a hand-built strut fuse without checking the profil
 probe using `make_unit_square_face` (a unit square in the XY plane) revolved about Z is DEGENERATE —
 the profile is perpendicular to the axis, and it returns `F=6` all-planar, which looks like a result
 and is not one. All eight bands are mesh-fallback output; four happened to come out watertight and four
-did not. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —
+did not.
+
+**HOW A BAND IS ACTUALLY BUILT — it is a CUT, not a fuse (correcting an earlier framing here).**
+`kumikoWrapBuilder.ts` starts from a `wedge` (a `revolve`, so it HAS cylindrical faces) and
+iteratively carves it: `for (const family of families) cutter = cutAll(cutter, family)`. The flat-wall
+span does the same with a box region (line ~413). `cutAll` is `compound_cut`, which delegates to
+`boolean(Cut, …)` per tool (batched via `cluster_tools_by_aabb` + `fuse_cluster`, else sequential),
+so every step runs the strict-gate-then-mesh-fallback path.
+
+**FLAT-WALL STRUT CUT IS HEALTHY — measured, do not re-probe it.** An existing capture,
+`~/.cache/brepkit-parity-captures/2026-07-23/kumiko-goma/` (`cut1-region.bin` + 180 `cut1-tool<i>.bin`;
+replay it by symlinking `cut1-region.bin` to `cut1-base.bin` and using `PREFIX=cut1`), replays clean:
+region F=147 all-planar free=0 over=0, every strut F=6 free=0 over=0, result **F=1146 all-planar,
+free=0 over=0, 11.6s** — and F=1146 matches the "each ~F=1146" figure in `gomaCaptureBisect`'s own
+doc comment. NOTE all-planar is CORRECT here and is NOT a fallback tell: a box slab cut by box prisms
+has no curved surfaces to lose. So this capture cannot exercise the suspect path.
+**THE REMAINING SUSPECT IS THE CORNER-WEDGE CUT** (`kumikoWrapBuilder.ts` ~734), which starts from a
+`revolve` wedge and carves it with revolve/helix struts — the only place where missing cylinders are
+diagnostic. It is NOT in the cache; capture it (hook that `cutAll` the way `gomaCaptureBisect` hooks
+`cutAllBisect`) before doing anything else. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —
 either make the mesh co-refinement produce closed output for these operands, or make
 `mesh_boolean_fallback` REJECT a non-watertight result instead of warning and consuming it (note
 rejecting means the op fails outright, since there is no further fallback; that is a product call).

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -880,17 +880,17 @@ sitting in the operand dump the whole time — **EVERY band is 100% planar, the 
 wrapping the corner; their total absence is the parity skill's canonical fallback tell ("all-planar
 with zero curved surfaces on a shape that should have cylinders is fallback regardless of the
 number"). **CAVEAT, measured afterwards — the tell is weaker than it first reads and rests
-specifically on the REVOLVE struts.** `helical_sweep` output is all-planar BY CONSTRUCTION (the helix
-is a NURBS approximated by segments and the sweep emits planar quads: turns=0.25 segs=8 gives
-`F=42 mix=[("plane",42)]`), so the helix-swept diagonals contribute no curved faces even on a
+specifically on the `revolve` struts.** `helical_sweep` output is all-planar BY CONSTRUCTION (the
+helix is a NURBS approximated by segments and the sweep emits planar quads: `turns=0.25 segs=8`
+gives `F=42 mix=[("plane", 42)]`), so the helix-swept diagonals contribute no curved faces even on a
 perfectly analytic path, and neither do the chord-box falling diagonals. What still makes
 zero-curved damning is that `revolve` with a proper axis-containing profile DOES emit cylinders
-(census row `revolve cylinder (parallel→Cyl, caps→Plane)`, cyl=1), so each vertical and
-near-horizontal revolve strut should leave a cylindrical wall in the band, and none survives. DO NOT
-try to confirm this with a hand-built strut fuse without checking the profile plane first: a probe
-using `make_unit_square_face` (a unit square in the XY plane) revolved about Z is DEGENERATE — the
-profile is perpendicular to the axis, and it returns F=6 all-planar, which looks like a result and
-is not one. All eight bands are mesh-fallback output; four happened to come out watertight and four
+(census row `revolve cylinder (parallel→Cyl, caps→Plane)`, `cyl=1`), so each vertical and
+near-horizontal `revolve` strut should leave a cylindrical wall in the band, and none survives. DO
+NOT try to confirm this with a hand-built strut fuse without checking the profile plane first: a
+probe using `make_unit_square_face` (a unit square in the XY plane) revolved about Z is DEGENERATE —
+the profile is perpendicular to the axis, and it returns `F=6` all-planar, which looks like a result
+and is not one. All eight bands are mesh-fallback output; four happened to come out watertight and four
 did not. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —
 either make the mesh co-refinement produce closed output for these operands, or make
 `mesh_boolean_fallback` REJECT a non-watertight result instead of warning and consuming it (note

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -879,7 +879,18 @@ sitting in the operand dump the whole time — **EVERY band is 100% planar, the 
 24 cylinders. A band built from revolves and helix sweeps MUST have cylindrical strut surfaces
 wrapping the corner; their total absence is the parity skill's canonical fallback tell ("all-planar
 with zero curved surfaces on a shape that should have cylinders is fallback regardless of the
-number"). All eight bands are mesh-fallback output; four happened to come out watertight and four
+number"). **CAVEAT, measured afterwards — the tell is weaker than it first reads and rests
+specifically on the REVOLVE struts.** `helical_sweep` output is all-planar BY CONSTRUCTION (the helix
+is a NURBS approximated by segments and the sweep emits planar quads: turns=0.25 segs=8 gives
+`F=42 mix=[("plane",42)]`), so the helix-swept diagonals contribute no curved faces even on a
+perfectly analytic path, and neither do the chord-box falling diagonals. What still makes
+zero-curved damning is that `revolve` with a proper axis-containing profile DOES emit cylinders
+(census row `revolve cylinder (parallel→Cyl, caps→Plane)`, cyl=1), so each vertical and
+near-horizontal revolve strut should leave a cylindrical wall in the band, and none survives. DO NOT
+try to confirm this with a hand-built strut fuse without checking the profile plane first: a probe
+using `make_unit_square_face` (a unit square in the XY plane) revolved about Z is DEGENERATE — the
+profile is perpendicular to the axis, and it returns F=6 all-planar, which looks like a result and
+is not one. All eight bands are mesh-fallback output; four happened to come out watertight and four
 did not. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —
 either make the mesh co-refinement produce closed output for these operands, or make
 `mesh_boolean_fallback` REJECT a non-watertight result instead of warning and consuming it (note


### PR DESCRIPTION
#1233 concluded the goma bands are mesh-fallback output because they carry **zero curved faces**. That conclusion holds, but the supporting argument as written was too broad. This records what it actually rests on, and a trap found while checking.

Docs only; no code change.

## The tell is narrower than it reads

`helical_sweep` output is **all-planar by construction** — the helix is a NURBS approximated by segments and the sweep emits planar quads:

```
turns=0.25 segs=8:  F=42  mix=[("plane", 42)]
```

So the helix-swept rising diagonals contribute no curved faces *even on a perfectly analytic path*, and neither do the chord-box falling diagonals. "All-planar" alone therefore proves less than #1233 implied.

## What still makes zero-curved damning

The **revolve** struts. `revolve` with a proper axis-containing profile does emit cylinders — census row `revolve cylinder (parallel→Cyl, caps→Plane)`, `cyl=1`. So each vertical and near-horizontal strut should leave a cylindrical wall in the band, and **none survives**. That is the part of the argument that carries the conclusion.

## A trap worth recording

Do not try to confirm this with a hand-built strut fuse without checking the profile plane first. A probe using `make_unit_square_face` — a unit square in the **XY** plane — revolved about **Z** is degenerate: the profile is perpendicular to the axis. It returns `F=6` all-planar, which looks like a result and is not one.

That probe has been deleted rather than committed, since an unfaithful repro in the tree is worse than none — the doctrine's own warning is *"never grind on a hand-built repro without proving it matches the real tool geometry first."*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the “all‑planar” fallback tell and fixed the framing: bands are cut from a `revolve` wedge; `helical_sweep` is all‑planar by design, so zero‑curved faces are damning only when cylinders from `revolve` struts go missing in the corner‑wedge cut. Confirmed the flat‑wall strut cut is healthy (all‑planar, expected), noted the `make_unit_square_face`→`revolve` Z probe is degenerate, normalized code font, and called out that the corner‑wedge `cutAll` path needs capturing.

<sup>Written for commit c4269ecc63337703b92f58878340619f918368c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

