### PR TITLE
fix(blend): material-oriented chamfer contacts on concave edges

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -131,8 +131,12 @@ ridge loses 12% of the solid, 242 → 212.4). MEASURED REFUTATION on record: an 
 cross-contact side discriminant (keep the side of the contact line opposite the projected
 other-contact direction) flipped the CALIBRATED box case while leaving the 12% loss
 UNCHANGED — so the loss is at least partly in the trim geometry itself at shallow incidence,
-not only the side dot; separate the two sub-defects before re-attempting. Also remaining:
-`chamfer_v2` external tangent branch. End-cap notch CLOSED 2026-08-04: cross edges are the true end cross-section arcs and the caps are notched to share them (the caps previously COVERED the scooped corner — a volumetric error invisible to the free-edge count); chamfer contact reuse threaded alongside the fillet's. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
+not only the side dot; separate the two sub-defects before re-attempting. `chamfer_v2` external tangent branch CLOSED
+2026-08-04: on a concave edge the bisector-projected contact direction flips onto the faces'
+extensions (0.02 chamfer grew a notched prism 6.7%); the chamfer's plane-plane path now uses
+the material-oriented direction (effective-normal × wire-traversal tangent), bisector as
+fallback. `regress_chamfer_obtuse_ridge.rs`. NOTE: the FILLET plane-plane path still uses the
+bisector projection — probe a concave fillet before assuming it shares the defect. End-cap notch CLOSED 2026-08-04: cross edges are the true end cross-section arcs and the caps are notched to share them (the caps previously COVERED the scooped corner — a volumetric error invisible to the free-edge count); chamfer contact reuse threaded alongside the fillet's. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
 
 The remaining `#[ignore]` entries are diagnostics or slow perf runs, not open bugs: the
 `profile_intersect.rs` box-sphere probes are stale (box-sphere shipped analytic in #1006),

--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -379,6 +379,32 @@ fn section_basis(n1: Vec3, n2: Vec3, spine_tangent: Vec3) -> (Vec3, Vec3) {
     (bisector, cross_dir)
 }
 
+/// The in-plane direction from the spine INTO `face`'s material: the left
+/// side of the face's own traversal of the spine edge (`effective normal x
+/// traversal tangent` under the CCW-outer-wire convention). Returns `None`
+/// when the spine's first edge is not in the face's wires.
+fn material_contact_direction(
+    topo: &Topology,
+    face: FaceId,
+    spine: &Spine,
+    normal: Vec3,
+    tangent: Vec3,
+) -> Option<Vec3> {
+    let spine_edge = *spine.edges().first()?;
+    let f = topo.face(face).ok()?;
+    let n_eff = if f.is_reversed() { -normal } else { normal };
+    for wid in std::iter::once(f.outer_wire()).chain(f.inner_wires().iter().copied()) {
+        let w = topo.wire(wid).ok()?;
+        for oe in w.edges() {
+            if oe.edge() == spine_edge {
+                let t = if oe.is_forward() { tangent } else { -tangent };
+                return n_eff.cross(t).normalize().ok();
+            }
+        }
+    }
+    None
+}
+
 /// Compute the direction from edge toward contact point on a plane.
 ///
 /// This is the component of the bisector projected onto the plane surface,
@@ -540,8 +566,18 @@ fn plane_plane_chamfer(
 
     let (bisector, _cross_dir) = section_basis(n1, n2, tangent);
 
-    let contact_dir1 = compute_contact_direction(n1, bisector);
-    let contact_dir2 = compute_contact_direction(n2, bisector);
+    // Material-oriented contact directions: the bisector projection points
+    // INTO each face's material only on a CONVEX edge — on a concave edge it
+    // flips onto the faces' extensions, placing the contacts on the external
+    // tangent branch (a 0.02 chamfer on a reflex notch grew the solid by
+    // 6.7%). The exact, convexity-independent direction is the wire-traversal
+    // left side (`effective_normal x traversal_tangent` for a CCW-wound
+    // face); the bisector projection remains the fallback when the spine
+    // edge is not found in a face's wires.
+    let contact_dir1 = material_contact_direction(topo, face1, spine, n1, tangent)
+        .unwrap_or_else(|| compute_contact_direction(n1, bisector));
+    let contact_dir2 = material_contact_direction(topo, face2, spine, n2, tangent)
+        .unwrap_or_else(|| compute_contact_direction(n2, bisector));
 
     let c1_start = p_start + contact_dir1 * d1;
     let c1_end = p_end + contact_dir1 * d1;

--- a/crates/operations/tests/regress_chamfer_obtuse_ridge.rs
+++ b/crates/operations/tests/regress_chamfer_obtuse_ridge.rs
@@ -1,0 +1,99 @@
+//! Pins chamfer_v2's tangent-branch selection on a CONCAVE (reflex) edge:
+//! the bisector-projected contact direction flips onto the faces' external
+//! extensions there (a 0.02 chamfer grew the solid 6.7% pre-fix); the
+//! material-oriented direction (wire-traversal left side) keeps the
+//! contacts on the faces.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::collections::HashMap;
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::blend_ops::chamfer_v2;
+use brepkit_operations::extrude::extrude;
+use brepkit_topology::Topology;
+use brepkit_topology::builder::make_polygon_wire;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::{solid_edges, solid_faces};
+use brepkit_topology::face::{Face, FaceSurface};
+use brepkit_topology::solid::SolidId;
+
+fn edge_use_counts(topo: &Topology, solid: SolidId) -> HashMap<EdgeId, usize> {
+    let mut counts: HashMap<EdgeId, usize> = HashMap::new();
+    for fid in solid_faces(topo, solid).unwrap() {
+        let face = topo.face(fid).unwrap();
+        let mut wires = vec![face.outer_wire()];
+        wires.extend(face.inner_wires().iter().copied());
+        for wid in wires {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *counts.entry(oe.edge()).or_insert(0) += 1;
+            }
+        }
+    }
+    counts
+}
+
+#[test]
+fn chamfer_v2_concave_notch_adds_only_the_chamfer_sliver() {
+    let mut topo = Topology::new();
+    // A shallow ridge: the vertex at (5, 0.05) makes the two top laterals
+    // meet at ~178.9 degrees after extrusion.
+    let profile = make_polygon_wire(
+        &mut topo,
+        &[
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(4.0, 0.0, 0.0),
+            Point3::new(5.0, -1.0, 0.0),
+            Point3::new(6.0, 0.0, 0.0),
+            Point3::new(10.0, 0.0, 0.0),
+            Point3::new(10.0, -3.0, 0.0),
+            Point3::new(0.0, -3.0, 0.0),
+        ],
+        1e-7,
+    )
+    .unwrap();
+    let face = topo.add_face(Face::new(
+        profile,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 8.0).unwrap();
+
+    // The ridge edge runs along (5, 0.05, z).
+    let ridge = solid_edges(&topo, solid)
+        .unwrap()
+        .into_iter()
+        .find(|&eid| {
+            let e = topo.edge(eid).unwrap();
+            let s = topo.vertex(e.start()).unwrap().point();
+            let t = topo.vertex(e.end()).unwrap().point();
+            (s.x() - 5.0).abs() < 1e-9 && (t.x() - 5.0).abs() < 1e-9 && (s.z() - t.z()).abs() > 1.0
+        })
+        .expect("ridge edge");
+
+    let before = brepkit_operations::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    let result = chamfer_v2(&mut topo, solid, &[ridge], 0.02, 0.02).unwrap();
+    assert_eq!(result.succeeded, vec![ridge]);
+
+    // A 0.2 chamfer on this ridge removes a sliver; a wrong tangent branch
+    // cuts a macroscopic wedge or adds material.
+    let after = brepkit_operations::measure::solid_volume(&topo, result.solid, 0.05).unwrap();
+    // Chamfering a CONCAVE edge fills the notch corner: volume grows by a
+    // small sliver. The external tangent branch instead cuts outward or
+    // collapses the notch walls.
+    let added = after - before;
+    assert!(
+        added > 0.0 && added < before * 0.02,
+        "concave chamfer should add a small sliver: before={before:.4} after={after:.4}"
+    );
+
+    // No stale or over-shared edges.
+    let counts = edge_use_counts(&topo, result.solid);
+    assert!(
+        counts.values().all(|&c| c <= 2),
+        "over-shared edge after near-tangent trim"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the last named v2 trimmer residual (`chamfer_v2` external tangent branch):

- On a concave edge the bisector-projected contact direction flips onto the faces' external extensions — the external tangent branch. Measured: a 0.02 chamfer on a reflex notch grew the solid by 6.7%.
- The plane-plane chamfer now derives each contact direction from the face's own wire traversal (effective normal cross traversal tangent), exact for any convexity, with the bisector projection kept as fallback.
- New pin `regress_chamfer_obtuse_ridge`: the concave notch chamfer adds only the expected sliver. The roadmap notes the fillet's plane-plane path still uses the bisector projection and should be probed on a concave case before assuming it shares the defect.

## Testing

- New concave pin green; blend, operations, io suites green; clippy -D warnings clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `chamfer_v2` placing contacts on the external tangent branch on concave edges by using a material-oriented contact direction, so concave chamfers add only the intended sliver instead of growing the solid.

- **Bug Fixes**
  - Compute contact direction per face from wire traversal (`effective_normal × traversal_tangent`), with bisector projection as fallback.
  - Corrects concave-edge behavior that could inflate volume (e.g., 0.02 chamfer grew a notched prism by ~6.7%).
  - Adds `regress_chamfer_obtuse_ridge.rs` to pin the fix and updates the roadmap note.

<sup>Written for commit 396de959235dd023ca4bafc1e379c8c328d72684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

