### PR TITLE
docs(roadmap): kumiko lattice second-pass map

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -192,10 +192,18 @@ micro-section (a REAL lattice end-facet feature, 20000×tol, not noise) was graz
 sampled in-both filter, the arrangement then rejects the pendant chain, and the face under-splits.
 SHIPPED prerequisite: F1's plane×plane Line filter now uses the exact polygon clip instead of
 16-sample aliasing (the fix the old comment said "needs a test against true face extents" — the
-AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING:
-admit exact-clip-verified micro Line sections (or extend `rescue_corner_crossing`'s gates) so a
-0.002 chain-closing piece survives the graze filter — the lattice bands have such micro-facets at
-every band end, so this likely accounts for many of the 82 op29 fuse failures at once.
+AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING (map deepened 2026-08-03, second pass):
+the chain's ends are crossings with the PARTNER face's outline (face 370), landing ~5e-4 OFF
+845's own boundary line — `find_splits_on_line`'s exact-tol (1e-7) anchor gate correctly rejects
+them (do NOT widen it to model scale; the 0.002 gaps are real geometry, not fit error). The
+partition needs the CLOSING micro-section from the (845 × A-band-end-facet) pair, which never
+reaches the splitter. Hunt that pair with targeted FF logging; candidate deaths, in order:
+pair-level reject-aabb on the flat facet's degenerate AABB; `clip_line_to_polygon_general`'s
+`hi − lo < 1e-6` fraction floor (a 0.002 window can sit under it when the raw line is long);
+the sample-clip graze drop. Every lattice band end has these micro-facets, so one death site
+likely accounts for many of the 82 op29 fuse failures at once. Probe recipe: BK_OPEN_SHELL →
+BK_SUBFACE_BOX around the quad → per-face section probes at split_face_2d entry (pattern in
+git history at c9847a44's parent).
 CAPTURE GAP worth fixing once: `compoundCut(base, tools[])` passes its tools as an ARRAY, so a
 number-only argument filter captures the base and silently drops every tool — the op then cannot be
 replayed at all. Flatten arrays and typed arrays in any boolean-capture hook.


### PR DESCRIPTION
Records the second probe pass on the kumiko lattice fixture: the section chain's ends are crossings with the PARTNER face's outline, ~5e-4 off face 845's own boundary line — `find_splits_on_line`'s exact-tol anchor gate rejects them correctly (the 0.002 gaps are real lattice geometry, not fit error; widening the gate to model scale would be wrong). The required closing micro-section comes from the (845 × A-band-end-facet) pair and never reaches the splitter. The row lists the candidate death sites in priority order (pair reject-aabb on the flat facet, the 1e-6 fraction floor in `clip_line_to_polygon_general`, the sample-clip graze) and the probe recipe. Roadmap-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deepens the kumiko lattice roadmap with a second-pass probe map to guide debugging of the under-split. Clarifies that partner-outline crossings (~5e-4 off face 845) are rightly rejected by `find_splits_on_line`, identifies the missing closing micro-section from the 845 × band‑end‑facet pair, lists likely kill points (`reject-aabb`, `clip_line_to_polygon_general` fraction floor, sample‑clip graze), and adds a focused probe recipe without widening tolerances.

<sup>Written for commit 39633c29a85a93b33e9f65938d8c6711d07755db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

