### PR TITLE
docs(readme): re-measure the performance table on brepkit 2.128.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,20 +146,28 @@ Layered Cargo workspace. Each crate depends only on the same or lower layers, an
 
 Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs/tree/main/benchmarks) (5 iterations, Node.js, Linux x86_64). WASM is single-threaded. Native benchmarks use criterion.
 
-| Operation                    | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
-| ---------------------------- | -------------- | ----------- | ------- | ---------------- |
-| fuse(box, box) (×10)         | 0.5 ms         | 43.3 ms     | 87x     | 122 µs           |
-| cut(box, cylinder) (×10)     | 59.6 ms        | 72.0 ms     | 1.2x    | 24.1 ms          |
-| intersect(box, sphere) (×10) | 0.3 ms         | 62.6 ms     | 209x    | 104 µs           |
-| box + chamfer                | 0.1 ms         | 5.6 ms      | 56x     | 44 µs            |
-| box + fillet                 | 0.3 ms         | 6.3 ms      | 21x     | 73 µs            |
-| multi-boolean (16 holes)     | 7.0 ms         | 31.2 ms     | 4.5x    | 4.1 ms           |
-| mesh sphere (tol=0.01)       | 33.4 ms        | 49.7 ms     | 1.5x    | 1.5 ms           |
-| exportSTEP (×10)             | 1.1 ms         | 18.6 ms     | 17x     | n/a              |
+| Operation                    | brepkit (WASM) | OCCT (WASM) | Speedup    | brepkit (native) |
+| ---------------------------- | -------------- | ----------- | ---------- | ---------------- |
+| fuse(box, box) (×10)         | 0.5 ms         | 44.3 ms     | 89x        | 121 µs           |
+| cut(box, cylinder) (×10)     | 19.7 ms        | 65.4 ms     | 3.3x       | 8.7 ms           |
+| intersect(box, sphere) (×10) | 0.3 ms         | 58.7 ms     | 196x       | 103 µs           |
+| box + chamfer                | 0.2 ms         | 5.7 ms      | 29x        | 45 µs            |
+| box + fillet                 | 31.7 ms        | 6.1 ms      | 0.2x       | 74 µs \*         |
+| multi-boolean (16 holes)     | 8.0 ms         | 30.4 ms     | 3.8x       | 4.4 ms           |
+| mesh sphere (tol=0.01)       | 35.5 ms        | 49.8 ms     | 1.4x       | 720 µs           |
+| exportSTEP (×10)             | 0.8 ms         | 14.9 ms     | 19x        | n/a              |
 
 Booleans preserve analytic surfaces, so face counts stay low across chained operations. A nine-step compound boolean settles at 72 faces while a mesh-based approach would reach roughly 7,000.
 
-> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. Native benchmarks: `cargo bench -p brepkit-operations --bench cad_operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-06-23.
+`box + fillet` is the one row where brepkit loses, by 5x. The JS `fillet` binding
+routes through the rolling-ball blend engine, which produces G1-continuous NURBS
+blend surfaces and costs about 31 ms on this case.
+
+\* The native `box + fillet` figure is not comparable to the WASM one: the criterion
+case calls the planar fillet directly, a different engine from the one the binding
+selects. Read that cell as the planar engine's cost, not as the same operation.
+
+> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. WASM figures are the median of three runs of `kernel-comparison.bench.test.ts` against a local `wasm-pack --target nodejs --release` build. Native benchmarks: `cargo bench -p brepkit-operations --bench cad_operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-08-02 on brepkit 2.128.8.
 
 ## Data Exchange
 


### PR DESCRIPTION
Refreshes the README perf table, which was stamped 2026-06-23. Every figure below was measured today; nothing is carried over.

## Method

The old table was produced by the brepjs bench suite, which resolves `brepkit-wasm` from `node_modules`. On 2026-06-23 brepjs pinned **2.116.1**, so the table described a published release rather than brepkit main. This run aliases `brepkit-wasm` to a local `wasm-pack --target nodejs --release` build of this commit, via a scratch vitest config (the procedure in the `parity-benchmarking` skill). Figures are the median of three runs.

The alias was verified load-bearing before any number was taken: pointing it at a nonexistent path makes the suite still report **23/23 passing** while silently emitting zero brepkit rows. A green run is not evidence that brepkit was measured; the `[brepkit]` rows in `latest.md` are.

## What actually moved

- **`cut(box, cylinder)` improved 3x**, 59.6 to 19.7 ms in WASM, and 24.1 to 8.7 ms natively.
- **`mesh sphere` roughly halved natively**, 1.5 ms to 720 µs, with WASM flat.
- Everything else is within run-to-run noise.

## `box + fillet` is not a regression

The row goes from a claimed 21x faster to 5x slower, so I chased it before publishing:

1. Both kernels agree. 2.116.1 and 2.128.8 both take ~31 ms and return an identical result (volume 7949.5, 26 faces).
2. `try_fillet` is byte-identical at the old commit, and the rolling-ball engine already cost 17 ms natively there.
3. Running **today's harness against 2.116.1** reproduces `fuse` (0.5), `cut` (58.3), `intersect` (0.3) and `chamfer` (0.1) within noise, but gives **30.9 ms** for the fillet.

So the published 0.3 ms never described this operation on either kernel. The cause is that one row name covers two engines: the JS binding goes through `try_fillet`, which prefers `fillet_rolling_ball` (~31 ms, G1-continuous NURBS blends), while the criterion case calls `fillet` directly (~74 µs, planar). The old table put the planar number in a column measuring the rolling-ball path. Both are now stated, with a footnote saying the native cell is not comparable.

Not fixed here, per instruction to identify the cause and stop. Worth noting separately: **both** engines in that chain are `#[deprecated]`, and the deprecated rolling-ball one is what the public `fillet` binding selects.

## Verification

- 3 runs, medians reported; the fillet row was stable at 32.0 / 31.3 / 31.7 ms.
- Kernel identity confirmed by A/B against a `npm pack brepkit-wasm@2.116.1` extract.
- The bench's own comment says "Punch 4 holes" but the loop is 4x4, so the README's "16 holes" label is correct and unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the README performance table with fresh measurements on brepkit 2.128.8 using a local `brepkit-wasm` build. Highlights: `cut(box, cylinder)` is 3x faster; native `mesh sphere` roughly halved; other rows are within noise.

- **Bug Fixes**
  - Corrects the `box + fillet` row: the JS binding uses the rolling-ball engine (~31 ms) while the native criterion case measures the planar engine (~74 µs). Adds a footnote to mark the native cell as not comparable.
  - Updates benchmark notes (method, date) and OCCT figures from `occt-wasm`.

<sup>Written for commit 6cd63baeccb2ab9e83be3bc30f9419a0bd455298. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

