### PR TITLE
docs: correct README, book, and agent-doc drift; guard it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: ./scripts/check-boundaries.sh
 
+  doc-paths:
+    name: Doc Paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: ./scripts/check-doc-paths.sh
+
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,11 @@ Quick reference — find the right file for any task:
 | 3D curves (Line, Circle, Ellipse, Parabola, Hyperbola) | `curves.rs` |
 | 2D curves (Line2D, Circle2D, Ellipse2D) | `curves2d.rs` |
 | Analytic surfaces (Cylinder, Cone, Sphere, Torus) | `surfaces.rs` |
-| Surface-surface intersection | `nurbs/intersection.rs` |
+| Surface-surface intersection | `nurbs/intersection/` (mod, surface_marching, surface_seeding, curve_surface, plane, line, chaining, tests) |
 | Analytic-analytic intersection | `analytic_intersection.rs` |
 | AABB / bounding boxes | `aabb.rs` |
 | BVH (bounding volume hierarchy) | `bvh.rs` |
-| CDT (constrained Delaunay) | `cdt.rs` |
+| CDT (constrained Delaunay) | `cdt/` (mod, insert, locate, constraints, adjacency, tests) |
 | Convex hull | `convex_hull.rs` |
 | Filtered exact predicates | `filtered.rs` |
 | Float tolerance | `tolerance.rs` |
@@ -150,7 +150,7 @@ Quick reference — find the right file for any task:
 | Pave block splitting + edge creation | `pave_filler/make_blocks.rs`, `make_split_edges.rs` |
 | FaceInfo population | `pave_filler/fill_face_info.rs` |
 | Builder (face splitting + assembly) | `builder/mod.rs`, `builder/assemble.rs` |
-| Face splitting (UV-space) | `builder/face_splitter.rs`, `builder/classify_2d.rs` |
+| Face splitting (UV-space) | `builder/face_splitter/` (mod, containment, conversion, edge_splitting, sampling, special_cases), `builder/classify_2d.rs` |
 | PCurve computation | `builder/pcurve_compute.rs` |
 | Plane frame (3D↔UV projection) | `builder/plane_frame.rs` |
 | Wire loop reconstruction | `builder/wire_builder.rs` |
@@ -309,6 +309,8 @@ Quick reference — find the right file for any task:
 | Blend v2 wrappers (fillet/chamfer) | `blend_ops.rs` |
 | Offset v2 (delegates to brepkit-offset) | `offset_v2.rs` |
 | Shared winding utilities | `winding.rs` |
+| Edge projection with hidden-line removal | `projection.rs` |
+| Shared loft/sweep/pipe/revolve end caps | `cap.rs` |
 
 ### L3: io (`crates/io/src/`)
 | Task | File(s) |
@@ -320,6 +322,17 @@ Quick reference — find the right file for any task:
 | OBJ read/write | `obj/reader.rs`, `obj/writer.rs` |
 | PLY read/write | `ply/reader.rs`, `ply/writer.rs` |
 | glTF read/write | `gltf/reader.rs`, `gltf/writer.rs` |
+
+### L4: render (`crates/render/src/`)
+| Task | File(s) |
+|------|---------|
+| Public API, `RenderOpts`, `RenderOutput` | `lib.rs` |
+| Camera and view/projection matrices | `camera.rs` |
+| Solid → GPU vertex/index/edge buffers | `mesh.rs` |
+| wgpu device setup, render passes, readback | `pipeline.rs` |
+| GPU compute mesher for analytic quadrics | `compute_mesh.rs` |
+| Interactive viewer (feature = `window`) | `viewer.rs` |
+| Error types | `error.rs` |
 
 ### L4: wasm (`crates/wasm/src/`)
 | Task | File(s) |
@@ -515,14 +528,20 @@ Pattern: see `obj/` module (simplest), `step/` (most complex)
 
 1. **Create module** `io/src/format/mod.rs`, `reader.rs`, `writer.rs`
 2. **Add module** to `io/src/lib.rs`
