### PR TITLE
test(algo): probes and findings for the lattice open growth shell

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -268,6 +268,44 @@ sample** — both can land outside the lump, and here they disagree on two pairs
 points taken adjacent to an actual face and offset along its normal mean anything. So the standing,
 supported finding is the narrow one: no face belongs at the quad, hence the faces owning those four
 free edges are what needs explaining. Whether the lump as a whole is spurious is OPEN.
+**NEXT: chase SHELL CONNECTIVITY, not a drop-it discriminator.** The earlier proposal — drop a
+growth shell whose interior looks internal — is retargeted: the faces are legitimate, so dropping is
+never right here. The question is why the shell walker emits this set as a SEPARATE shell instead of
+joining it across the quad region. Useful context if that work needs the operands: they are NOT in
+scope at assembly (`build_solid`/`build_solid_with_origins` take only `selected: &[SelectedFace]`
+plus cap planes, and `SelectedFace` carries `face_id`, `source_face`, `reversed` — no operand tag),
+and `brepkit-algo` cannot call `operations::classify_point` under the layer rules.
+
+**SYSTEMATIC BUT PAIR-SPECIFIC.** Within op29's tool merges, `1+2` (67 faces), `2+3` (33) and `3+4`
+(65) all abort while `1+3` and `1+4` fuse clean (F=872 / F=1024, free=0). So it is neither a one-off
+nor universal — it depends on the pair.
+**RESOLVED: every lump face is a LEGITIMATE union boundary; the lump is real material that failed
+to CONNECT.** Sampling per face either side along its own normal, with the sample taken at the face
+INTERIOR (vertex centroid of the outer wire), over 24 faces of the `1+2` lump:
+
+| side | reading | count |
+|---|---|---|
+| minus | Inside A or Inside B | **24 of 24** |
+| plus | Outside / Outside | 23 of 24 |
+
+Material behind every face, empty in front — that is exactly what a union boundary face looks like.
+Combined with the quad result (material on BOTH sides there, so no cap belongs), the coherent
+picture is: **the lump is a genuine piece of the union whose faces are correct, and the failure is
+that the shell walker put it in a SEPARATE shell instead of connecting it** to the neighbouring
+faces across the quad region. Not a missing face, not a spurious selection, not an under-partition.
+So the assembly guard is RIGHT to refuse to drop it, and a "drop it when it looks internal"
+discriminator would have been the wrong fix — chase shell connectivity instead.
+
+**RETRACTED, with the method lesson.** An earlier pass reported "8 of 24 faces bound empty space on
+both sides, stable across offsets 0.02/0.05/0.15" and built a per-face-discriminator plan on it.
+That was an artifact of sampling the midpoint of the face's first boundary EDGE: at a convex edge,
+offsetting perpendicular to the face exits the material on BOTH sides, so perfectly good faces read
+as bounding nothing. Offset-stability did not save it (the artifact is offset-independent), and
+neither did deflection-stability (identical verdicts at 0.01/0.002/0.0005) — both looked like
+robustness and were measuring the same wrong point. **When classifying which side of a face carries
+material, sample the face INTERIOR; an edge or vertex point is never valid.** The same rule already
+appears here for notched sub-face seeds; this is the classification-probe form of it.
+
 PROPOSED DISCRIMINATOR: a growth shell whose INTERIOR classifies inside one of the operands is not
 new boundary and can be dropped; the fused-foot lump was genuinely outside both.
 

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -239,13 +239,27 @@ plane), so it can only be a trimmed piece of an INPUT face; a boolean emits noth
 uncovered 0.000000. Scanning ALL source faces, only one fails to tile and by 8e-6, i.e. fan-
 triangulation noise. So every source face is fully covered and the quad is not a missing piece of
 any of them.
