### PR TITLE
docs(roadmap): kumiko eighth pass localized to coplanar-phase inner-wire blindness

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -207,12 +207,24 @@ fit-error-vs-exact-gate class (43 → 35). Junction registry additionally: guard
 spacing ≥1.1e-2) plus boundary-VERTEX adoption in the snap (the partner-surface refine is
 degenerate when the boundary lies IN the partner surface). Foils: algo 208 green, ops green, io
 green with the honeycomb residual re-pin (pcut2 IMPROVED 38 → 28, pcut1 52 → 53, pcut3 held 0).
-REMAINING (eighth pass): the fixture aborts on an open 67-face growth shell with exactly TWO
-free edges at the z=34.8 coplanar top corner — clean coordinates
-(38.0,-42.75,34.8)/(38.05,-42.95,34.8)/(38.05,-42.7487,34.8), owners `Id(1436)<-365` and
-`Id(2309)<-364` each using one unmatched edge. This is a topological cover gap in the
-phase_ff_coplanar handling of that corner (a face not split / region not covered), NOT a weld
-problem. An `emit_riding_sections` variant (exact-vertex sub-spans for chain-riding coplanar
+REMAINING (eighth pass, localized 2026-08-03): the fixture aborts on an open 67-face growth
+shell with exactly TWO free edges at the z=34.8 coplanar top corner — clean coordinates,
+owners `Id(1436)<-365` (a DIAGONAL lattice edge (38.0,-42.75)→(38.05,-42.95), z=34.8) and
+`Id(2309)<-364` (the x=38.05 top-edge piece y∈[-42.95,-42.7487]). Probed with COP_PAIR/COP_SEC
+eprintlns in `process_coplanar_pair`: the z=34.8 coplanar pair is A-top `Id(364)` (outer wire =
+a 4-edge RECTANGLE whose corner is exactly the shared free-edge vertex (38.05,-42.95)) ×
+B-top `Id(852)` (16 outer edges, extends past x=38.05), and the pair emitted ZERO coplanar
+sections. The diagonal free edge is an INNER-WIRE segment of A-top (the lattice outline hole),
+and `face_boundary_polygon_2d` / `face_boundary_edges_2d` in `phase_ff_coplanar.rs` read ONLY
+`face.outer_wire()` — B's edges are clipped against A's outer rectangle with the holes
+invisible, `is_shared_boundary_edge` cannot see B edges riding A's inner wires, and the
+common-block pass never links inner-wire boundary pieces. Same one-wire blindness the junction
+snap had before its inner-wire fix (snap-clip campaign). FIX SHAPE: include inner wires in the
+polygon (point-in-polygon with even-odd over all loops), the edge list, and the shared-edge /
+common-block passes; then re-check whether A-top's split product still over-covers the hole
+triangle at the corner (the top product's wire takes the rectangle corner instead of the
+inner diagonal, which is what leaves both edges use-1).
+An `emit_riding_sections` variant (exact-vertex sub-spans for chain-riding coplanar
 candidates) was implemented and REVERTED: A/B showed zero effect on these 2 edges.
 Instrument recipe that finally localized the mint: bisect topology vertex scans across pipeline
 stages, then an env-gated backtrace in `Vertex::new` on the literal coordinate — probes at the


### PR DESCRIPTION
Records the eighth-pass localization of the kumiko lattice band fuse (after #1277 took the fixture from 43 free edges to 2):

- The two remaining free edges at the z=34.8 top corner are an inner-wire diagonal of A-top (owner a split product of the diagonal wall) and the x=38.05 top-edge piece.
- The z=34.8 coplanar pair (A-top Id(364), a 4-edge outer rectangle whose corner is the shared free-edge vertex, x B-top Id(852)) emitted zero coplanar sections.
- Root direction: `face_boundary_polygon_2d` / `face_boundary_edges_2d` in `phase_ff_coplanar.rs` read only the outer wire, so the lattice-shaped inner holes are invisible to the clip, the shared-edge test, and the common-block pass. Same one-wire blindness the junction snap had before its inner-wire fix.
- Fix shape for the ninth pass is recorded in the entry, plus one refuted approach (`emit_riding_sections`, A/B zero effect).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Kumiko roadmap to record the eighth-pass localization: inner-wire blindness in the coplanar phase leaves two free edges at the z=34.8 top corner. Documents the geometry and A/B pair, identifies outer-wire-only processing in `phase_ff_coplanar.rs` as the root cause, outlines a fix to include inner wires across clip/shared-edge/common-block, and notes the reverted `emit_riding_sections` attempt.

<sup>Written for commit 41c5b481bbd33100adfd2e6f4668e86045eab5a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