-3. **Writer signature**: `pub fn write_format(topo: &Topology, solid_id: SolidId) -> Result<Vec<u8>, IoError>`
-4. **Reader signature**: `pub fn read_format(topo: &mut Topology, data: &[u8]) -> Result<SolidId, IoError>`
+3. **Writer signature**: text formats return `String`, binary formats return `Vec<u8>`:
+   - B-Rep, text: `pub fn write_step(topo: &Topology, solids: &[SolidId]) -> Result<String, IoError>`
+   - Mesh, binary: `pub fn write_ply(..., deflection: f64) -> Result<Vec<u8>, IoError>`
+4. **Reader signature**: the input comes first, `topo` second, and B-Rep readers return
+   every solid in the file:
+   - B-Rep: `pub fn read_step(input: &str, topo: &mut Topology) -> Result<Vec<SolidId>, IoError>`
+   - Mesh formats pair a `read_ply(data) -> TriangleMesh` with a
+     `read_ply_solid(..) -> SolidId` that also needs `&mut Topology`
 5. **Add WASM bindings** `importFormat` / `exportFormat` in `bindings/io.rs`
 6. **Add to `executeBatch` dispatch** in `bindings/batch.rs` if commonly used
 
 ### Recipe 3: Add a new operation
 
-Pattern: see `extrude.rs` (basic), `boolean.rs` (complex)
+Pattern: see `extrude.rs` (basic), `boolean/` (complex)
 
 1. **Create file** `operations/src/op_name.rs`
 2. **Define function**: `pub fn op_name(topo: &mut Topology, ...) -> Result<SolidId, OperationsError>`
@@ -572,6 +591,7 @@ cargo clippy --all-targets -- -D warnings  # Lint
 cargo fmt --all                            # Format
 cargo build -p brepkit-wasm --target wasm32-unknown-unknown  # WASM
 ./scripts/check-boundaries.sh              # Verify layer deps
+./scripts/check-doc-paths.sh               # Verify doc file paths still resolve
 ```
 
 ### Profiling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,10 @@ a comment. This is a one-time requirement.
 2. Make your changes
 3. Run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
 4. Run `cargo test --workspace`
-5. Commit with a [conventional commit](https://www.conventionalcommits.org/) message
-6. Open a pull request
+5. If you changed crate dependencies or moved a file named in the docs, run
+   `./scripts/check-boundaries.sh` and `./scripts/check-doc-paths.sh` (CI runs both)
+6. Commit with a [conventional commit](https://www.conventionalcommits.org/) message
+7. Open a pull request
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Solid modeling kernel for Rust and WebAssembly.
 
 </div>
 
-One exact-geometry engine, from Rust and from JavaScript. Drill a hole, measure it, export it.
+One exact-geometry engine, from Rust and from JavaScript. Cut a solid, measure it, export it.
 
 ```rust
 use brepkit_operations::primitives::{make_box, make_cylinder};
@@ -26,14 +26,15 @@ use brepkit_topology::Topology;
 
 let mut topo = Topology::new();
 
-// A block with a cylindrical hole
+// Primitives are anchored at the origin, so this cylinder rounds off the
+// block's corner. Use `transform_solid` to place it somewhere else.
 let block = make_box(&mut topo, 30.0, 20.0, 10.0)?;
-let hole = make_cylinder(&mut topo, 5.0, 15.0)?;
-let drilled = boolean(&mut topo, BooleanOp::Cut, block, hole)?;
+let cutter = make_cylinder(&mut topo, 5.0, 15.0)?;
+let notched = boolean(&mut topo, BooleanOp::Cut, block, cutter)?;
 
 // Measure and export
-let vol = solid_volume(&topo, drilled, 0.1)?;
-let step = write_step(&topo, &[drilled])?;
+let vol = solid_volume(&topo, notched, 0.1)?;
+let step = write_step(&topo, &[notched])?;
 ```
 
 ```js
@@ -41,14 +42,15 @@ import { BrepKernel } from 'brepkit-wasm';
 
 const kernel = new BrepKernel();
 
-// A block with a cylindrical hole
+// Primitives are anchored at the origin, so this cylinder rounds off the
+// block's corner. Use `transformSolid` to place it somewhere else.
 const block = kernel.makeBox(30, 20, 10);
