### PR TITLE
fix(algo): analytic torus arm for the ray-cast classifier

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -125,7 +125,6 @@ doc comment — read that, not this.**
 | **Mesh-boolean fallback emits OPEN meshes that are CONSUMED** (open since 2026-07-16) | operations | `mesh_boolean_fallback` warns its output is not a closed 2-manifold and uses it anyway; there is no further fallback, so rejecting means the op fails outright. A product call, not just a fix |
 | **Divider residual geometry** (3 cases, re-confirmed 2026-08-01 with the compound + shell fixes overlaid: 3 failed / 12 passed, 820 s) | algo/GFA | `mitsukude lattice on dividers` (**boundary 6** — was non-manifold 4 before the shell fix, so the signature MOVED), `kumiko dividers perforate the compartment walls`, `dividers + scoops keep the ramp footings solid` (boundary 4). The first two are the SAME 2x2x6 mitsukude bin with 2x1 compartments differing only in `dividers: true/false`, which argues against the divider carry-through being the cause; `__kernel-tests__/mitsukudeNmProbe.test.ts` isolates pattern vs compartments vs footprint |
 | **snapClip 0.6 mm-nozzle export chain** breaks at op-cut-3 (posBad=10, analytic but leaky) | algo/GFA | Root is marched FF sections on curved faces carrying `pave_block_id=None`, bypassing the pave machinery. Canonical altitude is pave-block attachment at phase-FF/make_blocks; every face-splitter-level attempt broke calibrated chains |
-| **algo ray-cast classifier has no `Torus` arm** — torus faces fall to the flat Newell-polygon fallback | algo | PREVENTIVE, no failing repro: re-probed 2026-08-03, every torus landscape green (lib torus tests, `parity_boolean_curved`, `cut_torus_by_box_notch_is_analytic_watertight`, census `torus − box` analytic). Rank below repro-backed work. If built: the quartic ray×torus machinery exists in `check/src/classify/ray_surface.rs` but algo cannot depend on check — the solver would have to move to math |
 | **v2 trimmer residuals** (4, all evidenced by the regress test's 12 free edges) | blend | Keep-side selection is degenerate under tangency; `create_blend_face` builds its own contact edges; no end-cap notch trim; `chamfer_v2` solves the external tangent branch. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
 
 The remaining `#[ignore]` entries are diagnostics or slow perf runs, not open bugs: the
@@ -672,6 +671,12 @@ Measured A/B, same day, same tool commit, each overlay md5-verified through brep
   firing that helps against one that hurts.
 
 ## Closed: root cause + where the detail lives
+- **Torus ray-cast arm** — whole-torus faces (degenerate boundary, < 3 polygon verts) were
+  DROPPED from parity counting entirely, and full-tube laterals fell to the flat polygon
+  fallback. `FaceGeom::Torus` + `math::intersect_line_torus` (the solver already lived in
+  math, no layer move needed) close both; TWO-RIM tube bands decline by design
+  (side-ambiguous from boundary vertices alone). Full-u detection is largest-gap-based
+  (max−min fails on sampled circles). `ray_cast.rs::whole_torus_classifies_inside_and_outside`
 
 - **Kumiko corner cut** — 4 roots: no rescue for a partial cylinder band; graze refinement scaled to
   face extent not arc length; NURBS boundary edges represented by their CHORD; and a reverse-twin

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -56,6 +56,20 @@ enum FaceGeom {
         v_max: f64,
         u_gap: Option<(f64, f64)>,
     },
+    /// A toroidal face covering the full major (u) revolution: either the
+    /// whole torus (degenerate fundamental-polygon boundary — previously
+    /// dropped from parity counting entirely) or a tube-angle band bounded
+    /// by full rim circles. Crossings come from the residual-verified
+    /// ray/torus quartic in `brepkit_math`, filtered to the tube-angle band.
+    /// The flat polygon fallback mis-counts against the doubly-curved
+    /// surface (up to four real crossings per ray).
+    Torus {
+        surface: brepkit_math::surfaces::ToroidalSurface,
+        /// Tube-angle band as `(v_start, span)` with `span` in `(0, TAU)`,
+        /// membership tested periodically from `v_start`. `None` = the full
+        /// tube (whole torus).
+        v_band: Option<(f64, f64)>,
+    },
 }
 
 /// Classify a point by ray casting against the solid's faces.
@@ -518,6 +532,82 @@ fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, 
             }
         }
 
