### PR TITLE
docs(roadmap): kumiko twenty-fourth pass pins the wall straddle drop

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -416,12 +416,21 @@ NOT lie on 935's plane at all (plane check: 0.0186 residual) — it lies on the 
 WALL plane. The "hexagon on 935" model was wrong: the six-edge hole rim is a 3D loop
 across several faces, and the missing cover is a product of WALL 398 (or its B-side
 partner at x=38.05) whose top boundary should run at z=9.8922 between y=-41.30 and
-y=-42.7477. TWENTY-FOURTH PASS: the fifteenth-pass recipe aimed at 398 — SEL-probe all
-sub-faces with `source_face == 398` (and the B-side x=38.05 partner face), their
-classifications and probe points; the missing wall strip is either dropped-Inside
-(straddle again) or never traced. Note face 398 is a TALL wall (z 4.5..9.9) whose
-z=4.5 corner the earlier passes already closed — the two campaigns' corners are its
-bottom and top edges. Also REVERTED this pass (no effect,
+y=-42.7477. TWENTY-FOURTH PASS
+(2026-08-04, answered): wall 398 splits into THREE — `1489` Outside (y≈-38.8, kept),
+`1490` INSIDE/DROPPED (probe (38.05,-41.19,6.78)), `1491` Outside (y≈-42.83, kept).
+1490 is ANOTHER STRADDLE: genuinely inside B's band at its probe (low z), but its
+top-south strip (z>9.86, y -41.30..-42.75) sits ABOVE B's slope and must be kept —
+that strip is exactly the six-edge hole's wall side. The wall lacks a split along
+z=9.8922 south of y=-41.30: the rim edges (38.05,y,9.8922) lie on x=38.05 ∩
+z=9.8922, i.e. the section owed by pair (398 × B's HORIZONTAL top face at z=9.8922),
+which is missing/truncated in 398's inputs. TWENTY-FIFTH PASS: find the B-face with
+plane z=9.8922 covering y∈[-42.75,-41.30] near x=38.05 (WALL-probe recipe with the
+normal test on z), then RESTRICT_IN/OUT-probe the pair (398 × it). The campaign's
+generic lesson is now sharp: every remaining defect is one instance of "a pair
+section truncated where operand geometry rides a boundary, cascading into a
+straddle-drop"; each pass peels one instance, and the same probe recipes
+(WALL/RESTRICT/SEL) resolve each in one run apiece. Also REVERTED this pass (no effect,
 principled but unverified): a degenerate-refine rescue in `snap_to_boundary_junction_
 band` (detect a flat refine objective, re-refine along the nearest TRANSVERSAL boundary
 edge within 3e-3) — the B endpoint never routes through a degenerate snap; keep the


### PR DESCRIPTION
Twenty-fourth-pass answer for the kumiko lattice band fuse:

- Wall 398 splits into three; the middle band straddles (inside B at its probe, but its top strip above B's slope is the missing hole cover) and drops whole.
- The wall lacks the z=9.8922 split south of y=-41.30, owed by its pair with B's horizontal top face there.
- The twenty-fifth-pass probe plan is recorded, plus the campaign's now-sharp generic lesson about boundary-riding section truncation cascading into straddle drops.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Kumiko roadmap with the 24th-pass result: wall 398 splits into three, and a straddling inside segment explains the missing hole cover due to a truncated boundary section at z=9.8922. Adds the 25th-pass probe plan to pair 398 with the horizontal face at z=9.8922 near x=38.05, and notes a reverted, no-effect refine rescue in `snap_to_boundary_junction_band`.

<sup>Written for commit fae6fc1dd085bc0eadc887d36c7184b8ce30d6cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