-const hole = kernel.makeCylinder(5, 15);
-const drilled = kernel.cut(block, hole);
+const cutter = kernel.makeCylinder(5, 15);
+const notched = kernel.cut(block, cutter);
 
 // Measure and export
-const vol = kernel.volume(drilled, 0.1);
-const step = kernel.exportStep(drilled); // Uint8Array
+const vol = kernel.volume(notched, 0.1);
+const step = kernel.exportStep(notched); // Uint8Array
 ```
 
 ## Why a CAD kernel?
@@ -97,6 +99,7 @@ brepkit is in active development. Core modeling is solid. Each feature below is 
 | **Assemblies**          | Hierarchy, transforms, bill of materials                                     | Beta         |
 | **Evolution**           | Face provenance through booleans                                             | Beta         |
 | **Defeaturing**         | Remove planar faces                                                          | Beta         |
+| **Rendering**           | Offscreen wgpu render to image plus face-id buffer (`brepkit-render`)        | Experimental |
 
 ## Known Limitations
 
@@ -113,7 +116,7 @@ A few areas are still maturing. Worth knowing before you build on them:
 
 brepkit deliberately does not:
 
-- **Render scenes or manage viewports.** It produces geometry and tessellated meshes. Camera, lighting, and shading belong to the caller (Three.js, wgpu, and the like).
+- **Bundle a viewport into the kernel.** The core emits exact geometry and tessellated meshes; camera, lighting, and shading belong to the caller (Three.js and the like). The optional `brepkit-render` crate provides offscreen wgpu rendering with a face-id buffer, for tests and headless verification, and is not required by any core operation.
 - **Plan toolpaths or slice.** Export STEP, STL, or 3MF and pass the output to a CAM tool or slicer.
 - **Model with meshes.** The kernel operates on exact B-Rep geometry. Subdivision surfaces, polygon meshes, and voxels are out of scope.
 - **Provide a GUI.** brepkit is a library. Building a UI around it, like [gridfinitylayouttool.com](https://gridfinitylayouttool.com), is the application's job.
@@ -137,6 +140,7 @@ Layered Cargo workspace. Each crate depends only on the same or lower layers, an
 | L3    | `brepkit-operations` | Booleans, fillet, chamfer, extrude, revolve, sweep, loft, shell, offset, measure, tessellation      |
 | L3    | `brepkit-io`         | Import and export: STEP, IGES, STL, 3MF, OBJ, PLY, glTF                                             |
 | L4    | `brepkit-wasm`       | JavaScript API via wasm-bindgen, with batch execution and checkpoint/restore                        |
+| L4    | `brepkit-render`     | Offscreen wgpu rendering to a color image plus a face-id buffer. Optional, nothing depends on it    |
 
 ## Performance
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -9,15 +9,17 @@ brepkit uses a strict layered architecture. Each layer may only depend on
 layers below it, never above or sideways.
 
 ```
