### PR TITLE
docs(roadmap): mark the kumiko lattice arm closed and the parked branch gone

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -644,9 +644,19 @@ corners ARE its vertices, which is why it is a valid conclusion here).
 
 ## Live campaign: kumiko / goma
 
-**State:** branch `fix/kumiko-corner-window-cut` closes four real engine defects with fixtures
-(`crates/io/tests/kumiko_corner_window_inmem.rs`, 5 tests) but is **PARKED and must not ship** —
-it regresses goma from 8 to 65 exported boundary edges and 540 s to 817 s.
+**STATE 2026-08-04: the lattice-band arm of this campaign is CLOSED on main** (#1302 —
+`kumiko_lattice_bands_fuse_closed` un-ignored; see the Closed section for the mechanism). The
+old parked branch `fix/kumiko-corner-window-cut` is GONE from the remote (its 5
+`kumiko_corner_window_inmem.rs` fixtures and their data went with it); its four documented
+roots remain unshipped, and re-attempting them means re-capturing fixtures first. The
+thickwall ready-repro still aborts identically on the new machinery (`open hole shell with 9
+faces`, pre-shell-fix operands — re-capture before drawing conclusions). REMAINING
+VERIFICATION for the divider/mitsukude scenario family is TOOL-SIDE: rebuild the kernel into
+the layout tool and run the scenario matrix (recipes below); the native suites cannot see it.
+
+**Historical state (pre-closure):** branch `fix/kumiko-corner-window-cut` closed four real
+engine defects with fixtures but was **PARKED** — it regressed goma from 8 to 65 exported
+boundary edges and 540 s to 817 s.
 
 Measured A/B, same day, same tool commit, each overlay md5-verified through brepjs's own resolution:
 


### PR DESCRIPTION
Post-closure tidy: the live-campaign section now records the #1302 closure, the disappearance of the old parked corner-window branch (fixtures would need re-capture), the unchanged thickwall ready-repro, and that the remaining divider-family verification is tool-side.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the roadmap to mark the kumiko lattice-band arm CLOSED on `main` per #1302 and tidy the live-campaign notes. Also record that `fix/kumiko-corner-window-cut` was removed and that remaining divider-family verification is tool-side.

- **Migration**
  - Re-capture fixtures before re-attempting the four corner-window defects.
  - Rebuild the kernel into the layout tool and run the divider/mitsukude scenario matrix.

<sup>Written for commit 043f6ac4a662aeee8330e30afbbfc5ab1be75975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

