### PR TITLE
fix(algo): line splits return the foot; pin the weld-band contract

### DIFF
--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -170,7 +170,10 @@ pub(super) fn find_splits_on_line(
         // and the fuse aborts on an open growth shell. The split point uses
         // the foot on the line, so boundary pieces stay exact.
         if dist < tol * 100.0 {
-            splits.push((t, sp));
+            // Return the FOOT, not the raw candidate: the candidate may sit
+            // anywhere in the weld band, and consumers thread the returned
+            // point into wires (section T-junction splits use it verbatim).
+            splits.push((t, closest));
         }
     }
     splits.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
@@ -799,5 +802,37 @@ mod tests {
         let d0 = (splits[0].1 - edge.start_3d).length();
         let d1 = (splits[1].1 - edge.start_3d).length();
         assert!(d0 < d1, "splits must walk start_3d → end_3d");
+    }
+
+    #[test]
+    fn line_split_accepts_weld_band_probe_and_returns_the_foot() {
+        // A probe 5 tol off the line must still anchor (section endpoints
+        // carry a few tol of clip rounding), and the returned point must be
+        // the exact foot on the line so wires stay on-edge.
+        let tol = 1e-7;
+        let edge = OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Line,
+            pcurve: Curve2D::Line(Line2D::new(Point2::new(0.0, 0.0), Vec2::new(1.0, 0.0)).unwrap()),
+            start_uv: Point2::new(0.0, 0.0),
+            end_uv: Point2::new(10.0, 0.0),
+            start_3d: Point3::new(0.0, 0.0, 0.0),
+            end_3d: Point3::new(10.0, 0.0, 0.0),
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: None,
+        };
+        let probe = Point3::new(4.0, 5.0 * tol, 0.0);
+        let splits = find_splits_on_line(&edge, &[probe], tol);
+        assert_eq!(splits.len(), 1, "weld-band probe must anchor");
+        let (t, foot) = splits[0];
+        assert!((t - 0.4).abs() < 1e-9);
+        assert!(
+            foot.y().abs() < 1e-15,
+            "returned point must be the foot on the line, got y={}",
+            foot.y()
+        );
+        // Beyond the weld band: rejected.
+        let far = Point3::new(4.0, 200.0 * tol, 0.0);
+        assert!(find_splits_on_line(&edge, &[far], tol).is_empty());
     }
 }


### PR DESCRIPTION
Follow-up to #1270's review comments: `find_splits_on_line` now returns the exact foot on the line rather than the raw candidate (which can sit anywhere in the weld band — the boundary-split consumer already re-evaluated for lines, but section T-junction splits thread the returned point into wires verbatim), and a focused unit test pins the weld-band contract in both directions (a few-tol probe anchors and yields the on-line foot; a beyond-band probe is rejected). Ops suite and clippy green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Line split detection now returns the exact foot on the line instead of the raw weld-band candidate to keep section T‑junction wires on‑edge. Adds a unit test that pins the weld-band contract: a few‑tol probe anchors to the foot; a beyond‑band probe is rejected.

<sup>Written for commit ffe55baa6f257b0fdfb65e358e126d4f203700d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