-┌─────────────────────────────────────┐
-│  L3: brepkit-wasm                   │  WASM bindings (JS API)
-├─────────────────┬───────────────────┤
-│  L2: operations │  L2: io           │  Modeling ops / Data exchange
-├─────────────────┴───────────────────┤
-│  L1: topology                       │  B-Rep data structures
-├─────────────────────────────────────┤
-│  L0: math                           │  Vectors, NURBS, predicates
-└─────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│  L4: brepkit-wasm          brepkit-render            │  JS API / offscreen GPU
+├──────────────────────────────────────────────────────┤
+│  L3: brepkit-operations    brepkit-io                │  Modeling ops / exchange
+├──────────────────────────────────────────────────────┤
+│  L2: algo  blend  check  heal  offset  sketch        │  Engines
+├──────────────────────────────────────────────────────┤
+│  L1: brepkit-topology      brepkit-geometry          │  B-Rep structures
+├──────────────────────────────────────────────────────┤
+│  L0: brepkit-math                                    │  Vectors, NURBS, predicates
+└──────────────────────────────────────────────────────┘
 ```
 
 ## Layer Rules
@@ -25,12 +27,21 @@ layers below it, never above or sideways.
 | Crate | Layer | Allowed Dependencies |
 |-------|-------|---------------------|
 | `brepkit-math` | L0 | External crates only |
+| `brepkit-geometry` | L1 | `brepkit-math` |
 | `brepkit-topology` | L1 | `brepkit-math` |
-| `brepkit-operations` | L2 | `brepkit-math`, `brepkit-topology` |
-| `brepkit-io` | L2 | `brepkit-math`, `brepkit-topology` |
-| `brepkit-wasm` | L3 | All workspace crates |
+| `brepkit-algo` | L2 | `math`, `topology`, `geometry` |
+| `brepkit-blend` | L2 | `math`, `topology`, `geometry` |
+| `brepkit-check` | L2 | `math`, `topology`, `geometry` |
+| `brepkit-heal` | L2 | `math`, `topology`, `geometry` |
+| `brepkit-offset` | L2 | `math`, `topology`, `geometry` |
+| `brepkit-sketch` | L2 | External crates only |
+| `brepkit-operations` | L3 | All L0 to L2 crates |
+| `brepkit-io` | L3 | `math`, `topology`, `operations` |
+| `brepkit-wasm` | L4 | All workspace crates |
+| `brepkit-render` | L4 | `math`, `topology`, `operations` |
 
-These rules are enforced by `scripts/check-boundaries.sh`.
+These rules are enforced by `scripts/check-boundaries.sh`, which runs in CI.
+`brepkit-render` is a leaf: nothing may depend on it.
 
 ## Arena-Based Topology
 
@@ -42,11 +53,23 @@ central `Arena` and referenced by typed index handles. This approach:
 - Makes ownership clear (the arena owns everything)
 - Provides O(1) entity lookup
 
-## NURBS-Native Geometry
+## Analytic Geometry, with NURBS as the General Case
 
-Geometric entities (curves, surfaces) use NURBS as the native
-representation. This means:
+Curves and surfaces are enums, not a single universal representation.
+`FaceSurface` is one of `Plane`, `Cylinder`, `Cone`, `Sphere`, `Torus`, or
+`Nurbs`; `EdgeCurve` is one of `Line`, `Circle`, `Ellipse`, or `NurbsCurve`.
 
-- Exact representation of conics (circles, ellipses) via rational NURBS
-- Uniform algorithms for evaluation, subdivision, and intersection
-- No special-casing for different curve/surface types
+Analytic types are deliberately special-cased rather than collapsed into
+NURBS:
+
+- Operations preserve them. A cylinder cut by a plane stays a `Cylinder`,
+  so face counts stay low across chained booleans instead of growing with
+  every step.
+- Intersections take exact closed-form paths where a pair allows one
+  (see `math/src/analytic_intersection.rs`), falling back to NURBS
+  marching only when no analytic solution exists.
+- STEP export writes them as native surface entities, so a round-trip is
+  lossless rather than an approximation.
+
+NURBS is the general representation that everything can convert into, and
+the one used for free-form geometry. It is the fallback, not the default.

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -29,8 +29,8 @@ layers below it, never above or sideways.
 | `brepkit-math` | L0 | External crates only |
 | `brepkit-geometry` | L1 | `brepkit-math` |
 | `brepkit-topology` | L1 | `brepkit-math` |
-| `brepkit-algo` | L2 | `math`, `topology`, `geometry` |
-| `brepkit-blend` | L2 | `math`, `topology`, `geometry` |
+| `brepkit-algo` | L2 | `math`, `topology` |
+| `brepkit-blend` | L2 | `math`, `topology` |
 | `brepkit-check` | L2 | `math`, `topology`, `geometry` |
 | `brepkit-heal` | L2 | `math`, `topology`, `geometry` |
 | `brepkit-offset` | L2 | `math`, `topology`, `geometry` |

--- a/book/src/concepts.md
+++ b/book/src/concepts.md
@@ -18,7 +18,8 @@ brepkit separates **topology** (how things are connected) from
 **geometry** (where things are in space):
 
 - **Topology**: Vertex → Edge → Wire → Face → Shell → Solid
-- **Geometry**: Points, curves (NURBS), surfaces (NURBS)
+- **Geometry**: Points; curves (line, circle, ellipse, NURBS); surfaces
+  (plane, cylinder, cone, sphere, torus, NURBS)
 
 A `Face` knows which `Wire` forms its boundary (topology) and which
 `Surface` defines its shape (geometry). This separation is key to

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -23,18 +23,27 @@ cargo test --workspace
 cargo build -p brepkit-wasm --target wasm32-unknown-unknown
 ```
 
