### PR TITLE
perf(fillet): stop tessellating every face to check for degeneracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,26 +148,18 @@ Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs
 
 | Operation                    | brepkit (WASM) | OCCT (WASM) | Speedup    | brepkit (native) |
 | ---------------------------- | -------------- | ----------- | ---------- | ---------------- |
-| fuse(box, box) (×10)         | 0.5 ms         | 44.3 ms     | 89x        | 121 µs           |
-| cut(box, cylinder) (×10)     | 19.7 ms        | 65.4 ms     | 3.3x       | 8.7 ms           |
-| intersect(box, sphere) (×10) | 0.3 ms         | 58.7 ms     | 196x       | 103 µs           |
-| box + chamfer                | 0.2 ms         | 5.7 ms      | 29x        | 45 µs            |
-| box + fillet                 | 31.7 ms        | 6.1 ms      | 0.2x       | 74 µs \*         |
-| multi-boolean (16 holes)     | 8.0 ms         | 30.4 ms     | 3.8x       | 4.4 ms           |
-| mesh sphere (tol=0.01)       | 35.5 ms        | 49.8 ms     | 1.4x       | 720 µs           |
-| exportSTEP (×10)             | 0.8 ms         | 14.9 ms     | 19x        | n/a              |
+| fuse(box, box) (×10)         | 0.5 ms         | 45.1 ms     | 90x        | 121 µs           |
+| cut(box, cylinder) (×10)     | 22.9 ms        | 67.0 ms     | 2.9x       | 8.7 ms           |
+| intersect(box, sphere) (×10) | 0.3 ms         | 60.8 ms     | 203x       | 103 µs           |
+| box + chamfer                | 0.2 ms         | 5.6 ms      | 28x        | 46 µs            |
+| box + fillet                 | 0.3 ms         | 6.1 ms      | 20x        | 127 µs           |
+| multi-boolean (16 holes)     | 8.1 ms         | 31.3 ms     | 3.9x       | 4.4 ms           |
+| mesh sphere (tol=0.01)       | 33.9 ms        | 50.1 ms     | 1.5x       | 720 µs           |
+| exportSTEP (×10)             | 0.8 ms         | 15.4 ms     | 19x        | n/a              |
 
-Booleans preserve analytic surfaces, so face counts stay low across chained operations. A nine-step compound boolean settles at 72 faces while a mesh-based approach would reach roughly 7,000.
+Booleans preserve analytic surfaces, so face counts stay low across chained operations. A nine-step compound boolean settles at 72 faces while a mesh-based approach would reach roughly 7,000. The same holds for blends: a straight edge filleted between two planar faces keeps an exact cylindrical wall rather than a NURBS approximation of one.
 
-`box + fillet` is the one row where brepkit loses, by 5x. The JS `fillet` binding
-routes through the rolling-ball blend engine, which produces G1-continuous NURBS
-blend surfaces and costs about 31 ms on this case.
-
-\* The native `box + fillet` figure is not comparable to the WASM one: the criterion
-case calls the planar fillet directly, a different engine from the one the binding
-selects. Read that cell as the planar engine's cost, not as the same operation.
-
-> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. WASM figures are the median of three runs of `kernel-comparison.bench.test.ts` against a local `wasm-pack --target nodejs --release` build. Native benchmarks: `cargo bench -p brepkit-operations --bench cad_operations`. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-08-02 on brepkit 2.128.8.
+> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. WASM figures are the median of three runs of `kernel-comparison.bench.test.ts` against a local `wasm-pack --target nodejs --release` build. Native benchmarks: `cargo bench -p brepkit-operations --bench cad_operations`, whose `box+fillet` case drives the same rolling-ball engine the JS binding selects. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Measured 2026-08-02 on brepkit 2.128.8.
 
 ## Data Exchange
 

--- a/crates/operations/benches/cad_operations.rs
+++ b/crates/operations/benches/cad_operations.rs
@@ -26,7 +26,7 @@ use brepkit_operations::boolean::{BooleanOp, boolean};
 use brepkit_operations::chamfer::chamfer;
 use brepkit_operations::copy::copy_solid;
 #[allow(deprecated)]
-use brepkit_operations::fillet::fillet;
+use brepkit_operations::fillet::{fillet, fillet_rolling_ball};
 use brepkit_operations::measure;
 use brepkit_operations::pattern;
 use brepkit_operations::primitives;
