### PR TITLE
docs(roadmap): kumiko nineteenth pass shrinks the defect to one six-edge hole

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -366,7 +366,23 @@ twin-aware pendant scan + mutually-nearest boundary-vertex bridge (band 3e-3,
 isolation 1e-2) fires at the ALREADY-HEALTHY z=4.5 corner (whose sliver is genuine
 structure) and breaks it (bridge edge use-3), while the z~9.9 target's true fix is the
 boundary-image expansion above, after which its C vertex exists and no bridge is
-needed. Do not re-attempt bridging; fix the boundary instead. Also REVERTED this pass (no effect,
+needed. Do not re-attempt bridging; fix the boundary instead.
+NINETEENTH PASS (2026-08-03, parked on `fix/outer-wire-images` @ 6eb334e6): BOTH pieces
+implemented and measured. (1) `boundary_edges_to_pcurve_with_images` expands the OUTER
+wire with pave-split edge images (Line edges, mirroring `rebuild_face_with_edge_images`)
+— face 935 now sees its exit vertex C on the boundary. (2) The pendant bridge RETURNS,
+correctly gated this time: twin-aware pendant test, own-other-endpoint exclusion,
+mutually-nearest boundary vertex within 3e-3, isolation >= 1e-2, dedupe, AND a new
+section-free-target gate (a target vertex any section already reaches is part of the
+section network — bridging onto it over-connected the healthy z=4.5 corner to use-3;
+exit paves like C are section-free). MEASURED: z=4.5 closes COMPLETELY; the z~9.9
+defect shrinks to ONE six-edge hole rim ((38.05,-41.30)→A→B→C→(-42.75)→
+(38.05,-42.7477)→back). Remaining defect: face 935's splitter STILL yields only 2
+sub-faces (2066 Outside kept / 2067 Inside dropped, probe unchanged) — the strip region
+bounded by the bridged chain is not traced as its own region. TWENTIETH PASS: find why
+(SPLIT_PATH probe on 935: which path fires; if the plane arrangement computes 3 regions
+but the adoption gate `result.len() > loops.len()` refuses, or the greedy merges the
+strip into 2067). Foils NOT yet run on the branch — run algo/ops/io before any ship. Also REVERTED this pass (no effect,
 principled but unverified): a degenerate-refine rescue in `snap_to_boundary_junction_
 band` (detect a flat refine objective, re-refine along the nearest TRANSVERSAL boundary
 edge within 3e-3) — the B endpoint never routes through a degenerate snap; keep the


### PR DESCRIPTION
Nineteenth-pass progress for the kumiko lattice band fuse (parked on `fix/outer-wire-images`):

- Outer-wire image expansion implemented: faces now see their exit paves as boundary vertices.
- The pendant bridge returns with the correct gates (including a new section-free-target gate that prevents the z=4.5 over-connection).
- Measured: z=4.5 closes completely; z~9.9 shrinks to one six-edge hole. The last defect is that face 935's splitter still yields 2 sub-faces instead of tracing the bridged strip as its own region; the twentieth-pass probe plan is recorded. Foils still to run before any ship.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the kumiko roadmap with the nineteenth pass. Documents outer‑wire boundary‑image expansion (`boundary_edges_to_pcurve_with_images`) and a correctly gated pendant bridge that closes z=4.5 and shrinks z~9.9 to one six‑edge hole, and notes the remaining face 935 splitter issue and next‑pass probes.

<sup>Written for commit 06cec58e229d0ff17d5a5427ad12e791d3b9e910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

