### PR TITLE
docs(roadmap): kumiko tenth pass parks the EF-IN absolute ceiling

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -233,6 +233,25 @@ class as the tessellation "hole-less containers defeat inner_wires guards" lesso
 coplanar phase.
 An `emit_riding_sections` variant (exact-vertex sub-spans for chain-riding coplanar
 candidates) was implemented and REVERTED: A/B showed zero effect on these 2 edges.
+TENTH PASS (2026-08-03): the pinched-hole theory was ALSO wrong (A-top `Id(364)` has ZERO inner
+wires; its split {2309, 2472} is a correct partition along B's outline). The true root of the
+z=34.8 corner: `fill_face_info::fill_ef_in`'s crossing-angle gate (`IN_FACE_MAX_DEVIATION_RATIO`
+0.2) admitted a LONG shallow-crossing leaf — B's slope-bottom edge crossing the east wall
+`Id(365)` (x=38.05 plane) sits 0.05 OFF the plane but at only 2.7% of its 1.8 chord — so pbs
+3890/3891 landed in 365's `pave_blocks_in`, the wall's splitter consumed off-plane section
+endpoints, and its partition warped (faces `1436`/`2311` with top-plane vertices in wall wires;
+`Id(9142)` used 3x). Fix on parked branch `diag/kumiko-in-gate-abs` (e0f3f799): an absolute
+ceiling `IN_FACE_MAX_DEVIATION_ABS = 1e-2` on the ratio band. MEASURED: the z=34.8 corner
+closes fully (abort 67 -> 51 faces, zero free edges at z=34.8), BUT the fixture's free count
+regresses 2 -> 14: the z≈4.5/9.9 junction-copy pairs (the seventh pass's 1.7e-4/3.5e-4
+disagreements) RESURFACE once those IN blocks stop feeding the corner splits — the shipped
+2-edge state was partly stitched by the same off-plane blocks. Eleventh pass: keep the abs
+ceiling and re-attack the resurfaced junction copies (they are the SAME positions the seventh
+pass measured, so the guarded-adoption path is the place to look at why they no longer unify —
+likely a registration-order change now that fewer resolve calls happen), then re-run foils
+before judging the ceiling's value (1e-2 sits between the grazing class's fit-error scale and
+the 0.05 wall offset; the calibrated 2-18%/24-58% ratio classes are unaffected for chords
+under 5e-2).
 Instrument recipe that finally localized the mint: bisect topology vertex scans across pipeline
 stages, then an env-gated backtrace in `Vertex::new` on the literal coordinate — probes at the
 phase level all lied because the noise was born at EMISSION, not intersection.


### PR DESCRIPTION
Records the tenth-pass result for the kumiko lattice band fuse:

- The ninth pass's pinched-hole theory is also refuted: A-top has zero inner wires and its split is a correct partition.
- True root of the z=34.8 corner: `fill_ef_in`'s deviation-ratio gate admits long shallow-crossing leaves (0.05 off the wall plane at 2.7% of a 1.8 chord), contaminating the east wall's splitter input and warping its partition.
- Fix parked on `diag/kumiko-in-gate-abs` (absolute ceiling 1e-2 on the ratio band): closes the z=34.8 corner fully (abort 67 -> 51 faces) but the fixture's free-edge count regresses 2 -> 14 because the seventh pass's junction-copy pairs resurface. The eleventh-pass plan is recorded in the entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record the Kumiko tenth-pass findings and park the EF-IN gate absolute ceiling fix. Documents the true cause of the z=34.8 corner issue and the measured impact of the proposed gate change.

- **Bug Fixes**
  - Ninth-pass “pinched-hole” theory refuted; A-top split was correct.
  - Root cause: `fill_ef_in` ratio gate (`IN_FACE_MAX_DEVIATION_RATIO`) admitted long shallow crossings, warping the east wall partition.
  - Parked fix on `diag/kumiko-in-gate-abs`: add `IN_FACE_MAX_DEVIATION_ABS = 1e-2`.
  - Results: corner closes (abort 67 → 51), but free edges rise 2 → 14 as junction-copy pairs resurface; eleventh pass will target those before tuning the ceiling.

<sup>Written for commit 94146cbbfa7ad2ee2dafe77b3e494f74e94ed93b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

