### PR TITLE
docs(roadmap): the full export matrix is green on the post-campaign kernel

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -673,8 +673,12 @@ faces`, pre-shell-fix operands — re-capture before drawing conclusions). TOOL-
 `gomaBoundaryProbe`, `kumikoNubProbe`, `dividerCrossLap`, `honeycombManifoldCheck` — 4 files,
 8/8 tests green in 53 s. Note the tool's test files were RENAMED since the recipes below were
 written (`topologyParity` and `mitsukudeNmProbe` no longer exist; the probes above are their
-successors). The full scenario matrix (~14 min/arm) remains unrun; the probes are the
-recorded isolation tests for the kumiko/goma/divider families.
+successors). THE FULL EXPORT MATRIX IS GREEN
+(2026-08-04, same kernel): all four arms — `binGenerator.export.baseStyles`, `.binStyles`
+(wall patterns incl. kumiko/mitsukude), `.customShape`, `.halfSockets` — 73/73 tests in ~31 s
+total under the DEFAULT vitest config (the profile config's include misses them). The
+historical "14 min/arm with failures" era is over; the matrix now runs in seconds and passes
+entirely. The isolation probes (4 files, 8/8) are green on the same build.
 
 **Historical state (pre-closure):** branch `fix/kumiko-corner-window-cut` closed four real
 engine defects with fixtures but was **PARKED** — it regressed goma from 8 to 65 exported


### PR DESCRIPTION
Capstone measurement: all four export-matrix arms (base styles, bin styles with the kumiko/mitsukude wall patterns, custom shapes, half sockets) pass 73/73 in about 31 seconds on the freshly built kernel - the families that historically ran 14 minutes per arm with failures. Recorded alongside the green isolation probes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the roadmap to record that the full export matrix is green on the post‑campaign kernel. All four arms—`binGenerator.export.baseStyles`, `.binStyles` (kumiko/mitsukude walls), `.customShape`, `.halfSockets`—pass 73/73 in ~31s under default `vitest`, with notes on probe renames and that the profile config’s include misses these tests.

<sup>Written for commit 4e5e63bbd1ff4d16e21f4bbd562523d5c48a4290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

