### PR TITLE
docs(roadmap): kumiko eleventh pass exhausts registry-side theories

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -252,6 +252,20 @@ likely a registration-order change now that fewer resolve calls happen), then re
 before judging the ceiling's value (1e-2 sits between the grazing class's fit-error scale and
 the 0.05 wall offset; the calibrated 2-18%/24-58% ratio classes are unaffected for chords
 under 5e-2).
+ELEVENTH PASS (2026-08-03): registry-side theories for the 14 resurfaced edges are EXHAUSTED —
+with a 2e-3 near-miss probe in `JunctionRegistry::resolve` there are ZERO near-misses at the
+twin positions, and pre-seeding the registry with ALL operand boundary vertices (first-wins
+exact ground truth, tried on the parked branch) leaves the 14 free edges byte-identical. So
+the twin endpoints (e.g. (38.049699651,-42.747694041,4.513595527) vs its operand-exact
+partner 3.5e-4 away) NEVER pass through phase-FF endpoint resolution; they are minted by the
+pave machinery (VE/EE/EF vertices or make_blocks) or the builder's edge splitting. NEXT
+INSTRUMENT (the recipe that cracked the seventh pass): env-gated backtrace in `Vertex::new`
+on the literal coordinate 38.049699651 to get the minting call path in one run, then apply
+the adopt-exact-geometry principle at that site. Also note: seeding was REVERTED (null
+result), and the warped wall faces the ceiling removed were "accidentally load-bearing" at
+the z=4.5/9.9 corners — geometrically invalid (0.05 off-plane vertices in plane-face wires)
+but topologically stitching, which is why the shipped 2-edge state looked better than this
+parked 14-edge state while being structurally worse.
 Instrument recipe that finally localized the mint: bisect topology vertex scans across pipeline
 stages, then an env-gated backtrace in `Vertex::new` on the literal coordinate — probes at the
 phase level all lied because the noise was born at EMISSION, not intersection.


### PR DESCRIPTION
Eleventh-pass findings for the kumiko lattice band fuse (parked branch `diag/kumiko-in-gate-abs`, 14 free edges):

- Zero registry near-misses at the twin positions, and pre-seeding the junction registry with all operand boundary vertices leaves the free edges byte-identical (experiment reverted). The twin endpoints never pass through phase-FF endpoint resolution.
- The minting site is therefore in the pave machinery or the builder's edge splitting; the next instrument is the Vertex::new backtrace on the literal coordinate, the same recipe that localized the seventh-pass root.
- Records why the shipped 2-edge state looked better than the parked 14-edge state while being structurally worse (off-plane wall wires were accidentally load-bearing).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add eleventh-pass notes to the Kumiko roadmap to document findings and redirect the investigation. Registry-side causes for the 14 resurfaced edges are ruled out (no `JunctionRegistry::resolve` near-misses; registry pre-seeding had no effect), so focus shifts to pave/builder edge minting with a `Vertex::new` backtrace next; we also note the removed warped wall faces were accidentally load-bearing, explaining why the earlier 2-edge state looked better while being structurally worse.

<sup>Written for commit 1954bc7c2988b6f8f781aff9e2f395244191fd72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

