### PR TITLE
fix(operations): accept multi-region booleans with rotated or ring pieces

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1221,6 +1221,27 @@ exactly, 13=13, 7=7, 23=23). TOOLING TRAP: `brepkit-render`'s `compute_mesh_lod`
 intermittently — **2 of 4 runs with AND without changes**, a pre-existing flake that aborts
 `cargo test --workspace` early and silently masks every later suite. Use
 `--exclude brepkit-render`, and never conclude a regression from one stashed-vs-restored run.
+**THIRD TERM FIXED AND THE GOMA CASCADE IS GONE — BUT THE MATRIX MOVED ONE TEST. KUMIKO IS STILL 14;
+DO NOT CALL IT CLOSED.** `components_are_disjoint_pieces` now decides nesting by RAY PARITY against
+the enclosing candidate's own tessellation (`component_encloses_point`), with AABB containment
+demoted to a pre-filter — containment is necessary for nesting but not sufficient, because a ring's
+box contains the box of a piece in its HOLE and a lattice is made of rings (that is why 217 of 226
+were still `disjoint=false`). Fixtures pin the truth table: rotated-separate disjoint, nested not
+disjoint, piece-in-a-ring's-hole disjoint. Read-only BY DESIGN — do not use
+`make_solid_from_face_subset` (needs `&mut Topology`, adds temp solids per boolean to the
+never-reclaiming arena, i.e. the #1237 cliff); uses `watertight_ray_triangle_intersect` (one hit per
+shared edge, so parity works across faces) and a √-prime direction (these pieces sit on feature-plane
+intersections where axis-aligned probes graze). goma standalone: **851s control → 2187s → 1123s →
+499s with ZERO GFA rejections**, STL 2,128,934 B. **MATRIX: 63 → 62 failed of 435, kumiko unchanged
+at 14.** The prediction "499s is inside the 600s timeout so the 14 clear" was WRONG — the same trap
+recorded for #1224. WHAT DID CHANGE, and it is large: goma runs **140s inside the matrix** instead of
+timing out, the rest of the kumiko block completes in **1–42s** instead of inheriting a poisoned
+kernel (they now fail on their own merits, not as cascade casualties), and the residual failures are
+small **boundary-edge** counts (5, 8, 12 observed) where goma previously exported **2567**. The count
+barely moves because the assertion is zero-tolerance: 5 boundary edges fails exactly as hard as 2567.
+NEXT: chase the residual handful of boundary edges per kumiko scenario — now isolated, reproducible
+in seconds rather than a 14-minute timeout, and no longer masked by poisoning. Branch
+`fix/gfa-multi-region-acceptance`, PR #1239.
 
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1187,6 +1187,40 @@ NOT readable), a JS ring buffer over `console.log`/`warn`/`error` captures the o
 a large KEEP and capture the chain from its START. **And note every `BK_*` knob (`BK_FLUX`,
 `BK_AREAS`, `BK_OPEN_SHELL`, `BK_FF_TRACE`, …) is NATIVE-ONLY**: `std::env::var` returns `Err` on
 wasm32-unknown-unknown, so passing them to a tool run silently does nothing.
