### PR TITLE
fix(algo): unify cross-solver junction anchors in the kumiko lattice fuse

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -283,6 +283,25 @@ wall-cut raw residual" caution in `phase_ef.rs`) — implement with the full foi
 honeycomb residual ceilings in the loop. The larger lesson for the campaign: every remaining
 kumiko defect traces to the operands disagreeing at ~1e-3 while the engine welds at 1e-5;
 per-vertex tolerance adoption at interference altitude is the unifying frontier.
+THIRTEENTH PASS (2026-08-03, SHIPPED from the former parked branch): the EF-IN absolute
+ceiling is scoped to STRAIGHT leaves (an unscoped ceiling broke `fuse_shelled_box_with_
+socket_loft` — the calibrated grazing arcs legitimately exceed 1e-2 absolute; a Line's
+deviation from a crossed plane grows linearly so ratio-small + absolute-large is always a
+long transversal crossing), and the FF junction registry is seeded with every previously
+minted pave vertex so FF refinements adopt the anchors EF already placed (14 -> 7 free
+edges). All foils green, honeycomb ceilings unchanged. REFUTED this pass: (a) guarded wide
+VV merge of cross-solid operand vertex pairs — byte-identical free edges (the twins are
+solver-minted, not operand vertices); (b) cluster-canonical adoption in `resolve`
+(CLUSTER_BAND 3e-3 / ISOLATION 1e-2, lexicographic canonical) — net-negative 7 -> 9 with
+new long free edges, because consumers that bypass endpoint resolution keep their own
+anchors and a canonical only helps if every consumer converges; (c) seeding alone on the
+pre-ceiling main — neutral (the old 2-edge state was stitched by the invalid off-plane
+wires the ceiling removes). FOURTEENTH-PASS TARGET: the one remaining cluster at the
+z≈9.9 crossing — copies spread 2.4e-3 (wider than the 1e-3 guarded band), chains
+(38.0,-41.3151..-41.3175, 9.8631..9.8633) plus their x=38.05 partners; the pairwise
+guard refuses multi-copy clusters, so the fix must make the NON-resolve consumers (the
+chains anchored at each copy) converge — likely by unifying at the pave/make_blocks
+altitude rather than widening any FF band.
 Instrument recipe that finally localized the mint: bisect topology vertex scans across pipeline
 stages, then an env-gated backtrace in `Vertex::new` on the literal coordinate — probes at the
 phase level all lied because the noise was born at EMISSION, not intersection.

--- a/crates/algo/src/pave_filler/fill_face_info.rs
+++ b/crates/algo/src/pave_filler/fill_face_info.rs
@@ -35,6 +35,15 @@ const ON_SURFACE_BAND_FACTOR: f64 = 100.0;
 /// bands cannot separate the two classes.
 const IN_FACE_MAX_DEVIATION_RATIO: f64 = 0.2;
 
+/// Absolute ceiling on the ratio band. A LONG leaf crossing at a shallow
+/// angle keeps a small deviation/chord ratio while sitting a macroscopic
+/// distance off the face — the kumiko band's slope-bottom edge crosses a
+/// wall plane 0.05 away at 2.7% of its 1.8 chord, and admitting it feeds
+/// the wall's splitter an off-plane section that warps the partition. A
+/// genuinely grazing contact hugs the surface in absolute terms as well;
+/// beyond this the leaf is transversal regardless of ratio.
+const IN_FACE_MAX_DEVIATION_ABS: f64 = 1e-2;
+
 /// Populate [`FaceInfo`] for all faces with their classified pave blocks.
 ///
 /// - `pave_blocks_on`: split boundary edges of each face
@@ -266,7 +275,8 @@ fn fill_ef_in(topo: &Topology, arena: &mut GfaArena) {
                         }
                     }
                     let chord = (pev.point() - psv.point()).length();
-                    dev <= on_band.max(IN_FACE_MAX_DEVIATION_RATIO * chord)
+                    dev <= on_band
+                        .max((IN_FACE_MAX_DEVIATION_RATIO * chord).min(IN_FACE_MAX_DEVIATION_ABS))
                 })
                 .collect();
             let fi = arena.face_info_mut(face_id);

--- a/crates/algo/src/pave_filler/fill_face_info.rs
+++ b/crates/algo/src/pave_filler/fill_face_info.rs
@@ -275,8 +275,19 @@ fn fill_ef_in(topo: &Topology, arena: &mut GfaArena) {
                         }
                     }
                     let chord = (pev.point() - psv.point()).length();