+        // Toroidal faces without inner wires: the whole torus (degenerate
+        // fundamental-polygon boundary yields < 3 distinct polygon points and
+        // previously fell out of parity counting entirely) or a full-major-
+        // revolution tube band bounded by rim circles. Partial-u patches keep
+        // the polygon fallback.
+        if let brepkit_topology::face::FaceSurface::Torus(t) = face.surface()
+            && face.inner_wires().is_empty()
+        {
+            use std::f64::consts::TAU;
+            let verts = wire_polygon(topo, face.outer_wire())?;
+            if verts.len() < 3 {
+                // Degenerate boundary: the untrimmed whole torus.
+                result.push(FaceGeom::Torus {
+                    surface: t.clone(),
+                    v_band: None,
+                });
+                continue;
+            }
+            let wire = topo.wire(face.outer_wire())?;
+            let mut has_closed_circle = false;
+            for oe in wire.edges() {
+                let edge = topo.edge(oe.edge())?;
+                if matches!(edge.curve(), brepkit_topology::edge::EdgeCurve::Circle(_))
+                    && edge.start() == edge.end()
+                {
+                    has_closed_circle = true;
+                    break;
+                }
+            }
+            if has_closed_circle {
+                // Band gated on full u coverage: the boundary must sweep the
+                // whole major revolution, else the patch keeps the fallback.
+                let mut us: Vec<f64> = Vec::with_capacity(verts.len());
+                let mut vs: Vec<f64> = Vec::with_capacity(verts.len());
+                for p in &verts {
+                    let (u, v) = t.project_point(*p);
+                    us.push(u.rem_euclid(TAU));
+                    vs.push(v.rem_euclid(TAU));
+                }
+                // Full major revolution iff the sampled boundary leaves no
+                // large angular gap (a genuine partial patch leaves at least
+                // its own missing arc; sampled rim circles leave only the
+                // inter-sample spacing).
+                us.sort_unstable_by(f64::total_cmp);
+                let mut u_gap = -1.0_f64;
+                for i in 0..us.len() {
+                    let next = us[(i + 1) % us.len()];
+                    u_gap = u_gap.max((next - us[i]).rem_euclid(TAU));
+                }
+                if u_gap <= 1.0 {
+                    // Tube coverage from the periodic v samples. Boundary
+                    // samples fully covering the tube (a seam-only boundary)
+                    // OR collapsing to a single v (a full tube cut along one
+                    // rim circle) both mean the face spans the whole tube. A
+                    // two-rim band is SIDE-AMBIGUOUS from boundary vertices
+                    // alone (the rims bound either half), so it keeps the
+                    // polygon fallback rather than guessing.
+                    vs.sort_unstable_by(f64::total_cmp);
+                    let mut gap = -1.0_f64;
+                    for i in 0..vs.len() {
+                        let next = vs[(i + 1) % vs.len()];
+                        let d = (next - vs[i]).rem_euclid(TAU);
+                        gap = gap.max(d);
+                    }
+                    let span = TAU - gap;
+                    if gap <= 1e-3 || span <= 1e-3 {
+                        result.push(FaceGeom::Torus {
+                            surface: t.clone(),
+                            v_band: None,
+                        });
+                        continue;
+                    }
+                }
+            }
+        }
+
         let verts = wire_polygon(topo, face.outer_wire())?;
         if verts.len() < 3 {
             continue;
@@ -636,6 +726,9 @@ fn ray_geom_crossings(
             v_max,
             u_gap,
         } => ray_cone_crossings(origin, ray_dir, surface, (*v_min, *v_max), *u_gap, tol),
+        FaceGeom::Torus { surface, v_band } => {
+            ray_torus_crossings(origin, ray_dir, surface, *v_band, tol)
+        }
     }
 }
 
@@ -773,6 +866,59 @@ fn near_gap_border(u: f64, gap: (f64, f64), eps: f64) -> bool {
         }
     }
     false
+}
+
+/// Count ray crossings with a full-major-revolution toroidal face.
+///
+/// Roots come from the residual-verified ray/torus quartic in
+/// `brepkit_math`; each accepted root's tube angle must fall inside the
+/// face's periodic `v_band` (`None` accepts the whole tube). Near-tangent
+/// root pairs and hits near the band borders flag the ray as unreliable,
+/// mirroring the cylinder/cone grazing conventions.
+fn ray_torus_crossings(
+    origin: Point3,
+    ray_dir: Vec3,
+    surface: &brepkit_math::surfaces::ToroidalSurface,
+    v_band: Option<(f64, f64)>,
+    tol: Tolerance,
+) -> (i32, bool) {
+    use std::f64::consts::TAU;
+    let near = 10.0 * tol.linear;
+    let Ok(dir) = ray_dir.normalize() else {
+        return (0, false);
+    };
+    let roots = brepkit_math::analytic_intersection::intersect_line_torus(surface, origin, dir);
+    let near_angle = near / surface.minor_radius().max(near);
+    let mut crossings = 0;
+    let mut suspicious = false;
+    for (i, &t) in roots.iter().enumerate() {
+        if t <= tol.linear {
+            continue;
+        }
+        // A close root pair is a graze: its two crossings cancel in parity
+        // only if BOTH land in the band, so flag the ray instead of trusting
+        // the count.
+        for &t2 in &roots[i + 1..] {
+            if (t2 - t).abs() <= near {
+                suspicious = true;
+            }
+        }
+        if let Some((v_start, span)) = v_band {
+            let hit = Point3::new(
+                origin.x() + dir.x() * t,
+                origin.y() + dir.y() * t,
+                origin.z() + dir.z() * t,
+            );
+            let (_, v) = surface.project_point(hit);
+            let vv = (v - v_start).rem_euclid(TAU);
+            suspicious |= vv <= near_angle || (span - vv).abs() <= near_angle;
+            if vv > span {
+                continue;
+            }
+        }
+        crossings += 1;
+    }
+    (crossings, suspicious)
 }
 
 /// Count ray crossings with a bounded conical face.
