### PR TITLE
fix(algo): keep exact operand geometry through arrangement emission and welds

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -192,16 +192,31 @@ micro-section (a REAL lattice end-facet feature, 20000×tol, not noise) was graz
 sampled in-both filter, the arrangement then rejects the pendant chain, and the face under-splits.
 SHIPPED prerequisite: F1's plane×plane Line filter now uses the exact polygon clip instead of
 16-sample aliasing (the fix the old comment said "needs a test against true face extents" — the
-AABB version regressed A1 to bnd=158; the polygon version keeps every foil green). REMAINING (sixth pass, 2026-08-03 — GROWTH SHELL CLOSES on the parked branch; abort now an
-open 50-face HOLE shell): branch `diag/kumiko-junction-snap` (85fd8023) adds a cross-pair
-JunctionRegistry (1e-4 cells, neighbor lookup, first-refiner-wins) so every pair's copy of a
-lattice-corner endpoint adopts one exact triple-junction point — pairwise refinement alone put
-copies ~1e-5 apart and minted micro-sliver free edges. MEASURED: growth shell closes for the
-first time; ops foils green (798). Remaining: the z 9.9 crossing still disagrees by 7.7e-4 —
-likely endpoints routed through trim arms the registry does not cover (Range×Indeterminate,
-the sample-clip path), so extend registry coverage there rather than widening the band (real
-facet scale is 2e-3; a 1e-3 band conflates true corners). The open-hole abort path now runs
-the same BK_OPEN_SHELL instrument as the growth side (also on the branch).
+AABB version regressed A1 to bnd=158; the polygon version keeps every foil green).
+SEVENTH PASS (2026-08-03, shipped from `diag/kumiko-junction-snap`): free edges 43 → **2**. The
+"7.7e-4 trim-arm disagreement" framing was WRONG — the twin free-edge chains were minted by the
+PLANE-ARRANGEMENT EMISSION, which reconstructed every sub-face vertex as
+`frame.evaluate(frame.project(p))`, PROJECTING operand facet-chain vertices (which sit up to
+~2e-5 OFF their face's stored plane) onto the plane while the unsplit neighbour faces kept the
+original positions. Three fixes shipped together, each measured: (1) arrangement emission carries
+each registered input endpoint's EXACT 3D through `exact3d` (35 → 2); (2) crossings snap-round
+onto registered vertices, endpoints pre-registered first-wins (supports 1); (3)
+`weld_coincident_vertices` snap widened 10·MERGE_TOL → 100·MERGE_TOL, the recurring
+fit-error-vs-exact-gate class (43 → 35). Junction registry additionally: guarded wide adoption
+(≤1e-3 AND 10x closer than the next junction — the measured bimodal gap: copies ≤7.9e-4, genuine
+spacing ≥1.1e-2) plus boundary-VERTEX adoption in the snap (the partner-surface refine is
+degenerate when the boundary lies IN the partner surface). Foils: algo 208 green, ops green, io
+green with the honeycomb residual re-pin (pcut2 IMPROVED 38 → 28, pcut1 52 → 53, pcut3 held 0).
+REMAINING (eighth pass): the fixture aborts on an open 67-face growth shell with exactly TWO
+free edges at the z=34.8 coplanar top corner — clean coordinates
+(38.0,-42.75,34.8)/(38.05,-42.95,34.8)/(38.05,-42.7487,34.8), owners `Id(1436)<-365` and
+`Id(2309)<-364` each using one unmatched edge. This is a topological cover gap in the
+phase_ff_coplanar handling of that corner (a face not split / region not covered), NOT a weld
+problem. An `emit_riding_sections` variant (exact-vertex sub-spans for chain-riding coplanar
+candidates) was implemented and REVERTED: A/B showed zero effect on these 2 edges.
+Instrument recipe that finally localized the mint: bisect topology vertex scans across pipeline
+stages, then an env-gated backtrace in `Vertex::new` on the literal coordinate — probes at the
+phase level all lied because the noise was born at EMISSION, not intersection.
 CAPTURE GAP worth fixing once: `compoundCut(base, tools[])` passes its tools as an ARRAY, so a
 number-only argument filter captures the base and silently drops every tool — the op then cannot be
 replayed at all. Flatten arrays and typed arrays in any boolean-capture hook.

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1754,7 +1754,7 @@ fn weld_coincident_vertices(topo: &mut Topology, face_ids: &mut [FaceId]) -> Res
     use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
     use brepkit_topology::vertex::VertexId;
 
-    let snap = MERGE_TOL * 10.0;
+    let snap = MERGE_TOL * 100.0;
 
     // Collect distinct vertices (id + position) referenced by the faces.
     let mut seen: HashSet<VertexId> = HashSet::new();

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -1336,14 +1336,15 @@ fn log_open_growth_shell(
             }
         }
         log::debug!(
-            "growth shell OPENSHELL free {} ({:.3},{:.3},{:.3})->({:.3},{:.3},{:.3}) same_id_outside={same_id_outside} coincident_other_id={coincident_other_id}",
+            "growth shell OPENSHELL free {} ({:.3},{:.3},{:.3})->({:.3},{:.3},{:.3}) len={:.3e} same_id_outside={same_id_outside} coincident_other_id={coincident_other_id}",
             e.curve().type_tag(),
             a.x(),
             a.y(),
             a.z(),
             b.x(),
             b.y(),
-            b.z()
+            b.z(),
+            (b - a).length()
         );
     }
 }