-                    dev <= on_band
-                        .max((IN_FACE_MAX_DEVIATION_RATIO * chord).min(IN_FACE_MAX_DEVIATION_ABS))
+                    // The absolute ceiling applies to STRAIGHT leaves only: a
+                    // line's deviation from a crossed plane grows linearly, so
+                    // ratio-small + absolute-large means a long transversal
+                    // crossing, never a graze. A curved contact (the
+                    // calibrated socket-loft corner arcs) hugs via curvature
+                    // and legitimately reaches larger absolute deviations at
+                    // its span ends; it keeps the pure ratio gate.
+                    let band = if matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Line) {
+                        (IN_FACE_MAX_DEVIATION_RATIO * chord).min(IN_FACE_MAX_DEVIATION_ABS)
+                    } else {
+                        IN_FACE_MAX_DEVIATION_RATIO * chord
+                    };
+                    dev <= on_band.max(band)
                 })
                 .collect();
             let fi = arena.face_info_mut(face_id);

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -128,6 +128,12 @@ impl JunctionRegistry {
         }
     }
 
+    fn seed(&mut self, p: Point3) {
+        if self.lookup(p, 1e-4).is_none() {
+            self.cells.insert(Self::key(p), p);
+        }
+    }
+
     fn nearest_two(&self, p: Point3) -> Option<(f64, Point3, f64)> {
         let mut best: Option<(f64, Point3)> = None;
         let mut second = f64::INFINITY;
@@ -157,6 +163,31 @@ pub fn perform(
     let faces_b = brepkit_topology::explorer::solid_faces(topo, solid_b)?;
 
     let mut junction_registry = JunctionRegistry::default();
+    // Seed the registry with every vertex the earlier phases already minted
+    // (operand vertices from block init plus VE/EE/VF/EF interference
+    // vertices). A section endpoint refined here lands up to ~1e-3 from the
+    // EF crossing another solver placed at the same physical corner (the
+    // operands themselves disagree at that scale); without the seed the FF
+    // side registers its own copy first-wins and the two anchors never
+    // weld. Guarded adoption (band + 10x ambiguity ratio) does the rest.
+    for pbs in arena.edge_pave_blocks.values() {
+        for &pb_id in pbs {
+            if let Some(pb) = arena.pave_blocks.get(pb_id) {
+                for vid in [pb.start.vertex, pb.end.vertex] {
+                    let resolved = arena.resolve_vertex(vid);
+                    if let Ok(v) = topo.vertex(resolved) {
+                        junction_registry.seed(v.point());
+                    }
+                }
+                for pave in &pb.extra_paves {
+                    let resolved = arena.resolve_vertex(pave.vertex);
+                    if let Ok(v) = topo.vertex(resolved) {
+                        junction_registry.seed(v.point());
+                    }
+                }
+            }
+        }
+    }
 
     // Pre-compute face AABBs for rejection
     let bboxes_a = compute_face_bboxes(topo, &faces_a, tol)?;


### PR DESCRIPTION
## Summary

Thirteenth pass of the kumiko lattice band campaign. Two verified fixes:

- **EF-IN absolute ceiling, scoped to straight leaves.** The crossing-angle gate (`IN_FACE_MAX_DEVIATION_RATIO` 0.2) admitted a long Line leaf sitting 0.05 off a wall plane at 2.7% of its chord; the wall splitter then consumed off-plane endpoints and emitted partition wires with out-of-plane vertices (geometrically invalid faces that happened to stitch the shell). A line's deviation from a crossed plane grows linearly, so ratio-small + absolute-large can only be a long transversal crossing; curved grazing contacts (the calibrated socket-loft arcs, which fail an unscoped ceiling) keep the pure ratio gate.
- **Pave-vertex seeding of the FF junction registry.** EF crossings and FF pair refinements each minted their own copy of shared lattice corners (3.5e-4 apart). Seeding the registry with all previously minted vertices lets the guarded adoption unify them: measured 14 -> 7 free edges on the fixture.

## Fixture state

`kumiko_lattice_bands_fuse_closed` stays `#[ignore]`d. The raw free-edge count moves 2 -> 7, but the old 2-state was stitched by the invalid off-plane wires this PR removes; the 7 remaining edges are one z~9.9 multi-copy cluster (copies spread 2.4e-3, wider than the guarded adoption band) — the fourteenth-pass target. A cluster-canonical adoption variant was tried and reverted (net-negative: consumers that bypass endpoint resolution keep their own anchors).

## Testing

- operations: 798 passed (including `fuse_shelled_box_with_socket_loft`, which pinned the ceiling's scoping)
- io: all green, honeycomb residual ceilings unchanged
- algo: all green; clippy `-D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents warped partitions and duplicate junctions in the kumiko lattice fuse by capping EF-IN crossing deviation for straight leaves and seeding the FF junction registry to unify anchors.

- **Bug Fixes**
  - EF-IN: Add 1e-2 absolute ceiling to the deviation-ratio gate for `Line` leaves; curved contacts keep ratio-only. Blocks long shallow crossings that produced off-plane partition vertices.
  - FF: Seed the junction registry with all previously minted vertices (operands + VE/EE/VF/EF) so new section endpoints adopt existing anchors. Unifies cross-solver junctions and cuts duplicate corners (fixture 14 → 7 free edges).

<sup>Written for commit d803d3bb132d9cfad3fae8d5ff700881601059b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