+**GFA IS THE SEED OF THE GOMA CHAIN, NOT THE MESH FALLBACK — AND THE BLOCKER IS THE MULTI-REGION
+ACCEPTANCE GATE (2026-07-26).** Ordering from a complete warn-level log (1069 lines, untruncated):
+first GFA rejection at line 11, first `open growth shell` at 28, first `mesh fallback output is NOT a
+closed 2-manifold` at **65**. So the long-open open-mesh-consumption item AMPLIFIES the cascade but
+does not start it; chase GFA. The rejected results are topologically fine (`validate=None`), so the
+refusal is one term of the acceptance conjunction — and since both gates are conjunctions, the bare
+rejection log says nothing. The `GFA reject detail` debug log added in that PR names the term; use it
+first. TWO TERMS FIXED (branch `fix/gfa-multi-region-acceptance`, goma **2187s → 1123s** and STL
+4,153,484 → 2,725,284 B, i.e. back within 0.35% of the control): (1)
+`components_are_disjoint_pieces` tested AABB OVERLAP, which equals disjointness only for
+axis-aligned pieces — two rotated bars a clear distance apart each span the whole diagonal envelope,
+so a lattice could never be accepted (fixture
+`tests::rotated_separate_pieces_are_recognised_as_disjoint`); now tests containment, since callers
+reach it only after `closed_manifold` + balanced Euler, so pieces are closed and hence disjoint-or-
+nested. (2) `euler_balanced` bounded the surplus at 2, assuming every component is a SPHERE — a
+lattice cut yields RINGS and a closed loop is genus 1 (χ=0), so 13 pieces containing 6 rings give
+χ=14 not 26; the bound is now `2·components` (fixture
+`euler_balance_allows_genus_across_components`). The pre-unify check stays single-component
+deliberately: it only decides whether `unify_faces` runs, and that pass can mangle a legitimate
+N-piece result. **STILL OPEN, and the exact next step: 217 of 226 remaining rejections are
+`disjoint=false`** (measured directly, not inferred) because AABB CONTAINMENT is also wrong for
+rings — a ring's box contains the box of a separate piece sitting in its HOLE. Closing it needs a
+REAL containment test; the read-only pieces exist (`tessellate::face::tessellate_with_uvs` +
+`brepkit_math::ray_triangle::watertight_ray_triangle_intersect`, whose shared-edge guarantee suits
+parity counting), gated behind the cheap AABB pre-filter. Do NOT reach for
+`make_solid_from_face_subset`: it needs `&mut Topology` and would add temp solids per boolean to an
+arena that never reclaims — the cliff fixed in #1237. REFUTED en route, do not re-chase: the Euler
+validator in `validate.rs` (logged as a WARNING only, never gates — "hard-failing would reject ~25%
+of currently working booleans"); absent multi-region acceptance (it exists and covers Cut); and
+phantom components from position-duplicate edges (a position-keyed count matched the edge-id count
+exactly, 13=13, 7=7, 23=23). TOOLING TRAP: `brepkit-render`'s `compute_mesh_lod` SIGSEGVs
+intermittently — **2 of 4 runs with AND without changes**, a pre-existing flake that aborts
+`cargo test --workspace` early and silently masks every later suite. Use
+`--exclude brepkit-render`, and never conclude a regression from one stashed-vs-restored run.
 
 Everything below this line about the odd bands describes behaviour observed on BROKEN INPUT and must
 not be treated as an engine defect: **RETRACTED — the "GFA classifier misjudgement" reading (#1229)

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -520,8 +520,13 @@ pub fn boolean(
                 // deviates from euler==2 solely because of inner wires would
                 // still trigger an unnecessary unify_faces pass.
                 let inner_wire_count_pre = solid_inner_wire_count(topo, result)?;
+                // Deliberately single-component: this only decides whether to
+                // run `unify_faces`, and that pass can mangle a legitimate
+                // N-piece result, so widening the bound here would change which
+                // multi-region results get unified — a separate question from
+                // acceptance, and one the calibrated foils cover.
                 let euler_balanced_pre = euler_pre2 - inner_shell_surplus == 2
-                    || euler_balanced(euler_pre2 - inner_shell_surplus, inner_wire_count_pre);
+                    || euler_balanced(euler_pre2 - inner_shell_surplus, inner_wire_count_pre, 1);
 
                 // Run unify_faces if the (hole-aware) Euler is off OR if the
                 // topology has 3+-face junctions, which can occur with a
@@ -622,7 +627,7 @@ pub fn boolean(
                 let euler_eff = euler - inner_shell_surplus;
                 let euler_ok = hollow_ok
                     && (euler_eff == 2
-                        || (euler_balanced(euler_eff, inner_wire_count) && closed_manifold));
+                        || (euler_balanced(euler_eff, inner_wire_count, 1) && closed_manifold));
                 if euler_ok && open_shell_ok && validate_boolean_result(topo, result).is_ok() {
                     log::info!(
                         "GFA boolean succeeded in {:.1}ms ({result_faces} faces)",
@@ -709,7 +714,7 @@ pub fn boolean(
                 // legitimately yields N disjoint chunks.
                 if matches!(op, BooleanOp::Cut | BooleanOp::Fuse | BooleanOp::Intersect)
                     && components >= 2
-                    && euler_corrected == expected_euler
+                    && euler_balanced(euler, inner_wire_count, i64::try_from(components).unwrap_or(i64::MAX))
                     && components_are_disjoint_pieces(topo, &components_vec)
                     && cut_safe
                     && intersect_safe
@@ -725,6 +730,20 @@ pub fn boolean(
                     );
                     return Ok(result);
                 }
+                // Which gate refused? Both acceptance paths are conjunctions,
+                // so the bare rejection below says nothing about the cause —
+                // and when `validate` is None the result is topologically fine
+                // and something else declined it.
+                log::debug!(
+                    "GFA reject detail {op:?}: euler={euler} euler_eff={euler_eff} \
+                     inner_wires={inner_wire_count} inner_shell_surplus={inner_shell_surplus} \
+                     euler_ok={euler_ok} open_shell_ok={open_shell_ok} \
+                     closed_manifold={closed_manifold} components={components} \
+                     expected_euler={expected_euler} euler_corrected={euler_corrected} \
+                     cut_safe={cut_safe} intersect_safe={intersect_safe} \
+                     disjoint={}",
+                    components_are_disjoint_pieces(topo, &components_vec)
+                );
             }
             log::warn!(
                 "GFA result not accepted in {:.1}ms (faces={result_faces}, \
@@ -2567,15 +2586,36 @@ fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -
         })
         .collect();
 
+    // Reject NESTING, not mere AABB overlap.
+    //
+    // Callers reach here only for a result that already passed
+    // `closed_manifold` with Euler == 2 * components, so every component is a
+    // closed manifold piece — and two closed pieces of one shell are either
+    // disjoint or nested. Nesting is the hazard worth rejecting (a blob sitting
+    // inside another piece's cavity is not a disjoint union); side-by-side
+    // pieces are exactly what multi-region acceptance is for.
+    //
+    // Overlap is the wrong predicate for that, because an AABB is only tight on
+    // axis-aligned geometry. Two ROTATED bars a clear distance apart each span
+    // the whole diagonal envelope, so their boxes interpenetrate and an
+    // overlap test calls them touching — which is why a kumiko lattice cut,
+    // whose members are diagonal, could never be accepted and fell back to the
+    // mesh path on every band (see
+    // `tests::disjointness_test_is_fooled_by_rotated_pieces`). Containment is
+    // tight in the direction that matters: nesting implies it, and rotation
+    // does not manufacture it.
     let eps = 1e-7;
+    let contains = |(o_min, o_max): (Point3, Point3), (i_min, i_max): (Point3, Point3)| {
+        o_min.x() - eps <= i_min.x()
+            && o_min.y() - eps <= i_min.y()
+            && o_min.z() - eps <= i_min.z()
+            && o_max.x() + eps >= i_max.x()
+            && o_max.y() + eps >= i_max.y()
+            && o_max.z() + eps >= i_max.z()
+    };
     for i in 0..aabbs.len() {
         for j in (i + 1)..aabbs.len() {
-            let (i_min, i_max) = aabbs[i];
-            let (j_min, j_max) = aabbs[j];
-            let x_overlap = i_min.x().max(j_min.x()) + eps < i_max.x().min(j_max.x());
-            let y_overlap = i_min.y().max(j_min.y()) + eps < i_max.y().min(j_max.y());
-            let z_overlap = i_min.z().max(j_min.z()) + eps < i_max.z().min(j_max.z());
-            if x_overlap && y_overlap && z_overlap {
+            if contains(aabbs[i], aabbs[j]) || contains(aabbs[j], aabbs[i]) {
                 return false;
             }
         }
@@ -2753,18 +2793,25 @@ fn solid_inner_wire_count(topo: &Topology, solid: SolidId) -> Result<i64, crate:
     Ok(count)
 }
 
-/// Genus-aware Euler balance for a closed orientable surface with holed faces.
+/// Genus-aware Euler balance for `components` closed orientable surfaces with
+/// holed faces.
 ///
-/// Euler-Poincare for a closed surface of genus `g`: `V - E + F - L = 2(1 - g)`,
-/// so the inner-wire surplus `euler - L` equals `2 - 2g` and is valid when it
-/// is an even number no greater than 2: `2` for genus 0, `0` for genus 1, and
-/// negative even values for genus >= 2 (e.g. a thin wall pierced by N
-/// through-holes has genus N). Odd or > 2 surpluses indicate a miscounted
-/// shell. Callers must pair this with a closed-manifold check — the relation
-/// only holds for closed surfaces.
-const fn euler_balanced(euler: i64, inner_wires: i64) -> bool {
+/// Euler-Poincare over `C` closed components of total genus `G`:
+/// `V - E + F - L = 2C - 2G`, so the inner-wire surplus `euler - L` is valid
+/// when it is even and no greater than `2C` — `2C` for all-genus-0 pieces, less
+/// by two per unit of genus (a thin wall pierced by N through-holes has genus
+/// N). Odd or `> 2C` surpluses indicate a miscounted shell.
+///
+/// The `2C` bound matters as much as the parity: a multi-region result is not
+/// obliged to be a bag of spheres. A kumiko lattice cut yields RINGS, and a
+/// closed loop of material is genus 1 (`chi = 0`), so demanding `euler == 2C`
+/// exactly rejected every lattice result and forced it onto the mesh path.
+///
+/// Callers must pair this with a closed-manifold check — the relation only holds
+/// for closed surfaces.
+const fn euler_balanced(euler: i64, inner_wires: i64, components: i64) -> bool {
     let surplus = euler - inner_wires;
-    surplus <= 2 && surplus % 2 == 0
+    surplus <= 2 * components && surplus % 2 == 0
 }
 
 /// Count edge uses across ALL shells of a solid (outer + inner cavity

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -745,7 +745,9 @@ pub fn boolean(
                         i64::try_from(components).unwrap_or(i64::MAX)
                     ),
                     euler - inner_wire_count,
-                    2 * i64::try_from(components).unwrap_or(i64::MAX / 2),
+                    i64::try_from(components)
+                        .unwrap_or(i64::MAX)
+                        .saturating_mul(2),
                     components_are_disjoint_pieces(topo, &components_vec)
                 );
             }
@@ -2654,12 +2656,18 @@ fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -
 
     // Reject NESTING, not mere AABB overlap.
     //
-    // Callers reach here only for a result that already passed
-    // `closed_manifold` with Euler == 2 * components, so every component is a
-    // closed manifold piece — and two closed pieces of one shell are either
-    // disjoint or nested. Nesting is the hazard worth rejecting (a blob sitting
-    // inside another piece's cavity is not a disjoint union); side-by-side
-    // pieces are exactly what multi-region acceptance is for.
+    // Nesting is the hazard worth rejecting (a blob sitting inside another
+    // piece's cavity is not a disjoint union); side-by-side pieces are exactly
+    // what multi-region acceptance is for.
+    //
+    // Assume nothing about the components handed in. The acceptance gate calls
+    // this on a GFA result that has cleared only `euler_balanced` — which is
+    // genus-tolerant, and whose `closed_manifold` companion is a LATER conjunct
+    // in the same `&&` chain, not a precondition. The input-splitting paths
+    // call it on components of a raw operand no gate has examined at all. So
+    // "every piece is a closed manifold, hence disjoint-or-nested" is not
+    // available here; the ray-parity confirmation below earns the answer
+    // instead of inferring it.
     //
     // Overlap is the wrong predicate for that, because an AABB is only tight on
     // axis-aligned geometry. Two ROTATED bars a clear distance apart each span
@@ -2667,8 +2675,8 @@ fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -
     // overlap test calls them touching — which is why a kumiko lattice cut,
     // whose members are diagonal, could never be accepted and fell back to the
     // mesh path on every band (see
-    // `tests::disjointness_test_is_fooled_by_rotated_pieces`). Containment is
-    // tight in the direction that matters: nesting implies it, and rotation
+    // `tests::rotated_separate_pieces_are_recognised_as_disjoint`). Containment
+    // is tight in the direction that matters: nesting implies it, and rotation
     // does not manufacture it.
     let eps = 1e-7;
     let contains = |(o_min, o_max): (Point3, Point3), (i_min, i_max): (Point3, Point3)| {
@@ -2901,7 +2909,7 @@ fn solid_inner_wire_count(topo: &Topology, solid: SolidId) -> Result<i64, crate:
 /// for closed surfaces.
 const fn euler_balanced(euler: i64, inner_wires: i64, components: i64) -> bool {
     let surplus = euler - inner_wires;
-    surplus <= 2 * components && surplus % 2 == 0
+    surplus <= components.saturating_mul(2) && surplus % 2 == 0
 }
 
 /// Count edge uses across ALL shells of a solid (outer + inner cavity

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -655,13 +655,11 @@ pub fn boolean(
                 // a piece carrying a blind pocket (a face with an inner wire)
                 // shifts raw Euler away from 2*N even at genus 0, so comparing
                 // raw Euler here rejected every pocketed piece. This mirrors the
-                // `euler_balanced(euler_eff, inner_wire_count)` correction the
-                // single-component gate above applies.
+                // `euler_balanced` correction the single-component gate above
+                // applies — which is why the bound below is `2 * components`
+                // rather than an equality against it.
                 let components_vec = crate::boolean::assembly::face_components(topo, result);
                 let components = components_vec.len();
-                #[allow(clippy::cast_possible_wrap)]
-                let expected_euler = (components as i64) * 2;
-                let euler_corrected = euler - inner_wire_count;
                 // For Cut, also verify no component is a "B-interior piece" —
                 // GFA can produce N closed manifolds where one of them is the
                 // tool's interior (sphere - cylinder example: 3 pieces =
@@ -739,9 +737,15 @@ pub fn boolean(
                      inner_wires={inner_wire_count} inner_shell_surplus={inner_shell_surplus} \
                      euler_ok={euler_ok} open_shell_ok={open_shell_ok} \
                      closed_manifold={closed_manifold} components={components} \
-                     expected_euler={expected_euler} euler_corrected={euler_corrected} \
                      cut_safe={cut_safe} intersect_safe={intersect_safe} \
-                     disjoint={}",
+                     euler_multi_ok={} surplus={} bound={} disjoint={}",
+                    euler_balanced(
+                        euler,
+                        inner_wire_count,
+                        i64::try_from(components).unwrap_or(i64::MAX)
+                    ),
+                    euler - inner_wire_count,
+                    2 * i64::try_from(components).unwrap_or(i64::MAX / 2),
                     components_are_disjoint_pieces(topo, &components_vec)
                 );
             }

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -2544,6 +2544,68 @@ fn component_aabb_centre(topo: &Topology, comp: &[FaceId]) -> Option<Point3> {
     ))
 }
 
+/// Does the closed surface made of `faces` enclose `p`?
+///
+/// Ray-parity against the component's own tessellation. Read-only by design:
+/// building a temporary solid per component would add entities to an arena that
+/// never reclaims, which is the growth cliff fixed in #1237.
+///
+/// `watertight_ray_triangle_intersect` reports exactly one hit on a shared edge,
+/// so parity is meaningful across face boundaries. The direction is deliberately
+/// irrational so the ray does not graze a face boundary or lie in a face plane —
+/// the degeneracy that makes axis-aligned probes unreliable on the feature-plane
+/// intersections these pieces are full of. Returns `None` when the component
+/// cannot be tessellated, so callers can fall back rather than guess.
+fn component_encloses_point(
+    topo: &Topology,
+    faces: &[FaceId],
+    p: Point3,
+    deflection: f64,
+) -> Option<bool> {
+    // A sqrt-prime direction: irrational in every component, so the ray cannot
+    // lie in a face plane or run along an edge — the same generic-direction
+    // escape the ray-cast classifier uses for degenerate probes.
+    let dir = Vec3::new(2.0_f64.sqrt(), 3.0_f64.sqrt(), 5.0_f64.sqrt())
+        .normalize()
+        .ok()?;
+    let mut crossings = 0usize;
+    let mut any_triangle = false;
+    for &fid in faces {
+        let mesh = crate::tessellate::tessellate_with_uvs(topo, fid, deflection).ok()?;
+        let pos = &mesh.mesh.positions;
+        for tri in mesh.mesh.indices.chunks_exact(3) {
+            let (a, b, c) = (
+                pos[tri[0] as usize],
+                pos[tri[1] as usize],
+                pos[tri[2] as usize],
+            );
+            any_triangle = true;
+            if let Some(hit) =
+                brepkit_math::ray_triangle::watertight_ray_triangle_intersect(p, dir, a, b, c)
+                && hit.t > 1e-9
+            {
+                crossings += 1;
+            }
+        }
+    }
+    any_triangle.then_some(crossings % 2 == 1)
+}
+
+/// Any vertex position on `faces`, for use as a probe point.
+fn any_vertex_of(topo: &Topology, faces: &[FaceId]) -> Option<Point3> {
+    for &fid in faces {
+        let face = topo.face(fid).ok()?;
+        let wire = topo.wire(face.outer_wire()).ok()?;
+        if let Some(oe) = wire.edges().first()
+            && let Ok(edge) = topo.edge(oe.edge())
+            && let Ok(v) = topo.vertex(edge.start())
+        {
+            return Some(v.point());
+        }
+    }
+    None
+}
+
 fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -> bool {
     let aabbs: Vec<(Point3, Point3)> = components
         .iter()
@@ -2613,10 +2675,34 @@ fn components_are_disjoint_pieces(topo: &Topology, components: &[Vec<FaceId>]) -
             && o_max.y() + eps >= i_max.y()
             && o_max.z() + eps >= i_max.z()
     };
+    // AABB containment is only the PRE-FILTER. It is necessary for nesting but
+    // far from sufficient: a ring's box contains the box of a separate piece
+    // sitting in its HOLE, and a lattice is full of rings. So a suspect pair
+    // gets a real ray-parity test against the enclosing candidate's own surface,
+    // and only genuine enclosure rejects. If the probe cannot be evaluated the
+    // pair falls back to the conservative answer.
     for i in 0..aabbs.len() {
         for j in (i + 1)..aabbs.len() {
-            if contains(aabbs[i], aabbs[j]) || contains(aabbs[j], aabbs[i]) {
+            let (outer, inner) = if contains(aabbs[i], aabbs[j]) {
+                (i, j)
+            } else if contains(aabbs[j], aabbs[i]) {
+                (j, i)
+            } else {
+                continue;
+            };
+            let (o_min, o_max) = aabbs[outer];
+            let diag = ((o_max.x() - o_min.x()).powi(2)
+                + (o_max.y() - o_min.y()).powi(2)
+                + (o_max.z() - o_min.z()).powi(2))
+            .sqrt();
+            let deflection = (diag / 200.0).max(1e-4);
+            let Some(probe) = any_vertex_of(topo, &components[inner]) else {
                 return false;
+            };
+            match component_encloses_point(topo, &components[outer], probe, deflection) {
+                Some(true) => return false,
+                Some(false) => {}
+                None => return false,
             }
         }
     }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -6537,3 +6537,132 @@ fn diag_tangency_count() {
         eprintln!("{label}: {msg}");
     }
 }
+
+/// Rotated-but-separate pieces must be recognised as disjoint.
+///
+/// `components_are_disjoint_pieces` gates the multi-region acceptance. It used
+/// to decide disjointness by testing whether component AABBs OVERLAP, which is
+/// equivalent to disjointness only for axis-aligned pieces: two rotated bars a
+/// clear distance apart each span the whole diagonal envelope, so their boxes
+/// interpenetrate and the test called them touching.
+///
+/// That single term is why a kumiko lattice cut — whose members are diagonal —
+/// could never be accepted, and fell back to the mesh path on every band. Every
+/// other term of the conjunction was satisfied on the goma rejections
+/// (`closed_manifold=true`, `components=4`, `euler_corrected == expected_euler
+/// == 8`, `cut_safe`, `intersect_safe`, validation Ok).
+#[test]
+fn rotated_separate_pieces_are_recognised_as_disjoint() {
+    use brepkit_math::mat::Mat4;
+    use brepkit_topology::explorer::solid_faces;
+
+    let mut topo = Topology::new();
+    let diag = std::f64::consts::FRAC_PI_4;
+    // 4 units of separation measured PERPENDICULAR to the bars' 45° axis.
+    // Offsetting along the axis instead would leave them collinear.
+    let perp = 4.0 / 2.0_f64.sqrt();
+
+    let bar_a = crate::primitives::make_box(&mut topo, 20.0, 1.0, 1.0).unwrap();
+    crate::transform::transform_solid(&mut topo, bar_a, &Mat4::rotation_z(diag)).unwrap();
+
+    let bar_b = crate::primitives::make_box(&mut topo, 20.0, 1.0, 1.0).unwrap();
+    crate::transform::transform_solid(
+        &mut topo,
+        bar_b,
+        &(Mat4::translation(-perp, perp, 0.0) * Mat4::rotation_z(diag)),
+    )
+    .unwrap();
+
+    let comps: Vec<Vec<FaceId>> = [bar_a, bar_b]
+        .iter()
+        .map(|&s| solid_faces(&topo, s).unwrap())
+        .collect();
+
+    // The bars are genuinely separate: neither one's centre lies in the other.
+    for (probe_of, against) in [(bar_a, bar_b), (bar_b, bar_a)] {
+        let bb = crate::measure::solid_bounding_box(&topo, probe_of).unwrap();
+        let centre = Point3::new(
+            (bb.min.x() + bb.max.x()) * 0.5,
+            (bb.min.y() + bb.max.y()) * 0.5,
+            (bb.min.z() + bb.max.z()) * 0.5,
+        );
+        assert_eq!(
+            crate::classify::classify_point(&topo, against, centre, 0.05, 1e-6).unwrap(),
+            crate::classify::PointClassification::Outside,
+            "bars must be disjoint for this test to mean anything"
+        );
+    }
+
+    // ...yet their AABBs overlap on every axis, which is all the gate looks at.
+    let (a_bb, b_bb) = (
+        crate::measure::solid_bounding_box(&topo, bar_a).unwrap(),
+        crate::measure::solid_bounding_box(&topo, bar_b).unwrap(),
+    );
+    assert!(
+        a_bb.min.x().max(b_bb.min.x()) < a_bb.max.x().min(b_bb.max.x())
+            && a_bb.min.y().max(b_bb.min.y()) < a_bb.max.y().min(b_bb.max.y())
+            && a_bb.min.z().max(b_bb.min.z()) < a_bb.max.z().min(b_bb.max.z()),
+        "the AABBs must overlap for this test to exercise the defect"
+    );
+
+    assert!(
+        super::components_are_disjoint_pieces(&topo, &comps),
+        "rotated-but-separate pieces must be accepted as disjoint despite overlapping AABBs"
+    );
+}
+
+/// A nested piece must still be refused as a "disjoint union".
+///
+/// This is the hazard the guard exists for and the reason it is not simply
+/// deleted: a small solid sitting inside another piece's cavity is not a
+/// multi-region result, and accepting it would let a void be kept as material.
+/// Nesting implies AABB containment, so the containment test still catches it
+/// while letting side-by-side rotated pieces through.
+#[test]
+fn nested_pieces_are_not_disjoint() {
+    use brepkit_math::mat::Mat4;
+    use brepkit_topology::explorer::solid_faces;
+
+    let mut topo = Topology::new();
+    let outer = crate::primitives::make_box(&mut topo, 20.0, 20.0, 20.0).unwrap();
+    let inner = crate::primitives::make_box(&mut topo, 2.0, 2.0, 2.0).unwrap();
+    crate::transform::transform_solid(&mut topo, inner, &Mat4::translation(9.0, 9.0, 9.0)).unwrap();
+
+    let comps: Vec<Vec<FaceId>> = [outer, inner]
+        .iter()
+        .map(|&s| solid_faces(&topo, s).unwrap())
+        .collect();
+
+    assert!(
+        !super::components_are_disjoint_pieces(&topo, &comps),
+        "a piece nested inside another must not count as a disjoint union"
+    );
+}
+
+/// Multi-region Euler acceptance must tolerate genus per piece.
+///
+/// `euler_balanced` used to compare against a fixed bound of 2, i.e. it assumed
+/// every component was a sphere. A kumiko lattice cut yields RINGS — a closed
+/// loop of material is genus 1, chi = 0 — so a 13-piece result containing 6
+/// rings has chi = 2*7 = 14, not 2*13 = 26, and the gate rejected it. Those are
+/// the exact numbers observed on the goma rejections (components=13 with
+/// euler_corrected=14; also 7/8, 14/16, 23/34).
+#[test]
+fn euler_balance_allows_genus_across_components() {
+    // All spheres: chi == 2C is the upper bound and must pass.
+    assert!(super::euler_balanced(26, 0, 13));
+    // 6 of the 13 pieces are rings (genus 1): the real goma signature.
+    assert!(super::euler_balanced(14, 0, 13));
+    assert!(super::euler_balanced(8, 0, 7));
+    assert!(super::euler_balanced(34, 0, 23));
+    // Single component keeps its old meaning exactly.
+    assert!(super::euler_balanced(2, 0, 1));
+    assert!(super::euler_balanced(0, 0, 1));
+    // Still rejected: above 2C (more pieces than components can account for)
+    // and odd surpluses (a miscounted shell).
+    assert!(!super::euler_balanced(28, 0, 13));
+    assert!(!super::euler_balanced(13, 0, 13));
+    assert!(!super::euler_balanced(4, 0, 1));
+    // Inner wires are subtracted before the bound applies.
+    assert!(super::euler_balanced(20, 6, 7));
+}

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -6666,3 +6666,50 @@ fn euler_balance_allows_genus_across_components() {
     // Inner wires are subtracted before the bound applies.
     assert!(super::euler_balanced(20, 6, 7));
 }
+
+/// A piece sitting in a RING's hole is disjoint, not nested.
+///
+/// This is the case AABB containment alone cannot answer, and the reason the
+/// containment pre-filter is backed by a real ray-parity test. A torus's
+/// bounding box contains the box of anything in its hole, but the hole is void:
+/// the two are separate solids. Lattices are made of rings, so getting this
+/// wrong rejected every lattice result (217 of 226 goma rejections were
+/// `disjoint=false`).
+#[test]
+fn a_piece_in_a_rings_hole_is_disjoint() {
+    use brepkit_math::mat::Mat4;
+    use brepkit_topology::explorer::solid_faces;
+
+    let mut topo = Topology::new();
+    let ring = crate::primitives::make_torus(&mut topo, 10.0, 2.0, 48).unwrap();
+    let plug = crate::primitives::make_box(&mut topo, 1.0, 1.0, 1.0).unwrap();
+    // Centre the plug in the ring's hole.
+    crate::transform::transform_solid(&mut topo, plug, &Mat4::translation(-0.5, -0.5, -0.5))
+        .unwrap();
+
+    let (ring_bb, plug_bb) = (
+        crate::measure::solid_bounding_box(&topo, ring).unwrap(),
+        crate::measure::solid_bounding_box(&topo, plug).unwrap(),
+    );
+    // Precondition: the ring's AABB really does contain the plug's, so the
+    // pre-filter fires and the real test is what decides.
+    assert!(
+        ring_bb.min.x() <= plug_bb.min.x()
+            && ring_bb.min.y() <= plug_bb.min.y()
+            && ring_bb.min.z() <= plug_bb.min.z()
+            && ring_bb.max.x() >= plug_bb.max.x()
+            && ring_bb.max.y() >= plug_bb.max.y()
+            && ring_bb.max.z() >= plug_bb.max.z(),
+        "the ring's AABB must contain the plug's for this test to exercise the pre-filter"
+    );
+
+    let comps: Vec<Vec<FaceId>> = [ring, plug]
+        .iter()
+        .map(|&s| solid_faces(&topo, s).unwrap())
+        .collect();
+
+    assert!(
+        super::components_are_disjoint_pieces(&topo, &comps),
+        "a plug in the ring's hole is not enclosed by the ring's material"
+    );
+}


### PR DESCRIPTION
## What

Three terms of GFA's multi-region acceptance gate rejected results that are topologically sound, forcing every kumiko lattice cut onto the mesh fallback and cascading from there.

**1. `components_are_disjoint_pieces` tested AABB *overlap*.** That equals disjointness only for axis-aligned pieces: two rotated bars a clear distance apart each span the whole diagonal envelope, so their boxes interpenetrate and the test reported contact. A lattice is diagonal by construction, so it could never be accepted.

**2. `euler_balanced` bounded the inner-wire surplus at 2**, i.e. it assumed every component was a sphere. A lattice cut yields **rings**, and a closed loop of material is genus 1 (`chi = 0`), so a 13-piece result containing 6 rings has `chi = 14`, not `2 * 13 = 26`. The bound is now a saturating `2 * components`, generalizing the relation the single-component path already applied.

**3. AABB *containment* was wrong too — for rings.** Swapping overlap for containment still left **217 of 226** remaining rejections at `disjoint=false` (measured directly, not inferred), because a ring's box contains the box of a separate piece sitting in its **hole**, and a lattice is made of rings. Containment is now only the cheap pre-filter; a suspect pair gets a real **ray-parity** test against the enclosing candidate's own tessellation (`component_encloses_point`), and only genuine enclosure rejects. Read-only by design: it uses `watertight_ray_triangle_intersect` (one hit per shared edge, so parity holds across faces) and a √-prime probe direction, since these pieces sit on feature-plane intersections where axis-aligned probes graze. If the probe cannot be evaluated, the pair falls back to the conservative answer.

Deliberately **not** `make_solid_from_face_subset`: it needs `&mut Topology` and would add temp solids per boolean to an arena that never reclaims — the cliff fixed in #1237.

The pre-unify check deliberately stays single-component: it only decides whether `unify_faces` runs, and that pass can mangle a legitimate N-piece result.

## Measured

gridfinity goma 1x1x6 export, overlay md5-verified in both `node_modules` locations:

| | wall-clock | STL bytes |
|---|---|---|
| control (no engine fixes) | 851s | 2,715,884 |
| before | 2187s | 4,153,484 |
| terms 1 + 2 | 1123s | 2,725,284 |
| **after (all three)** | **499s** | **2,128,934** |

The final run has **zero GFA rejections** — the dense mesh-fallback tessellation is gone, not merely reduced.

## Scope — what this does not close

**The kumiko matrix block is still 14 failures; the matrix total moves 63 → 62 of 435.** The prediction "499s is inside the 600s timeout, so the 14 clear" was **wrong** — the same trap recorded for #1224.

What did change is large, but it is about isolation rather than count: goma now runs **140s inside the matrix** instead of timing out, and the rest of the kumiko block completes in **1–42s** instead of inheriting a poisoned kernel, so those scenarios now fail on their own merits rather than as cascade casualties. The residual failures are small **boundary-edge** counts (5, 8, 12 observed) where goma previously exported **2567**. The count barely moves because the assertion is zero-tolerance: 5 boundary edges fails exactly as hard as 2567.

Next step is the residual handful of boundary edges per scenario — now reproducible in seconds instead of behind a 14-minute timeout, and no longer masked by poisoning.

## How these were found

The chain's ordering settles which end is the root. From a complete warn-level log (1069 lines, verified untruncated): first GFA rejection at line 11, first `open growth shell` at 28, first `mesh fallback output is NOT a closed 2-manifold` at **65**. So the long-open open-mesh-consumption item amplifies the cascade but does not seed it.

Both acceptance paths are conjunctions, so the bare rejection log says nothing about the cause — and `validate=None` showed the results were topologically fine. This PR adds a `GFA reject detail` debug log naming every term, which is what located all three defects. It reports the predicate's own result alongside the inputs that explain it (`euler_multi_ok`, `surplus`, and the same saturated bound the predicate itself uses), so the instrument cannot drift from the thing it measures.

## Refuted en route (recorded so they are not re-chased)

- The Euler validator in `validate.rs` — logged as a **warning only**, never gates ("hard-failing here would reject ~25% of currently working booleans").
- Missing multi-region acceptance — it exists, and covers `Cut`.
- Phantom components from position-duplicate edges — a position-keyed count matched the edge-id count exactly (13=13, 7=7, 23=23).

## Verification

- Workspace **2652 tests green across 104 suites**, clippy `-D warnings` clean, fmt, boundaries; CI green on the head commit
- Three fixtures pin the truth table: rotated-separate **disjoint**, nested **not** disjoint, piece-in-a-ring's-hole **disjoint**; plus a genus table matching the observed goma signatures
- `brepkit-render` excluded: its `compute_mesh_lod` SIGSEGVs intermittently — **2 of 4 runs both with and without these changes**, a pre-existing flake that aborts `--workspace` early and masks later suites

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GFA multi-region acceptance for rotated and ring-shaped pieces, removing false rejections and mesh fallback in kumiko lattices. On gridfinity goma 1x1x6, export time drops 2187s → 499s and STL shrinks to 2,128,934 B, with zero GFA rejections; the matrix now completes (62/435 failing; kumiko still 14).

- **Bug Fixes**
  - Disjointness: `components_are_disjoint_pieces` now prefilters with AABB containment and confirms nesting by ray parity against tessellated surfaces; rotated side-by-side pieces pass, nested pieces still fail, and a piece in a ring’s hole is accepted as disjoint (also corrects preconditions — callers may pass raw operands; falls back conservatively if tessellation fails).
  - Euler balance: `euler_balanced` now bounds the inner-wire surplus by a saturated `2 * components`; callers pass the component count for the final gate (the pre-unify check stays single-component).
  - Diagnostics/tests: added a "GFA reject detail" debug log that reports the Euler predicate result, surplus, and the same saturated bound used by the predicate; fixtures cover rotated disjoint, nested non-disjoint, and ring-hole disjoint scenarios.

<sup>Written for commit 48647199216270edde437f6fcbd53350341a6d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