-## Using from TypeScript
+## Using from JavaScript and TypeScript
+
+The maintained JS surface is the `brepkit-wasm` package, built from
+`crates/wasm`. It ships its own TypeScript declarations.
 
 ```bash
-cd bindings/ts
-npm install
-npm run build
+npm install brepkit-wasm
 ```
 
 ```typescript
-import { initBrepkit } from '@brepkit/wasm';
+import { BrepKernel } from 'brepkit-wasm';
 
-await initBrepkit();
+const kernel = new BrepKernel();
+const solid = kernel.makeBox(10, 20, 30);
+```
+
+To build it from a checkout instead of installing the release:
+
+```bash
+cargo xtask wasm-build
+node scripts/test-wasm-smoke.mjs
 ```
 
 ## Development

--- a/crates/io/tests/readme_sample.rs
+++ b/crates/io/tests/readme_sample.rs
@@ -1,0 +1,43 @@
+//! Pins the Rust example in README.md so an API change cannot silently rot it.
+//!
+//! Keep the body byte-identical to the README fence. If this test needs an edit,
+//! the README needs the same edit.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use brepkit_io::step::write_step;
+use brepkit_operations::boolean::{BooleanOp, boolean};
+use brepkit_operations::measure::solid_volume;
+use brepkit_operations::primitives::{make_box, make_cylinder};
+use brepkit_topology::Topology;
+
+#[test]
+fn readme_rust_example_compiles_and_runs() -> Result<(), Box<dyn std::error::Error>> {
+    let mut topo = Topology::new();
+
+    // Primitives are anchored at the origin, so this cylinder rounds off the
+    // block's corner. Use `transform_solid` to place it somewhere else.
+    let block = make_box(&mut topo, 30.0, 20.0, 10.0)?;
+    let cutter = make_cylinder(&mut topo, 5.0, 15.0)?;
+    let notched = boolean(&mut topo, BooleanOp::Cut, block, cutter)?;
+
+    // Measure and export
+    let vol = solid_volume(&topo, notched, 0.1)?;
+    let step = write_step(&topo, &[notched])?;
+
+    // Only the quarter of the cylinder inside the +x+y octant overlaps the block,
+    // so the cut takes a quarter-round scallop off one vertical corner. Pin that,
+    // not just "something was removed", or the README prose can drift back to
+    // claiming a through-hole.
+    let box_volume = 30.0 * 20.0 * 10.0;
+    let quarter_cylinder = std::f64::consts::PI * 5.0 * 5.0 * 10.0 / 4.0;
+    let removed = box_volume - vol;
+    assert!(
+        (removed - quarter_cylinder).abs() < 0.05 * quarter_cylinder,
+        "expected a quarter-cylinder notch (~{quarter_cylinder:.1}), removed {removed:.1}"
+    );
+
+    assert!(step.starts_with("ISO-10303-21;"), "not a STEP part 21 file");
+
+    Ok(())
+}

--- a/crates/io/tests/readme_sample.rs
+++ b/crates/io/tests/readme_sample.rs
@@ -1,7 +1,7 @@
 //! Pins the Rust example in README.md so an API change cannot silently rot it.
 //!
-//! Keep the body byte-identical to the README fence. If this test needs an edit,
-//! the README needs the same edit.
+//! The calls and their arguments mirror the README fence; the assertions below
+//! are extra. If a call or argument here has to change, change the README too.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/scripts/check-doc-paths.sh
+++ b/scripts/check-doc-paths.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 
 DOCS=(
   "CLAUDE.md"
-  .claude/skills/*/SKILL.md
+  .claude/skills/*.md
+  .claude/skills/*/*.md
 )
 
 # Paths that do not resolve on main by design.
@@ -25,6 +26,9 @@ ALLOWLIST=(
   # records as must-not-ship. Delete this entry if that branch ever lands.
   "crates/io/tests/kumiko_corner_window_inmem.rs"
   "kumiko_corner_window_inmem.rs"
+  # Named by fillet-blend/reference.md as a pass to design, not existing code.
+  # That paragraph states outright that no such file exists.
+  "reconcile.rs"
 )
 
 FAIL=0

