### PR TITLE
test(io): add BBOX and pin the corner-wedge root to shell orientation

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -934,10 +934,24 @@ both the corner-fan volume AND the curvature-robust flux test agree it is inward
 right. But look at what it IS: six faces with the SAME surface signature as each operand (both are
 `F=6`, 2 cylinders + 4 planes; wedge vol 284.873, strut vol 43.971), and a corner-fan magnitude
 closer to the wedge than the strut. **The strut never split the wedge at all — a whole operand came
-through, inverted.** A partial cut must produce MORE than six faces. So the defect is upstream of
-`perform_areas`: either the pair produced no sections (check phase FF for this pair) or face
-selection kept exactly one operand with flipped orientation. START HERE, with
-`CAPTURE_DIR=<call4> PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1` plus `BK_FF_TRACE`. Its sibling `operands_are_clean_analytic_wedges` runs unignored and guards the
+through, inverted.** A partial cut must produce MORE than six faces. **ROOT NAILED: BOTH SHELL-ORIENTATION TESTS MIS-READ A CORNER WEDGE
+BOUNDED BY TWO COAXIAL CYLINDERS.** Decisive route: `BBOX=1` shows tool0 is z[-8.307,2.192] while the
+base is z[2.700,20.800] — **fully DISJOINT** (tool3 likewise, above). For a disjoint `Cut(A,B)` GFA
+correctly keeps all of A's faces and none of B's, so the resulting 6-face shell IS the base wedge
+unmodified — and `BK_AREAS` reports it `signed_vol=-182.448 outward=Some(false) -> hole`, while
+`solid_volume` measures that same wedge at **+284.873**. Both cannot be right and the
+tessellation-based volume is the trustworthy one, so the corner-fan `signed_volume_of_shell` AND the
+curvature-robust `shell_is_outward_oriented` are BOTH wrong on this geometry. The signature is
+unmistakable: `-182.448` recurs IDENTICALLY across tool0 (6 faces), tool2 (6 faces) and tool4 (5
+faces) — three different shells cannot share a volume integral. Per-tool results (each tool cut
+against the base alone): all five fail "no outer shell found", tool0/tool3 with no sections at all
+(disjoint, correctly AABB-rejected) and tool1/tool2 with sections emitted, so the failure is
+downstream of sectioning in every case. NOTE the ops-level shortcut only detects CONTAINMENT
+(A⊂B, B⊂A, A=B) — **disjointness is not handled**, which is why a non-touching strut still routes
+through GFA and then the mesh fallback. FIX SHAPE: make the orientation decision correct for
+cylinder-bounded wedges (and/or short-circuit a disjoint Cut to A). Reproduce per tool by symlinking
+one `cut-tool<i>.bin` as `cut-tool0.bin` beside `cut-base.bin` and running
+`PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1 BBOX=1`. Its sibling `operands_are_clean_analytic_wedges` runs unignored and guards the
 fixture itself — an unvalidated operand already cost this campaign several passes. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —
 either make the mesh co-refinement produce closed output for these operands, or make
 `mesh_boolean_fallback` REJECT a non-watertight result instead of warning and consuming it (note

--- a/crates/io/examples/replay_cut_capture.rs
+++ b/crates/io/examples/replay_cut_capture.rs
@@ -46,6 +46,19 @@ fn describe(topo: &Topology, sid: brepkit_topology::solid::SolidId, label: &str)
     let free = uses.values().filter(|&&c| c == 1).count();
     let over = uses.values().filter(|&&c| c > 2).count();
     let vol = brepkit_operations::measure::solid_volume(topo, sid, 0.01).unwrap_or(f64::NAN);
+    if std::env::var("BBOX").is_ok()
+        && let Ok(bb) = brepkit_operations::measure::solid_bounding_box(topo, sid)
+    {
+        println!(
+            "    {label} bbox x[{:.3},{:.3}] y[{:.3},{:.3}] z[{:.3},{:.3}]",
+            bb.min.x(),
+            bb.max.x(),
+            bb.min.y(),
+            bb.max.y(),
+            bb.min.z(),
+            bb.max.z()
+        );
+    }
     println!(
         "  {label}: F={} mix={mix:?} free={free} over={over} vol={vol:.3}",
         faces.len()


### PR DESCRIPTION
Follows the 2 ms kumiko corner-wedge repro (#1235) to its root. Diagnostics only; no behavior change.

## The route

`BBOX=1` (new) on the operands:

```
base:  z[ 2.700, 20.800]
tool0: z[-8.307,  2.192]   ← fully DISJOINT (tool3 likewise, above)
```

For a disjoint `Cut(A, B)`, GFA correctly keeps all of A's faces and none of B's — so the resulting 6-face shell **is the base wedge, unmodified**. And `BK_AREAS` reports it:

```
faces=6  signed_vol=-182.448  outward=Some(false)  -> hole
```

while `solid_volume` measures that same wedge at **+284.873**.

## The root

Both cannot be right, and the tessellation-based volume is the trustworthy one. So the corner-fan `signed_volume_of_shell` **and** the curvature-robust `shell_is_outward_oriented` are **both wrong on this geometry** — a corner wedge bounded by two coaxial cylinders.

The signature is unmistakable: `-182.448` recurs **identically** across tool0 (6 faces), tool2 (6 faces) and tool4 (5 faces). Three different shells cannot share a volume integral.

## Per-tool

Each tool cut against the base alone — all five fail `no outer shell found`:

| tool | bbox vs base | sections | outcome |
|---|---|---|---|
| 0, 3 | disjoint | none (correctly AABB-rejected) | fail |
| 1, 2 | overlapping | emitted | fail |
| 4 | overlapping | none at the traced x | fail |

So the failure is **downstream of sectioning in every case**, which is why the earlier splitter and classifier leads all dead-ended.

## Also worth fixing

The ops-level shortcut detects only **containment** (A⊂B, B⊂A, A=B). **Disjointness is not handled**, so a non-touching strut still routes through GFA and then the mesh fallback — losing the wedge's cylinders for a cut that should have been a no-op.

## Fix shape

Make the orientation decision correct for cylinder-bounded wedges, and/or short-circuit a disjoint `Cut` to A.

Reproduce per tool by symlinking one `cut-tool<i>.bin` as `cut-tool0.bin` beside `cut-base.bin`, then `PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1 BBOX=1`.

## Verification

- `cargo nextest run -p brepkit-algo -p brepkit-io`: **431 passed**, 1 skipped.
- `cargo clippy`: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in bounding box dump to the `replay_cut_capture` example via BBOX=1, and pins the kumiko corner‑wedge failure to incorrect shell orientation on cylinder‑bounded wedges. Diagnostic-only; no behavior change.

- New Features
  - When `BBOX=1` is set, prints x/y/z bounds for each operand to spot disjoint `Cut(A,B)` cases.
  - Confirms the repro’s base and tool are fully disjoint, tying the failure to shell‑orientation logic.

<sup>Written for commit b692d7672606e149dbec7ee83d5a4d90852446f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