@@ -1430,6 +1431,7 @@ fn assemble(
     for hole in &hole_shells {
         if !shell_is_closed(topo, hole) {
             if hole.len() >= 4 {
+                log_open_growth_shell(topo, hole, &all_faces, face_source);
                 // Same fail-safe as the growth side: a sizeable open "hole"
                 // is a mis-signed or mis-selected LUMP, not a cavity sliver —
                 // silently discarding it deletes real material or cavity

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -2138,14 +2138,64 @@ fn arrangement_regions_from_inputs(
     // any other chord's endpoint that lands on its interior. Collect the
     // resulting break parameters, then emit sub-segments between consecutive
     // breaks.
+    //
+    // A computed break must UNIFY with the vertex set, not merely quantize: a
+    // proper crossing is re-derived independently from each input's chord
+    // fraction, and for nearly-parallel inputs (adjacent facet chains) the
+    // two derivations scatter by crossing-noise/sin(angle) — far above the
+    // quantization cell — leaving two degree-2 vertices where one degree-4
+    // vertex belongs. Worse, a break landing near an input ENDPOINT splits
+    // the chord at the scattered point while the neighbouring face keeps the
+    // exact operand vertex, minting a near-copy boundary edge that never
+    // welds. So: input endpoints register FIRST (ground truth), and every
+    // later point within the snap band adopts the earliest registered vertex
+    // via a coarse hash (first-wins).
+    let snap_band = tol * 1000.0;
+    let ckey = |p: Point2| -> (i64, i64) {
+        (
+            (p.x() / snap_band).round() as i64,
+            (p.y() / snap_band).round() as i64,
+        )
+    };
     let mut vert_pos: std::collections::HashMap<(i64, i64), Point2> =
         std::collections::HashMap::new();
-    let register =
+    let mut coarse: std::collections::HashMap<(i64, i64), Point2> =
+        std::collections::HashMap::new();
+    let mut register =
         |p: Point2, map: &mut std::collections::HashMap<(i64, i64), Point2>| -> (i64, i64) {
+            let (cx, cy) = ckey(p);
+            let mut adopted: Option<(f64, Point2)> = None;
+            for dx in -1..=1_i64 {
+                for dy in -1..=1_i64 {
+                    if let Some(&q) = coarse.get(&(cx + dx, cy + dy)) {
+                        let d = (q - p).length();
+                        if d <= snap_band && adopted.is_none_or(|(bd, _)| d < bd) {
+                            adopted = Some((d, q));
+                        }
+                    }
+                }
+            }
+            let p = adopted.map_or(p, |(_, q)| q);
             let k = qkey(p);
             map.entry(k).or_insert(p);
+            coarse.entry(ckey(p)).or_insert(p);
             k
         };
+    // Exact 3D per registered input-endpoint vertex. The generic emission
+    // reconstructs 3D as frame.evaluate(uv), which PROJECTS the point onto
+    // the stored plane — but an operand's facet-chain vertex can sit ~1e-5
+    // OFF that plane, and collapsing it moves the sub-face boundary off the
+    // neighbouring faces' copy of the same vertex, minting a twin edge that
+    // never welds. Boundary inputs register first, so their exact positions
+    // win over section endpoints at the same vertex.
+    let mut exact3d: std::collections::HashMap<(i64, i64), Point3> =
+        std::collections::HashMap::new();
+    for inp in &inputs {
+        let ka = register(inp.a, &mut vert_pos);
+        exact3d.entry(ka).or_insert(inp.edge.start_3d);
+        let kb = register(inp.b, &mut vert_pos);
+        exact3d.entry(kb).or_insert(inp.edge.end_3d);
+    }
 
     // True when a UV point lies on input `idx`'s actual arc geometry (within
     // `tol`). A break parameter is computed against an arc's straight CHORD, so
@@ -2642,8 +2692,14 @@ fn arrangement_regions_from_inputs(
                 // `evaluate_with_endpoints`/`domain_with_endpoints`). Vertices
                 // came from exact true-crossing/T registration, so the 3D from
                 // the frame matches the neighbouring pieces.
-                let s3 = frame.evaluate(su.x(), su.y());
-                let e3 = frame.evaluate(eu.x(), eu.y());
+                let s3 = exact3d
+                    .get(&from)
+                    .copied()
+                    .unwrap_or_else(|| frame.evaluate(su.x(), su.y()));
+                let e3 = exact3d
+                    .get(&to)
+                    .copied()
+                    .unwrap_or_else(|| frame.evaluate(eu.x(), eu.y()));
                 let pcurve = super::pcurve_compute::compute_pcurve_on_surface(
                     &inp.edge.curve_3d,
                     s3,
@@ -2722,8 +2778,14 @@ fn arrangement_regions_from_inputs(
             pcurve,
             start_uv: su,
             end_uv: eu,
-            start_3d: frame.evaluate(su.x(), su.y()),
-            end_3d: frame.evaluate(eu.x(), eu.y()),
+            start_3d: exact3d
+                .get(&from)
+                .copied()
+                .unwrap_or_else(|| frame.evaluate(su.x(), su.y())),
+            end_3d: exact3d
+                .get(&to)
+                .copied()
+                .unwrap_or_else(|| frame.evaluate(eu.x(), eu.y())),
             forward: true,
             source_edge_idx: Some(seg_id),
             pave_block_id: None,

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -55,6 +55,65 @@ fn ff_trace_x() -> Option<f64> {
 ///
 /// Returns [`AlgoError`] if any topology lookup or intersection computation fails.
 #[allow(clippy::too_many_lines)]
+/// Cross-pair triple-junction registry: endpoints of trimmed plane-plane
+/// sections that land near a face-boundary corner are pulled to ONE shared
+/// junction point per corner, first refiner wins. Pairwise refinement alone
+/// gives each pair its own solution (~1e-5 apart at a lattice corner where
+/// four faces meet), and the disagreeing copies mint micro-sliver free edges.
+#[derive(Default)]
+struct JunctionRegistry {
+    cells: std::collections::HashMap<(i64, i64, i64), Point3>,
+}
+
+impl JunctionRegistry {
+    const CELL: f64 = 1e-4;
+
+    fn key(p: Point3) -> (i64, i64, i64) {
+        #[allow(clippy::cast_possible_truncation)]
+        let q = |v: f64| (v / Self::CELL).round() as i64;
+        (q(p.x()), q(p.y()), q(p.z()))
+    }
+
+    fn lookup(&self, p: Point3, band: f64) -> Option<Point3> {
+        let (kx, ky, kz) = Self::key(p);
+        let mut best: Option<(f64, Point3)> = None;
+        for dx in -1..=1_i64 {
+            for dy in -1..=1_i64 {
+                for dz in -1..=1_i64 {
+                    if let Some(&j) = self.cells.get(&(kx + dx, ky + dy, kz + dz)) {
+                        let d = (j - p).length();
+                        if d <= band && best.is_none_or(|(bd, _)| d < bd) {
+                            best = Some((d, j));
+                        }
+                    }
+                }
+            }
+        }
+        best.map(|(_, j)| j)
+    }
+
+    fn resolve(
+        &mut self,
+        topo: &Topology,
+        fa: FaceId,
+        fb: FaceId,
+        p: Point3,
+        tol: Tolerance,
+    ) -> Point3 {
+        let band = tol.linear * 1000.0;
+        if let Some(j) = self.lookup(p, band) {
+            return j;
+        }
+        match snap_to_boundary_junction_band(topo, fa, fb, p, tol, band) {
+            Some(j) => {
+                self.cells.insert(Self::key(j), j);
+                j
+            }
+            None => p,
+        }
+    }
+}
+
 pub fn perform(
     topo: &mut Topology,
     solid_a: SolidId,
@@ -64,6 +123,8 @@ pub fn perform(
 ) -> Result<(), AlgoError> {
     let faces_a = brepkit_topology::explorer::solid_faces(topo, solid_a)?;
     let faces_b = brepkit_topology::explorer::solid_faces(topo, solid_b)?;
+
+    let mut junction_registry = JunctionRegistry::default();
 
     // Pre-compute face AABBs for rejection
     let bboxes_a = compute_face_bboxes(topo, &faces_a, tol)?;
@@ -263,46 +324,18 @@ pub fn perform(
                                 let f0 = a.0.max(b.0);
                                 let f1 = a.1.min(b.1);
                                 trim_raw_line(&raw, f0, f1, tol).and_then(|mut piece| {
-                                    // The trim fractions carry accumulated clip
-                                    // rounding (the kumiko lattice chain ends
-                                    // measured up to ~2e-5 off their face
-                                    // boundaries), so pull each endpoint to its
-                                    // exact triple junction when a boundary is
-                                    // within the wide trigger band; refinement
-                                    // is exact, and BOTH faces receive the same
-                                    // snapped copy. A piece that collapses
-                                    // (a sub-weld micro-fragment riding a
-                                    // junction) is dropped.
-                                    let band = tol.linear * 1000.0;
-                                    let weld = tol.linear * 100.0;
-                                    // Only adopt a snap that moves the
-                                    // endpoint beyond the weld band — closer
-                                    // endpoints are already handled by the
-                                    // weld-scale boundary anchor, and
-                                    // perturbing them mints zero-length
-                                    // junction slivers.
-                                    let sn = snap_to_boundary_junction_band(
-                                        topo,
-                                        fa,
-                                        fb,
-                                        piece.p_start,
-                                        tol,
-                                        band,
-                                    );
-                                    if (sn - piece.p_start).length() > weld {
-                                        piece.p_start = sn;
-                                    }
-                                    let en = snap_to_boundary_junction_band(
-                                        topo,
-                                        fa,
-                                        fb,
-                                        piece.p_end,
-                                        tol,
-                                        band,
-                                    );
-                                    if (en - piece.p_end).length() > weld {
-                                        piece.p_end = en;
-                                    }
+                                    // Unify junction endpoints ACROSS pairs:
+                                    // at a lattice corner more than one pair
+                                    // meets, and each pair's independent
+                                    // refinement lands ~1e-5 apart, minting
+                                    // micro-sliver free edges between the
+                                    // copies. First refiner registers the
+                                    // junction; every later endpoint within
+                                    // the band adopts it EXACTLY.
+                                    piece.p_start =
+                                        junction_registry.resolve(topo, fa, fb, piece.p_start, tol);
+                                    piece.p_end =
+                                        junction_registry.resolve(topo, fa, fb, piece.p_end, tol);
                                     ((piece.p_start - piece.p_end).length() > tol.linear * 10.0)
                                         .then_some(piece)
                                 })
@@ -1736,7 +1769,7 @@ fn snap_to_boundary_junction(
     p: Point3,
     tol: Tolerance,
 ) -> Point3 {
-    snap_to_boundary_junction_band(topo, fa, fb, p, tol, tol.linear * 100.0)
+    snap_to_boundary_junction_band(topo, fa, fb, p, tol, tol.linear * 100.0).unwrap_or(p)
 }
 
 /// [`snap_to_boundary_junction`] with an explicit trigger band. The refine
@@ -1751,7 +1784,7 @@ fn snap_to_boundary_junction_band(
     p: Point3,
     tol: Tolerance,
     weld: f64,
-) -> Point3 {
+) -> Option<Point3> {
     const NS: usize = 64;
     let surf_of = |fid: FaceId| topo.face(fid).ok().map(|f| f.surface().clone());
     // (distance, foot, foot's curve param, owning face, edge)
@@ -1810,9 +1843,7 @@ fn snap_to_boundary_junction_band(
             }
         }
     }
-    let Some((_, foot, tm, owner_fid, eid)) = best else {
-        return p;
-    };
+    let (_, foot, tm, owner_fid, eid) = best?;
     // The foot lies ON the boundary curve but is displaced along it by the
     // section's fit error. The true junction is where that boundary curve
     // meets the PARTNER face's surface — refine to it so every section
@@ -1820,10 +1851,10 @@ fn snap_to_boundary_junction_band(
     // independently) mints the SAME vertex.
     let other = if owner_fid == fa { fb } else { fa };
     let (Some(other_surf), Ok(edge)) = (surf_of(other), topo.edge(eid)) else {
-        return foot;
+        return Some(foot);
     };
     let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end())) else {
-        return foot;
+        return Some(foot);
     };
     let (sp, ep) = (sv.point(), ev.point());
     let dist_to_surf = |q: Point3| -> f64 {
@@ -1852,9 +1883,9 @@ fn snap_to_boundary_junction_band(
     let tj = 0.5 * (lo + hi);
     let junction = edge.curve().evaluate_with_endpoints(tj, sp, ep);
     if dist_to_surf(junction) <= tol.linear * 10.0 && (junction - foot).length() <= weld {
-        junction
+        Some(junction)
     } else {
-        foot
+        Some(foot)
     }
 }
 

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -67,6 +67,7 @@ struct JunctionRegistry {
 
 impl JunctionRegistry {
     const CELL: f64 = 1e-4;
+    const ADOPT_MAX: f64 = 1e-3;
 
     fn key(p: Point3) -> (i64, i64, i64) {
         #[allow(clippy::cast_possible_truncation)]
@@ -104,6 +105,20 @@ impl JunctionRegistry {
         if let Some(j) = self.lookup(p, band) {
             return j;
         }
+        // A cross-pair copy of an already-registered junction can sit up to
+        // ~8e-4 away when the two pairs refined against boundary features
+        // that themselves disagree at facet scale, which is outside the weld
+        // band above. Adopt the existing junction only when it is
+        // UNAMBIGUOUS: within the adoption ceiling and at least 10x closer
+        // than the next-nearest junction (measured genuine junction spacing
+        // is >= 1.1e-2, copies <= 7.9e-4 — a bimodal gap this guard encodes
+        // rather than assumes).
+        if let Some((d1, j1, d2)) = self.nearest_two(p)
+            && d1 <= Self::ADOPT_MAX
+            && d2 >= d1 * 10.0
+        {
+            return j1;
+        }
         match snap_to_boundary_junction_band(topo, fa, fb, p, tol, band) {
             Some(j) => {
                 self.cells.insert(Self::key(j), j);
@@ -111,6 +126,23 @@ impl JunctionRegistry {
             }
             None => p,
         }
+    }
+
+    fn nearest_two(&self, p: Point3) -> Option<(f64, Point3, f64)> {
+        let mut best: Option<(f64, Point3)> = None;
+        let mut second = f64::INFINITY;
+        for &j in self.cells.values() {
+            let d = (j - p).length();
+            match best {
+                Some((bd, _)) if d < bd => {
+                    second = bd;
+                    best = Some((d, j));
+                }
+                Some(_) => second = second.min(d),
+                None => best = Some((d, j)),
+            }
+        }
+        best.map(|(d, j)| (d, j, second))
     }
 }
 
@@ -213,19 +245,6 @@ pub fn perform(
             let v_range_b = v_ranges_b[idx_b];
             let raw_curves =
                 compute_raw_curves(surf_a, surf_b, bbox_a, bbox_b, v_range_a, v_range_b)?;
-            if traced {
-                log::debug!(
-                    "FF_TRACE pair a={} b={} raw_curves={} ax[{:.3},{:.3}] bx[{:.3},{:.3}]",
-                    surf_a.type_tag(),
-                    surf_b.type_tag(),
-                    raw_curves.len(),
-                    bbox_a.min.x(),
-                    bbox_a.max.x(),
-                    bbox_b.min.x(),
-                    bbox_b.max.x()
-                );
-            }
-
             // For plane-plane Line curves with all-straight-edge faces, trim
             // each curve to the mutual overlap of the two faces' clipped
             // ranges. Without this the section curve spans the union of both
@@ -532,7 +551,16 @@ pub fn perform(
             // partner face's wire. Keep only the in-both span (curves only).
             let before_restrict = raw_curves.len();
             let raw_curves = restrict_curves_to_faces(
-                topo, fa, fb, surf_a, surf_b, v_range_a, v_range_b, raw_curves, tol,
+                topo,
+                fa,
+                fb,
+                surf_a,
+                surf_b,
+                v_range_a,
+                v_range_b,
+                raw_curves,
+                tol,
+                &mut junction_registry,
             );
             if traced {
                 log::debug!(
@@ -1146,6 +1174,7 @@ fn restrict_curves_to_faces(
     v_range_b: Option<(f64, f64)>,
     raw_curves: Vec<RawCurve>,
     tol: Tolerance,
+    junctions: &mut JunctionRegistry,
 ) -> Vec<RawCurve> {
     let (Some(ext_a), Some(ext_b)) = (
         FaceExtent::new(topo, fa, surf_a, v_range_a, tol),
@@ -1244,7 +1273,7 @@ fn restrict_curves_to_faces(
             let n_fine = ((8.0 * approx_len / min_dim).ceil() as usize).clamp(N, 1024);
             if n_fine <= N {
                 out.extend(rescue_corner_crossing(
-                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb, tol,
+                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb, tol, junctions,
                 ));
                 continue;
             }
@@ -1263,13 +1292,13 @@ fn restrict_curves_to_faces(
             let (f0, f1) = longest_inboth_run(&inb_fine, closed);
             if f1 - f0 < 2 {
                 out.extend(rescue_corner_crossing(
-                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb_fine, tol,
+                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb_fine, tol, junctions,
                 ));
                 continue;
             }
             if closed && f1 - f0 < n_fine && !matches!(raw.curve, EdgeCurve::Circle(_)) {
                 emit_closed_curve_windows(
-                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb_fine, n_fine, tol, &mut out,
+                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb_fine, n_fine, tol, junctions, &mut out,
                 );
                 continue;
             }
@@ -1298,7 +1327,9 @@ fn restrict_curves_to_faces(
             // Non-wrapping windows get bisected in/out transitions and
             // boundary-junction snapping — sample-index endpoints sit ~0.03
             // off the junction and never weld.
-            emit_closed_curve_windows(topo, fa, fb, &raw, &ext_a, &ext_b, &inb, N, tol, &mut out);
+            emit_closed_curve_windows(
+                topo, fa, fb, &raw, &ext_a, &ext_b, &inb, N, tol, junctions, &mut out,
+            );
             continue;
         }
         out.push(raw);
@@ -1563,6 +1594,7 @@ fn rescue_corner_crossing(
     ext_b: &FaceExtent,
     inb: &[bool],
     tol: Tolerance,
+    junctions: &mut JunctionRegistry,
 ) -> Option<RawCurve> {
     // Open curves only: a closed near-tangent loop keeps the historical drop
     // (the seam-adoption / internal-loop paths own closed sections).
@@ -1632,9 +1664,8 @@ fn rescue_corner_crossing(
     // surfaces), while the boundary splitters gate candidates at the exact
     // 1e-7 tolerance — the recurring fit-error-vs-exact-gate class. Adopting
     // the boundary FOOT gives both faces the identical on-boundary junction.
-    let snap = |p: Point3| snap_to_boundary_junction(topo, fa, fb, p, tol);
-    let p_start = snap(point_at(t_lo));
-    let p_end = snap(point_at(t_hi));
+    let p_start = junctions.resolve(topo, fa, fb, point_at(t_lo), tol);
+    let p_end = junctions.resolve(topo, fa, fb, point_at(t_hi), tol);
     Some(RawCurve {
         curve: raw.curve.clone(),
         bbox: raw.bbox,
@@ -1662,6 +1693,7 @@ fn emit_closed_curve_windows(
     inb: &[bool],
     n: usize,
     tol: Tolerance,
+    junctions: &mut JunctionRegistry,
     out: &mut Vec<RawCurve>,
 ) {
     let span = raw.t_range.1 - raw.t_range.0;
@@ -1745,8 +1777,8 @@ fn emit_closed_curve_windows(
         if t_hi <= t_lo {
             continue;
         }
-        let p_start = snap_to_boundary_junction(topo, fa, fb, point_at(t_lo), tol);
-        let p_end = snap_to_boundary_junction(topo, fa, fb, point_at(t_hi), tol);
+        let p_start = junctions.resolve(topo, fa, fb, point_at(t_lo), tol);
+        let p_end = junctions.resolve(topo, fa, fb, point_at(t_hi), tol);
         out.push(RawCurve {
             curve: raw.curve.clone(),
             bbox: raw.bbox,
@@ -1758,21 +1790,9 @@ fn emit_closed_curve_windows(
 }
 
 /// Snap a fitted section endpoint onto the nearest boundary curve of either
-/// face (outer or inner wires) within the weld band, then refine along that
-/// boundary to its exact crossing with the PARTNER face's surface — the
-/// triple junction every section ending here must share. Returns the input
-/// point unchanged when no boundary is within the weld band.
-fn snap_to_boundary_junction(
-    topo: &Topology,
-    fa: FaceId,
-    fb: FaceId,
-    p: Point3,
-    tol: Tolerance,
-) -> Point3 {
-    snap_to_boundary_junction_band(topo, fa, fb, p, tol, tol.linear * 100.0).unwrap_or(p)
-}
-
-/// [`snap_to_boundary_junction`] with an explicit trigger band. The refine
+/// face (outer or inner wires) within the trigger band, then refine along
+/// that boundary to its exact crossing with the PARTNER face's surface — the
+/// triple junction every section ending here must share. The refine
 /// step is exact regardless of the trigger, so a wider band only extends
 /// WHICH endpoints get pulled to their true triple junction; the kumiko
 /// lattice chain ends carry up to ~2e-5 of accumulated trim rounding and sit
@@ -1844,6 +1864,26 @@ fn snap_to_boundary_junction_band(
         }
     }
     let (_, foot, tm, owner_fid, eid) = best?;
+    // A foot landing weld-close to the boundary edge's own endpoint means
+    // the junction IS that existing vertex — adopt it exactly. The
+    // partner-surface refinement below is degenerate when the boundary
+    // curve lies IN the partner surface (coincident faces): the distance
+    // objective is flat, the ternary search converges on noise, and every
+    // pair mints a different copy of the same corner. The operand vertex is
+    // the one position all pairs share.
+    if let Ok(e) = topo.edge(eid)
+        && let (Ok(sv), Ok(ev)) = (topo.vertex(e.start()), topo.vertex(e.end()))
+    {
+        let (sp, ep) = (sv.point(), ev.point());
+        let (dmin, vp) = if (sp - foot).length() <= (ep - foot).length() {
+            ((sp - foot).length(), sp)
+        } else {
+            ((ep - foot).length(), ep)
+        };
+        if dmin <= weld {
+            return Some(vp);
+        }
+    }
     // The foot lies ON the boundary curve but is displaced along it by the
     // section's fit error. The true junction is where that boundary curve
     // meets the PARTNER face's surface — refine to it so every section
@@ -5294,9 +5334,22 @@ mod tests {
             "probe point (5,0.2) must be strictly inside the square"
         );
         let mut out = Vec::new();
+        let mut junctions = JunctionRegistry::default();
         // Both extents the same square: the second face in a real pair only
         // narrows the window further, which this test doesn't need.
-        emit_closed_curve_windows(&topo, face, face, &raw, &ext, &ext, &inb, N, tol, &mut out);
+        emit_closed_curve_windows(
+            &topo,
+            face,
+            face,
+            &raw,
+            &ext,
+            &ext,
+            &inb,
+            N,
+            tol,
+            &mut junctions,
+            &mut out,
+        );
         assert_eq!(out.len(), 1, "one crossing window expected");
         let w = &out[0];
         assert!(

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -262,7 +262,50 @@ pub fn perform(
                             (FaceClip::Range(a), FaceClip::Range(b)) => {
                                 let f0 = a.0.max(b.0);
                                 let f1 = a.1.min(b.1);
-                                trim_raw_line(&raw, f0, f1, tol)
+                                trim_raw_line(&raw, f0, f1, tol).and_then(|mut piece| {
+                                    // The trim fractions carry accumulated clip
+                                    // rounding (the kumiko lattice chain ends
+                                    // measured up to ~2e-5 off their face
+                                    // boundaries), so pull each endpoint to its
+                                    // exact triple junction when a boundary is
+                                    // within the wide trigger band; refinement
+                                    // is exact, and BOTH faces receive the same
+                                    // snapped copy. A piece that collapses
+                                    // (a sub-weld micro-fragment riding a
+                                    // junction) is dropped.
+                                    let band = tol.linear * 1000.0;
+                                    let weld = tol.linear * 100.0;
+                                    // Only adopt a snap that moves the
+                                    // endpoint beyond the weld band — closer
+                                    // endpoints are already handled by the
+                                    // weld-scale boundary anchor, and
+                                    // perturbing them mints zero-length
+                                    // junction slivers.
+                                    let sn = snap_to_boundary_junction_band(
+                                        topo,
+                                        fa,
+                                        fb,
+                                        piece.p_start,
+                                        tol,
+                                        band,
+                                    );
+                                    if (sn - piece.p_start).length() > weld {
+                                        piece.p_start = sn;
+                                    }
+                                    let en = snap_to_boundary_junction_band(
+                                        topo,
+                                        fa,
+                                        fb,
+                                        piece.p_end,
+                                        tol,
+                                        band,
+                                    );
+                                    if (en - piece.p_end).length() > weld {
+                                        piece.p_end = en;
+                                    }
+                                    ((piece.p_start - piece.p_end).length() > tol.linear * 10.0)
+                                        .then_some(piece)
+                                })
                             }
                             // One face produced an interval, the other could
                             // not build a usable polygon (degenerate wire,
@@ -1693,9 +1736,24 @@ fn snap_to_boundary_junction(
     p: Point3,
     tol: Tolerance,
 ) -> Point3 {
+    snap_to_boundary_junction_band(topo, fa, fb, p, tol, tol.linear * 100.0)
+}
+
+/// [`snap_to_boundary_junction`] with an explicit trigger band. The refine
+/// step is exact regardless of the trigger, so a wider band only extends
+/// WHICH endpoints get pulled to their true triple junction; the kumiko
+/// lattice chain ends carry up to ~2e-5 of accumulated trim rounding and sit
+/// outside the default weld band.
+fn snap_to_boundary_junction_band(
+    topo: &Topology,
+    fa: FaceId,
+    fb: FaceId,
+    p: Point3,
+    tol: Tolerance,
+    weld: f64,
+) -> Point3 {
     const NS: usize = 64;
     let surf_of = |fid: FaceId| topo.face(fid).ok().map(|f| f.surface().clone());
-    let weld = tol.linear * 100.0;
     // (distance, foot, foot's curve param, owning face, edge)
     let mut best: Option<(f64, Point3, f64, FaceId, brepkit_topology::edge::EdgeId)> = None;
     for fid in [fa, fb] {

--- a/crates/io/tests/gridfinity_honeycomb_cut_inmem.rs
+++ b/crates/io/tests/gridfinity_honeycomb_cut_inmem.rs
@@ -219,9 +219,16 @@ fn honeycomb_cut_residual_documented() {
     // in this file (`wallcut_step_is_watertight`,
     // `honeycomb_cut_no_longer_throws`,
     // `honeycomb_cut_pcut0_is_watertight_and_analytic`) are unchanged.
+    //
+    // Re-pinned with the plane-arrangement exact-3D emission (kumiko lattice
+    // bands): sub-face vertices now keep their operands' off-plane positions
+    // instead of being projected onto the stored plane, and the builder weld
+    // widened to the weld scale. pcut2 IMPROVED 38 -> 28; pcut1 nudged
+    // 52 -> 53 (one boundary stitch previously leaned on a projected copy);
+    // pcut3 (0) and every production-level test in this file held.
     let residual_free: &[(&str, usize)] = &[
-        ("a2hcomb_pcut1.bin", 52),
-        ("a2hcomb_pcut2.bin", 38),
+        ("a2hcomb_pcut1.bin", 53),
+        ("a2hcomb_pcut2.bin", 28),
         ("a2hcomb_pcut3.bin", 0),
     ];
     for &(tool, expect_free) in residual_free {


### PR DESCRIPTION
## Summary

Kumiko lattice band fuse campaign, seventh pass: free edges on the abort shell go **43 -> 2**, with the honeycomb residual pcut2 improving 38 -> 28 as collateral.

Three measured fixes:

- **Plane-arrangement emission kept exact operand 3D.** Sub-face vertices were rebuilt as `frame.evaluate(frame.project(p))`, which projects operand facet-chain vertices (up to ~2e-5 off the face's stored plane) onto the plane. The unsplit neighbour faces keep the original positions, so every split product minted twin edges that never weld. Registered input endpoints now carry their exact 3D through emission (`exact3d`), and computed crossings snap-round onto registered vertices with endpoints pre-registered first-wins. Measured on the fixture: 35 -> 2 free edges.
- **Builder vertex weld at weld scale.** `weld_coincident_vertices` snapped at `10 * MERGE_TOL` (1e-6), exactly fit-error scale; widened to `100 * MERGE_TOL`. Measured: 43 -> 35.
- **Junction registry hardening** (extends the registry introduced on this branch): guarded wide adoption (accept a junction within 1e-3 only when 10x closer than the next-nearest; measured bimodal gap on the fixture is copies <= 7.9e-4 vs genuine spacing >= 1.1e-2), boundary-vertex adoption when the snap foot lands weld-close to an edge endpoint (the partner-surface refinement is degenerate when the boundary lies in the partner surface), and coverage of the rescue and closed-window sample paths.

## Remaining (recorded in the roadmap)

The fixture still aborts, now on an open 67-face growth shell with exactly two free edges at the z=34.8 coplanar top corner (clean coordinates, a topological cover gap in the coplanar phase, not a weld problem). Eighth pass continues there; `kumiko_lattice_bands_fuse_closed` stays `#[ignore]`d.

## Testing

- algo: 208 passed
- operations: all green
- io: all green after re-pinning the documented honeycomb residual ceilings (pcut2 improved 38 -> 28, pcut1 nudged 52 -> 53, pcut3 held 0); every production-level test in that file unchanged
- clippy `-D warnings`, fmt, boundary check: clean
- `brepkit-render` `compute_mesh_lod` segfaults identically with and without this change (GPU sandbox limitation; CI is authoritative)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plane-arrangement emission and vertex welds to keep exact operand geometry and unify triple‑junctions, collapsing twin edges and reducing free edges from 43 to 2 on the kumiko lattice fuse. Also improves honeycomb residuals (pcut2 38 → 28) with all tests green.

- **Bug Fixes**
  - Arrangement emission now preserves exact 3D for input endpoints (`exact3d`) and snaps computed crossings to registered vertices (first‑wins).
  - Vertex weld widened to `100 * MERGE_TOL` to match weld scale.
  - Junction registry hardened: adopt an existing junction within 1e‑3 only if it’s 10× closer than the next; adopt boundary vertices when the snap foot is weld‑close; apply to rescue and closed‑window paths.
  - Better diagnostics: growth-side open‑shell logs include edge length and are invoked on hole shells.

Testing: algo 208 green; operations green; IO re‑pinned ceilings (pcut1 52 → 53, pcut2 38 → 28, pcut3 0).

<sup>Written for commit ed9b13914f1ad70ad98e729ce0fd7976b86b835c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