-So both natural readings are now dead: the sections are not lost at FF (refuted #1) and the faces
-are not under-partitioned (refuted #2). THE REMAINING HYPOTHESIS, and the one to test next: the
-67-face lump may be a SPURIOUS selection rather than a real chunk missing its cap — the guard exists
-because dropping a real lump deletes material, but if this lump should not have been selected at all
-then its openness is a symptom. Test by classifying interior points of the lump's faces against both
-operands with the independent `classify_point` oracle: if the lump is genuinely outside the union,
-the defect is in selection, not in face creation.
+**AND THE "MISSING FACE" FRAMING IS ITSELF OVERTURNED (refuted #3, the important one).** Classifying
+either side of the quad with the independent operations oracle (`POINT_IN` on `replay_pair`, now
+wired; instrument verified — a far-away point reads Outside/Outside):
+
+| point | vs A | vs B |
+|---|---|---|
+| quad + normal | **Inside** | Outside |
+| quad − normal | **Inside** | Inside |
+| lump interior (36.257,-40.550,30.530) | **Inside** | Outside |
+
+Both sides of the quad are INSIDE the union, so **no face belongs there at all** — one would be an
+internal membrane. And the lump's own interior is inside operand A, i.e. the 67 faces enclose
+material A already accounts for. So this was never a missing face: **the lump is an internal
+artifact and dropping it is the CORRECT outcome.** The `>= 4 faces` fail-safe is misfiring — it
+exists because dropping a real lump silently deletes material (the lite fused-foot: 72 faces,
+~2700 units^3), and it cannot currently tell that case from this one.
+PROPOSED DISCRIMINATOR, to try next and measure against the foils: a growth shell whose INTERIOR
+classifies inside one of the operands is not new boundary and can be dropped; the fused-foot lump
+was genuinely outside both. Note `brepkit-algo` cannot call `operations::classify_point` (layer
+rules) and must use its own `classifier/ray_cast.rs`, and that an OPEN shell cannot be classified
+reliably — classify against the closed OPERANDS, as the measurements above do.
 CAUTION on `BK_SUBFACE_BOX`: it tests face VERTICES against the box, so a face whose corners sit
 outside will not register; do not conclude a face is absent from that probe alone (the quad's own
 corners ARE its vertices, which is why it is a valid conclusion here).

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -284,10 +284,25 @@ to prevent a silent material-deleting regression.
 **SYSTEMATIC BUT PAIR-SPECIFIC.** Within op29's tool merges, `1+2` (67 faces), `2+3` (33) and `3+4`
 (65) all abort while `1+3` and `1+4` fuse clean (F=872 / F=1024, free=0). So it is neither a one-off
 nor universal — it depends on the pair.
-**EVIDENCE LIMIT:** see the correction above — the internal-artifact conclusion is WITHDRAWN. No
-whole-lump classification currently stands, because no valid interior sample has been taken for any
-of the three lumps. Getting one needs a point adjacent to a face of the lump, offset along that
-face's normal, not a centre-of-mass shortcut.
+**VALID SAMPLING DONE — the lump MIXES real boundary with faces that bound nothing.**
+`BK_OPEN_SHELL_FACEPTS=1` emits, per lump face, a point either side offset 0.02 along that face's
+own normal (the only sound sample for a non-convex open shell), and `POINT_IN` now takes a
+semicolon-separated batch. Over 24 faces of the `1+2` lump, every PLUS-side point is Outside/Outside,
+and the MINUS side splits:
+
+| minus-side | count | reading |
+|---|---|---|
+| Outside / Outside | **8** | empty on BOTH sides — bounds nothing, spurious |
+| Outside A / Inside B | 6 | legitimate union boundary |
+| Inside / Inside | 2 | legitimate |
+| OnBoundary A / Inside B | 1 | legitimate |
+| OnBoundary A / Outside B | 7 | ambiguous: 0.02 lands ON A's surface, retry with a larger offset |
+
+So the lump is neither "all real material" (which the guard assumes) nor "all internal artifact"
+(the withdrawn claim): roughly a third of its faces bound empty space on both sides. That is
+consistent with the quad result — no face belongs there — and it means the guard is refusing to drop
+a shell that is partly junk. A discriminator therefore cannot be a single whole-lump verdict; it has
+to be per-face, and the 7 OnBoundary rows must be resolved first or they will bias any threshold.
 CAUTION on `BK_SUBFACE_BOX`: it tests face VERTICES against the box, so a face whose corners sit
 outside will not register; do not conclude a face is absent from that probe alone (the quad's own
 corners ARE its vertices, which is why it is a valid conclusion here).

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -230,9 +230,21 @@ suite number.
 and the standing note that plane-plane "stays theoretically susceptible ... no repro exhibits it".
 Ungating #1224's exact slab clip to plane-plane leaves the fuse failing IDENTICALLY (same 67-face
 lump, 368 ms). So this repro does not exhibit that hazard and the gate should stay as it is.
-NEXT: find why no sub-face is emitted for that quad. The neighbours at the same x-gap ARE emitted,
-so the splitter reaches this region — start from what distinguishes the missing quad from
-Id(1447)/Id(1961), which are the same 0.05 mm width in the same gap.
+**NARROWED to an incomplete partition of ONE oblique source face.** The quad's four corners are
+coplanar (normal ~(0.570,-0.244,-0.777) — a slanted lattice-strut plane, not axis-aligned), so it
+must be a trimmed piece of an INPUT face; booleans only emit trimmed patches of input surfaces.
+`BK_SUBFACE_BOX` tight on the quad identifies the source: **`src=Id(371)`**, which splits into
+- `Id(1446)` x[32.792,38.050] y[-42.950,-38.150] z[26.253,29.289] — Outside, SELECTED
+- `Id(1447)` x[38.000,38.050] **y[-40.932,-39.699]** z[29.260,29.289] — Inside, dropped (correct
+  for a Fuse)
+
+and the missing quad occupies x[38.000,38.050] **y[-42.750,-40.909]** z[29.260,29.866] — the
+ADJACENT y-band in the same 0.05 mm x-gap, which receives NO sub-face at all. So the defect is not
+selection and not classification: the splitter's partition of `Id(371)` does not cover the whole
+face. Start by measuring the pieces' total area against the source face's.
+NOTE the neighbouring 0.05 mm slivers on OTHER sources (Id 1961 from Id(860), Id 1966 from Id(862))
+are emitted and correctly classified Inside, so the splitter does reach this region generally —
+whatever fails is specific to `Id(371)`'s partition.
 
 ## Live campaign: kumiko / goma
 

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -268,6 +268,20 @@ sample** — both can land outside the lump, and here they disagree on two pairs
 points taken adjacent to an actual face and offset along its normal mean anything. So the standing,
 supported finding is the narrow one: no face belongs at the quad, hence the faces owning those four
 free edges are what needs explaining. Whether the lump as a whole is spurious is OPEN.
+**Connectivity probe so far, and an honest status.** `BK_SUBFACE_SRC=all` now also reports sources
+whose pieces TILE but where NONE was selected — a hole an area-gap scan cannot see. There are three
+such sources, all tiny (areas 0.040, 0.009, 0.001), none matching the ~0.117 quad. So the boundary
+gap is not a fully-dropped source either, and the four free edges still have no face anywhere
+sharing their positions (`same_id_outside=0 coincident_other_id=0`).
+
+**Take stock before continuing.** This single failure has now had five successive diagnoses, four of
+them overturned by later measurement (FF aliasing, incomplete partition, missing face, spurious
+lump). The refutations are durable and the probes are reusable, but the rate of progress toward a
+FIX is low and each pass has cost a full iteration. `debugging-doctrine` exists for exactly this
+shape. Anyone picking this up should consider whether a different entry point is cheaper than
+continuing the current thread — for example instrumenting the shell WALKER directly (why it starts a
+new shell at these edges) rather than continuing to characterise the result it produced.
+
 **NEXT: chase SHELL CONNECTIVITY, not a drop-it discriminator.** The earlier proposal — drop a
 growth shell whose interior looks internal — is retargeted: the faces are legitimate, so dropping is
 never right here. The question is why the shell walker emits this set as a SEPARATE shell instead of

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -209,6 +209,31 @@ CAVEAT on probe numbers here: a standalone probe run of `scenario-dividers-on` r
 notes record (in-matrix runs are cache-warm); do NOT compare a standalone probe number against a
 suite number.
 
+## Open growth shell: the 364 ms lattice fuse, characterized
+
+`crates/io/tests/kumiko_lattice_fuse_inmem.rs` is the first sub-second repro this family has had.
+`BK_OPEN_SHELL=1` with `replay_pair` gives the anatomy directly:
+
+- The lump is **67 planar faces, signed volume +153.5**, bbox x[32.792,39.722] y[-42.950,-38.150]
+  z[26.253,34.800] — a genuine chunk, not a sliver, which is why the guard refuses to drop it.
+- Its unpaired edges are **exactly four, and they form a CLOSED QUADRILATERAL**
+  (38.050,-42.748,29.866) -> (38.000,-42.750,29.830) -> (38.000,-40.932,29.260) ->
+  (38.050,-40.909,29.289). So this is ONE MISSING FACE, not a tear.
+- That quad BRIDGES x=38.000 and x=38.050, i.e. it caps the tool's deliberate
+  **`SLAB_OVERLAP = 0.05`** gap — the same 0.05 mm overlap the goma notes record.
+- Every one of the four carries `same_id_outside=0 coincident_other_id=0`: the partner exists
+  nowhere in the selection under any identity, so it was never created rather than mis-selected.
+- `BK_SUBFACE_BOX` over the gap shows neighbouring 0.05 mm slivers ARE created and classified
+  `Inside` (Id 1447, 1961, 1966), which is correct for a Fuse — but nothing covers the quad itself.
+
+**REFUTED: plane-plane FF aliasing is NOT the mechanism**, despite the matching 0.05 mm signature
+and the standing note that plane-plane "stays theoretically susceptible ... no repro exhibits it".
+Ungating #1224's exact slab clip to plane-plane leaves the fuse failing IDENTICALLY (same 67-face
+lump, 368 ms). So this repro does not exhibit that hazard and the gate should stay as it is.
+NEXT: find why no sub-face is emitted for that quad. The neighbours at the same x-gap ARE emitted,
+so the splitter reaches this region — start from what distinguishes the missing quad from
+Id(1447)/Id(1961), which are the same 0.05 mm width in the same gap.
+
 ## Live campaign: kumiko / goma
 
 **State:** branch `fix/kumiko-corner-window-cut` closes four real engine defects with fixtures

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -247,14 +247,27 @@ wired; instrument verified — a far-away point reads Outside/Outside):
 |---|---|---|
 | quad + normal | **Inside** | Outside |
 | quad − normal | **Inside** | Inside |
