### PR TITLE
docs(roadmap): kumiko sixth pass — growth shell closes on parked branch

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -192,18 +192,16 @@ micro-section (a REAL lattice end-facet feature, 20000×tol, not noise) was graz
 sampled in-both filter, the arrangement then rejects the pendant chain, and the face under-splits.
 SHIPPED prerequisite: F1's plane×plane Line filter now uses the exact polygon clip instead of
 16-sample aliasing (the fix the old comment said "needs a test against true face extents" — the
-AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING (fifth pass, 2026-08-03 — root B mechanics CONFIRMED, fix parked; abort at 88):
-Branch `diag/kumiko-junction-snap` (146c09a1) carries a foil-green junction snap for plane-plane
-trim endpoints (band 1000·tol via snap_to_boundary_junction_band, adopted only when the move
-exceeds the weld band). MEASURED: it closes root B at the section level — face 965's chain ends
-land at d=0.0 and 3.6e-15 and the 8-micron fragment collapses — but the fixture still aborts at
-88 faces: the NEIGHBOURING pairs' old micro-fragments now collapse to EXACTLY zero-length free
-edges that `remove_zero_length_edges` fails to strip. Two questions gate shipping the snap:
-(1) why the stripper misses exactly-degenerate Line edges here (kept-face wire path? MERGE_TOL
-quantization?), and (2) whether the other trim arms (Range×Indeterminate, the sample-clip) need
-the same snap so every copy of a junction endpoint agrees. Do not ship the snap without closing
-(1) — the debris it reshapes is otherwise ambiguous between old fragments and new mints.
-Probe recipe unchanged; per-face section probe with boundary distances is decisive.
+AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING (sixth pass, 2026-08-03 — GROWTH SHELL CLOSES on the parked branch; abort now an
+open 50-face HOLE shell): branch `diag/kumiko-junction-snap` (85fd8023) adds a cross-pair
+JunctionRegistry (1e-4 cells, neighbor lookup, first-refiner-wins) so every pair's copy of a
+lattice-corner endpoint adopts one exact triple-junction point — pairwise refinement alone put
+copies ~1e-5 apart and minted micro-sliver free edges. MEASURED: growth shell closes for the
+first time; ops foils green (798). Remaining: the z 9.9 crossing still disagrees by 7.7e-4 —
+likely endpoints routed through trim arms the registry does not cover (Range×Indeterminate,
+the sample-clip path), so extend registry coverage there rather than widening the band (real
+facet scale is 2e-3; a 1e-3 band conflates true corners). The open-hole abort path now runs
+the same BK_OPEN_SHELL instrument as the growth side (also on the branch).
 CAPTURE GAP worth fixing once: `compoundCut(base, tools[])` passes its tools as an ARRAY, so a
 number-only argument filter captures the base and silently drops every tool — the op then cannot be
 replayed at all. Flatten arrays and typed arrays in any boolean-capture hook.


### PR DESCRIPTION
Records the junction-registry milestone on `diag/kumiko-junction-snap` (85fd8023): cross-pair unification of lattice-corner endpoints closes the growth shell for the first time (ops foils green); the abort becomes an open 50-face hole shell at the z 9.9 crossing whose copies still disagree by 7.7e-4 — pointing at trim arms the registry does not yet cover rather than a band shortfall (real facet scale is 2e-3, so band-widening would conflate true corners). Roadmap-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Kumiko roadmap to record the sixth pass: a cross‑pair JunctionRegistry on `diag/kumiko-junction-snap` unifies lattice‑corner endpoints, closing the growth shell. Documents the remaining open 50‑face hole at the z 9.9 crossing (7.7e‑4 mismatch likely from uncovered trim arms), notes that the abort now uses `BK_OPEN_SHELL`, and flags a `compoundCut` array‑capture gap.

<sup>Written for commit 4562b5de15a16023132c8bd63756d13ce1564e3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