@@ -292,15 +292,34 @@ fn bench_box_chamfer_all(c: &mut Criterion) {
     });
 }
 
-/// `box(20,20,20)` + fillet all edges r=1.
+/// `box(20,20,20)` + fillet all edges r=1, flat-bevel engine.
+///
+/// This is NOT the engine the `fillet` JS binding selects; see
+/// `bench_box_fillet_all_rolling_ball` for that one.
 fn bench_box_fillet_all(c: &mut Criterion) {
-    c.bench_function("box+fillet", |b| {
+    c.bench_function("box+fillet (bevel)", |b| {
         b.iter(|| {
             let mut topo = Topology::new();
             let solid = primitives::make_box(&mut topo, 20.0, 20.0, 20.0).unwrap();
             let edges = collect_edges(&topo, solid);
             #[allow(deprecated)]
             black_box(fillet(&mut topo, solid, &edges, 1.0).unwrap());
+        });
+    });
+}
+
+/// `box(20,20,20)` + fillet all edges r=1, rolling-ball engine.
+///
+/// `try_fillet` tries rolling-ball first and accepts it whenever the shell
+/// closes, so this is what the public `fillet` binding actually costs.
+fn bench_box_fillet_all_rolling_ball(c: &mut Criterion) {
+    c.bench_function("box+fillet", |b| {
+        b.iter(|| {
+            let mut topo = Topology::new();
+            let solid = primitives::make_box(&mut topo, 20.0, 20.0, 20.0).unwrap();
+            let edges = collect_edges(&topo, solid);
+            #[allow(deprecated)]
+            black_box(fillet_rolling_ball(&mut topo, solid, &edges, 1.0).unwrap());
         });
     });
 }
@@ -653,6 +672,7 @@ criterion_group! {
     targets =
         bench_box_chamfer_all,
         bench_box_fillet_all,
+        bench_box_fillet_all_rolling_ball,
         bench_multi_boolean,
 }
 

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -1600,10 +1600,14 @@ pub fn fillet_rolling_ball(
             // A cylinder's own normal runs radially outward from its axis, so
             // derive the flag from that rather than reusing the NURBS surface's
             // (the two parameterizations need not agree on orientation).
-            let mid_radial = ((contact1_start - cylinder.origin())
-                + (contact2_start - cylinder.origin()))
-            .normalize()
-            .unwrap_or(bisector_ref);
+            // Project the axis component out before testing: only the radial
+            // part is the surface normal, so an axial drift in either the
+            // contacts or `bisector_ref` cannot flip the comparison.
+            let mid_span =
+                (contact1_start - cylinder.origin()) + (contact2_start - cylinder.origin());
+            let mid_radial = (mid_span - cylinder.axis() * mid_span.dot(cylinder.axis()))
+                .normalize()
+                .unwrap_or(bisector_ref);
             all_specs.push(FaceSpec::CylindricalFace {
                 vertices: strip_vertices,
                 cylinder,

--- a/crates/operations/src/fillet/rolling_ball.rs
+++ b/crates/operations/src/fillet/rolling_ball.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use brepkit_math::nurbs::surface::NurbsSurface;
 use brepkit_math::nurbs::surface_fitting::interpolate_surface;
+use brepkit_math::surfaces::CylindricalSurface;
 use brepkit_math::tolerance::Tolerance;
 use brepkit_math::vec::{Point3, Vec3};
 use brepkit_topology::Topology;
@@ -1558,12 +1559,65 @@ pub fn fillet_rolling_ball(
         let strip_normal = fillet_surface.normal(0.5, 0.5).unwrap_or(bisector_ref);
         let strip_reversed = strip_normal.dot(bisector_ref) > 0.0;
 
-        all_specs.push(FaceSpec::Surface {
-            vertices: vec![contact1_start, contact2_start, contact2_end, contact1_end],
-            surface: FaceSurface::Nurbs(fillet_surface),
-            reversed: strip_reversed,
-            inner_wires: vec![],
-        });
+        // A straight edge between two planar faces (the `n_v == 2` case above,
+        // which builds an exact rational-quadratic arc swept linearly) rolls an
+        // exact quarter-cylinder: axis along the edge, radius = the fillet
+        // radius. Emit it as an analytic `CylindricalFace` rather than the
+        // equivalent NURBS so the wall stays exact for downstream booleans and
+        // STEP export, and so area/tessellation take their analytic paths. The
+        // NURBS form is kept as the fallback whenever the corners do not sit on
+        // the cylinder we derived, so a mis-derived axis can never ship.
+        let strip_vertices = vec![contact1_start, contact2_start, contact2_end, contact1_end];
+        let analytic_strip = if n_v == 2 {
+            // The ball centre sits one radius off a contact point along that
+            // face's normal, on the material side. Pick the sign that lands
+            // equidistant from BOTH contacts.
+            let snap = tol.linear * 100.0;
+            [-1.0_f64, 1.0]
+                .into_iter()
+                .find_map(|sgn| {
+                    let center = Point3::new(
+                        contact1_start.x() + sgn * n1_start.x() * radius,
+                        contact1_start.y() + sgn * n1_start.y() * radius,
+                        contact1_start.z() + sgn * n1_start.z() * radius,
+                    );
+                    (((contact2_start - center).length() - radius).abs() < snap).then_some(center)
+                })
+                .and_then(|center| CylindricalSurface::new(center, edge_dir, radius).ok())
+                .filter(|cyl| {
+                    strip_vertices.iter().all(|p| {
+                        let d = *p - cyl.origin();
+                        let axial = d.dot(cyl.axis());
+                        let radial = d - cyl.axis() * axial;
+                        (radial.length() - radius).abs() < snap
+                    })
+                })
+        } else {
+            None
+        };
+
+        if let Some(cylinder) = analytic_strip {
+            // A cylinder's own normal runs radially outward from its axis, so
+            // derive the flag from that rather than reusing the NURBS surface's
+            // (the two parameterizations need not agree on orientation).
+            let mid_radial = ((contact1_start - cylinder.origin())
+                + (contact2_start - cylinder.origin()))
+            .normalize()
+            .unwrap_or(bisector_ref);
+            all_specs.push(FaceSpec::CylindricalFace {
+                vertices: strip_vertices,
+                cylinder,
+                reversed: mid_radial.dot(bisector_ref) > 0.0,
+                inner_wires: vec![],
+            });
+        } else {
+            all_specs.push(FaceSpec::Surface {
+                vertices: strip_vertices,
+                surface: FaceSurface::Nurbs(fillet_surface),
+                reversed: strip_reversed,
+                inner_wires: vec![],
+            });
+        }
 
         // Record contact points at each vertex for vertex blend detection.
         let start_vi = edge.start().index();
@@ -1949,6 +2003,14 @@ pub fn fillet_rolling_ball(
                 let cap_norm = cap_surface.normal(0.5, 0.5).unwrap_or(outward);
                 let cap_reversed = cap_norm.dot(outward) < 0.0;
 
+                // This corner is geometrically a spherical triangle, but it is
+                // NOT emitted as `FaceSurface::Sphere`: a sphere face bounded by
+                // a triangular wire measures its own area over the wrong extent
+                // (9.42 = 3pi per corner instead of the octant's pi/2), which
+                // drops a filleted 10-cube from 975.59 to 973.70. Until sphere
+                // faces carry a correct trimmed extent, the rational patch above
+                // is the accurate representation even though it only tracks the
+                // sphere to within a few percent.
                 all_specs.push(FaceSpec::Surface {
                     vertices: ordered_points,
                     surface: FaceSurface::Nurbs(cap_surface),
@@ -2173,6 +2235,18 @@ pub fn fillet_rolling_ball(
         .map_err(crate::OperationsError::Topology)?;
     let area_floor = (radius * radius) * 1e-6;
     for fid in faces {
+        // Fast accept first. `face_area` tessellates NURBS faces, and the
+        // corner patch's degenerate column subdivides far past what its
+        // curvature warrants (up to 1490 triangles for a patch the size of a
+        // sphere octant), so measuring every face that way cost more than
+        // building the whole fillet. A boundary wire that already encloses real
+        // area cannot bound a collapsed face, so clearing the floor on the
+        // cheap polygon is conclusive; anything it cannot clear still goes
+        // through the exact measurement below, leaving the guard's verdict
+        // unchanged.
+        if boundary_polygon_area(topo, fid)? > area_floor {
+            continue;
+        }
         let area = crate::measure::face_area(topo, fid, radius * 0.1)?;
         if area <= area_floor {
             return Err(crate::OperationsError::InvalidInput {
@@ -2339,4 +2413,26 @@ fn build_two_edge_corner_patch(
         reversed,
         inner_wires: vec![],
     })
+}
+
+/// Area of a face's outer boundary wire, via Newell's method.
+///
+/// A lower bound on the face's true area for the blend patches this engine
+/// emits, used only as a fast "clearly not degenerate" test.
+fn boundary_polygon_area(topo: &Topology, face_id: FaceId) -> Result<f64, crate::OperationsError> {
+    let pts = crate::boolean::face_polygon(topo, face_id)?;
+    if pts.len() < 3 {
+        return Ok(0.0);
+    }
+    let mut n = Vec3::new(0.0, 0.0, 0.0);
+    for i in 0..pts.len() {
+        let a = pts[i];
+        let b = pts[(i + 1) % pts.len()];
+        n += Vec3::new(
+            a.y() * b.z() - a.z() * b.y(),
+            a.z() * b.x() - a.x() * b.z(),
+            a.x() * b.y() - a.y() * b.x(),
+        );
+    }
+    Ok(n.length() * 0.5)
 }

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -236,7 +236,26 @@ fn rolling_ball_fillet_single_edge() {
 }
 
 #[test]
-fn rolling_ball_fillet_has_nurbs_face() {
+fn rolling_ball_rejects_closed_rim_so_dispatcher_falls_through() {
+    // The degeneracy guard's whole purpose: a cylinder's closed circular rim
+    // collapses its blend strip to zero area, and `try_fillet` relies on the
+    // error to fall through to the walking engine. The guard clears healthy
+    // faces via a cheap boundary-polygon area, so this pins that the shortcut
+    // cannot accept a collapsed face and silently ship the corrupt solid.
+    let mut topo = Topology::new();
+    let cyl = crate::primitives::make_cylinder(&mut topo, 10.0, 20.0).expect("cylinder");
+    let edges = solid_edge_ids(&topo, cyl);
+
+    let err = fillet_rolling_ball(&mut topo, cyl, &edges, 0.5)
+        .expect_err("rolling-ball must reject a closed circular rim");
+    assert!(
+        err.to_string().contains("degenerate face"),
+        "expected the degeneracy guard to fire, got: {err}"
+    );
+}
+
+#[test]
+fn rolling_ball_straight_edge_wall_is_exact_cylinder() {
     let mut topo = Topology::new();
     let cube = make_unit_cube_manifold(&mut topo);
 
@@ -247,14 +266,22 @@ fn rolling_ball_fillet_has_nurbs_face() {
     let s = topo.solid(result).expect("result solid");
     let sh = topo.shell(s.outer_shell()).expect("shell");
 
-    // At least one face should be a NURBS surface (the fillet).
-    let has_nurbs = sh.faces().iter().any(|&fid| {
-        matches!(
-            topo.face(fid).expect("face").surface(),
-            FaceSurface::Nurbs(_)
-        )
-    });
-    assert!(has_nurbs, "rolling-ball fillet should produce NURBS faces");
+    // A straight edge between two planar faces rolls an EXACT quarter-cylinder,
+    // so the blend wall must be a Cylinder, not a NURBS approximation of one.
+    // Degrading it to NURBS costs downstream booleans their analytic path and
+    // makes the wall tessellate far denser than its curvature warrants.
+    let walls: Vec<_> = sh
+        .faces()
+        .iter()
+        .filter(|&&fid| !topo.face(fid).expect("face").surface().is_planar())
+        .collect();
+    assert_eq!(walls.len(), 1, "one blend wall expected");
+    let surface = topo.face(*walls[0]).expect("face").surface();
+    assert!(
+        matches!(surface, FaceSurface::Cylinder(cyl) if (cyl.radius() - 0.1).abs() < 1e-9),
+        "straight-edge blend wall must be an exact r=0.1 Cylinder, got {:?}",
+        surface.type_tag()
+    );
 }
 
 #[test]
@@ -1166,9 +1193,9 @@ fn fillet_rolling_ball_second_pass_on_nurbs_solid() {
         let sh = topo.shell(s.outer_shell()).unwrap();
         sh.faces()
             .iter()
-            .any(|&fid| matches!(topo.face(fid).unwrap().surface(), FaceSurface::Nurbs(_)))
+            .any(|&fid| !topo.face(fid).unwrap().surface().is_planar())
     };
-    assert!(has_nurbs, "first fillet must produce a NURBS face");
+    assert!(has_nurbs, "first fillet must produce a blend face");
 
     // Second fillet on a different edge.
     let edges2 = solid_edge_ids(&topo, result1);
@@ -1362,14 +1389,11 @@ fn fillet_edge_adjacent_to_nurbs_blend_is_watertight() {
             .unwrap();
         sh.faces()
             .iter()
-            .filter(|&&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Nurbs(_)))
+            .filter(|&&f| !topo.face(f).unwrap().surface().is_planar())
             .map(|f| f.index())
             .collect()
     };
-    assert!(
-        !nurbs.is_empty(),
-        "first fillet must create a NURBS blend face"
-    );
+    assert!(!nurbs.is_empty(), "first fillet must create a blend face");
 
     let mut ef: HashMap<usize, Vec<FaceId>> = HashMap::new();
     {

--- a/crates/operations/src/fillet/tests.rs
+++ b/crates/operations/src/fillet/tests.rs
@@ -248,9 +248,13 @@ fn rolling_ball_rejects_closed_rim_so_dispatcher_falls_through() {
 
     let err = fillet_rolling_ball(&mut topo, cyl, &edges, 0.5)
         .expect_err("rolling-ball must reject a closed circular rim");
+    let reason = match &err {
+        crate::OperationsError::InvalidInput { reason } => reason,
+        other => unreachable!("expected InvalidInput from the degeneracy guard, got: {other:?}"),
+    };
     assert!(
-        err.to_string().contains("degenerate face"),
-        "expected the degeneracy guard to fire, got: {err}"
+        reason.contains("degenerate face"),
+        "expected the degeneracy guard to fire, got: {reason}"
     );
 }
 
@@ -1187,7 +1191,8 @@ fn fillet_rolling_ball_second_pass_on_nurbs_solid() {
     let result1 = fillet_rolling_ball(&mut topo, solid, &[edges1[0]], 0.1)
         .expect("first rolling-ball fillet should succeed");
 
-    // Confirm NURBS face was created.
+    // Confirm a blend face was created (a cylinder here, NURBS for curved
+    // neighbours).
     let has_nurbs = {
         let s = topo.solid(result1).unwrap();
         let sh = topo.shell(s.outer_shell()).unwrap();
@@ -1383,7 +1388,7 @@ fn fillet_edge_adjacent_to_nurbs_blend_is_watertight() {
     let vol1 = crate::measure::solid_volume(&topo, first, 0.05).unwrap();
 
     // Collect NURBS blend faces and edge→faces adjacency.
-    let nurbs: HashSet<usize> = {
+    let blend_faces: HashSet<usize> = {
         let sh = topo
             .shell(topo.solid(first).unwrap().outer_shell())
             .unwrap();
@@ -1393,7 +1398,10 @@ fn fillet_edge_adjacent_to_nurbs_blend_is_watertight() {
             .map(|f| f.index())
             .collect()
     };
-    assert!(!nurbs.is_empty(), "first fillet must create a blend face");
+    assert!(
+        !blend_faces.is_empty(),
+        "first fillet must create a blend face"
+    );
 
     let mut ef: HashMap<usize, Vec<FaceId>> = HashMap::new();
     {
@@ -1418,7 +1426,7 @@ fn fillet_edge_adjacent_to_nurbs_blend_is_watertight() {
         .find(|&e| {
             ef.get(&e.index()).is_some_and(|fs| {
                 fs.len() == 2
-                    && fs.iter().any(|f| nurbs.contains(&f.index()))
+                    && fs.iter().any(|f| blend_faces.contains(&f.index()))
                     && dihedral_deg(&topo, e, fs) > 5.0
             })
         })

--- a/crates/operations/src/query.rs
+++ b/crates/operations/src/query.rs
@@ -191,16 +191,15 @@ mod tests {
         let sh = topo
             .shell(topo.solid(filleted).unwrap().outer_shell())
             .unwrap();
+        // The blend face, whatever surface type it carries. A straight box
+        // edge blends to an exact cylinder; only curved neighbours give NURBS.
         let nurbs: HashSet<usize> = sh
             .faces()
             .iter()
-            .filter(|&&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Nurbs(_)))
+            .filter(|&&f| !topo.face(f).unwrap().surface().is_planar())
             .map(|f| f.index())
             .collect();
-        assert!(
-            !nurbs.is_empty(),
-            "first fillet must create a NURBS blend face"
-        );
+        assert!(!nurbs.is_empty(), "first fillet must create a blend face");
 
         let mut ef: HashMap<usize, HashSet<FaceId>> = HashMap::new();
         for &fid in sh.faces() {

--- a/crates/operations/src/query.rs
+++ b/crates/operations/src/query.rs
@@ -193,13 +193,16 @@ mod tests {
             .unwrap();
         // The blend face, whatever surface type it carries. A straight box
         // edge blends to an exact cylinder; only curved neighbours give NURBS.
-        let nurbs: HashSet<usize> = sh
+        let blend_faces: HashSet<usize> = sh
             .faces()
             .iter()
             .filter(|&&f| !topo.face(f).unwrap().surface().is_planar())
             .map(|f| f.index())
             .collect();
-        assert!(!nurbs.is_empty(), "first fillet must create a blend face");
+        assert!(
+            !blend_faces.is_empty(),
+            "first fillet must create a blend face"
+        );
 
         let mut ef: HashMap<usize, HashSet<FaceId>> = HashMap::new();
         for &fid in sh.faces() {
@@ -217,7 +220,7 @@ mod tests {
             let Some(fs) = ef.get(&e.index()) else {
                 continue;
             };
-            if fs.len() != 2 || !fs.iter().any(|f| nurbs.contains(&f.index())) {
+            if fs.len() != 2 || !fs.iter().any(|f| blend_faces.contains(&f.index())) {
                 continue;
             }
             if edge_is_tangent(&topo, e, fs).unwrap() {

--- a/crates/wasm/src/helpers.rs
+++ b/crates/wasm/src/helpers.rs
@@ -649,7 +649,6 @@ mod fillet_tests {
     fn try_fillet_nurbs_blend_neighbor_is_watertight() {
         use std::collections::HashMap;
 
-        use brepkit_topology::face::FaceSurface;
         use brepkit_topology::validation::{validate_shell_closed, validate_shell_manifold};
 
         // #834 via the consumer path: a single fillet creates a NURBS blend
@@ -666,19 +665,19 @@ mod fillet_tests {
             validate_shell_closed(sh, &topo).expect("first fillet should be watertight");
         }
 
-        let nurbs: HashSet<usize> = {
+        let blend_faces: HashSet<usize> = {
             let sh = topo
                 .shell(topo.solid(first).unwrap().outer_shell())
                 .unwrap();
             sh.faces()
                 .iter()
-                .filter(|&&f| matches!(topo.face(f).unwrap().surface(), FaceSurface::Nurbs(_)))
+                .filter(|&&f| !topo.face(f).unwrap().surface().is_planar())
                 .map(|f| f.index())
                 .collect()
         };
         assert!(
-            !nurbs.is_empty(),
-            "first fillet must create a NURBS blend face"
+            !blend_faces.is_empty(),
+            "first fillet must create a blend face"
         );
 
         let mut ef: HashMap<usize, HashSet<usize>> = HashMap::new();
@@ -711,7 +710,7 @@ mod fillet_tests {
                 filletable.contains(&e.index())
                     && ef
                         .get(&e.index())
-                        .is_some_and(|fs| fs.iter().any(|f| nurbs.contains(f)))
+                        .is_some_and(|fs| fs.iter().any(|f| blend_faces.contains(f)))
             })
             .expect("a filletable edge bordering the NURBS blend face");
 


### PR DESCRIPTION
`box + fillet` was the one head-to-head row brepkit lost: **31.7 ms in wasm against the reference kernel's 6.1 ms**, a 5x loss. It is now **0.3 ms, 20x faster**.

```
box+fillet   17.054 ms -> 127.18 us   native (criterion, same machine)
box+fillet   31.7 ms   -> 0.3 ms      wasm (vs 6.1 ms reference)
```

## Where the time went

Phase-timing the engine put **19.3 ms of a 19.8 ms run in the degeneracy guard** at the end. Building the fillet took 0.4 ms; assembly was 93 µs.

The guard calls `face_area` on every face at deflection `radius * 0.1`. `face_area` tessellates NURBS faces, and the corner blend is a degree-(2,2) rational patch with a **degenerate column** (a triangular region forced onto a square domain). The resulting singular corner makes adaptive subdivision emit up to **1490 triangles for a patch the size of a sphere octant**, where 128 suffices:

| corner patch | triangles | face_area |
|---|---|---|
| 3 of 8 | 128 to 362 | 0.36 to 0.82 ms |
| 5 of 8 | 806 to 1490 | 1.7 to 3.0 ms |

Same geometry, different cost: the point ordering decides which physical corner the singularity lands on. Coarsening the deflection does not help at all (the mesher floors out at 128 triangles by deflection 0.1 and stays there through 10.0), which is why this is a patch-structure problem rather than a tolerance one.

## The fix

**Guard.** Clear a face on its boundary-polygon area (Newell) first, and fall back to the exact `face_area` only when that cheap bound cannot clear the floor. A wire that already encloses real area cannot bound a collapsed face, so the verdict is unchanged and every borderline face is still measured exactly.

The guard exists so `try_fillet` gets an error on a closed circular rim and falls through to the walking engine. That rejection still fires, and there is now a test pinning it so the shortcut cannot silently swallow it.

**Analytic wall.** A straight edge between two planar faces rolls an exact quarter-cylinder; it was emitted as the equivalent rational NURBS. It is now a `CylindricalFace` whenever the derived axis actually carries all four corners, with the NURBS form retained as the fallback. Worth ~20% on its own, and it keeps the wall analytic for downstream booleans and STEP export. Assembly already builds true `Circle3D` arcs for the angular edges of a cylindrical face, so the boundary is shared correctly with the corner patches.

## Verification

- **Topology identical**: 26 faces, 48 edges, 24 vertices before and after.
- **Volume slightly closer to truth**: 7949.4916 to 7949.5373, against an exact Minkowski value of 7949.8348 for a 20-cube filleted at r=1.
- Cylindrical wall areas are now exact: 12 x 4pi = 150.7964.
- Full workspace suite green (2677 passed). The `brepkit-render` `compute_mesh_lod` SIGSEGV reproduces on unmodified `main` with these changes stashed, uses no fillet, and its three assertions pass; it is a pre-existing wgpu teardown crash, not from this PR.
- README table refreshed from the same run, and its `box + fillet` footnote (which existed only because the criterion case measured a different engine) is gone: the bench now drives the rolling-ball path the binding actually selects, with the flat-bevel engine kept as `box+fillet (bevel)`.

## Deliberately not done

The corner patch is geometrically a spherical triangle, and emitting `FaceSurface::Sphere` would make it exact rather than the current few-percent approximation. I tried it and reverted: a sphere face bounded by a triangular wire measures its own area over the wrong extent (**9.42 = 3pi per corner instead of the octant's pi/2**), dropping a filleted 10-cube from 975.59 to 973.70. That needs trimmed-extent support on sphere faces first, so it is left as a follow-up with the finding recorded in a comment at the site.

Engine order in `try_fillet` is untouched, per the product decision recorded in the fillet-blend skill.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tessellating every face in the rolling-ball fillet guard and adds analytic cylinders for straight-edge walls. Box + fillet drops from 31.7 ms to 0.3 ms in WASM and from 17.05 ms to 127 µs native.

- **Performance**
  - Degeneracy guard checks boundary polygon area first; falls back to exact `face_area` only when needed.
  - Keeps the closed circular rim rejection and pins it with a test.
  - Bench suite separates `box+fillet (bevel)` from the rolling-ball case; README benchmark table updated to measure the rolling-ball engine.
  - Cylinder wall orientation now projects the axis component out before comparison to avoid reversal flips.

- **New Features**
  - Straight edge between planar faces emits a `CylindricalFace` when the derived axis carries all corners; NURBS remains as fallback.
  - Tests recognize any non-planar blend face (cylinder or NURBS) to match the exact wall; analytic cylinder preserves area and improves downstream booleans and STEP export.

<sup>Written for commit ff9b498577e5d362b9cbd17eb49f9473c3c27800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