@@ -1081,6 +1227,41 @@ mod tests {
         ));
         let shell = topo.add_shell(Shell::new(vec![face]).unwrap());
         topo.add_solid(Solid::new(shell, vec![]))
+    }
+
+    #[test]
+    fn whole_torus_classifies_inside_and_outside() {
+        use brepkit_math::surfaces::ToroidalSurface;
+        // Whole torus R=3 r=1 about Z at the origin: a single face with a
+        // degenerate point-seam boundary (the untrimmed fundamental polygon).
+        let mut topo = Topology::default();
+        let t = ToroidalSurface::new(Point3::new(0.0, 0.0, 0.0), 3.0, 1.0).unwrap();
+        let seam_p = t.evaluate(0.0, 0.0);
+        let v0 = topo.add_vertex(Vertex::new(seam_p, 1e-7));
+        let circle = brepkit_math::curves::Circle3D::new(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            4.0,
+        )
+        .unwrap();
+        let e = topo.add_edge(Edge::new(v0, v0, EdgeCurve::Circle(circle)));
+        let wire = topo.add_wire(Wire::new(vec![OrientedEdge::new(e, true)], true).unwrap());
+        let face = topo.add_face(Face::new(wire, vec![], FaceSurface::Torus(t)));
+        let shell = topo.add_shell(Shell::new(vec![face]).unwrap());
+        let solid = topo.add_solid(Solid::new(shell, vec![]));
+
+        // In the tube: on the spine circle.
+        let inside = classify_ray_cast(&topo, solid, Point3::new(3.0, 0.0, 0.0)).unwrap();
+        assert_eq!(inside, crate::builder::face_class::FaceClass::Inside);
+        // The donut hole is OUTSIDE the solid.
+        let hole = classify_ray_cast(&topo, solid, Point3::new(0.0, 0.0, 0.0)).unwrap();
+        assert_eq!(hole, crate::builder::face_class::FaceClass::Outside);
+        // Beyond the outer equator.
+        let out = classify_ray_cast(&topo, solid, Point3::new(6.0, 0.0, 0.0)).unwrap();
+        assert_eq!(out, crate::builder::face_class::FaceClass::Outside);
+        // Above the tube.
+        let above = classify_ray_cast(&topo, solid, Point3::new(3.0, 0.0, 2.0)).unwrap();
+        assert_eq!(above, crate::builder::face_class::FaceClass::Outside);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the deferred roadmap item "algo ray-cast classifier has no Torus arm".

- Whole-torus faces (degenerate boundary, under 3 polygon vertices) were previously dropped from parity counting entirely; full-tube laterals fell to the flat Newell-polygon fallback, which mis-counts up to four real crossings.
- `FaceGeom::Torus` collects both cases and counts crossings via the residual-verified ray/torus quartic already in `brepkit_math`, filtered to the tube-angle band, with near-tangent root pairs and band-border hits flagged as unreliable (mirroring the cylinder/cone conventions).
- Two-rim tube bands are declined by design (side-ambiguous from boundary vertices alone) and keep the current fallback; full-major-revolution detection is largest-gap-based because max-minus-min fails on sampled rim circles.

## Testing

- New `whole_torus_classifies_inside_and_outside` (spine Inside; donut hole, outer equator, and above-tube Outside)
- Calibrated `coaxial_torus` suite: 9/9 unchanged
- algo 209, operations and io suites all green; clippy `-D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an analytic torus arm to the ray-cast classifier to correctly count ray/torus crossings for whole tori and full-tube lateral faces. Fixes dropped faces and miscounts that led to wrong inside/outside results around toroidal geometry.

- Introduced `FaceGeom::Torus` and use the residual-verified ray/torus quartic from `brepkit_math`, with an optional tube-angle band to filter hits.
- Detect whole tori (degenerate boundary) and full-major-revolution tube bands via largest angular gap; keep two-rim bands on the polygon fallback by design.
- Flag near-tangent and band-border hits as unreliable (consistent with cylinder/cone), and added a `whole_torus_classifies_inside_and_outside` test; existing suites remain green.

<sup>Written for commit 134b3228e32a31340a1c8e3f4cb75da5494c0ccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

