### PR TITLE
test(blend): ready repro for the concave-fillet branch defect

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -135,8 +135,13 @@ not only the side dot; separate the two sub-defects before re-attempting. `chamf
 2026-08-04: on a concave edge the bisector-projected contact direction flips onto the faces'
 extensions (0.02 chamfer grew a notched prism 6.7%); the chamfer's plane-plane path now uses
 the material-oriented direction (effective-normal × wire-traversal tangent), bisector as
-fallback. `regress_chamfer_obtuse_ridge.rs`. NOTE: the FILLET plane-plane path still uses the
-bisector projection — probe a concave fillet before assuming it shares the defect. End-cap notch CLOSED 2026-08-04: cross edges are the true end cross-section arcs and the caps are notched to share them (the caps previously COVERED the scooped corner — a volumetric error invisible to the free-edge count); chamfer contact reuse threaded alongside the fillet's. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
+fallback. `regress_chamfer_obtuse_ridge.rs`. The FILLET
+plane-plane path DOES share a concave defect but milder and DIFFERENT (probed 2026-08-04,
+`regress_fillet_concave_notch.rs` ignored ready-repro: a 0.02 fillet on the reflex notch
+REMOVES 0.077 instead of adding the sliver). REFUTED: transplanting only the chamfer's
+material-oriented contact directions makes it WORSE (removes 10.5) and breaks the calibrated
+convex pins — the fillet's concave case couples the cylinder-centre side, section
+orientation, and keep-side and must be treated as one geometry change. End-cap notch CLOSED 2026-08-04: cross edges are the true end cross-section arcs and the caps are notched to share them (the caps previously COVERED the scooped corner — a volumetric error invisible to the free-edge count); chamfer contact reuse threaded alongside the fillet's. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
 
 The remaining `#[ignore]` entries are diagnostics or slow perf runs, not open bugs: the
 `profile_intersect.rs` box-sphere probes are stale (box-sphere shipped analytic in #1006),

--- a/crates/operations/tests/regress_fillet_concave_notch.rs
+++ b/crates/operations/tests/regress_fillet_concave_notch.rs
@@ -1,0 +1,102 @@
+//! Probe: does the FILLET's plane-plane path share the chamfer's concave
+//! tangent-branch defect? Its contact directions still come from the
+//! bisector projection.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::collections::HashMap;
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::blend_ops::fillet_v2;
+use brepkit_operations::extrude::extrude;
+use brepkit_topology::Topology;
+use brepkit_topology::builder::make_polygon_wire;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::{solid_edges, solid_faces};
+use brepkit_topology::face::{Face, FaceSurface};
+use brepkit_topology::solid::SolidId;
+
+fn edge_use_counts(topo: &Topology, solid: SolidId) -> HashMap<EdgeId, usize> {
+    let mut counts: HashMap<EdgeId, usize> = HashMap::new();
+    for fid in solid_faces(topo, solid).unwrap() {
+        let face = topo.face(fid).unwrap();
+        let mut wires = vec![face.outer_wire()];
+        wires.extend(face.inner_wires().iter().copied());
+        for wid in wires {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *counts.entry(oe.edge()).or_insert(0) += 1;
+            }
+        }
+    }
+    counts
+}
+
+#[test]
+#[ignore = "ready repro: a 0.02 fillet on a reflex notch REMOVES 0.077 instead of adding the \
+            blend sliver. REFUTED: swapping only the contact directions to the \
+            material-oriented form (the chamfer fix) makes it WORSE (removes 10.5) and breaks \
+            the calibrated convex pins — the fillet's concave case needs the full geometry \
+            (cylinder centre side, section orientation, keep-side) treated together."]
+fn fillet_v2_concave_notch_adds_only_the_fillet_sliver() {
+    let mut topo = Topology::new();
+    // A shallow ridge: the vertex at (5, 0.05) makes the two top laterals
+    // meet at ~178.9 degrees after extrusion.
+    let profile = make_polygon_wire(
+        &mut topo,
+        &[
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(4.0, 0.0, 0.0),
+            Point3::new(5.0, -1.0, 0.0),
+            Point3::new(6.0, 0.0, 0.0),
+            Point3::new(10.0, 0.0, 0.0),
+            Point3::new(10.0, -3.0, 0.0),
+            Point3::new(0.0, -3.0, 0.0),
+        ],
+        1e-7,
+    )
+    .unwrap();
+    let face = topo.add_face(Face::new(
+        profile,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 8.0).unwrap();
+
+    // The ridge edge runs along (5, 0.05, z).
+    let ridge = solid_edges(&topo, solid)
+        .unwrap()
+        .into_iter()
+        .find(|&eid| {
+            let e = topo.edge(eid).unwrap();
+            let s = topo.vertex(e.start()).unwrap().point();
+            let t = topo.vertex(e.end()).unwrap().point();
+            (s.x() - 5.0).abs() < 1e-9 && (t.x() - 5.0).abs() < 1e-9 && (s.z() - t.z()).abs() > 1.0
+        })
+        .expect("ridge edge");
+
+    let before = brepkit_operations::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    let result = fillet_v2(&mut topo, solid, &[ridge], 0.02).unwrap();
+    assert_eq!(result.succeeded, vec![ridge]);
+
+    // A 0.2 chamfer on this ridge removes a sliver; a wrong tangent branch
+    // cuts a macroscopic wedge or adds material.
+    let after = brepkit_operations::measure::solid_volume(&topo, result.solid, 0.05).unwrap();
+    // Chamfering a CONCAVE edge fills the notch corner: volume grows by a
+    // small sliver. The external tangent branch instead cuts outward or
+    // collapses the notch walls.
+    let added = after - before;
+    assert!(
+        added > 0.0 && added < before * 0.02,
+        "concave fillet should add a small sliver: before={before:.4} after={after:.4}"
+    );
+
+    // No stale or over-shared edges.
+    let counts = edge_use_counts(&topo, result.solid);
+    assert!(
+        counts.values().all(|&c| c <= 2),
+        "over-shared edge after near-tangent trim"
+    );
+}


### PR DESCRIPTION
Adds the concave-fillet sibling of the chamfer tangent-branch repro (ignored ready-repro), with the measured refutation of the direct fix transplant documented in the ignore reason and roadmap. No behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ignored ready repro for the concave fillet tangent-branch defect and updates the roadmap with measured findings and a refuted fix. No behavior change.

- **New Features**
  - Added `crates/operations/tests/regress_fillet_concave_notch.rs` (ignored): a 0.02 fillet on a reflex notch incorrectly removes 0.077 instead of adding a small sliver.
  - Updated `.claude/skills/roadmap/SKILL.md`: notes that transplanting the chamfer’s material-oriented contact directions worsens removal (~10.5) and breaks convex pins; the concave fillet fix must couple cylinder centre side, section orientation, and keep-side.

<sup>Written for commit 43551b37fbe6c395b92cc344971a9a26e8546f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

