### PR TITLE
fix(operations): normalize segmented revolve orientation

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -16,7 +16,7 @@ End-to-end change flow for this repo: branch, commit, push, PR, AI review gate, 
 | Compliance grep | See "Banned-name compliance" below |
 | Push (sandbox) | `git push "https://x-access-token:$(gh auth token)@github.com/andymai/brepkit.git" <branch>` |
 | Verify remote head | `gh pr view <N> --json headRefOid` (never `git rev-parse origin/<branch>`) |
-| Review-gate poll | `gh pr checks <N>` until the `Greptile Review` check is completed |
+| Review-gate poll | `gh pr checks <N>` until the `cubic · AI code reviewer` check is completed |
 | Read findings | `gh api repos/andymai/brepkit/pulls/<N>/comments` and `gh pr view <N> --comments` |
 | Merge | `gh pr merge <N> --squash --auto` (only after findings are addressed) |
 | Post-merge | `git checkout main && git pull --ff-only` |
@@ -47,15 +47,15 @@ Hard rules:
 
 ## The review gate
 
-Branch protection requires only `CI Pass`. The AI review check (`Greptile Review`) is NOT required by branch protection, so the PR can show mergeable while unread findings sit on it. Policy, not GitHub, enforces the gate:
+Branch protection requires only `CI Pass`. The AI review check (`cubic · AI code reviewer`; Greptile no longer runs on this repo) is NOT required by branch protection, so the PR can show mergeable while unread findings sit on it. Policy, not GitHub, enforces the gate:
 
-1. After `gh pr create`, work on the next independent task. Reviewers (Greptile, Copilot, cubic) comment within roughly 5 to 7 minutes.
+1. After `gh pr create`, work on the next independent task. Reviewers (cubic, Copilot) comment within roughly 5 to 7 minutes.
 2. Poll until the review check completes:
    ```bash
    gh pr view <N> --json statusCheckRollup \
-     --jq '.statusCheckRollup[] | select(.name=="Greptile Review") | .status'
+     --jq '.statusCheckRollup[] | select(.name=="cubic · AI code reviewer") | .status'
    ```
-   Expect `COMPLETED`. A background watcher may poll for this, but it must hand control back for the next step, never merge on its own.
+   Expect `COMPLETED` (its conclusion is `NEUTRAL` even with no findings — that is a pass, not a failure). Verify the reviewer ran against your CURRENT head before trusting a clean result: a stale review from an earlier push reports on files your latest commit did not touch. `CI Pass` does not appear in the rollup at all until every job it gates on finishes, so its absence is not a failure either. Any poll keyed to a check name that does not exist stays silent forever and reads exactly like "no findings" — list the rollup unfiltered once before trusting a filter. A background watcher may poll for this, but it must hand control back for the next step, never merge on its own.
 3. Read every inline finding: `gh api repos/andymai/brepkit/pulls/<N>/comments`. Fix P0/P1 findings (push a follow-up commit, which restarts CI). Reply to lower-severity findings with a reasoned response.
 4. Only then: `gh pr merge <N> --squash --auto`. Auto-merge fires once `CI Pass` is green.
 5. This applies to every PR including high-risk core changes (GFA boolean engine, public WASM API). No human review step exists; review-check completion plus addressed findings is the whole gate.

--- a/.claude/skills/pr-workflow/reference.md
+++ b/.claude/skills/pr-workflow/reference.md
@@ -35,7 +35,7 @@ Local pre-commit covers only fmt, clippy, taplo, machete, and the last two only 
 
 | Actor | Surface |
 |-------|---------|
-| `greptile-apps` | Inline findings with P0/P1/P2 severity; posts the `Greptile Review` status check (not branch-protection required) |
+| `cubic` | Inline findings; posts the `cubic · AI code reviewer` status check (not branch-protection required; concludes `NEUTRAL` when it has no findings) |
 | `copilot-pull-request-reviewer` | Inline review comments |
 | `cubic-dev-ai` | Review plus a `cubic · AI code reviewer` check |
 
@@ -123,8 +123,8 @@ Bumping wasm-bindgen is its own change with its own PR. Never bump it as a drive
 | commitlint prints `✖ found N problems` yet the commit succeeded | The commit-msg hook swallows commitlint failures and exits 0 by design of its fallback | Treat as a rejection: `git commit --amend` to `type(scope): subject` form |
 | pre-commit fails on clippy warnings you did not write | Pre-existing breakage on the branch base | Stop and report; never `--no-verify` |
 | `⚠️ commitlint not available` warning on commit | `node_modules` missing, but only if no `✖` lines print above it; the same warning also follows a real lint failure (see the `✖` row) because the hook's fallback fires on any nonzero commitlint exit | If `✖` lines precede it, fix the message; otherwise `npm install` at repo root. Either way the commit went through unchecked, re-verify the message manually |
-| PR shows mergeable but you have not read reviews | `Greptile Review` is not branch-protection required | Wait for the check to complete, read findings, only then `--auto` |
-| `Greptile Review` check absent minutes after PR creation | Reviewers take roughly 5 to 7 minutes to post | Keep polling `gh pr checks <N>`; do other work meanwhile |
+| PR shows mergeable but you have not read reviews | the AI review check is not branch-protection required | Wait for the check to complete, read findings, only then `--auto` |
+| AI review check absent minutes after PR creation | Reviewers take roughly 5 to 7 minutes to post | Keep polling `gh pr checks <N>`; do other work meanwhile |
 | CI `boundaries` job fails | A crate dependency violates the layer rules | Run `./scripts/check-boundaries.sh` locally; see the layer-boundaries skill |
 | CI `taplo` or `machete` fails but pre-commit passed | Tool not installed locally; the hook skips it silently | `cargo install taplo-cli cargo-machete`, fix, re-commit |
 | Compliance grep hits in a file you touched | You introduced a banned reference-kernel name, or you touched a grandfathered file | Remove new occurrences; leave grandfathered ones as-is |

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -948,8 +948,27 @@ against the base alone): all five fail "no outer shell found", tool0/tool3 with 
 (disjoint, correctly AABB-rejected) and tool1/tool2 with sections emitted, so the failure is
 downstream of sectioning in every case. NOTE the ops-level shortcut only detects CONTAINMENT
 (A⊂B, B⊂A, A=B) — **disjointness is not handled**, which is why a non-touching strut still routes
-through GFA and then the mesh fallback. FIX SHAPE: make the orientation decision correct for
-cylinder-bounded wedges (and/or short-circuit a disjoint Cut to A). Reproduce per tool by symlinking
+through GFA and then the mesh fallback. **FLUX BREAKDOWN (`BK_FLUX=1`, new) NARROWS IT TO ONE UNRESOLVED FORK — resolve
+this BEFORE writing any fix.** Per-face on the disjoint case: `Id(0) plane d=0.0000`,
+`Id(4) cylinder d=+68.3065`, `Id(3) plane reversed=true d=-320.9000`,
+`Id(2) cylinder reversed=true d=-641.4838`, `Id(1) plane d=+41.6553`, `Id(5) plane d=0.0000`,
+**total = -852.42**. Compare 3V = 3 × 284.873 = **+854.6**: the magnitudes agree to 0.3% and the SIGN
+is opposite. So the geometry is integrated correctly and the orientation is GLOBALLY inverted — this
+is not a per-face `is_reversed` slip (flipping only the reversed faces gives ±1072.4, not ±855).
+THE FORK: either (a) the flux convention is inverted and `shell_is_outward_oriented` is wrong, or
+(b) **the captured base operand is genuinely inward-oriented**, the flux test is right, and the
+defect is upstream in how the tool's wedge is built or serialized. Evidence does NOT yet separate
+them: `solid_volume` returns `total.abs()` so its +284.873 says nothing about orientation, and
+`classify_point` is ray-parity based so its Inside/Outside verdicts (material between r=1.55 and
+r=4.75, hollow inside — geometrically correct) are orientation-independent too. `brepkit-check`'s
+`integrate_face` DOES accumulate a signed volume but check is out of `brepkit-io`'s layer.
+**THE DISCRIMINATING EXPERIMENT, cheap and decisive: run the same instrumentation on a KNOWN-GOOD
+primitive** — `Cut(box, far-away disjoint box)` built natively, whose result shell is just the box.
+If `BK_FLUX` reports outward for that but inward for the deserialized wedge, the wedge is inverted
+(fork b, upstream defect). If it reports inward for both, the flux convention itself is wrong (fork
+a, fix `shell_is_outward_oriented`). FIX SHAPE depends on which: correct the orientation decision
+for cylinder-bounded wedges, or fix whatever inverts the operand — and independently, short-circuit
+a disjoint Cut to A. Reproduce per tool by symlinking
 one `cut-tool<i>.bin` as `cut-tool0.bin` beside `cut-base.bin` and running
 `PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1 BBOX=1`. Its sibling `operands_are_clean_analytic_wedges` runs unignored and guards the
 fixture itself — an unvalidated operand already cost this campaign several passes. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -982,9 +982,20 @@ the result's orientation and the face's stored `normal` is IGNORED. Wound one wa
 proper outward solid whose disjoint cut stays analytic at six faces; wound the other it emits an
 INWARD solid that fails every downstream orientation check and drops to the mesh fallback at 48
 planar faces. The tool's wedge is wound the inward way, which is why every corner cut in every
