### PR TITLE
docs(roadmap): tool-side scenario probes green on the post-campaign kernel

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -666,9 +666,15 @@ old parked branch `fix/kumiko-corner-window-cut` is GONE from the remote (its 5
 `kumiko_corner_window_inmem.rs` fixtures and their data went with it); its four documented
 roots remain unshipped, and re-attempting them means re-capturing fixtures first. The
 thickwall ready-repro still aborts identically on the new machinery (`open hole shell with 9
-faces`, pre-shell-fix operands — re-capture before drawing conclusions). REMAINING
-VERIFICATION for the divider/mitsukude scenario family is TOOL-SIDE: rebuild the kernel into
-the layout tool and run the scenario matrix (recipes below); the native suites cannot see it.
+faces`, pre-shell-fix operands — re-capture before drawing conclusions). TOOL-SIDE RE-PROBE DONE
+2026-08-04 on the post-campaign kernel (wasm built `--skip-opt`, deployed via the
+`parity-loop.sh` copy step; bypass pnpm's dep check by invoking
+`./node_modules/.bin/vitest` directly or the purge prompt clobbers the copied kernel):
+`gomaBoundaryProbe`, `kumikoNubProbe`, `dividerCrossLap`, `honeycombManifoldCheck` — 4 files,
+8/8 tests green in 53 s. Note the tool's test files were RENAMED since the recipes below were
+written (`topologyParity` and `mitsukudeNmProbe` no longer exist; the probes above are their
+successors). The full scenario matrix (~14 min/arm) remains unrun; the probes are the
+recorded isolation tests for the kumiko/goma/divider families.
 
 **Historical state (pre-closure):** branch `fix/kumiko-corner-window-cut` closed four real
 engine defects with fixtures but was **PARKED** — it regressed goma from 8 to 65 exported


### PR DESCRIPTION
First tool-side validation since the kumiko campaign and blend fixes shipped: the goma/kumiko/divider/honeycomb isolation probes all pass on the freshly built kernel (8/8 in 53s). Records the renamed test files and the pnpm dep-check pitfall in the recipe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record tool-side validation on the post-campaign kernel: 8/8 tests passed in 53s across `gomaBoundaryProbe`, `kumikoNubProbe`, `dividerCrossLap`, and `honeycombManifoldCheck`. Docs now note the renamed probes and a `pnpm` dep-check workaround when running `vitest`.

- **Migration**
  - Build wasm with `--skip-opt` and deploy via the `parity-loop.sh` copy step.
  - Run `./node_modules/.bin/vitest` directly to bypass `pnpm`’s dep check, which otherwise purges the copied kernel.
  - Use the new probe names; `topologyParity` and `mitsukudeNmProbe` were removed.

<sup>Written for commit a30b88603a58584ea2971612ed30213a8cf99271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