-| lump interior (36.257,-40.550,30.530) | **Inside** | Outside |
 
 Both sides of the quad are INSIDE the union, so **no face belongs there at all** — one would be an
-internal membrane. And the lump's own interior is inside operand A, i.e. the 67 faces enclose
-material A already accounts for. So this was never a missing face: **the lump is an internal
-artifact and dropping it is the CORRECT outcome.** The `>= 4 faces` fail-safe is misfiring — it
-exists because dropping a real lump silently deletes material (the lite fused-foot: 72 faces,
-~2700 units^3), and it cannot currently tell that case from this one.
+internal membrane. That much is solid: the samples sit immediately either side of a real boundary,
+offset along its normal.
+
+**CORRECTION, and the method lesson behind it.** An earlier pass added "and the lump's own interior
+is inside A", concluding the whole lump is an internal artifact. That is NOT established and the
+claim is withdrawn. It rested on a BBOX-CENTRE sample; adding a vertex-CENTROID sample (now printed
+by the `BK_OPEN_SHELL` probe) contradicts it outright:
+
+| pair | bbox centre | vertex centroid |
+|---|---|---|
+| 1+2 | Inside A | **Outside / Outside** |
+| 2+3 | Outside / Outside | **Inside A** |
+| 3+4 | Outside / Inside B | Outside / Inside B |
+
+**For a non-convex OPEN shell neither a bbox centre nor a vertex centroid is a valid interior
+sample** — both can land outside the lump, and here they disagree on two pairs out of three. Only
+points taken adjacent to an actual face and offset along its normal mean anything. So the standing,
+supported finding is the narrow one: no face belongs at the quad, hence the faces owning those four
+free edges are what needs explaining. Whether the lump as a whole is spurious is OPEN.
 PROPOSED DISCRIMINATOR: a growth shell whose INTERIOR classifies inside one of the operands is not
 new boundary and can be dropped; the fused-foot lump was genuinely outside both.
 
@@ -271,12 +284,10 @@ to prevent a silent material-deleting regression.
 **SYSTEMATIC BUT PAIR-SPECIFIC.** Within op29's tool merges, `1+2` (67 faces), `2+3` (33) and `3+4`
 (65) all abort while `1+3` and `1+4` fuse clean (F=872 / F=1024, free=0). So it is neither a one-off
 nor universal — it depends on the pair.
-**EVIDENCE LIMIT, stated so nobody over-reads it:** the internal-artifact conclusion is established
-only for the `1+2` lump, where two independent probes agree (both sides of the quad AND the lump
-interior read Inside A). For `2+3` (Outside/Outside) and `3+4` (Outside/Inside B) only a BBOX-CENTRE
-point was tested, and a bbox centre need not lie inside a non-convex shell — those two readings are
-inconclusive, not evidence of a different mechanism. Before generalizing, sample a genuinely
-interior point per lump.
+**EVIDENCE LIMIT:** see the correction above — the internal-artifact conclusion is WITHDRAWN. No
+whole-lump classification currently stands, because no valid interior sample has been taken for any
+of the three lumps. Getting one needs a point adjacent to a face of the lump, offset along that
+face's normal, not a centre-of-mass shortcut.
 CAUTION on `BK_SUBFACE_BOX`: it tests face VERTICES against the box, so a face whose corners sit
 outside will not register; do not conclude a face is absent from that probe alone (the quad's own
 corners ARE its vertices, which is why it is a valid conclusion here).

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -255,11 +255,28 @@ material A already accounts for. So this was never a missing face: **the lump is
 artifact and dropping it is the CORRECT outcome.** The `>= 4 faces` fail-safe is misfiring — it
 exists because dropping a real lump silently deletes material (the lite fused-foot: 72 faces,
 ~2700 units^3), and it cannot currently tell that case from this one.