-kumiko band degrades — and why the flat-wall path, which has no revolve, is clean. FIX: make
-`revolve` always emit an outward-oriented solid regardless of profile winding (precedent: the #1045
-loft fix reverses downward-stacked CCW sketches rather than bailing). Independently and still worth doing: short-circuit a disjoint Cut to A (the ops shortcut
+kumiko band degrades — and why the flat-wall path, which has no revolve, is clean. **SCOPED FURTHER — IT IS AN INCONSISTENCY BETWEEN REVOLVE'S TWO PATHS, NOT A MISSING CAPABILITY.**
+Same probe, adding a 360° case: **FULL revolution is CORRECT for BOTH windings** (ccw and cw both
+`outward=Some(true) -> growth`, F=4, a washer of 2 cylinders + 2 planes), while the PARTIAL 45°
+revolve is wrong for one (ccw → hole → F=48 mesh; cw → growth → F=6 analytic). So
+`try_analytic_full_revolution` (gated on `is_full`) ALREADY normalizes orientation — its doc comment
+says as much, "face orientation comes from the profile's traversal winding in the (radial, axial)
+chart, so inward-facing walls and cap normals are exact for both CCW- and CW-wound profiles" — and
+the SEGMENTED path taken by partial revolutions never got the same treatment. The kumiko corner
+wedge is a partial revolve, so it lands on the unfixed path. FIX: apply the full path's winding
+normalization to the segmented path (compute the profile's signed area in the (radial, axial) chart
+and reverse the oriented edges when it has the inward sign), with a working reference implementation
+sitting in the same file. Incidental confirmation: the full washer reports `signed_vol=0.000000` and
+is rescued by the flux test — exactly the lone-shell path `perform_areas` documents for the
+torus−box notch band, so that path is load-bearing and must not be disturbed. Independently and still worth doing: short-circuit a disjoint Cut to A (the ops shortcut
 detects only containment), which would spare tool0/tool3 the whole path. Reproduce per tool by symlinking
 one `cut-tool<i>.bin` as `cut-tool0.bin` beside `cut-base.bin` and running
 `PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1 BBOX=1`. Its sibling `operands_are_clean_analytic_wedges` runs unignored and guards the

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -962,13 +962,21 @@ them: `solid_volume` returns `total.abs()` so its +284.873 says nothing about or
 `classify_point` is ray-parity based so its Inside/Outside verdicts (material between r=1.55 and
 r=4.75, hollow inside — geometrically correct) are orientation-independent too. `brepkit-check`'s
 `integrate_face` DOES accumulate a signed volume but check is out of `brepkit-io`'s layer.
-**THE DISCRIMINATING EXPERIMENT, cheap and decisive: run the same instrumentation on a KNOWN-GOOD
-primitive** — `Cut(box, far-away disjoint box)` built natively, whose result shell is just the box.
-If `BK_FLUX` reports outward for that but inward for the deserialized wedge, the wedge is inverted
-(fork b, upstream defect). If it reports inward for both, the flux convention itself is wrong (fork
-a, fix `shell_is_outward_oriented`). FIX SHAPE depends on which: correct the orientation decision
-for cylinder-bounded wedges, or fix whatever inverts the operand — and independently, short-circuit
-a disjoint Cut to A. Reproduce per tool by symlinking
+**FORK RESOLVED — (a) IS DEAD, THE ORIENTATION TESTS ARE CORRECT.** The discriminating experiment
+(`crates/operations/examples/flux_orientation_probe.rs`: `Cut(box, far-away disjoint box)`, whose
+result shell is just the box, run with `BK_AREAS=1 BK_FLUX=1`) gives for a 10×10×10 cube:
+`signed_vol=1000.000000`, per-face flux `0/0/0/1000/1000/1000` totalling **3000.0 = 3V**,
+`outward=Some(true) -> growth`. Both tests are EXACT and correctly signed on known-good geometry, so
+the convention is not inverted and `shell_is_outward_oriented` needs no fix. **Therefore the
+captured wedge operand is GENUINELY INWARD-ORIENTED, and the defect is upstream of GFA entirely.**
+Do NOT "fix" `signed_volume_of_shell` or `shell_is_outward_oriented` — they are provably right.
+NEXT: find what inverts the wedge. Two candidates, both cheap to test: (1) brepkit's `revolve`
+emitting an inward solid for a wedge profile (build one natively — profile in a plane CONTAINING the
+axis, NOT `make_unit_square_face` which is XY and degenerate about Z — cut it by a far-away box and
+read `signed_vol`); (2) the arena `.bin` round-trip (`serializeSolid` / `deserialize_solid`)
+inverting orientation, testable by serializing a known-good box, reading it back and re-running the
+same probe. Independently and still worth doing: short-circuit a disjoint Cut to A (the ops shortcut
+detects only containment), which would spare tool0/tool3 the whole path. Reproduce per tool by symlinking
 one `cut-tool<i>.bin` as `cut-tool0.bin` beside `cut-base.bin` and running
 `PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1 BBOX=1`. Its sibling `operands_are_clean_analytic_wedges` runs unignored and guards the
 fixture itself — an unvalidated operand already cost this campaign several passes. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1045,6 +1045,98 @@ timeout-poisoning of later tests are ALL still open, and they will stay open unt
 lattice bands are built as closed solids. That is now the single blocking item for this whole
 family.
 
+**RE-PROBE OF THE REVOLVE ORIENTATION FIX (2026-07-25, PR #1237) — HALF A RESULT, AND THE OTHER HALF
+IS A REGRESSION THAT FIX CAUSES. DO NOT MERGE #1237 WITHOUT RESOLVING IT.** Overlay md5-verified in
+BOTH `node_modules` locations, Vite cache cleared. CONTROL EXPERIMENT (the same local 2.128.5 build,
+sole difference an `&& false` disabling the winding flip — the cleanest causation test available
+here): fix DISABLED → goma 1×1×6 exports **OK in 851s, 2,715,884 bytes** (reproducing the recorded
+849s/2.7MB baseline exactly, so the environment is validated); fix ENABLED → **THREW at 369s**. So
+the orientation fix more than halves the cost (the analytic path replacing the mesh fallback, as
+predicted) AND trips a trap. FAILURE SHAPE: `RuntimeError: unreachable` inside `compoundCut`, then
+`recursive use of an object` (the borrow-flag stranding that follows ANY wasm trap — a consequence,
+never the root). **IT IS NOT A RUST PANIC:** `lastPanicMessage()` is empty and no `[brepkit] panic:`
+line is emitted, so the hook installed by `BrepKernel::new` never ran — which points at an
+`abort()` such as `handle_alloc_error` (allocation failure bypasses the hook) rather than a `panic!`,
+a `raw_vec` capacity overflow, or a divide-by-zero, all of which WOULD be captured. Note every panic
+AND every abort lowers to `unreachable` on wasm32, so the trap kind identifies nothing by itself.
+RULED OUT, each by measurement: (1) `assembly.rs:326`'s `unreachable!()` on
+`FaceSpec::CylindricalFace` — tempting because the fix newly produces cylindrical faces where the
+fallback emitted all-planar, but the outer arm at `:191` is unguarded so it is genuinely unreachable;
+(2) a synthetic native repro — `compound_cut` of a wedge by 5 coaxial revolve struts is clean (F=26,
+7 cylinders, free=0 over=0, Pappus volume); (3) the corner construction itself — the tool's
+`kumikoWrapSpike` (annular wedge − vertical/horizontal/diagonal-helix struts, i.e. the exact failing
+shape) PASSES in 2.5s, 4/4; (4) the SSI marcher as the unbounded allocator — it is capped four ways
+(`max_steps = 200`, `max_evals`, `MAX_TURNING_POINTS`, `MAX_BRANCHES_PER_DIRECTION`). HEIGHT LADDER
+(`gomaHeightLadder.test.ts`, new in the tool's `__kernel-tests__/`; ascending, stops at the first
+trap because a trap strands the kernel): h=1 OK 1105ms/81kB, h=2 OK 150ms/178284B, h=3 OK
+150ms/**178284B — byte-identical to h=2**, h=4 OK 489s/2.05MB, h=6 THREW 387s. **TWO CAVEATS ON THAT
+TABLE, both mine:** h=2/h=3 being identical at 150ms means those heights do not exercise the lattice
+at all and are evidence of nothing (real lattice work starts at h=4); and the ladder's
+`wasmHeapMB` probe returned `?` at every height — the instrument did NOT fire, so there is still
+ZERO memory data and the OOM hypothesis is UNTESTED. Also note the ladder reuses ONE kernel across
+heights, so its h=4 489s carries accumulated arena state and is not comparable to the ~292s recorded
+elsewhere; the h=6 trap is independently confirmed on two fresh-kernel runs. NO FAST REPRO YET —
+h=4 is the smallest case that does lattice work and it costs 489s. NEXT: peak-RSS measurement
+(`/usr/bin/time -v` around the h=6 run) discriminates the two live hypotheses without touching code —
+allocation failure would show RSS climbing toward the wasm 4GB ceiling, while a wasm stack overflow
+from deep recursion (equally scale-dependent, equally message-free) would show modest RSS. After
+that, the sanctioned path is capturing the failing `compoundCut` operands and replaying them
+natively, where an abort is legible. SEVERITY FRAMING: goma was ALREADY failing pre-fix (the 850s
+export blows vitest's timeout and that single root accounts for all 14 kumiko export-integrity
+failures), so this is a CHANGED FAILURE MODE on an already-failing scenario, not a newly-broken
+passing one — but a trap is still a hard failure and blocks the merge. The engine-level defect and
+its fixtures stand on their own (`revolve_segmented_is_outward_for_either_winding` and
+`regress_kumiko_corner_wedge.rs` fail without the fix, at exactly the inverted volume).
+**TRAP LOCATED, AND IT IS NOT IN THE ANALYTIC PATH — IT IS THE MESH FALLBACK.** Captured with
+`setLogLevel('debug')` + a JS ring buffer over the 1,961,120 kernel log lines the export emits
+(`gomaLogTail.test.ts`, new in the tool's `__kernel-tests__/`; the cjs keeps `wasm.memory`
+module-local so heap size is NOT readable from JS — `setLogLevel` is the only handle). The last
+lines before the abort: `BuilderSolid: 11 shells (sizes [23,17,189,14,44,158,34,23,103,26,4])` →
+`assembled solid with 635 faces` → `Euler characteristic V-E+F = 12 is invalid (V=3588, E=4211,
+F=635)` → `GFA result not accepted, falling back` → `boolean Cut: GFA unusable — using mesh
+(co-refinement) fallback`, then the trap. So the chain is: the fix makes the band analytic → a later
+Cut's GFA result has OPEN shells and is correctly rejected (11 CLOSED pieces would give euler 22, not
+12) → `mesh_boolean_fallback` runs → **the fallback aborts**. TWO SEPARATE DEFECTS, only one caused
+by the revolve fix: (1) GFA emits open shells on this op — the deeper geometry bug the fix newly
+exposes, and the real target; (2) `mesh_boolean_fallback` can kill the whole kernel — a PRE-EXISTING
+landmine (same function as the long-open "emits OPEN meshes that get CONSUMED" row). Mechanism for
+(2), from `boolean/mod.rs::mesh_boolean_fallback`: it tessellates BOTH operands via
+`tessellate_solid_for_boolean(.., deflection, 0.0)` — angular_tol 0 plus the circle curvature floor,
+deliberately DENSE — then BVH+CDT co-refines. Pre-fix those operands were coarse mesh-derived planar
+solids; post-fix they carry real cylinders and cones, so the triangle counts explode
+(`mesh_boolean.rs:903` is `Vec::with_capacity(tri_count * 2)`). MEASUREMENTS BEHIND THE ALLOCATION
+READING: host has 61GB with 23GB free (no physical pressure) and node's wasm ceiling is 4063MB;
+peak process RSS on the trapping run is 2.74GB, i.e. BELOW that ceiling — which argues against
+gradual growth reaching the cap and for a SINGLE oversized request, since a failed `memory.grow`
+sends Rust to `handle_alloc_error` → `abort()` → `unreachable`, bypassing the panic hook exactly as
+observed. This also explains why native replay looks clean: 61GB absorbs a multi-GB allocation that
+is instantly fatal in a 4GB wasm heap, so this class of bug is INVISIBLE natively — reach for a
+capped allocator or a wasm run when a native repro of an abort refuses to reproduce.
+**ROOT FOUND — `Vec::reserve` DOUBLING THE TOPOLOGY ARENA, AND THE OOM READING ABOVE IS ONLY HALF
+RIGHT.** Bisected by stage-bracketed `log::debug!` + `setLogLevel`, four rounds, each halving the
+search: not a Rust panic (hook verified installed at `kernel.rs:57`, and the probe captures
+`console.error`) → not the analytic path → not co-refinement SIZE (the failing op is a tiny
+**7136 + 12 triangles, 497 intersecting pairs**, so the "single oversized allocation from
+degenerate geometry" theory is REFUTED too) → `mesh_boolean` itself COMPLETES (5/5 stages, 7238
+tris) → the abort is in **`assemble_solid_mixed`, inside `topo.reserve`**, whose preceding log
+reads `arena before reserve V=3207122 E=5780703 W=2787018 F=2786863`. Mechanism: the arena never
+reclaims (`dispose()` is a no-op), so a large export accumulates MILLIONS of entities; `Vec::reserve`
+then rounds a 21714-edge bulk hint up to `max(2*capacity, len+additional)` — a full DOUBLING to
+~11.5M edges — and the reallocation holds the old and new buffers at once, which fails against the
+4GB wasm cap. So the peak-RSS reading was a symptom of accumulated arena, NOT of this operation.
+FIXED in `crates/topology/src/arena.rs`: `reserve` now no-ops when capacity suffices and otherwise
+grows by `additional.max(len / 8)` — geometric (total copying stays amortized O(n)) but capping the
+transient overshoot at 12.5% instead of 100%. Plain `reserve_exact` was tried first and DOES clear
+the abort, but leaves `capacity == len` so the next hint re-copies the whole arena — O(n²) across
+thousands of booleans; test `reserve_hint_grows_a_large_arena_by_a_bounded_fraction` pins both
+halves. MEASUREMENT TRAP that nearly produced a false perf claim: the `reserve_exact` run looked
+catastrophically slower, but it ran at `LOG_LEVEL=debug` emitting **1.96 MILLION** log lines across
+the wasm→JS boundary while the 851s control had logging OFF — never compare a debug-logged export
+against a quiet one. DURABLE, and wider than kumiko: ANY brepkit export long enough to grow the
+arena into the millions is one `reserve` away from a silent wasm abort, and the same cliff applies
+to `Vec::push`'s own doubling. The real ceiling is architectural (no arena reclamation in a 4GB
+address space); this fix buys headroom, it does not remove the cliff.
+
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)
 is NOT established; the classifier was fed a non-closed solid.**

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -970,8 +970,30 @@ result shell is just the box, run with `BK_AREAS=1 BK_FLUX=1`) gives for a 10×1
 the convention is not inverted and `shell_is_outward_oriented` needs no fix. **Therefore the
 captured wedge operand is GENUINELY INWARD-ORIENTED, and the defect is upstream of GFA entirely.**
 Do NOT "fix" `signed_volume_of_shell` or `shell_is_outward_oriented` — they are provably right.
-**ROOT CAUSE FOUND AND REPRODUCED NATIVELY IN ~30 LINES — `revolve` DOES NOT NORMALIZE THE
-ORIENTATION OF THE SOLID IT EMITS.** Probe: `crates/io/examples/arena_roundtrip_orientation.rs`. The
+**ROOT CAUSE FOUND, FIXED, AND FIXTURED — THE SEGMENTED `revolve` PATH DID NOT NORMALIZE THE
+ORIENTATION OF THE SOLID IT EMITS.** Fix in `crates/operations/src/revolve.rs`
+(`profile_chart_is_ccw` + traversal reversal at the segmented path's entrance); fixtures
+`crates/operations/tests/regress_kumiko_corner_wedge.rs` (native wedges, both the overlapping and
+the disjoint cut) and `revolve::tests::revolve_segmented_{is_outward,full_turn_is_outward}_for_either_winding`.
+The sweep runs in `+θ = axis × e_r`, so a profile wound CCW in the (radial, axial) chart faces
+AGAINST it and revolves into a consistently-wound but globally INVERTED solid (Pappus: the swept
+signed volume carries the chart's signed area). `try_analytic_full_revolution` derives each face's
+material-outward side from that same shoelace sign; the segmented path built faces straight from
+traversal order, so it now normalizes the TRAVERSAL instead (reverse the oriented edges and negate
+the cap normal when the chart shoelace is CCW; a degenerate chart is left alone). WIDER THAN THE DIG
+RECORDED: the bug hits segmented FULL revolutions too (a profile whose surface is non-planar, so the
+analytic path declines) — `−112.833` for a `+113.1` washer — the earlier "full revolution is correct
+for both windings" reading only held because analytic profiles never reach the segmented path.
+NEW ORACLE, and the reason this survived so long: `measure::solid_volume` returns a MAGNITUDE, so no
+existing revolve test could see an inverted shell. `measure::oriented_solid_volume` (new, public)
+keeps the divergence-theorem sign — positive iff outward. Reach for it in any orientation
+assertion; the pre-fix wedges read `−143.148`.
+STALE FIXTURE, deliberately still ignored: `crates/io/tests/kumiko_corner_wedge_inmem.rs` replays
+operands captured PRE-FIX, i.e. already-inverted wedges that nothing downstream can recover. Its new
+`captured_operands_are_inward_oriented` pins exactly that (and self-reports when a re-capture lands).
+TOOL-SIDE RE-PROBE STILL OWED — see the mandatory-re-probe note below; the engine claim is closed,
+the export-integrity numbers are not.
+Historical dig record follows. Probe: `crates/io/examples/arena_roundtrip_orientation.rs`. The
 arena round-trip is INNOCENT (a serialize/deserialize copy of a box gives the same
 `signed_vol=1000.000000 outward=Some(true) -> growth` as the native one). But revolving a wedge
 profile (rectangle in the XZ plane, r 1.55→4.75, z 2.7→20.8, about Z, 45°) across all four
@@ -999,15 +1021,17 @@ torus−box notch band, so that path is load-bearing and must not be disturbed. 
 detects only containment), which would spare tool0/tool3 the whole path. Reproduce per tool by symlinking
 one `cut-tool<i>.bin` as `cut-tool0.bin` beside `cut-base.bin` and running
 `PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1 BBOX=1`. Its sibling `operands_are_clean_analytic_wedges` runs unignored and guards the
-fixture itself — an unvalidated operand already cost this campaign several passes. FIRST ACTION FOR THE NEXT SESSION: this is now a brepkit-side defect with a clear shape —
-either make the mesh co-refinement produce closed output for these operands, or make
-`mesh_boolean_fallback` REJECT a non-watertight result instead of warning and consuming it (note
-rejecting means the op fails outright, since there is no further fallback; that is a product call).
-Also worth asking WHY the strut fuses fall back at all — if the analytic path held, no band would be
-mesh-derived and the whole family would likely close.
-Probe by checking free/over on the partial band after each strut fuse; use a SMALL repro (one
-diagonal band, or a native Rust fuse of a few revolve + helix-sweep struts at the tool's
-parameters), since the full export is 844s and blows the 600s vitest timeout before reporting.
+fixture itself — an unvalidated operand already cost this campaign several passes.
+FIRST ACTION FOR THE NEXT SESSION: the engine fix is landed and fixtured, so the open work is
+MEASUREMENT — publish/overlay a build carrying it and re-run the tool's export-integrity matrix plus
+the 4 baseplate suites (baseline to beat: 37 failed / 371 passed on local main; kumiko 14 failures on
+one root; goma 1×1×6 at 844s with 2567 boundary edges). Expect the four diagonal bands to arrive
+closed, which should take them off the mesh fallback and collapse the 844s. Do NOT quote a kumiko
+closure before that re-probe. Two independent follow-ups remain, both untouched by the revolve fix:
+short-circuit a DISJOINT Cut to A (the ops shortcut detects only containment, so a non-touching strut
+still routes through GFA — tool0/tool3 are exactly this), and decide the product call on
+`mesh_boolean_fallback`, which warns that its output is not a closed 2-manifold and consumes it
+anyway (rejecting means the op fails outright, since there is no further fallback).
 
 **MANDATORY POST-GFA RE-PROBE DONE, AND THE ANSWER IS THAT #1224 MOVED THE SCENARIO NOT AT ALL.**
 `gomaBoundaryProbe` (goma 1×1×6 export + STL edge-use oracle) on the overlaid 2.128.5 build:

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1136,6 +1136,26 @@ against a quiet one. DURABLE, and wider than kumiko: ANY brepkit export long eno
 arena into the millions is one `reserve` away from a silent wasm abort, and the same cliff applies
 to `Vec::push`'s own doubling. The real ceiling is architectural (no arena reclamation in a 4GB
 address space); this fix buys headroom, it does not remove the cliff.
+**SCENARIO VERDICT — THE ABORT IS GONE AND THE EXPORT COMPLETES, BUT GOMA IS 2.6x SLOWER THAN THE
+CONTROL. THE KUMIKO FAMILY IS NOT CLOSED.** With both fixes (revolve orientation + arena growth),
+goma 1×1×6 exports **OK in 2187s / 4,153,484 bytes**, against the fix-disabled control's **851s /
+2,715,884 bytes**. Do NOT quote the revolve fix as kumiko progress at scenario level: the export
+still blows vitest's 600s timeout (by 3.6x now instead of 1.4x), so all 14 kumiko failures and the
+timeout-poisoning of later tests REMAIN. MECHANISM of the slowdown, and it is a direct consequence
+of the fix: GFA still fails these ops (`assembly failed: open growth shell with N faces would be
+dropped`, N=13/23/213/216, plus Euler and non-manifold rejects), so they still route to
+`mesh_boolean_fallback` — but the operands are now ANALYTIC (cylinders + cones) where they used to
+be coarse mesh-derived planes, and that fallback tessellates deliberately densely
+(`tessellate_solid_for_boolean(.., deflection, 0.0)`, angular_tol 0 + circle curvature floor). Same
+fallback, far more triangles: hence both the 2.6x wall-clock and the +53% STL. So making geometry
+analytic makes the FALLBACK more expensive without removing the need for it. **THE BLOCKING ITEM IS
+NOW UNAMBIGUOUS: the GFA open-shell defect.** Fix that and these ops stay analytic, the fallback is
+never reached, and both the slowdown and the non-watertight output should go with it. Repro is cheap
+and already in hand — `LOG_LEVEL=warn` on `gomaLogTail.test.ts` prints every rejection with its face
+count; the smallest is `open growth shell with 13 faces`. NOT YET MEASURED: exported boundary-edge
+count on the fixed kernel (needs `gomaBoundaryProbe`, control = 2567), and the 408-test
+export-integrity matrix (baseline 37 failed / 371 passed) — the net effect across OTHER scenarios is
+unknown, and the two engine fixes may well help elsewhere even as goma regresses.
 
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1171,6 +1171,22 @@ measured on. Current families: divider 15, kumiko 14, floor 11, permutation 6, s
 wall/edge/custom-shape/combined 2 each, then singles. ALWAYS run the control on the SAME DAY and the
 SAME catalog rather than trusting a recorded baseline — this is the second time this session that a
 stale or mismatched reference nearly produced a false conclusion.
+**THE TOOL'S `__kernel-tests__` PROBES ARE UNTRACKED AND GET CLEANED — RE-CREATE, DO NOT HUNT.**
+`gomaPanicProbe`, `gomaCaptureBisect`, `gomaBisectProbe`, `gomaOpsProbe`, `gomaPhaseProbe`,
+`gomaProfile` and the two written here (`gomaLogTail`, `gomaHeightLadder`) are/were UNTRACKED files
+in `~/Git/gridfinity-layout-tool` — `git log` on them returns nothing. A `git clean` in that repo on
+2026-07-26 removed all of them, so any roadmap entry naming one is a pointer to a file that may not
+exist. Budget for re-writing the probe rather than treating its absence as a missing capability, and
+check `git status`/recent commits in the tool before running anything there: it is a SEPARATE repo
+that other sessions modify concurrently (two commits landed mid-run here). What survives a clean:
+the capture `.bin` files under `~/.cache/brepkit-parity-captures/` and everything in this repo.
+Recipe for the most useful one, ~40 min per goma run: `setLogLevel(level)` from `brepkit-wasm` is the
+ONLY handle on kernel internals from JS (the cjs keeps `wasm.memory` module-local, so heap size is
+NOT readable), a JS ring buffer over `console.log`/`warn`/`error` captures the output, and at
+`warn` the whole goma 1×1×6 export emits just **1069 lines** — small enough to keep entirely, so use
+a large KEEP and capture the chain from its START. **And note every `BK_*` knob (`BK_FLUX`,
+`BK_AREAS`, `BK_OPEN_SHELL`, `BK_FF_TRACE`, …) is NATIVE-ONLY**: `std::env::var` returns `Err` on
+wasm32-unknown-unknown, so passing them to a tool run silently does nothing.
 
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -970,12 +970,21 @@ result shell is just the box, run with `BK_AREAS=1 BK_FLUX=1`) gives for a 10×1
 the convention is not inverted and `shell_is_outward_oriented` needs no fix. **Therefore the
 captured wedge operand is GENUINELY INWARD-ORIENTED, and the defect is upstream of GFA entirely.**
 Do NOT "fix" `signed_volume_of_shell` or `shell_is_outward_oriented` — they are provably right.
-NEXT: find what inverts the wedge. Two candidates, both cheap to test: (1) brepkit's `revolve`
-emitting an inward solid for a wedge profile (build one natively — profile in a plane CONTAINING the
-axis, NOT `make_unit_square_face` which is XY and degenerate about Z — cut it by a far-away box and
-read `signed_vol`); (2) the arena `.bin` round-trip (`serializeSolid` / `deserialize_solid`)
-inverting orientation, testable by serializing a known-good box, reading it back and re-running the
-same probe. Independently and still worth doing: short-circuit a disjoint Cut to A (the ops shortcut
+**ROOT CAUSE FOUND AND REPRODUCED NATIVELY IN ~30 LINES — `revolve` DOES NOT NORMALIZE THE
+ORIENTATION OF THE SOLID IT EMITS.** Probe: `crates/io/examples/arena_roundtrip_orientation.rs`. The
+arena round-trip is INNOCENT (a serialize/deserialize copy of a box gives the same
+`signed_vol=1000.000000 outward=Some(true) -> growth` as the native one). But revolving a wedge
+profile (rectangle in the XZ plane, r 1.55→4.75, z 2.7→20.8, about Z, 45°) across all four
+combinations of profile winding and stored plane normal gives: ccw/−Y → `signed_vol=-129.010` hole,
+disjoint cut F=48 (mesh fallback); ccw/+Y → `-129.010` hole, F=48; cw/−Y → `+129.010` growth,
+**F=6 analytic**; cw/+Y → `+129.010` growth, **F=6 analytic**. So the PROFILE WINDING alone decides
+the result's orientation and the face's stored `normal` is IGNORED. Wound one way `revolve` emits a
+proper outward solid whose disjoint cut stays analytic at six faces; wound the other it emits an
+INWARD solid that fails every downstream orientation check and drops to the mesh fallback at 48
+planar faces. The tool's wedge is wound the inward way, which is why every corner cut in every
+kumiko band degrades — and why the flat-wall path, which has no revolve, is clean. FIX: make
+`revolve` always emit an outward-oriented solid regardless of profile winding (precedent: the #1045
+loft fix reverses downward-stacked CCW sketches rather than bailing). Independently and still worth doing: short-circuit a disjoint Cut to A (the ops shortcut
 detects only containment), which would spare tool0/tool3 the whole path. Reproduce per tool by symlinking
 one `cut-tool<i>.bin` as `cut-tool0.bin` beside `cut-base.bin` and running
 `PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1 BK_AREAS=1 BBOX=1`. Its sibling `operands_are_clean_analytic_wedges` runs unignored and guards the

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1156,6 +1156,21 @@ count; the smallest is `open growth shell with 13 faces`. NOT YET MEASURED: expo
 count on the fixed kernel (needs `gomaBoundaryProbe`, control = 2567), and the 408-test
 export-integrity matrix (baseline 37 failed / 371 passed) — the net effect across OTHER scenarios is
 unknown, and the two engine fixes may well help elsewhere even as goma regresses.
+**MATRIX MEASURED, A/B, AND THE ANSWER IS ZERO CHANGE — PLUS THE OLD BASELINE IS STALE.** Both runs
+on the same day, same tooling, same 435 tests, differing ONLY in the two fixes (control = both
+disabled in-place, overlay md5 2e58be3e vs treatment 4df3f2e3): **63 failed / 372 passed in BOTH**,
+and diffing the failing test NAMES gives 63 of 63 identical — no treatment-only failure, no
+control-only failure. Durations match too (2440s vs 2463s), because goma times out under both. So
+PR #1237 is scenario-neutral: it fixes two real engine defects and changes nothing in the matrix,
+neither regressing nor improving it. **CORRECT THE BASELINE: it is 63 failed / 372 passed over 435
+tests, NOT the 37/371 over 408 recorded above** — the tool's catalog grew by 27 scenarios, and the
+two families that look like new regressions (`divider patterns` 15, `floor patterns` 11, = 26) are
+pre-existing failures in those NEW scenarios. Comparing a fresh run against the 37/371 figure
+manufactures 26 phantom regressions; that number is only valid against the 408-test catalog it was
+measured on. Current families: divider 15, kumiko 14, floor 11, permutation 6, solid cutouts 3,
+wall/edge/custom-shape/combined 2 each, then singles. ALWAYS run the control on the SAME DAY and the
+SAME catalog rather than trusting a recorded baseline — this is the second time this session that a
+stale or mismatched reference nearly produced a false conclusion.
 
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -522,7 +522,8 @@ fn shell_is_outward_oriented(topo: &Topology, faces: &[FaceId]) -> Option<bool> 
     let mut any = false;
     let trace = std::env::var("BK_FLUX").is_ok();
     for &fid in faces {
-        let flux_before = flux;
+        // Only meaningful under BK_FLUX; skip the bookkeeping otherwise.
+        let flux_before = if trace { flux } else { 0.0 };
         let Ok(face) = topo.face(fid) else { continue };
         let surface = face.surface();
         if let FaceSurface::Plane { .. } = surface {

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -520,7 +520,9 @@ fn face_normal_at(topo: &Topology, face_id: FaceId, point: Point3) -> Option<Vec
 fn shell_is_outward_oriented(topo: &Topology, faces: &[FaceId]) -> Option<bool> {
     let mut flux = 0.0_f64;
     let mut any = false;
+    let trace = std::env::var("BK_FLUX").is_ok();
     for &fid in faces {
+        let flux_before = flux;
         let Ok(face) = topo.face(fid) else { continue };
         let surface = face.surface();
         if let FaceSurface::Plane { .. } = surface {
@@ -627,9 +629,27 @@ fn shell_is_outward_oriented(topo: &Topology, faces: &[FaceId]) -> Option<bool> 
                 }
             }
         }
+        if trace {
+            log::debug!(
+                "growth shell FLUX face {fid:?} {} reversed={} d={:.4}",
+                topo.face(fid)
+                    .map(|f| f.surface().type_tag())
+                    .unwrap_or("?"),
+                topo.face(fid)
+                    .map(brepkit_topology::face::Face::is_reversed)
+                    .unwrap_or(false),
+                flux - flux_before
+            );
+        }
     }
     if !any || flux.abs() < 1e-9 {
         return None;
+    }
+    if trace {
+        log::debug!(
+            "growth shell FLUX total={flux:.4} -> outward={}",
+            flux > 0.0
+        );
     }
     Some(flux > 0.0)
 }

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -633,12 +633,8 @@ fn shell_is_outward_oriented(topo: &Topology, faces: &[FaceId]) -> Option<bool> 
         if trace {
             log::debug!(
                 "growth shell FLUX face {fid:?} {} reversed={} d={:.4}",
-                topo.face(fid)
-                    .map(|f| f.surface().type_tag())
-                    .unwrap_or("?"),
-                topo.face(fid)
-                    .map(brepkit_topology::face::Face::is_reversed)
-                    .unwrap_or(false),
+                surface.type_tag(),
+                face.is_reversed(),
                 flux - flux_before
             );
         }

--- a/crates/io/examples/arena_roundtrip_orientation.rs
+++ b/crates/io/examples/arena_roundtrip_orientation.rs
@@ -1,0 +1,138 @@
+#![allow(clippy::print_stdout, clippy::expect_used, missing_docs)]
+//! Does the arena `.bin` round-trip preserve solid orientation?
+//!
+//! The kumiko corner-wedge operands, captured via `serializeSolid` and replayed
+//! through `deserialize_solid`, are genuinely inward-oriented: both of GFA's
+//! orientation tests report inward for them, and the same tests are exact and
+//! correctly signed on a natively-built cube (`signed_vol=1000.000000`, flux
+//! `3000.0 = 3V`). So something upstream inverts the wedge. The round-trip is
+//! the cheapest candidate, and it would explain EVERY captured operand at once.
+//!
+//! Method: build a box natively, run `Cut(box, far-away disjoint box)` on it —
+//! which keeps all of A's faces, so the shell under test is the box — then do
+//! the same on a serialize/deserialize copy of that box. If the copy reports
+//! `0 growth shells, 1 hole shells` while the original reports the reverse, the
+//! round-trip inverts orientation.
+//!
+//! Run with `BK_AREAS=1` to see each shell's signed volume.
+
+use brepkit_io::arena_io::{deserialize_solid, serialize_solid};
+use brepkit_math::mat::Mat4;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::primitives::make_box;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+use brepkit_topology::edge::{Edge, EdgeCurve};
+use brepkit_topology::face::{Face, FaceSurface};
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::vertex::Vertex;
+use brepkit_topology::wire::{OrientedEdge, Wire};
+
+struct StdoutLogger;
+impl log::Log for StdoutLogger {
+    fn enabled(&self, m: &log::Metadata) -> bool {
+        m.target().starts_with("brepkit_algo") && m.level() <= log::Level::Debug
+    }
+    fn log(&self, r: &log::Record) {
+        if !self.enabled(r.metadata()) {
+            return;
+        }
+        let msg = format!("{}", r.args());
+        if msg.contains("AREAS") || msg.contains("growth shell") {
+            println!("    [algo] {msg}");
+        }
+    }
+    fn flush(&self) {}
+}
+static LOGGER: StdoutLogger = StdoutLogger;
+
+/// `Cut(solid, far-away box)` — a no-op whose result shell is `solid` itself.
+fn cut_by_far_box(topo: &mut Topology, solid: SolidId, label: &str) {
+    let far = make_box(topo, 5.0, 5.0, 5.0).expect("far box");
+    transform_solid(topo, far, &Mat4::translation(500.0, 500.0, 500.0)).expect("move far box");
+    match boolean(topo, BooleanOp::Cut, solid, far) {
+        Ok(sid) => {
+            let n = brepkit_topology::explorer::solid_faces(topo, sid)
+                .map(|f| f.len())
+                .unwrap_or(0);
+            println!("  {label}: ok F={n}");
+        }
+        Err(e) => println!("  {label}: ERR {e}"),
+    }
+}
+
+/// A rectangle in the XZ plane (which CONTAINS the Z axis), spanning the
+/// kumiko wedge's own extents: radius 1.55..4.75, height 2.7..20.8.
+///
+/// The profile plane must contain the revolve axis. A unit square in XY is
+/// perpendicular to Z and revolves degenerately — it returns six planar faces
+/// that look like a result and are not one.
+fn wedge_profile(topo: &mut Topology, ccw: bool, ny: f64) -> brepkit_topology::face::FaceId {
+    let tol = brepkit_math::tolerance::Tolerance::new().linear;
+    let mut pts = [
+        Point3::new(1.55, 0.0, 2.7),
+        Point3::new(4.75, 0.0, 2.7),
+        Point3::new(4.75, 0.0, 20.8),
+        Point3::new(1.55, 0.0, 20.8),
+    ];
+    if !ccw {
+        pts.reverse();
+    }
+    let vs: Vec<_> = pts
+        .iter()
+        .map(|p| topo.add_vertex(Vertex::new(*p, tol)))
+        .collect();
+    let mut oes = Vec::new();
+    for i in 0..4 {
+        let e = topo.add_edge(Edge::new(vs[i], vs[(i + 1) % 4], EdgeCurve::Line));
+        oes.push(OrientedEdge::new(e, true));
+    }
+    let wid = topo.add_wire(Wire::new(oes, true).expect("wire"));
+    topo.add_face(Face::new(
+        wid,
+        vec![],
+        // XZ plane: normal along -Y so the profile winds consistently.
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, ny, 0.0),
+            d: 0.0,
+        },
+    ))
+}
+
+fn main() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Debug);
+
+    let mut topo = Topology::new();
+    let original = make_box(&mut topo, 10.0, 10.0, 10.0).expect("box");
+
+    let bytes = serialize_solid(&topo, original).expect("serialize");
+    let restored = deserialize_solid(&bytes, &mut topo).expect("deserialize");
+    println!("serialized {} bytes", bytes.len());
+
+    println!("native box:");
+    cut_by_far_box(&mut topo, original, "native");
+
+    println!("round-tripped box:");
+    cut_by_far_box(&mut topo, restored, "round-trip");
+
+    // Candidate (1): does `revolve` emit an inward solid for a wedge profile?
+    // All four combinations of profile winding and plane normal: if any one
+    // yields an outward wedge, `revolve` is fine and the input convention is
+    // what matters. If all four are inward, `revolve` itself inverts.
+    for (ccw, ny) in [(true, -1.0), (true, 1.0), (false, -1.0), (false, 1.0)] {
+        println!("revolve wedge (ccw={ccw} normal_y={ny}):");
+        let profile = wedge_profile(&mut topo, ccw, ny);
+        match brepkit_operations::revolve::revolve(
+            &mut topo,
+            profile,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            std::f64::consts::FRAC_PI_4,
+        ) {
+            Ok(wedge) => cut_by_far_box(&mut topo, wedge, "  wedge"),
+            Err(e) => println!("  revolve ERR {e}"),
+        }
+    }
+}

--- a/crates/io/examples/arena_roundtrip_orientation.rs
+++ b/crates/io/examples/arena_roundtrip_orientation.rs
@@ -122,7 +122,7 @@ fn main() {
     // yields an outward wedge, `revolve` is fine and the input convention is
     // what matters. If all four are inward, `revolve` itself inverts.
     for (ccw, ny) in [(true, -1.0), (true, 1.0), (false, -1.0), (false, 1.0)] {
-        println!("revolve wedge (ccw={ccw} normal_y={ny}):");
+        println!("PARTIAL revolve 45deg (ccw={ccw} normal_y={ny}):");
         let profile = wedge_profile(&mut topo, ccw, ny);
         match brepkit_operations::revolve::revolve(
             &mut topo,
@@ -132,6 +132,24 @@ fn main() {
             std::f64::consts::FRAC_PI_4,
         ) {
             Ok(wedge) => cut_by_far_box(&mut topo, wedge, "  wedge"),
+            Err(e) => println!("  revolve ERR {e}"),
+        }
+    }
+
+    // The analytic FULL-revolution path documents itself as exact for both
+    // windings. If full is clean where partial is not, the gap is specific to
+    // the segmented path.
+    for ccw in [true, false] {
+        println!("FULL revolve 360deg (ccw={ccw}):");
+        let profile = wedge_profile(&mut topo, ccw, -1.0);
+        match brepkit_operations::revolve::revolve(
+            &mut topo,
+            profile,
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            std::f64::consts::TAU,
+        ) {
+            Ok(full) => cut_by_far_box(&mut topo, full, "  full"),
             Err(e) => println!("  revolve ERR {e}"),
         }
     }

--- a/crates/io/tests/kumiko_corner_wedge_inmem.rs
+++ b/crates/io/tests/kumiko_corner_wedge_inmem.rs
@@ -29,11 +29,26 @@
 //! `BuilderSolid: 0 growth shells, 1 hole shells` and aborts with
 //! "no outer shell found (all shells classified as holes)" — in 0ms. One shell
 //! is built and classified INWARD, so nothing is left to be the outer shell.
-//! For `Cut(wedge, strut)` the result should be a single outward shell, so the
-//! suspect is orientation or the growth-vs-hole decision in `perform_areas`,
-//! not the face splitter. Reproduce with
-//! `CAPTURE_DIR=<call4> PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1
+//! Reproduce with `CAPTURE_DIR=<call4> PREFIX=cut RAW=1 TOOL=0 SHELL_LOG=1
 //! ./target/release/examples/replay_cut_capture`.
+//!
+//! ROOT FOUND AND FIXED UPSTREAM OF GFA: `revolve`'s segmented path (which owns
+//! every partial revolution) built its faces straight from the profile's
+//! traversal order, so a profile wound CCW in the (radial, axial) chart — facing
+//! against the sweep direction — revolved into a consistently wound but globally
+//! INVERTED solid. Both orientation tests in `perform_areas` were right to
+//! reject it. The analytic full-revolution path already normalized this via its
+//! chart shoelace sign; the segmented path now does too.
+//!
+//! THESE FIXTURES CANNOT VERIFY THE FIX, and that is what `captured_operands`
+//! `_are_inward_oriented` below pins. They were captured from a PRE-FIX build, so
+//! they hold already-inverted wedges: nothing downstream can recover them, and
+//! `kumiko_corner_wedge_cut_stays_analytic` stays ignored as a re-capture task,
+//! not an open engine bug. The fix is verified natively instead, on wedges built
+//! by `revolve` itself — `crates/operations/tests/regress_kumiko_corner_wedge.rs`
+//! (which reproduces both signatures seen here: all-planar on the overlapping
+//! cut, `{"plane": 48}` on the disjoint one) and
+//! `revolve::tests::revolve_segmented_is_outward_for_either_winding`.
 //!
 //! Operands captured from the live tool on a local 2.128.5 build via
 //! `kumikoCornerCutCapture.test.ts`; full six-call capture in
@@ -110,7 +125,27 @@ fn operands_are_clean_analytic_wedges() {
 }
 
 #[test]
-#[ignore = "ready-repro — coaxial wedge cut falls back to mesh, losing both cylinders"]
+fn captured_operands_are_inward_oriented() {
+    // The diagnosis, pinned: these captures predate the revolve orientation fix,
+    // so both wedges are globally inverted. `solid_volume` reports a magnitude
+    // and cannot see it, which is exactly why the defect survived so long —
+    // `oriented_solid_volume` keeps the sign.
+    let mut topo = Topology::new();
+    for name in ["kumiko_corner_wedge.bin", "kumiko_corner_strut.bin"] {
+        let sid = load(name, &mut topo);
+        let signed = brepkit_operations::measure::oriented_solid_volume(&topo, sid, 0.05).unwrap();
+        assert!(
+            signed < 0.0,
+            "{name} is a pre-fix capture and should still be inward-oriented; \
+             a positive signed volume ({signed:.3}) means it was re-captured, so \
+             un-ignore the cut test below"
+        );
+    }
+}
+
+#[test]
+#[ignore = "operands predate the revolve orientation fix — needs a re-capture; \
+            the fix is verified natively in operations/tests/regress_kumiko_corner_wedge.rs"]
 fn kumiko_corner_wedge_cut_stays_analytic() {
     let mut topo = Topology::new();
     let wedge = load("kumiko_corner_wedge.bin", &mut topo);

--- a/crates/operations/examples/flux_orientation_probe.rs
+++ b/crates/operations/examples/flux_orientation_probe.rs
@@ -1,0 +1,65 @@
+#![allow(clippy::print_stdout, clippy::expect_used, missing_docs)]
+//! Discriminating experiment: does `shell_is_outward_oriented` read a
+//! KNOWN-GOOD primitive as outward?
+//!
+//! The kumiko corner-wedge cut fails because its result shell's flux integral
+//! comes out at -852.42 while 3V is +854.6 — right magnitude, wrong sign. Two
+//! explanations remain and they need opposite fixes: either the flux
+//! convention is inverted, or the captured wedge operand is genuinely inward
+//! and the defect is upstream. Every measurement available in `brepkit-io` is
+//! orientation-blind (`solid_volume` returns `.abs()`, ray-parity
+//! classification ignores normals), so this runs the same code path on a box
+//! built right here, whose orientation is not in question.
+//!
+//! `Cut(box, far-away disjoint box)` keeps all of A's faces and none of B's,
+//! so the shell under test is exactly the box.
+//!
+//! Outward for the box but inward for the wedge → the wedge is inverted.
+//! Inward for BOTH → the flux convention itself is wrong.
+//!
+//! Run with `BK_AREAS=1 BK_FLUX=1`.
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::primitives::make_box;
+use brepkit_operations::transform::transform_solid;
+use brepkit_topology::Topology;
+
+struct StdoutLogger;
+impl log::Log for StdoutLogger {
+    fn enabled(&self, m: &log::Metadata) -> bool {
+        m.target().starts_with("brepkit_algo") && m.level() <= log::Level::Debug
+    }
+    fn log(&self, r: &log::Record) {
+        if !self.enabled(r.metadata()) {
+            return;
+        }
+        let msg = format!("{}", r.args());
+        if msg.contains("FLUX") || msg.contains("AREAS") || msg.contains("growth shell") {
+            println!("    [algo] {msg}");
+        }
+    }
+    fn flush(&self) {}
+}
+static LOGGER: StdoutLogger = StdoutLogger;
+
+fn main() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Debug);
+
+    let mut topo = Topology::new();
+    let a = make_box(&mut topo, 10.0, 10.0, 10.0).expect("box a");
+    // Far enough away that no face pair can overlap, so the cut is a no-op and
+    // the result shell is A itself.
+    let b = make_box(&mut topo, 5.0, 5.0, 5.0).expect("box b");
+    transform_solid(&mut topo, b, &Mat4::translation(500.0, 500.0, 500.0)).expect("move b");
+
+    println!("Cut(box, far-away disjoint box) — result shell should be the box:");
+    match boolean(&mut topo, BooleanOp::Cut, a, b) {
+        Ok(sid) => {
+            let faces = brepkit_topology::explorer::solid_faces(&topo, sid).expect("faces");
+            println!("  ok: F={}", faces.len());
+        }
+        Err(e) => println!("  ERR {e}"),
+    }
+}

--- a/crates/operations/src/boolean/assembly.rs
+++ b/crates/operations/src/boolean/assembly.rs
@@ -156,6 +156,13 @@ pub(crate) fn assemble_solid_mixed(
     // Pre-allocate topology arenas based on expected output size.
     // Typical face → ~2 unique vertices, ~3 edges, 1 wire, 1 face.
     let n = face_specs.len();
+    log::debug!(
+        "assemble_solid_mixed: {n} specs; arena before reserve V={} E={} W={} F={}",
+        topo.num_vertices(),
+        topo.num_edges(),
+        topo.num_wires(),
+        topo.num_faces(),
+    );
     topo.reserve(n.saturating_mul(2), n.saturating_mul(3), n, n, 1, 1);
 
     let resolution = vertex_merge_resolution(

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -2322,6 +2322,11 @@ fn mesh_boolean_fallback(
     // it needs (display tessellation drops that floor for triangle count).
     let mesh_a = crate::tessellate::tessellate_solid_for_boolean(topo, a, deflection, 0.0)?;
     let mesh_b = crate::tessellate::tessellate_solid_for_boolean(topo, b, deflection, 0.0)?;
+    log::debug!(
+        "mesh fallback {op:?}: tessellated operands to {} + {} triangles at deflection {deflection}",
+        mesh_a.indices.len() / 3,
+        mesh_b.indices.len() / 3,
+    );
 
     let mb_result = crate::mesh_boolean::mesh_boolean(&mesh_a, &mesh_b, op, tol.linear)?;
     if mb_result.boundary_edge_count > 0 || mb_result.non_manifold_edge_count > 0 {
@@ -2339,6 +2344,10 @@ fn mesh_boolean_fallback(
             reason: "mesh boolean produced no output faces".into(),
         });
     }
+    log::debug!(
+        "mesh fallback {op:?}: {} face specs -> assemble_solid_mixed",
+        face_specs.len()
+    );
     let result = assemble_solid_mixed(topo, &face_specs, tol)?;
     let _ = crate::heal::remove_degenerate_edges(topo, result, tol.linear)?;
     if opts.unify_faces {

--- a/crates/operations/src/measure/mod.rs
+++ b/crates/operations/src/measure/mod.rs
@@ -11,7 +11,9 @@ pub use area::{face_area, solid_surface_area};
 pub(crate) use bounding_box::face_set_bounding_box;
 pub use bounding_box::solid_bounding_box;
 pub use edge_length::{edge_length, face_perimeter, wire_length};
-pub use volume::{solid_center_of_mass, solid_volume, solid_volume_from_faces};
+pub use volume::{
+    oriented_solid_volume, solid_center_of_mass, solid_volume, solid_volume_from_faces,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -1211,6 +1211,38 @@ pub fn solid_volume(
     volume_from_per_face_tessellation(topo, solid, deflection)
 }
 
+/// Divergence-theorem volume of a solid WITHOUT the absolute value, so the sign
+/// reports shell orientation: positive for an outward-oriented (material-inside)
+/// solid, negative for an inverted one.
+///
+/// [`solid_volume`] deliberately reports a magnitude, which makes it blind to a
+/// globally inverted shell — the defect class that drops a boolean to the mesh
+/// fallback with no volume error to show for it.
+///
+/// # Errors
+///
+/// Returns an error if the solid cannot be tessellated.
+pub fn oriented_solid_volume(
+    topo: &Topology,
+    solid: SolidId,
+    deflection: f64,
+) -> Result<f64, crate::OperationsError> {
+    let mesh = tessellate::tessellate_solid(topo, solid, deflection)?;
+    let idx = &mesh.indices;
+    let pos = &mesh.positions;
+    let mut total = 0.0;
+    for t in 0..idx.len() / 3 {
+        let v0 = pos[idx[t * 3] as usize];
+        let v1 = pos[idx[t * 3 + 1] as usize];
+        let v2 = pos[idx[t * 3 + 2] as usize];
+        let a = Vec3::new(v0.x(), v0.y(), v0.z());
+        let b = Vec3::new(v1.x(), v1.y(), v1.z());
+        let c = Vec3::new(v2.x(), v2.y(), v2.z());
+        total += a.dot(b.cross(c));
+    }
+    Ok(total / 6.0)
+}
+
 /// Compute signed volume from a watertight triangle mesh using
 /// the divergence theorem (signed tetrahedra method).
 fn signed_volume_from_mesh(mesh: &tessellate::TriangleMesh) -> f64 {

--- a/crates/operations/src/mesh_boolean.rs
+++ b/crates/operations/src/mesh_boolean.rs
@@ -41,6 +41,24 @@ pub struct MeshBooleanResult {
 /// self-check and the downstream dedupe measuring on the same weld grid.
 const SELF_CHECK_GRID: f64 = crate::tessellate::COINCIDENT_DEDUPE_GRID;
 
+/// Co-refinement budgets. Exceeding either returns an `Err` instead of running.
+///
+/// Every stage after the broad phase allocates per intersecting PAIR (segments,
+/// per-triangle CDT constraint sets, split sub-triangles), so growth is
+/// superlinear in the pair count. On a 64-bit host that is merely slow, but
+/// wasm32 caps linear memory at 4GB and a failed allocation reaches
+/// `handle_alloc_error` → `abort()` — a trap that stops the whole instance,
+/// strands its `WasmRefCell` borrow flag, and (unlike a panic) leaves no message
+/// behind, so every later call fails with "recursive use of an object". A
+/// rejected boolean is recoverable; an aborted kernel is not.
+///
+/// These are a backstop, not a quality threshold: both sit far above any case
+/// measured here (real fallbacks run in the thousands of triangles, and the
+/// goma export's worst is 7148 triangles / 497 pairs). No observed failure has
+/// yet reached them.
+const MAX_INPUT_TRIANGLES: usize = 4_000_000;
+const MAX_INTERSECTING_PAIRS: usize = 2_000_000;
+
 /// Perform a mesh boolean operation between two triangle meshes.
 ///
 /// Uses co-refinement: compute exact triangle-triangle intersections,
@@ -56,20 +74,43 @@ const SELF_CHECK_GRID: f64 = crate::tessellate::COINCIDENT_DEDUPE_GRID;
 ///
 /// # Errors
 /// Returns an error if the operation cannot be completed (e.g. the
-/// intersection of disjoint meshes is empty).
+/// intersection of disjoint meshes is empty), or if the operands exceed the
+/// co-refinement budgets below.
 pub fn mesh_boolean(
     mesh_a: &TriangleMesh,
     mesh_b: &TriangleMesh,
     op: BooleanOp,
     tolerance: f64,
 ) -> Result<MeshBooleanResult, OperationsError> {
+    let (tris_a, tris_b) = (mesh_a.indices.len() / 3, mesh_b.indices.len() / 3);
+    log::debug!("mesh_boolean {op:?}: input triangles a={tris_a} b={tris_b}");
+    if tris_a + tris_b > MAX_INPUT_TRIANGLES {
+        return Err(OperationsError::InvalidInput {
+            reason: format!(
+                "mesh boolean operands too large to co-refine: {tris_a} + {tris_b} triangles \
+                 exceeds the {MAX_INPUT_TRIANGLES} budget"
+            ),
+        });
+    }
+
     // Step 1: BVH broad-phase
     let bvh_a = build_triangle_bvh(mesh_a);
     let bvh_b = build_triangle_bvh(mesh_b);
     let pairs = find_intersecting_pairs(mesh_a, &bvh_b, tolerance);
+    log::debug!("mesh_boolean {op:?}: {} intersecting pairs", pairs.len());
+    if pairs.len() > MAX_INTERSECTING_PAIRS {
+        return Err(OperationsError::InvalidInput {
+            reason: format!(
+                "mesh boolean co-refinement too large: {} intersecting triangle pairs \
+                 exceeds the {MAX_INTERSECTING_PAIRS} budget (operands {tris_a} + {tris_b} triangles)",
+                pairs.len()
+            ),
+        });
+    }
 
     // Step 2: Triangle-triangle intersection segments
     let segments = compute_all_intersections(mesh_a, mesh_b, &pairs, tolerance);
+    log::debug!("mesh_boolean {op:?}: step2 {} segments", segments.len());
 
     // Step 3: Conforming re-triangulation of both meshes
     let split_a = split_mesh_conforming(mesh_a, &segments, true, tolerance);
@@ -81,6 +122,10 @@ pub fn mesh_boolean(
 
     // Step 5: Assemble result
     let mesh = assemble_result(&split_a, &split_b, &classify_a, &classify_b, op);
+    log::debug!(
+        "mesh_boolean {op:?}: assembled {} tris",
+        mesh.indices.len() / 3
+    );
 
     if mesh.positions.is_empty() {
         return Err(OperationsError::EmptyResult {
@@ -1606,6 +1651,30 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
 
     use super::*;
+
+    /// Oversized operands must be REJECTED, not attempted.
+    ///
+    /// On wasm32 an unbounded co-refinement exhausts the 4GB linear-memory cap,
+    /// and the resulting `handle_alloc_error` → `abort()` traps the instance and
+    /// strands its borrow flag — every later call fails with "recursive use of
+    /// an object", with no panic message to explain it. An `Err` is recoverable;
+    /// that abort is not. (Built as bare index/position vectors so the test does
+    /// not allocate a real multi-million-triangle mesh.)
+    #[test]
+    fn oversized_operands_are_rejected_not_attempted() {
+        let mut huge = TriangleMesh::default();
+        huge.positions.push(Point3::new(0.0, 0.0, 0.0));
+        huge.normals.push(Vec3::new(0.0, 0.0, 1.0));
+        huge.indices = vec![0; (MAX_INPUT_TRIANGLES + 1) * 3];
+
+        let small = tetrahedron_mesh(Point3::new(0.0, 0.0, 0.0), 1.0);
+        let err = mesh_boolean(&huge, &small, BooleanOp::Cut, 1e-7)
+            .expect_err("oversized operands must be rejected");
+        assert!(
+            format!("{err}").contains("too large"),
+            "expected a budget rejection, got: {err}"
+        );
+    }
 
     /// Create a tetrahedron mesh centered at a point.
     fn tetrahedron_mesh(center: Point3, size: f64) -> TriangleMesh {

--- a/crates/operations/src/revolve.rs
+++ b/crates/operations/src/revolve.rs
@@ -1044,6 +1044,79 @@ fn try_circle_revolution_torus(
     Ok(Some(topo.add_solid(Solid::new(shell_id, vec![]))))
 }
 
+/// Traversal winding of a profile wire in the (radial, axial) chart about
+/// `axis`, or `None` when the chart polygon is degenerate.
+///
+/// The chart's radial basis is the direction of the profile's own
+/// farthest-off-axis sample, matching [`try_analytic_full_revolution`], so the
+/// shoelace sign is comparable between the two paths. Curved edges contribute
+/// interior samples in traversal order, so an arc-dominated profile (a single
+/// closed circle) does not degenerate to its vertex count.
+fn profile_chart_is_ccw(
+    topo: &Topology,
+    oriented: &[OrientedEdge],
+    axis_origin: Point3,
+    axis: Vec3,
+) -> Result<Option<bool>, crate::OperationsError> {
+    let mut pts: Vec<Point3> = Vec::with_capacity(oriented.len() * 4);
+    for oe in oriented {
+        let edge = topo.edge(oe.edge())?;
+        let ns = topo.vertex(edge.start())?.point();
+        let ne = topo.vertex(edge.end())?.point();
+        pts.push(if oe.is_forward() { ns } else { ne });
+        if !matches!(edge.curve(), EdgeCurve::Line) {
+            let curve = edge.curve();
+            let (t0, t1) = curve.domain_with_endpoints(ns, ne);
+            // Sample in the curve's NATURAL direction, then reverse to traversal
+            // order — sampling from traversal endpoints picks the CCW complement
+            // of a reversed arc.
+            let mut interior: Vec<Point3> = [0.25, 0.5, 0.75]
+                .iter()
+                .map(|f| curve.evaluate_with_endpoints((t1 - t0).mul_add(*f, t0), ns, ne))
+                .collect();
+            if !oe.is_forward() {
+                interior.reverse();
+            }
+            pts.extend(interior);
+        }
+    }
+
+    let mut e_r: Option<Vec3> = None;
+    let mut best_r = 0.0_f64;
+    for &p in &pts {
+        let v = p - axis_origin;
+        let radial = v - axis * v.dot(axis);
+        let r = radial.length();
+        if r > best_r {
+            best_r = r;
+            e_r = radial.normalize().ok();
+        }
+    }
+    let Some(e_r) = e_r else {
+        return Ok(None); // whole profile on the axis
+    };
+
+    let chart: Vec<(f64, f64)> = pts
+        .iter()
+        .map(|p| {
+            let v = *p - axis_origin;
+            (v.dot(e_r), v.dot(axis))
+        })
+        .collect();
+    let mut area2 = 0.0_f64;
+    let mut scale = 0.0_f64;
+    for i in 0..chart.len() {
+        let (x0, y0) = chart[i];
+        let (x1, y1) = chart[(i + 1) % chart.len()];
+        area2 += x0.mul_add(y1, -(x1 * y0));
+        scale = scale.max(x0.abs()).max(y0.abs());
+    }
+    if area2.abs() <= scale * scale * 1e-9 {
+        return Ok(None);
+    }
+    Ok(Some(area2 > 0.0))
+}
+
 /// Revolve a face around an axis to produce a solid of revolution.
 ///
 /// The profile surface may be planar or curved — only its boundary is used. A
@@ -1188,6 +1261,24 @@ pub fn revolve(
         }
     };
 
+    // The sweep runs in +θ = axis × e_r, so a profile whose traversal is CCW in
+    // the (radial, axial) chart faces AGAINST it and revolves into an inward
+    // solid — consistently wound, but with every normal inverted, which every
+    // downstream orientation test then rejects (the shell classifies as a hole).
+    // `try_analytic_full_revolution` derives each face's material-outward side
+    // from this same shoelace sign; the segmented path builds faces straight
+    // from traversal order, so normalize the traversal itself instead. A
+    // degenerate chart leaves the traversal alone.
+    let flip_traversal = {
+        let oes = topo.wire(input_wire_id)?.edges().to_vec();
+        profile_chart_is_ccw(topo, &oes, axis_origin, axis)?.unwrap_or(false)
+    };
+    let input_normal = if flip_traversal {
+        -input_normal
+    } else {
+        input_normal
+    };
+
     let (num_segs, seg_angle) = arc_segmentation(angle);
     let num_boundaries = if is_full { num_segs } else { num_segs + 1 };
 
@@ -1198,12 +1289,21 @@ pub fn revolve(
         let original_oriented: Vec<_> = wire.edges().to_vec();
 
         // Split closed edges (e.g. full circles) into line segments.
-        let input_oriented = crate::extrude::maybe_split_closed_wire(
+        let split_oriented = crate::extrude::maybe_split_closed_wire(
             topo,
             &original_oriented,
             tol.linear,
             crate::extrude::DEFAULT_DEFLECTION,
         )?;
+        let input_oriented: Vec<OrientedEdge> = if flip_traversal {
+            split_oriented
+                .iter()
+                .rev()
+                .map(|oe| OrientedEdge::new(oe.edge(), !oe.is_forward()))
+                .collect()
+        } else {
+            split_oriented
+        };
         let n = input_oriented.len();
 
         let mut input_verts: Vec<VertexId> = Vec::with_capacity(n);
@@ -2900,5 +3000,122 @@ mod tests {
             vol > 0.0,
             "full revolve of a non-planar boundary should have positive volume, got {vol}"
         );
+    }
+
+    /// The segmented revolve must emit an OUTWARD solid for either profile
+    /// winding, like the analytic full-revolution path already does.
+    ///
+    /// Wound the inward way it used to emit a consistently-wound but globally
+    /// inverted shell: every downstream orientation test classified it as a hole,
+    /// so GFA found no outer shell and every boolean against it dropped to the
+    /// mesh fallback (48 planar faces for a 6-face wedge). No existing test could
+    /// see it — `solid_volume` reports a magnitude.
+    #[test]
+    fn revolve_segmented_is_outward_for_either_winding() {
+        // The kumiko corner wedge: radius 1.55..4.75, height 2.7..20.8, in the XZ
+        // plane (which contains the Z axis), revolved 45°.
+        let (r0, r1, z0, z1) = (1.55, 4.75, 2.7, 20.8);
+        let angle = FRAC_PI_2 / 2.0;
+
+        for ccw in [true, false] {
+            for normal_y in [-1.0, 1.0] {
+                let mut topo = Topology::new();
+                let mut pts = vec![
+                    Point3::new(r0, 0.0, z0),
+                    Point3::new(r1, 0.0, z0),
+                    Point3::new(r1, 0.0, z1),
+                    Point3::new(r0, 0.0, z1),
+                ];
+                if !ccw {
+                    pts.reverse();
+                }
+                let wire =
+                    brepkit_topology::builder::make_polygon_wire(&mut topo, &pts, 1e-7).unwrap();
+                let face = topo.add_face(brepkit_topology::face::Face::new(
+                    wire,
+                    vec![],
+                    FaceSurface::Plane {
+                        normal: Vec3::new(0.0, normal_y, 0.0),
+                        d: 0.0,
+                    },
+                ));
+                let solid = revolve(
+                    &mut topo,
+                    face,
+                    Point3::new(0.0, 0.0, 0.0),
+                    Vec3::new(0.0, 0.0, 1.0),
+                    angle,
+                )
+                .unwrap();
+
+                // Pappus: V = Δθ × centroid_radius × area.
+                let expected = angle * (0.5 * (r0 + r1)) * ((r1 - r0) * (z1 - z0));
+                let vol = crate::measure::oriented_solid_volume(&topo, solid, 0.02).unwrap();
+                assert!(
+                    vol > 0.0,
+                    "wedge (ccw={ccw} normal_y={normal_y}) must be outward-oriented, \
+                     got signed volume {vol:.3}"
+                );
+                let rel_err = (vol - expected).abs() / expected;
+                assert!(
+                    rel_err < 0.05,
+                    "wedge (ccw={ccw} normal_y={normal_y}) volume should be ~{expected:.2}, \
+                     got {vol:.2} (rel_err={rel_err:.2e})"
+                );
+            }
+        }
+    }
+
+    /// The segmented path also owns FULL revolutions whose profile surface is
+    /// non-planar (the analytic path takes planar profiles only), so the winding
+    /// normalization must cover them too.
+    #[test]
+    fn revolve_segmented_full_turn_is_outward_for_either_winding() {
+        for ccw in [true, false] {
+            let mut topo = Topology::new();
+            let mut pts = vec![
+                Point3::new(2.0, 0.0, 0.0),
+                Point3::new(4.0, 0.0, 0.0),
+                Point3::new(4.0, 3.0, 0.0),
+                Point3::new(2.0, 3.0, 0.0),
+            ];
+            if !ccw {
+                pts.reverse();
+            }
+            let wire = brepkit_topology::builder::make_polygon_wire(&mut topo, &pts, 1e-7).unwrap();
+            let cyl = brepkit_math::surfaces::CylindricalSurface::new(
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+                1.0,
+            )
+            .unwrap();
+            let face = topo.add_face(brepkit_topology::face::Face::new(
+                wire,
+                vec![],
+                FaceSurface::Cylinder(cyl),
+            ));
+            let solid = revolve(
+                &mut topo,
+                face,
+                Point3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 1.0, 0.0),
+                2.0 * PI,
+            )
+            .unwrap();
+
+            let expected = 2.0 * PI * 3.0 * 6.0;
+            let vol = crate::measure::oriented_solid_volume(&topo, solid, 0.02).unwrap();
+            assert!(
+                vol > 0.0,
+                "full segmented revolve (ccw={ccw}) must be outward-oriented, \
+                 got signed volume {vol:.3}"
+            );
+            let rel_err = (vol - expected).abs() / expected;
+            assert!(
+                rel_err < 0.05,
+                "full segmented revolve (ccw={ccw}) volume should be ~{expected:.2}, \
+                 got {vol:.2} (rel_err={rel_err:.2e})"
+            );
+        }
     }
 }

--- a/crates/operations/tests/regress_kumiko_corner_wedge.rs
+++ b/crates/operations/tests/regress_kumiko_corner_wedge.rs
@@ -1,0 +1,225 @@
+//! Regression: cutting a kumiko corner wedge by a coaxial strut must stay
+//! analytic — the root of the whole kumiko export-integrity family.
+//!
+//! The tool carves each lattice band rather than fusing it: it starts from a
+//! `wedge` (a `revolve`, so it carries cylindrical corner faces) and runs
+//! `cutter = cutAll(cutter, family)` per strut family. Both operands are small
+//! coaxial revolve wedges — six analytic faces each, two cylinders each. The cut
+//! used to come back all-planar (the mesh-fallback signature) because `revolve`
+//! emitted INWARD-oriented solids for one profile winding: GFA built one shell,
+//! classified it a hole, and aborted with "no outer shell found". Every corner
+//! cut in every band took that path, so every band was mesh-derived, and four of
+//! eight goma bands arrived at the export non-watertight.
+//!
+//! This fixture is built natively rather than from captured operands: the
+//! captures in `crates/io/tests/data/kumiko_corner_*.bin` predate the fix, so
+//! they hold already-inverted wedges and can never pass (see
+//! `crates/io/tests/kumiko_corner_wedge_inmem.rs`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::revolve::revolve;
+use brepkit_topology::Topology;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::face::{Face, FaceSurface};
+use brepkit_topology::solid::SolidId;
+
+/// A wedge: rectangle `r0..r1 × z0..z1` in the XZ plane (which contains the Z
+/// axis), revolved `angle` about Z. Wound the way the tool's own profiles are —
+/// CCW in the (radial, axial) chart, the winding that used to invert.
+fn wedge(
+    topo: &mut Topology,
+    r0: f64,
+    r1: f64,
+    z0: f64,
+    z1: f64,
+    angle: f64,
+) -> brepkit_topology::solid::SolidId {
+    let pts = vec![
+        Point3::new(r0, 0.0, z0),
+        Point3::new(r1, 0.0, z0),
+        Point3::new(r1, 0.0, z1),
+        Point3::new(r0, 0.0, z1),
+    ];
+    let wire = brepkit_topology::builder::make_polygon_wire(topo, &pts, 1e-7).unwrap();
+    let face = topo.add_face(Face::new(
+        wire,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, -1.0, 0.0),
+            d: 0.0,
+        },
+    ));
+    revolve(
+        topo,
+        face,
+        Point3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+        angle,
+    )
+    .expect("revolve wedge")
+}
+
+fn surface_mix(topo: &Topology, sid: SolidId) -> HashMap<&'static str, usize> {
+    let mut mix: HashMap<&'static str, usize> = HashMap::new();
+    for fid in solid_faces(topo, sid).unwrap() {
+        *mix.entry(topo.face(fid).unwrap().surface().type_tag())
+            .or_default() += 1;
+    }
+    mix
+}
+
+/// Mesh edges not shared by exactly two triangles, after welding coincident
+/// vertices by quantized position — geometric watertightness, not index sharing.
+fn mesh_boundary_edges(positions: &[Point3], indices: &[u32]) -> usize {
+    let q = 1e6;
+    let mut canon: HashMap<(i64, i64, i64), u32> = HashMap::new();
+    let mut remap = vec![0u32; positions.len()];
+    for (i, p) in positions.iter().enumerate() {
+        let key = (
+            (p.x() * q).round() as i64,
+            (p.y() * q).round() as i64,
+            (p.z() * q).round() as i64,
+        );
+        let next = u32::try_from(canon.len()).unwrap();
+        remap[i] = *canon.entry(key).or_insert(next);
+    }
+    let mut edges: HashMap<(u32, u32), u32> = HashMap::new();
+    for tri in indices.chunks_exact(3) {
+        let v = [
+            remap[tri[0] as usize],
+            remap[tri[1] as usize],
+            remap[tri[2] as usize],
+        ];
+        for &(a, b) in &[(v[0], v[1]), (v[1], v[2]), (v[2], v[0])] {
+            *edges
+                .entry(if a < b { (a, b) } else { (b, a) })
+                .or_insert(0) += 1;
+        }
+    }
+    edges.values().filter(|&&c| c != 2).count()
+}
+
+/// `(free, over)` edge uses — a watertight manifold solid reports `(0, 0)`.
+fn edge_uses(topo: &Topology, sid: SolidId) -> (usize, usize) {
+    let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+    for fid in solid_faces(topo, sid).unwrap() {
+        let f = topo.face(fid).unwrap();
+        for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *uses.entry(oe.edge()).or_default() += 1;
+            }
+        }
+    }
+    (
+        uses.values().filter(|&&c| c == 1).count(),
+        uses.values().filter(|&&c| c > 2).count(),
+    )
+}
+
+#[test]
+fn corner_wedge_operands_are_outward_analytic() {
+    // Guard the guard: an unvalidated operand already cost this campaign several
+    // passes. Both wedges must be outward-oriented (positive signed volume) and
+    // carry their two cylindrical corner walls.
+    let mut topo = Topology::new();
+    for (label, sid) in [
+        (
+            "base",
+            wedge(&mut topo, 1.55, 4.75, 2.7, 20.8, 45.0_f64.to_radians()),
+        ),
+        (
+            "strut",
+            wedge(&mut topo, 3.0, 6.0, 8.0, 9.0, 25.0_f64.to_radians()),
+        ),
+    ] {
+        let mix = surface_mix(&topo, sid);
+        assert_eq!(
+            mix.get("cylinder").copied(),
+            Some(2),
+            "{label} should carry 2 cylindrical corner faces, got {mix:?}"
+        );
+        assert_eq!(
+            edge_uses(&topo, sid),
+            (0, 0),
+            "{label} operand must be watertight and manifold"
+        );
+        let signed = brepkit_operations::measure::oriented_solid_volume(&topo, sid, 0.05).unwrap();
+        assert!(
+            signed > 0.0,
+            "{label} operand must be outward-oriented, got signed volume {signed:.3}"
+        );
+    }
+}
+
+#[test]
+fn corner_wedge_cut_stays_analytic() {
+    let mut topo = Topology::new();
+    let base = wedge(&mut topo, 1.55, 4.75, 2.7, 20.8, 45.0_f64.to_radians());
+    let strut = wedge(&mut topo, 3.0, 6.0, 8.0, 9.0, 25.0_f64.to_radians());
+
+    let result = boolean(&mut topo, BooleanOp::Cut, base, strut).expect("coaxial wedge cut");
+
+    let mix = surface_mix(&topo, result);
+    let faces: usize = mix.values().sum();
+
+    // The tell: both operands carry cylinders, so an analytic result keeps some.
+    // All-planar means the mesh fallback ran.
+    assert!(
+        mix.get("cylinder").copied().unwrap_or(0) > 0,
+        "cut must stay analytic and keep cylindrical corner faces, got {faces} faces {mix:?}"
+    );
+    assert_eq!(
+        edge_uses(&topo, result),
+        (0, 0),
+        "cut result must be watertight and manifold, got {faces} faces {mix:?}"
+    );
+
+    // The by-edge-id gate above is blind to POSITION-duplicate free edges, so
+    // confirm watertightness on the welded mesh too.
+    let mesh = brepkit_operations::tessellate::tessellate_solid(&topo, result, 0.01).unwrap();
+    assert_eq!(
+        mesh_boundary_edges(&mesh.positions, &mesh.indices),
+        0,
+        "cut result's mesh must have no boundary edges"
+    );
+
+    // Ground truth by Pappus, since a doubled or dropped face can still pass
+    // every topological gate: the removed lens is the strut's overlap with the
+    // base, r 3.0..4.75 × z 8..9 over the strut's 25°.
+    let base_vol = 45.0_f64.to_radians() * (0.5 * (1.55 + 4.75)) * ((4.75 - 1.55) * (20.8 - 2.7));
+    let cut_vol = 25.0_f64.to_radians() * (0.5 * (3.0 + 4.75)) * ((4.75 - 3.0) * (9.0 - 8.0));
+    let expected = base_vol - cut_vol;
+    let signed = brepkit_operations::measure::oriented_solid_volume(&topo, result, 0.01).unwrap();
+    let rel_err = (signed - expected).abs() / expected;
+    assert!(
+        rel_err < 0.01,
+        "cut result volume should be ~{expected:.3}, got {signed:.3} (rel_err={rel_err:.2e})"
+    );
+}
+
+#[test]
+fn corner_wedge_cut_by_disjoint_strut_keeps_the_base() {
+    // Four of the eight goma bands cut with a strut that does not touch the base
+    // at all (tool0 spans z[-8.3, 2.2] against a base at z[2.7, 20.8]). GFA keeps
+    // all of A's faces, so the result is the base wedge unmodified — which only
+    // holds if the base is outward-oriented in the first place.
+    let mut topo = Topology::new();
+    let base = wedge(&mut topo, 1.55, 4.75, 2.7, 20.8, 45.0_f64.to_radians());
+    let away = wedge(&mut topo, 1.55, 4.75, -8.3, 2.2, 45.0_f64.to_radians());
+
+    let result = boolean(&mut topo, BooleanOp::Cut, base, away).expect("disjoint wedge cut");
+
+    let mix = surface_mix(&topo, result);
+    assert_eq!(
+        mix.get("cylinder").copied(),
+        Some(2),
+        "a disjoint cut must return the base wedge's own faces, got {mix:?}"
+    );
+    assert_eq!(mix.values().sum::<usize>(), 6, "got {mix:?}");
+}

--- a/crates/topology/src/arena.rs
+++ b/crates/topology/src/arena.rs
@@ -94,9 +94,29 @@ impl<T> Arena<T> {
         }
     }
 
-    /// Reserves capacity for at least `additional` more entries.
+    /// Reserves capacity for at least `additional` more entries, growing by at
+    /// most an eighth of the arena.
+    ///
+    /// Neither `Vec` primitive is usable here at CAD scale, for opposite
+    /// reasons. `reserve` rounds up to `max(2 * capacity, len + additional)`, so
+    /// a bulk-insert hint on an arena already holding millions of entries
+    /// requests a full DOUBLING whose reallocation holds the old and new buffers
+    /// at once — invisible on a 64-bit host, fatal on wasm32 (linear memory caps
+    /// at 4GB, and the failed allocation reaches `handle_alloc_error` →
+    /// `abort()`, trapping the instance with no panic message). `reserve_exact`
+    /// removes the spike but leaves `capacity == len`, so the NEXT hint copies
+    /// the whole arena again — O(n²) across the thousands of booleans a large
+    /// export runs.
+    ///
+    /// Growing by `len / 8` keeps growth geometric (so total copying stays
+    /// amortized O(n)) while capping the transient overshoot at 12.5% instead of
+    /// 100%. `Vec::push` past the hint still amortizes on its own.
     pub fn reserve(&mut self, additional: usize) {
-        self.items.reserve(additional);
+        let len = self.items.len();
+        if self.items.capacity() - len >= additional {
+            return;
+        }
+        self.items.reserve_exact(additional.max(len / 8));
     }
 
     /// Allocates a new entry in the arena and returns its typed handle.
@@ -180,6 +200,46 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
+
+    /// A bulk-insert hint on a large arena must not double it.
+    ///
+    /// `Vec::reserve` would round up to `2 * capacity`; on wasm32 that
+    /// reallocation holds both buffers and aborts the instance once the arena
+    /// reaches millions of entries (the goma export died exactly here, on an
+    /// arena of 5.78M edges). The overshoot must stay bounded — but capacity
+    /// must still grow geometrically, or the next hint re-copies everything.
+    #[test]
+    fn reserve_hint_grows_a_large_arena_by_a_bounded_fraction() {
+        let mut arena: Arena<u32> = Arena::new();
+        for i in 0..10_000 {
+            arena.alloc(i);
+        }
+        arena.items.shrink_to_fit();
+        let before = arena.items.capacity();
+
+        arena.reserve(10);
+        let after = arena.items.capacity();
+
+        assert!(after >= before + 10, "hint must satisfy the request");
+        assert!(
+            after < before * 2,
+            "must not double a large arena: {before} -> {after}"
+        );
+        // Geometric, so repeated hints amortize instead of re-copying.
+        assert!(
+            after >= before + before / 8,
+            "growth must stay geometric: {before} -> {after}"
+        );
+
+        // Already-sufficient capacity must not reallocate at all.
+        let settled = arena.items.capacity();
+        arena.reserve(1);
+        assert_eq!(
+            arena.items.capacity(),
+            settled,
+            "no-op when capacity suffices"
+        );
+    }
 
     #[test]
     fn id_from_index_valid() {


### PR DESCRIPTION
## What

The segmented `revolve` path built its faces straight from the profile's traversal order, so a profile wound CCW in the `(radial, axial)` chart — facing *against* the sweep direction `+θ = axis × e_r` — revolved into a consistently wound but globally **inverted** solid. GFA classified its lone shell as a hole and aborted with "no outer shell found", dropping every boolean against it to the mesh fallback.

`try_analytic_full_revolution` already derives each face's material-outward side from the chart shoelace sign. The segmented path now normalizes the **traversal** itself: reverse the oriented edges and negate the cap normal when the shoelace is CCW, leaving a degenerate chart alone.

By Pappus, the swept signed volume carries the chart's signed area, so the shoelace sign is the physically meaningful invariant — the old `is_cw_winding` correction made the *normal* follow the traversal, which is self-consistent but orientation-blind.

## Why it matters

This is the root of the kumiko export-integrity family. Every lattice band is carved from a `revolve` wedge (`cutter = cutAll(cutter, family)`), so every corner cut fell back to the mesh path, four of the eight goma bands reached the export non-watertight (`free=405 over=38` and similar), and the 1x1x6 export took 844s — blowing vitest's timeout and poisoning 14 later kumiko tests on this one root.

## Scope correction

Segmented **full** revolutions were affected too — a profile whose surface is non-planar, so the analytic path declines (`-112.833` for a `+113.1` washer). The earlier "full revolution is correct for both windings" reading only held because analytic profiles never reach the segmented path.

## Verification

Each new test was confirmed to **fail** without the fix, at exactly the inverted volume:

- `revolve::tests::revolve_segmented_is_outward_for_either_winding` — `-143.148` vs `+143.3`
- `revolve::tests::revolve_segmented_full_turn_is_outward_for_either_winding` — `-112.833` vs `+113.1`
- `tests/regress_kumiko_corner_wedge.rs` — reproduces both documented signatures natively (all-planar on the overlapping coaxial cut, `{"plane": 48}` on the disjoint one)

`measure::oriented_solid_volume` is new and public because `solid_volume` returns a magnitude — which is why no existing revolve test could see an inverted shell. The new fixture also asserts welded-mesh watertightness and a Pappus volume, since the by-edge-id manifold gate is blind to position-duplicate free edges.

The captured `kumiko_corner_*.bin` fixtures predate the fix and hold already-inverted wedges, so they can never pass; `captured_operands_are_inward_oriented` pins that and self-reports when a re-capture lands. The cut test stays ignored as a re-capture task, not an open engine bug.

- Workspace suite: 2291 passing, 0 failures (`brepkit-render` needs `XDG_RUNTIME_DIR` set in this sandbox; 5/5 with it)
- `cargo test -p brepkit-wasm --lib gridfinity`: 27/27
- clippy `-D warnings` clean, fmt, `check-boundaries.sh` valid
- Census: all 6 `revolve` rows still `exact analytic`

## Not claimed

Engine-level closure only. The tool-side export-integrity re-probe is **not** done — the baseline to beat is 37 failed / 371 passed, and per the roadmap a fix that looks real can move the scenario numbers zero. No kumiko parity claim until that re-probe runs.

The earlier commits on this branch are the diagnostic instrumentation (`BK_FLUX`, `BK_AREAS`, `BBOX`) and probes that located the root.