### PR TITLE
fix(algo): weld-scale boundary anchoring for line splits

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -192,18 +192,16 @@ micro-section (a REAL lattice end-facet feature, 20000×tol, not noise) was graz
 sampled in-both filter, the arrangement then rejects the pendant chain, and the face under-splits.
 SHIPPED prerequisite: F1's plane×plane Line filter now uses the exact polygon clip instead of
 16-sample aliasing (the fix the old comment said "needs a test against true face extents" — the
-AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING (map deepened 2026-08-03, second pass):
-the chain's ends are crossings with the PARTNER face's outline (face 370), landing ~5e-4 OFF
-845's own boundary line — `find_splits_on_line`'s exact-tol (1e-7) anchor gate correctly rejects
-them (do NOT widen it to model scale; the 0.002 gaps are real geometry, not fit error). The
-partition needs the CLOSING micro-section from the (845 × A-band-end-facet) pair, which never
-reaches the splitter. Hunt that pair with targeted FF logging; candidate deaths, in order:
-pair-level reject-aabb on the flat facet's degenerate AABB; `clip_line_to_polygon_general`'s
-`hi − lo < 1e-6` fraction floor (a 0.002 window can sit under it when the raw line is long);
-the sample-clip graze drop. Every lattice band end has these micro-facets, so one death site
-likely accounts for many of the 82 op29 fuse failures at once. Probe recipe: BK_OPEN_SHELL →
-BK_SUBFACE_BOX around the quad → per-face section probes at split_face_2d entry (pattern in
-git history at c9847a44's parent).
+AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING (third pass, 2026-08-03 — root A CLOSED, abort moved 67 to 86 faces):
+the "0.002 real geometry" claim from pass two was a DISPLAY-ROUNDING artifact of the probe
+targets; full-precision measurement put the chain ends 2.1e-7 and 2.3e-7 off face 845's boundary
+edges — the canonical recurring trap (exact-tol gate meeting few-tol section rounding).
+`find_splits_on_line`'s boundary-anchor distance now accepts at weld scale (100·tol), matching
+the dedup band in the same function; the 845 quad closes and the abort moves to a NEW 86-face
+lump at z 13..19 with a different signature: 11+ free edges and some with `coincident_other_id=1`
+(partition mismatch between coincident selected faces, not a missing face). Sequential peeling —
+expect more roots. Probe recipe unchanged (BK_OPEN_SHELL first; the free-edge dump names the
+region).
 CAPTURE GAP worth fixing once: `compoundCut(base, tools[])` passes its tools as an ARRAY, so a
 number-only argument filter captures the base and silently drops every tool — the op then cannot be
 replayed at all. Flatten arrays and typed arrays in any boolean-capture hook.

--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -162,7 +162,14 @@ pub(super) fn find_splits_on_line(
         }
         let closest = edge.start_3d + edge_dir * t;
         let dist = (sp - closest).length();
-        if dist < tol {
+        // Weld-scale acceptance, not exact-tol: a plane-plane section
+        // endpoint carries clip/trim rounding of a few tol — the kumiko
+        // lattice chain ends measured 2.1e-7 and 2.3e-7 off their boundary
+        // edges — and rejecting the anchor leaves the section chain a
+        // pendant the arrangement rightly refuses, so the face under-splits
+        // and the fuse aborts on an open growth shell. The split point uses
+        // the foot on the line, so boundary pieces stay exact.
+        if dist < tol * 100.0 {
             splits.push((t, sp));
         }
     }


### PR DESCRIPTION
## Summary

`find_splits_on_line` gated the boundary-anchor distance at exact tolerance (1e-7), but plane×plane section endpoints carry a few tol of clip/trim rounding — full-precision probes put the kumiko lattice chain ends **2.1e-7 and 2.3e-7** off their boundary edges. The rejected anchor left the section chain a pendant, the plane arrangement (correctly) refused it, the face under-split, and the fuse aborted on an open growth shell. This is the codebase's canonical recurring trap (exact-tol gate meeting section rounding; the same function's dedup already uses the weld band).

The acceptance now uses weld scale (100·tol). The split point takes the foot on the line, so boundary sub-pieces remain exactly on the edge; the near-miss endpoint welds downstream as before.

## Status

Peels the first root of the kumiko lattice fixture: the 67-face abort (the 845 quad, now closed) moves to an 86-face lump with a different signature (partition mismatches, `coincident_other_id=1`). Sequential peeling continues; the roadmap row carries the updated map — including the correction that pass two's "0.002 real geometry" reading was a display-rounding artifact of the probe targets.

## Verification

- Full workspace green (107 suites, `--exclude brepkit-render`) — every plane-face boolean foil passes with the widened anchor; clippy `-D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept boundary anchors at weld scale (100·tol) in `find_splits_on_line` to handle small rounding on plane–plane section endpoints and avoid under-split faces. This closes the 845 quad in the kumiko lattice fixture and advances the failure to a new 86-face partition mismatch.

- **Bug Fixes**
  - Changed anchor check from `dist < tol` to `dist < tol * 100.0` (matches the function’s weld-band dedup); the split point uses the foot on the line so boundary pieces stay exact.
  - Prevents rejected anchors that left pendant chains and led to open-shell fuse aborts; plane-face boolean foils pass with the widened anchor.

<sup>Written for commit 4ddc1871828558c889a0903ba2d6e99251994edf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