-PROPOSED DISCRIMINATOR, to try next and measure against the foils: a growth shell whose INTERIOR
-classifies inside one of the operands is not new boundary and can be dropped; the fused-foot lump
-was genuinely outside both. Note `brepkit-algo` cannot call `operations::classify_point` (layer
-rules) and must use its own `classifier/ray_cast.rs`, and that an OPEN shell cannot be classified
-reliably — classify against the closed OPERANDS, as the measurements above do.
+PROPOSED DISCRIMINATOR: a growth shell whose INTERIOR classifies inside one of the operands is not
+new boundary and can be dropped; the fused-foot lump was genuinely outside both.
+
+**COST AND BLAST RADIUS, measured before attempting it — this is why it is not done yet.** The
+operands are NOT in scope at assembly: `build_solid`/`build_solid_with_origins` take only
+`selected: &[SelectedFace]` plus cap planes, and `SelectedFace` carries `face_id`, `source_face`,
+`reversed` — no operand tag and no solid. So the discriminator needs either the operand solids
+plumbed down (changes a load-bearing signature) or `assemble` returning open lumps for the caller to
+judge. `brepkit-algo` also cannot call `operations::classify_point` (layer rules) and must use its
+own `classifier/ray_cast.rs`; and an OPEN shell cannot be classified reliably, so any test must run
+against the closed OPERANDS as the measurements above do. Do not rush this into a guard that exists
+to prevent a silent material-deleting regression.
+
+**SYSTEMATIC BUT PAIR-SPECIFIC.** Within op29's tool merges, `1+2` (67 faces), `2+3` (33) and `3+4`
+(65) all abort while `1+3` and `1+4` fuse clean (F=872 / F=1024, free=0). So it is neither a one-off
+nor universal — it depends on the pair.
+**EVIDENCE LIMIT, stated so nobody over-reads it:** the internal-artifact conclusion is established
+only for the `1+2` lump, where two independent probes agree (both sides of the quad AND the lump
+interior read Inside A). For `2+3` (Outside/Outside) and `3+4` (Outside/Inside B) only a BBOX-CENTRE
+point was tested, and a bbox centre need not lie inside a non-convex shell — those two readings are
+inconclusive, not evidence of a different mechanism. Before generalizing, sample a genuinely
+interior point per lump.
 CAUTION on `BK_SUBFACE_BOX`: it tests face VERTICES against the box, so a face whose corners sit
 outside will not register; do not conclude a face is absent from that probe alone (the quad's own
 corners ARE its vertices, which is why it is a valid conclusion here).

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -296,13 +296,19 @@ and the MINUS side splits:
 | Outside A / Inside B | 6 | legitimate union boundary |
 | Inside / Inside | 2 | legitimate |
 | OnBoundary A / Inside B | 1 | legitimate |
-| OnBoundary A / Outside B | 7 | ambiguous: 0.02 lands ON A's surface, retry with a larger offset |
+| OnBoundary A / Outside B | 7 | COINCIDENT with A's surface — see below, not an artifact |
+
+**Offset-stability check (0.02 / 0.05 / 0.15) settles both groups.** The `Outside/Outside` count is
+**8 at every offset** — an offset-independent fact, not a sampling accident. And the `OnBoundary A`
+rows persist at 0.15 too, which is far past any tolerance: those faces are genuinely COINCIDENT with
+operand A's surface rather than ambiguously sampled. So the stable decomposition of the 24 sampled
+faces is roughly **8 bounding nothing + 7 coincident with A + 7 legitimate boundary**.
 
 So the lump is neither "all real material" (which the guard assumes) nor "all internal artifact"
-(the withdrawn claim): roughly a third of its faces bound empty space on both sides. That is
-consistent with the quad result — no face belongs there — and it means the guard is refusing to drop
-a shell that is partly junk. A discriminator therefore cannot be a single whole-lump verdict; it has
-to be per-face, and the 7 OnBoundary rows must be resolved first or they will bias any threshold.
+(the withdrawn claim): a third of its faces bound empty space on both sides, and another third sit
+on an operand surface — which puts the coincident-face/same-domain machinery in scope as a likely
+contributor. A discriminator therefore cannot be a single whole-lump verdict; it has to be per-face,
+and it now has a measured signature to key on.
 CAUTION on `BK_SUBFACE_BOX`: it tests face VERTICES against the box, so a face whose corners sit
 outside will not register; do not conclude a face is absent from that probe alone (the quad's own
 corners ARE its vertices, which is why it is a valid conclusion here).

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -230,21 +230,25 @@ suite number.
 and the standing note that plane-plane "stays theoretically susceptible ... no repro exhibits it".
 Ungating #1224's exact slab clip to plane-plane leaves the fuse failing IDENTICALLY (same 67-face
 lump, 368 ms). So this repro does not exhibit that hazard and the gate should stay as it is.
-**NARROWED to an incomplete partition of ONE oblique source face.** The quad's four corners are
-coplanar (normal ~(0.570,-0.244,-0.777) — a slanted lattice-strut plane, not axis-aligned), so it
-must be a trimmed piece of an INPUT face; booleans only emit trimmed patches of input surfaces.
-`BK_SUBFACE_BOX` tight on the quad identifies the source: **`src=Id(371)`**, which splits into
-- `Id(1446)` x[32.792,38.050] y[-42.950,-38.150] z[26.253,29.289] — Outside, SELECTED
-- `Id(1447)` x[38.000,38.050] **y[-40.932,-39.699]** z[29.260,29.289] — Inside, dropped (correct
-  for a Fuse)
+The quad's four corners are coplanar (normal ~(0.570,-0.244,-0.777) — a slanted lattice-strut
+plane), so it can only be a trimmed piece of an INPUT face; a boolean emits nothing else.
 
