### PR TITLE
fix(algo): exact polygon clip for plane-plane lines in the FF prefilter

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -183,19 +183,19 @@ five kumiko roots (`9ecb2bb2`, `e58fec63`, `2fa915e9`, `de6bdcb8`, `1d41afea`); 
 under it. So the corner-cut work does not reach this configuration, and "overlay the parked branch
 and see" is a dead experiment. VERIFY WHICH BRANCH A MEASURED KERNEL CAME FROM before proposing a
 branch-comparison — that check turned a planned experiment into an already-answered one.
-**FULLY REDUCED TO A 364 ms FIXTURE — `crates/io/tests/kumiko_lattice_fuse_inmem.rs`.** All 31
-booleans of the export were replayed natively:
-- ops 0-28 are clean, analytic, `free=0 over=0`.
-- **`op29`** cuts the bin body (F=78, 12 cones + 24 cylinders) with 8 lattice tools, takes **99 s**,
-  and returns **`F=5716 ALL-PLANAR free=2 over=3`** — every curved face gone, the fallback tell.
-- `op30` then fuses that already-broken body, so it is pure GIGO; do not start there.
-`compound_cut` batches by merging its tools into ONE solid first, so those merges are FUSES — and
-inside op29 they fail **82 times**, 80 with `open growth shell`, each dropping to a mesh fallback
-whose own output is not a closed 2-manifold. Isolating one merge gives the fixture:
-**`fuse(F=414 band, F=653 band)`, both clean and planar, aborts in 364 ms with `open growth shell
-with 67 faces`.** Same family as the kumiko corner campaign — so the `divider` and `kumiko` matrix
-families share machinery. NOTE the parked branch does NOT fix it (see above: the capture kernel
-contained all five of its roots).
+**FULLY REDUCED TO A 364 ms FIXTURE — `crates/io/tests/kumiko_lattice_fuse_inmem.rs` — AND THE
+ROOT CHAIN IS NOW LOCALIZED TO ONE MISSING QUAD (2026-08-03).** The 67-face open lump has exactly
+FOUR free edges bounding one 0.05-wide skewed quad. Probe chain (BK_OPEN_SHELL → BK_SUBFACE_BOX →
+BK_FF_TRACE → per-face section probes): the quad is a strip of B-slant face 845 that never split
+at x=38.05 because its section CHAIN dangles 0.002 short of 845's boundary — the closing 0.002
+micro-section (a REAL lattice end-facet feature, 20000×tol, not noise) was graze-dropped by the
+sampled in-both filter, the arrangement then rejects the pendant chain, and the face under-splits.
+SHIPPED prerequisite: F1's plane×plane Line filter now uses the exact polygon clip instead of
+16-sample aliasing (the fix the old comment said "needs a test against true face extents" — the
+AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING:
+admit exact-clip-verified micro Line sections (or extend `rescue_corner_crossing`'s gates) so a
+0.002 chain-closing piece survives the graze filter — the lattice bands have such micro-facets at
+every band end, so this likely accounts for many of the 82 op29 fuse failures at once.
 CAPTURE GAP worth fixing once: `compoundCut(base, tools[])` passes its tools as an ARRAY, so a
 number-only argument filter captures the base and silently drops every tool — the op then cannot be
 replayed at all. Flatten arrays and typed arrays in any boolean-capture hook.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -391,12 +391,27 @@ pub fn perform(
                     if (0..=N).map(|i| sample(i, N)).any(in_both) {
                         return true;
                     }
-                    // Remaining (plane×plane) lines keep their original
-                    // treatment: no refinement, because refining every far pair
-                    // would be pure cost and the exact test above is the answer
-                    // wherever it is safe to apply.
+                    // Plane×plane lines that the sampled test missed get the
+                    // exact answer against the faces' TRUE OUTLINES (the fix
+                    // the AABB slab-clip could not safely provide here: an
+                    // inflated AABB grossly over-approximates a planar face
+                    // and admitted spurious lines into the A1-corner nub
+                    // fuse). The in-both window of a lattice facet can be far
+                    // under the sample pitch — a mitsukude band's 0.05 mm
+                    // side facets lost 80+ real sections to this aliasing and
+                    // sent every wall-pattern fuse to the mesh fallback.
+                    // Polygon clips are hull ranges on non-convex outlines,
+                    // so this can only over-admit (downstream trims);
+                    // indeterminate polygons keep the historical drop.
                     if matches!(raw.curve, EdgeCurve::Line) {
-                        return false;
+                        let ca = clip_line_to_face(topo, fa, raw);
+                        let cb = clip_line_to_face(topo, fb, raw);
+                        return match (ca, cb) {
+                            (FaceClip::Range(a), FaceClip::Range(b)) => {
+                                a.0.max(b.0) < a.1.min(b.1) - 1e-9
+                            }
+                            _ => false,
+                        };
                     }
                     let approx_len: f64 = (0..N)
                         .map(|i| (sample(i + 1, N) - sample(i, N)).length())


### PR DESCRIPTION
## Summary

The FF prefilter's 16-sample in-both test aliases on plane×plane Line sections: a lattice facet's true in-both window can be far under the sample pitch, and the mitsukude wall-pattern bands lose 80+ real sections this way (the `kumiko_lattice_fuse_inmem` open-shell family — each drop under-splits a face and sends the fuse to the mesh fallback).

The existing slab-clip fix (#1224) was deliberately gated to quadric partners because an inflated AABB grossly over-approximates a planar face — widening it regressed the A1-corner nub fuse to bnd=158. The filter comment recorded the correct fix shape: "a test against true face extents rather than AABBs". This implements it: lines that fail the sampled test get the exact answer against both faces' **true outlines** via `clip_line_to_face`. Hull ranges on non-convex outlines can only over-admit (downstream trimming handles that); indeterminate polygons keep the historical drop, so no current keep is lost and no AABB-style spurious admission is possible.

## Status

Prerequisite, not a close: the fixture still aborts on a second, now fully-localized root — the 67-face lump's four free edges bound ONE 0.05-wide quad whose section chain dangles 0.002 short of its face boundary because the chain-closing 0.002 micro-section (a real lattice end-facet feature, 20000×tol) is graze-dropped. The roadmap row carries the complete probe chain and the remaining fix shape.

## Verification

- Full workspace green (107 suites, `--exclude brepkit-render`) — including the A1-corner family and every face-splitter foil; clippy `-D warnings` clean.
- FF trace confirms previously-dropped flat-wall pairs now emit their sections.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes aliasing in the FF prefilter by using an exact polygon clip for plane-plane lines when the 16-sample in-both test misses. Recovers real sections in lattice/wall-pattern cases without reintroducing AABB-based false positives.

- **Bug Fixes**
  - Added a fallback that clips the line against both faces’ true outlines via `clip_line_to_face` and admits on overlapping ranges; only runs when the sampled test fails.
  - Avoids inflated AABB slab-clip regressions; non-convex outlines use hull ranges (safe to over-admit; downstream trims), and indeterminate polygons remain dropped.

<sup>Written for commit c0f62fde05a6207a32c30daa84f9e3c06abf0c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