--- a/scripts/check-doc-paths.sh
+++ b/scripts/check-doc-paths.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify every Rust source path named in agent-facing docs still resolves.
+#
+# CLAUDE.md and the skill files are loaded as ground truth at the start of a
+# session, so a path that has gone stale sends a session to a file that no
+# longer exists. Refactors that split a `foo.rs` into a `foo/` directory are
+# the usual cause and nothing else catches them.
+#
+# Paths are matched as suffixes against the real file list, so both
+# `nurbs/curve.rs` and `math/src/traits.rs` resolve.
+
+DOCS=(
+  "CLAUDE.md"
+  .claude/skills/*/SKILL.md
+)
+
+# Paths that do not resolve on main by design.
+ALLOWLIST=(
+  # Cookbook templates naming the file a contributor is about to create.
+  "io/src/format/mod.rs"
+  "operations/src/op_name.rs"
+  # Lives on the parked branch fix/kumiko-corner-window-cut, which the roadmap
+  # records as must-not-ship. Delete this entry if that branch ever lands.
+  "crates/io/tests/kumiko_corner_window_inmem.rs"
+  "kumiko_corner_window_inmem.rs"
+)
+
+FAIL=0
+
+FILE_LIST=$(find crates xtask/src tests -name '*.rs' -type f -not -path '*/target/*' 2>/dev/null | sed 's|^|/|')
+
+is_allowlisted() {
+  local path="$1"
+  for a in "${ALLOWLIST[@]}"; do
+    [ "$path" = "$a" ] && return 0
+  done
+  return 1
+}
+
+for doc in "${DOCS[@]}"; do
+  [ -f "$doc" ] || continue
+
+  # Backticked tokens ending in .rs, e.g. `math/src/cdt.rs`
+  paths=$(grep -oE '`[A-Za-z0-9_./-]+\.rs`' "$doc" | tr -d '`' | sort -u || true)
+  [ -z "$paths" ] && continue
+
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    is_allowlisted "$p" && continue
+
+    if ! echo "$FILE_LIST" | grep -qF "/${p}"; then
+      echo "VIOLATION: $doc references '$p', which does not exist"
+      # A split into a directory is the common case; point at it directly.
+      dir="${p%.rs}"
+      if echo "$FILE_LIST" | grep -qE "/${dir}/[^/]+\.rs$"; then
+        members=$(echo "$FILE_LIST" | grep -oE "/${dir}/[^/]+\.rs$" | sed "s|.*/||; s|\.rs$||" | sort | tr '\n' ' ')
+        echo "           it is now a directory: ${dir}/ (${members% })"
+      fi
+      FAIL=1
+    fi
+  done <<< "$paths"
+done
+
+if [ $FAIL -ne 0 ]; then
+  echo "❌ Doc path check failed."
+  echo "   Update the path, or add it to ALLOWLIST in scripts/check-doc-paths.sh"
+  echo "   if it names a file the reader is meant to create."
+  exit 1
+fi
+
+echo "✅ Doc paths OK."


### PR DESCRIPTION
The README, CLAUDE.md, and the book had drifted from the code. This corrects what is verifiably wrong and adds a CI check so the file-path class of drift cannot recur.

## What was wrong

**README** (last content edit 2026-06-23)
- The `Scope` section said brepkit deliberately does not render, and told readers that "camera, lighting, and shading belong to the caller (Three.js, wgpu, and the like)". `crates/render` landed three days later and does exactly that. The bullet now describes `brepkit-render` as an optional, non-required L4 crate, and the architecture table and status table list it.
- The headline example's comment claimed "a block with a cylindrical hole". Primitives are origin-anchored (`make_box` corner at origin, `make_cylinder` axis on z), so the cylinder overlaps only the +x+y quarter and takes a corner notch. Measured: it removes 203 of 6000, where a through-hole would remove 785. The comment now says what the code does and points at `transform_solid` for placement.

**CLAUDE.md**
- Four module-map paths pointed at files that had been split into directories: `math/src/cdt.rs`, `math/src/nurbs/intersection.rs`, `algo/src/builder/face_splitter.rs`, and Recipe 3's `boolean.rs`.
- Recipe 2's IO signatures were wrong in three ways: readers take the input first and `topo` second (not the reverse), B-Rep readers return `Vec<SolidId>` (not `SolidId`), and text formats return `String` while only binary formats return `Vec<u8>`.
- No module map existed for `brepkit-render`; `operations/src/projection.rs` and `cap.rs` were undocumented.

**book/** (last touched 2026-03-21)
- The layer model showed 5 crates across L0 to L3. There are 14 across L0 to L4, and `operations`, `io`, and `wasm` were all listed at the wrong layer with the wrong dependencies.
- The geometry chapter claimed "No special-casing for different curve/surface types". That is the opposite of the design: `FaceSurface` and `EdgeCurve` are enums whose analytic variants are deliberately preserved through operations and written natively to STEP.
- Getting-started pointed users at `bindings/ts` (`@brepkit/wasm`), a 70-line scaffold that is not a workspace member, not referenced by any CI workflow, and never tested. The maintained surface is `brepkit-wasm`.

## What is new

- `scripts/check-doc-paths.sh` asserts every backticked `*.rs` path in CLAUDE.md and the skill files resolves under `crates/`, `xtask/src/`, or `tests/`. It runs as a hard-failing `Doc Paths` CI job and is verified in both directions (it fails on an injected bad path and passes on a clean tree). Two cookbook templates and one file that lives on the parked `fix/kumiko-corner-window-cut` branch are allowlisted with their reasons.
- `crates/io/tests/readme_sample.rs` compiles and runs the README's Rust example and asserts the quarter-cylinder volume, so the prose cannot drift back.

## Verification

- Both README samples were executed. The Rust one runs as a test; the JS one ran against a local `wasm-pack --target nodejs` build of this commit and returns a `Uint8Array` STEP payload as its comment claims.
- Checked and found **accurate**, so left alone: every `Known Limitations` entry (inertia tensor absent from `operations` and `wasm`, PLY import not bound, defeaturing planar-only, IGES planar placeholders), the Data Exchange table (all 7 formats have both a reader and a writer), every Status-table feature, and the book's "no C/C++ dependencies" claim (`cc` enters only via `criterion`, a dev-dependency, and never reaches `brepkit-wasm`).
- The perf table is deliberately untouched. It is stamped 2026-06-23 and is now the oldest claim in the README; refreshing it needs the brepjs head-to-head harness and is a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes doc drift in README, `CLAUDE.md`, and the book, and adds a CI guard that validates doc file paths across all agent docs. Also pins the README Rust example and documents the optional `brepkit-render` crate.

- **Bug Fixes**
  - README: correct headline example (corner notch vs. hole), update measure/export code, and note optional `brepkit-render` in scope and crate table.
  - `CLAUDE.md`: fix split-path references (CDT, NURBS intersections, face splitter, boolean), correct IO recipe signatures (argument order, return types, plurality), add missing `projection.rs`/`cap.rs`, and include an L4 `render` module map.
  - Book: update layer model to L0–L4 with accurate crate placement and corrected L2 deps (e.g., `algo`/`blend` depend only on math/topology; `render` is a leaf), clarify analytic geometry is preserved (not collapsed to NURBS), and point getting-started to `brepkit-wasm` with a simple usage snippet.

- **New Features**
  - CI guard: `scripts/check-doc-paths.sh` verifies every backticked `*.rs` path in `CLAUDE.md` and `.claude/skills/**/*.md` resolves; added as a “Doc Paths” job in CI with an allowlist for templates, a parked test file, and a deliberate `reconcile.rs` reference.
  - Test: `crates/io/tests/readme_sample.rs` compiles/runs the README Rust sample, asserts a quarter-cylinder notch is removed, and checks the STEP header.
  - Contributor docs: `CONTRIBUTING.md` now calls out running `check-boundaries.sh` and `check-doc-paths.sh` (both run in CI).

<sup>Written for commit 43d53a89e08f9dec2448cc5a7cb9cedfb2153bd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