-and the missing quad occupies x[38.000,38.050] **y[-42.750,-40.909]** z[29.260,29.866] — the
-ADJACENT y-band in the same 0.05 mm x-gap, which receives NO sub-face at all. So the defect is not
-selection and not classification: the splitter's partition of `Id(371)` does not cover the whole
-face. Start by measuring the pieces' total area against the source face's.
-NOTE the neighbouring 0.05 mm slivers on OTHER sources (Id 1961 from Id(860), Id 1966 from Id(862))
-are emitted and correctly classified Inside, so the splitter does reach this region generally —
-whatever fails is specific to `Id(371)`'s partition.
+**REFUTED #2: it is NOT an incomplete face partition.** `BK_SUBFACE_SRC=<id>|all` (new, in
+`builder/mod.rs`) totals a source face's pieces against the source's own area. The obvious suspect
+`Id(371)` — whose pieces bracket the quad — tiles EXACTLY: 29.143651 = 29.076256 + 0.067395,
+uncovered 0.000000. Scanning ALL source faces, only one fails to tile and by 8e-6, i.e. fan-
+triangulation noise. So every source face is fully covered and the quad is not a missing piece of
+any of them.
+So both natural readings are now dead: the sections are not lost at FF (refuted #1) and the faces
+are not under-partitioned (refuted #2). THE REMAINING HYPOTHESIS, and the one to test next: the
+67-face lump may be a SPURIOUS selection rather than a real chunk missing its cap — the guard exists
+because dropping a real lump deletes material, but if this lump should not have been selected at all
+then its openness is a symptom. Test by classifying interior points of the lump's faces against both
+operands with the independent `classify_point` oracle: if the lump is genuinely outside the union,
+the defect is in selection, not in face creation.
+CAUTION on `BK_SUBFACE_BOX`: it tests face VERTICES against the box, so a face whose corners sit
+outside will not register; do not conclude a face is absent from that probe alone (the quad's own
+corners ARE its vertices, which is why it is a valid conclusion here).
 
 ## Live campaign: kumiko / goma
 

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1268,15 +1268,25 @@ fn log_open_growth_shell(
         let d: f64 = faceopt.trim().parse().unwrap_or(0.02);
         for &fid in gs.iter().take(24) {
             let Ok(f) = topo.face(fid) else { continue };
+            // Sample the face's INTERIOR, not an edge midpoint. A point on a
+            // boundary edge is not usable: at a convex edge, offsetting
+            // perpendicular to the face exits the material on BOTH sides, which
+            // reads as "this face bounds nothing" for perfectly good faces.
             let Some(p) = topo.wire(f.outer_wire()).ok().and_then(|w| {
-                let e = topo.edge(w.edges().first()?.edge()).ok()?;
-                let a = topo.vertex(e.start()).ok()?.point();
-                let b = topo.vertex(e.end()).ok()?.point();
-                Some(brepkit_math::vec::Point3::new(
-                    (a.x() + b.x()) * 0.5,
-                    (a.y() + b.y()) * 0.5,
-                    (a.z() + b.z()) * 0.5,
-                ))
+                let mut acc = [0.0_f64; 3];
+                let mut n = 0.0_f64;
+                for oe in w.edges() {
+                    let e = topo.edge(oe.edge()).ok()?;
+                    for vid in [e.start(), e.end()] {
+                        let q = topo.vertex(vid).ok()?.point();
+                        acc[0] += q.x();
+                        acc[1] += q.y();
+                        acc[2] += q.z();
+                        n += 1.0;
+                    }
+                }
+                (n > 0.0)
+                    .then(|| brepkit_math::vec::Point3::new(acc[0] / n, acc[1] / n, acc[2] / n))
             }) else {
                 continue;
             };
@@ -1285,8 +1295,9 @@ fn log_open_growth_shell(
             if f.is_reversed() {
                 n = -n;
             }
+            let src = face_source.get(&fid).copied().flatten();
             log::debug!(
-                "OPENSHELL facept {fid:?} plus={:.4},{:.4},{:.4} minus={:.4},{:.4},{:.4}",
+                "OPENSHELL facept {fid:?} src={src:?} plus={:.4},{:.4},{:.4} minus={:.4},{:.4},{:.4}",
                 p.x() + n.x() * d,
                 p.y() + n.y() * d,
                 p.z() + n.z() * d,

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1194,6 +1194,40 @@ fn log_open_growth_shell(
             }
         }
     }
+    // Vertex centroid of the whole lump. A BBOX centre is not a usable interior
+    // sample for a non-convex shell (it can sit outside the lump entirely), and
+    // reading one as "the lump's interior" is how a classification probe
+    // silently answers about the wrong region.
+    let mut c = [0.0_f64; 3];
+    let mut nv = 0.0_f64;
+    for &fid in gs {
+        let Ok(f) = topo.face(fid) else { continue };
+        for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+            let Ok(w) = topo.wire(wid) else { continue };
+            for oe in w.edges() {
+                let Ok(e) = topo.edge(oe.edge()) else {
+                    continue;
+                };
+                for vid in [e.start(), e.end()] {
+                    if let Ok(v) = topo.vertex(vid) {
+                        let p = v.point();
+                        c[0] += p.x();
+                        c[1] += p.y();
+                        c[2] += p.z();
+                        nv += 1.0;
+                    }
+                }
+            }
+        }
+    }
+    if nv > 0.0 {
+        log::debug!(
+            "growth shell OPENSHELL centroid ({:.4},{:.4},{:.4})",
+            c[0] / nv,
+            c[1] / nv,
+            c[2] / nv
+        );
+    }
     log::debug!(
         "growth shell OPENSHELL faces={} signed_volume={:.6}",
         gs.len(),

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1260,7 +1260,12 @@ fn log_open_growth_shell(
     // the lump entirely). A legitimate union boundary face has one side inside
     // the union and the other outside; a face with BOTH sides on the same side
     // is an internal membrane and should not be in the result.
-    if std::env::var("BK_OPEN_SHELL_FACEPTS").is_ok() {
+    if let Ok(faceopt) = std::env::var("BK_OPEN_SHELL_FACEPTS") {
+        // Offset distance is tunable because a fixed one is not safe on this
+        // geometry: too small and the sample lands ON a coincident operand
+        // surface (OnBoundary, useless), too large and it leaves the local
+        // feature entirely. Read two distances and keep only agreeing verdicts.
+        let d: f64 = faceopt.trim().parse().unwrap_or(0.02);
         for &fid in gs.iter().take(24) {
             let Ok(f) = topo.face(fid) else { continue };
             let Some(p) = topo.wire(f.outer_wire()).ok().and_then(|w| {
@@ -1280,7 +1285,6 @@ fn log_open_growth_shell(
             if f.is_reversed() {
                 n = -n;
             }
-            let d = 0.02;
             log::debug!(
                 "OPENSHELL facept {fid:?} plus={:.4},{:.4},{:.4} minus={:.4},{:.4},{:.4}",
                 p.x() + n.x() * d,

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1254,6 +1254,45 @@ fn log_open_growth_shell(
             ),
         }
     }
+    // Per-face samples offset either side of the face along its own normal.
+    // This is the ONLY kind of interior sample that means anything for a
+    // non-convex open shell (a bbox centre or vertex centroid can sit outside
+    // the lump entirely). A legitimate union boundary face has one side inside
+    // the union and the other outside; a face with BOTH sides on the same side
+    // is an internal membrane and should not be in the result.
+    if std::env::var("BK_OPEN_SHELL_FACEPTS").is_ok() {
+        for &fid in gs.iter().take(24) {
+            let Ok(f) = topo.face(fid) else { continue };
+            let Some(p) = topo.wire(f.outer_wire()).ok().and_then(|w| {
+                let e = topo.edge(w.edges().first()?.edge()).ok()?;
+                let a = topo.vertex(e.start()).ok()?.point();
+                let b = topo.vertex(e.end()).ok()?.point();
+                Some(brepkit_math::vec::Point3::new(
+                    (a.x() + b.x()) * 0.5,
+                    (a.y() + b.y()) * 0.5,
+                    (a.z() + b.z()) * 0.5,
+                ))
+            }) else {
+                continue;
+            };
+            let (u, v) = f.surface().project_point(p).unwrap_or((0.0, 0.0));
+            let mut n = f.surface().normal(u, v);
+            if f.is_reversed() {
+                n = -n;
+            }
+            let d = 0.02;
+            log::debug!(
+                "OPENSHELL facept {fid:?} plus={:.4},{:.4},{:.4} minus={:.4},{:.4},{:.4}",
+                p.x() + n.x() * d,
+                p.y() + n.y() * d,
+                p.z() + n.z() * d,
+                p.x() - n.x() * d,
+                p.y() - n.y() * d,
+                p.z() - n.z() * d
+            );
+        }
+    }
+
     // What else was SELECTED near the lump? If the missing partners are base
     // faces that were never created, nothing of the base appears here; if they
     // exist but were not walked in, they show up.

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -97,13 +97,30 @@ fn log_source_face_partition(topo: &Topology, subs: &[SubFace], selected: &[bop:
                 e.2 += 1;
             }
         }
+        let by_src2 = by_src.clone();
         let mut rows: Vec<_> = by_src
             .into_iter()
             .map(|(src, (tot, n, sel))| (face_area_estimate(topo, src) - tot, src, tot, n, sel))
             .filter(|(gap, _, _, _, _)| gap.abs() > 1e-6)
             .collect();
         rows.sort_by(|a, b| b.0.abs().total_cmp(&a.0.abs()));
-        log::debug!("SRCPART scan: {} source faces do not tile", rows.len());
+        // A source whose pieces TILE it but where NONE was selected leaves a
+        // hole in the result boundary just as surely as an under-partition, and
+        // an area-gap scan cannot see it — the pieces all exist.
+        let mut dropped: Vec<_> = by_src2
+            .iter()
+            .filter(|(_, (_, _, sel))| *sel == 0)
+            .map(|(src, (tot, n, _))| (*src, *tot, *n))
+            .collect();
+        dropped.sort_by(|a, b| b.1.total_cmp(&a.1));
+        log::debug!(
+            "SRCPART scan: {} source faces do not tile, {} fully dropped (no piece selected)",
+            rows.len(),
+            dropped.len()
+        );
+        for (src, tot, n) in dropped.iter().take(12) {
+            log::debug!("SRCPART fully-dropped src={src:?} pieces={n} area={tot:.6}");
+        }
         for (gap, src, tot, n, sel) in rows.iter().take(12) {
             log::debug!(
                 "SRCPART gap={gap:.6} src={src:?} pieces={n} selected={sel} pieceTotal={tot:.6}"

--- a/crates/algo/src/builder/mod.rs
+++ b/crates/algo/src/builder/mod.rs
@@ -70,6 +70,110 @@ pub struct SubFace {
 /// The decisive probe for a missing result face: it separates "the splitter
 /// never produced a sub-face here" from "it did, and selection dropped it".
 /// Those need opposite fixes, so guessing between them wastes a whole dig.
+/// `BK_SUBFACE_SRC=<n>`: total the sub-faces produced from ONE source face and
+/// compare against the source's own area.
+///
+/// A boolean emits only trimmed patches of input surfaces, so a source face's
+/// pieces must tile it. When they do not, a region of the result simply has no
+/// face and the shell comes back open — which reads downstream as a selection
+/// or classification bug and is neither.
+fn log_source_face_partition(topo: &Topology, subs: &[SubFace], selected: &[bop::SelectedFace]) {
+    let Ok(want) = std::env::var("BK_SUBFACE_SRC") else {
+        return;
+    };
+    // `BK_SUBFACE_SRC=all` scans every source face instead of one, reporting
+    // only those whose pieces fail to tile them — the cheap way to find a
+    // missing result face without guessing which source it came from.
+    if want.trim() == "all" {
+        let chosen: std::collections::HashSet<FaceId> =
+            selected.iter().map(|s| s.face_id).collect();
+        let mut by_src: std::collections::HashMap<FaceId, (f64, usize, usize)> =
+            std::collections::HashMap::new();
+        for sf in subs {
+            let e = by_src.entry(sf.source_face).or_insert((0.0, 0, 0));
+            e.0 += face_area_estimate(topo, sf.face_id);
+            e.1 += 1;
+            if chosen.contains(&sf.face_id) {
+                e.2 += 1;
+            }
+        }
+        let mut rows: Vec<_> = by_src
+            .into_iter()
+            .map(|(src, (tot, n, sel))| (face_area_estimate(topo, src) - tot, src, tot, n, sel))
+            .filter(|(gap, _, _, _, _)| gap.abs() > 1e-6)
+            .collect();
+        rows.sort_by(|a, b| b.0.abs().total_cmp(&a.0.abs()));
+        log::debug!("SRCPART scan: {} source faces do not tile", rows.len());
+        for (gap, src, tot, n, sel) in rows.iter().take(12) {
+            log::debug!(
+                "SRCPART gap={gap:.6} src={src:?} pieces={n} selected={sel} pieceTotal={tot:.6}"
+            );
+        }
+        return;
+    }
+    let Ok(want) = want.trim().parse::<usize>() else {
+        return;
+    };
+    let chosen: std::collections::HashSet<FaceId> = selected.iter().map(|s| s.face_id).collect();
+    let mut total = 0.0;
+    let mut n = 0;
+    let mut src_id: Option<FaceId> = None;
+    for sf in subs {
+        if sf.source_face.index() != want {
+            continue;
+        }
+        src_id = Some(sf.source_face);
+        let a = face_area_estimate(topo, sf.face_id);
+        total += a;
+        n += 1;
+        log::debug!(
+            "SRCPART sub {:?} area={a:.6} class={:?} selected={}",
+            sf.face_id,
+            sf.classification,
+            chosen.contains(&sf.face_id)
+        );
+    }
+    let src_area = src_id.map_or(f64::NAN, |f| face_area_estimate(topo, f));
+    log::debug!(
+        "SRCPART source Id({want}) area={src_area:.6} pieces={n} pieceTotal={total:.6}          uncovered={:.6}",
+        src_area - total
+    );
+}
+
+/// Fan-triangulated area of a face's outer wire, minus its inner wires. Good
+/// enough to compare a partition against its source; exact for planar faces.
+fn face_area_estimate(topo: &Topology, fid: FaceId) -> f64 {
+    let Ok(face) = topo.face(fid) else {
+        return 0.0;
+    };
+    let ring = |wid| -> f64 {
+        let Ok(w) = topo.wire(wid) else { return 0.0 };
+        let mut pts: Vec<brepkit_math::vec::Point3> = Vec::new();
+        for oe in w.edges() {
+            let Ok(e) = topo.edge(oe.edge()) else {
+                continue;
+            };
+            let vid = if oe.is_forward() { e.start() } else { e.end() };
+            if let Ok(v) = topo.vertex(vid) {
+                pts.push(v.point());
+            }
+        }
+        if pts.len() < 3 {
+            return 0.0;
+        }
+        let mut acc = brepkit_math::vec::Vec3::new(0.0, 0.0, 0.0);
+        for i in 1..pts.len() - 1 {
+            let u = pts[i] - pts[0];
+            let v = pts[i + 1] - pts[0];
+            acc += u.cross(v);
+        }
+        acc.length() * 0.5
+    };
+    let outer = ring(face.outer_wire());
+    let inner: f64 = face.inner_wires().iter().map(|w| ring(*w)).sum();
+    (outer - inner).max(0.0)
+}
+
 fn log_subfaces_in_box(topo: &Topology, subs: &[SubFace], selected: &[bop::SelectedFace]) {
     let Ok(spec) = std::env::var("BK_SUBFACE_BOX") else {
         return;
@@ -217,6 +321,7 @@ impl Builder {
             &self.sd_within_rank_dups,
         );
         log_subfaces_in_box(&self.topo, &self.sub_faces, &selected);
+        log_source_face_partition(&self.topo, &self.sub_faces, &selected);
         let cap_planes = self.partial_overlap_cap_planes(&selected);
         let solid_id = assemble::assemble_solid(&mut self.topo, &selected, &cap_planes)?;
         Ok((self.topo, solid_id))
@@ -237,6 +342,7 @@ impl Builder {
             &self.sd_within_rank_dups,
         );
         log_subfaces_in_box(&self.topo, &self.sub_faces, &selected);
+        log_source_face_partition(&self.topo, &self.sub_faces, &selected);
         let cap_planes = self.partial_overlap_cap_planes(&selected);
         let (solid_id, origins) =
             assemble::assemble_solid_with_origins(&mut self.topo, &selected, &cap_planes)?;

--- a/crates/io/examples/replay_pair.rs
+++ b/crates/io/examples/replay_pair.rs
@@ -82,6 +82,26 @@ fn main() {
         _ => brepkit_algo::bop::BooleanOp::Fuse,
     };
 
+    // POINT_IN=x,y,z classifies a point against BOTH operands with the
+    // independent operations-level oracle. For a Fuse, a face is needed
+    // wherever one side of a surface is inside the union and the other is not.
+    if let Ok(spec) = std::env::var("POINT_IN") {
+        let c: Vec<f64> = spec
+            .split(',')
+            .filter_map(|t| t.trim().parse().ok())
+            .collect();
+        if c.len() == 3 {
+            let p = brepkit_math::vec::Point3::new(c[0], c[1], c[2]);
+            for (label, sid) in [("A", a), ("B", b)] {
+                match brepkit_operations::classify::classify_point(&topo, sid, p, 0.01, 1e-7) {
+                    Ok(v) => println!("  POINT_IN {label}: {v:?}"),
+                    Err(e) => println!("  POINT_IN {label}: ERR {e}"),
+                }
+            }
+        }
+        return;
+    }
+
     // TOOLS=<comma-separated paths> replays a compound_cut, which is how the
     // kumiko wrap chain is actually built; a pairwise replay cannot reach it.
     if let Ok(list) = std::env::var("TOOLS") {

--- a/crates/io/examples/replay_pair.rs
+++ b/crates/io/examples/replay_pair.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::print_stdout, clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use brepkit_io::arena_io::deserialize_solid;
@@ -86,18 +87,29 @@ fn main() {
     // independent operations-level oracle. For a Fuse, a face is needed
     // wherever one side of a surface is inside the union and the other is not.
     if let Ok(spec) = std::env::var("POINT_IN") {
-        let c: Vec<f64> = spec
-            .split(',')
-            .filter_map(|t| t.trim().parse().ok())
-            .collect();
-        if c.len() == 3 {
+        // Semicolon-separated points, so a batch is classified in one process
+        // instead of one process per point.
+        for (i, one) in spec.split(';').filter(|t| !t.trim().is_empty()).enumerate() {
+            let c: Vec<f64> = one
+                .split(',')
+                .filter_map(|t| t.trim().parse().ok())
+                .collect();
+            if c.len() != 3 {
+                continue;
+            }
             let p = brepkit_math::vec::Point3::new(c[0], c[1], c[2]);
+            let mut row = format!("  POINT_IN[{i}] ({:.3},{:.3},{:.3})", c[0], c[1], c[2]);
             for (label, sid) in [("A", a), ("B", b)] {
                 match brepkit_operations::classify::classify_point(&topo, sid, p, 0.01, 1e-7) {
-                    Ok(v) => println!("  POINT_IN {label}: {v:?}"),
-                    Err(e) => println!("  POINT_IN {label}: ERR {e}"),
+                    Ok(v) => {
+                        let _ = write!(row, "  {label}={v:?}");
+                    }
+                    Err(_) => {
+                        let _ = write!(row, "  {label}=ERR");
+                    }
                 }
             }
+            println!("{row}");
         }
         return;
     }

--- a/crates/io/examples/replay_pair.rs
+++ b/crates/io/examples/replay_pair.rs
@@ -89,6 +89,13 @@ fn main() {
     if let Ok(spec) = std::env::var("POINT_IN") {
         // Semicolon-separated points, so a batch is classified in one process
         // instead of one process per point.
+        // Deflection matters: classify_point tessellates, and this lattice has
+        // 0.05mm features that a coarse deflection cannot represent, which
+        // makes the verdict itself an artifact of the setting.
+        let defl: f64 = std::env::var("POINT_DEFL")
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(0.01);
         for (i, one) in spec.split(';').filter(|t| !t.trim().is_empty()).enumerate() {
             let c: Vec<f64> = one
                 .split(',')
@@ -100,7 +107,7 @@ fn main() {
             let p = brepkit_math::vec::Point3::new(c[0], c[1], c[2]);
             let mut row = format!("  POINT_IN[{i}] ({:.3},{:.3},{:.3})", c[0], c[1], c[2]);
             for (label, sid) in [("A", a), ("B", b)] {
-                match brepkit_operations::classify::classify_point(&topo, sid, p, 0.01, 1e-7) {
+                match brepkit_operations::classify::classify_point(&topo, sid, p, defl, 1e-7) {
                     Ok(v) => {
                         let _ = write!(row, "  {label}={v:?}");
                     }


### PR DESCRIPTION
## What this is

Diagnostic probes and recorded findings for the `open growth shell` assembly abort — the family behind goma, the kumiko corner wedge, and the mitsukude wall pattern. **No behaviour change**: every probe is env-gated, and the workspace stays at 2658 passed / 0 failed.

It is worth landing because the roadmap knowledge is the deliverable, and this session already watched an untracked diagnostic worktree get deleted mid-run.

## Probes added

| knob | what it answers |
|---|---|
| `BK_SUBFACE_SRC=<id>\|all` | do a source face's pieces tile it, and were any selected? Also reports sources that tile but had **every** piece dropped — a boundary hole an area-gap scan cannot see |
| `BK_OPEN_SHELL_FACEPTS=<offset>` | per lump face, points either side along its own normal, sampled at the face **interior** |
| `POINT_IN=a;b;c` + `POINT_DEFL` | batch point classification against both operands with the independent oracle |
| `TOOLS=<paths>` on `replay_pair` | replays a `compound_cut`, which a pairwise replay cannot reach |

## What was established

The lattice fuse aborts with `open growth shell with 67 faces` in **364 ms** from two clean planar operands. Measuring it:

- all 24 sampled lump faces have **material behind and empty space in front** — legitimate union boundary faces
- the supposed missing quad has material on **both** sides, so no cap belongs there
- so the lump is real material whose faces are correct, and the failure is that the shell walker emitted it as a **separate shell instead of connecting it**

## What was refuted (the durable part)

Four explanations, each killed by measurement and recorded so they aren't re-attempted:

1. **plane×plane FF aliasing** — ungating #1224's exact clip leaves the fuse failing identically
2. **incomplete face partition** — the suspect source tiles exactly (uncovered 0.000000); scanning all sources finds one 8e-6 gap, i.e. triangulation noise
3. **fully-dropped source faces** — three exist, all tiny, none the quad
4. **spurious lump / drop-it discriminator** — retracted; the guard is right to refuse, and this fix would have deleted real material

## Method lesson, recorded in the roadmap

Finding 4 was my own instrument: sampling the **midpoint of a face's first boundary edge**, where at a convex edge both perpendicular offsets exit the material, so good faces read as bounding nothing. Neither offset-stability (0.02/0.05/0.15) nor deflection-stability (0.01/0.002/0.0005) caught it — both looked like robustness while re-measuring the same wrong point.

The roadmap also records, plainly, that this failure has had five diagnoses with four overturned, and suggests instrumenting the shell **walker** rather than continuing to characterise its output.

## Verification

Workspace 2658 passed / 0 failed (`--exclude brepkit-render`), clippy `-D warnings` clean, fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds gated diagnostic probes to characterize the lattice “open growth shell” fuse failure. No behavior changes; tests remain 2658 passed / 0 failed.

- **New Features**
  - `BK_SUBFACE_SRC=<id|all>` totals sub-face areas per source face and reports fully dropped sources.
  - `BK_OPEN_SHELL_FACEPTS=<offset>` samples each lump face on both sides along its normal at the face interior.
  - `POINT_IN=a;b;c` with `POINT_DEFL` batch-classifies points against both operands in `replay_pair`.
  - `TOOLS=<paths>` in `replay_pair` to replay `compound_cut` scenarios.

<sup>Written for commit 12279fec05fa2c8a46ebcbe3957077af0c153abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

