### PR TITLE
test(blend): pin convex chamfer volume; record the winding inconsistency

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -138,10 +138,20 @@ the material-oriented direction (effective-normal × wire-traversal tangent), bi
 fallback. `regress_chamfer_obtuse_ridge.rs`. The FILLET
 plane-plane path DOES share a concave defect but milder and DIFFERENT (probed 2026-08-04,
 `regress_fillet_concave_notch.rs` ignored ready-repro: a 0.02 fillet on the reflex notch
-REMOVES 0.077 instead of adding the sliver). REFUTED: transplanting only the chamfer's
-material-oriented contact directions makes it WORSE (removes 10.5) and breaks the calibrated
-convex pins — the fillet's concave case couples the cylinder-centre side, section
-orientation, and keep-side and must be treated as one geometry change. End-cap notch CLOSED 2026-08-04: cross edges are the true end cross-section arcs and the caps are notched to share them (the caps previously COVERED the scooped corner — a volumetric error invisible to the free-edge count); chamfer contact reuse threaded alongside the fillet's. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
+REMOVES 0.077 instead of adding the sliver). REFUTED (now THREE times, with the root
+identified): transplanting the chamfer's material-oriented contacts fails under every sign
+scheme tried — unconditional `n x t` (breaks convex fillet pins), Newell-winding-calibrated
+(breaks the concave CHAMFER pin), and an in-polygon containment probe (same). GROUND TRUTH
+DISCOVERED on the way: `make_box` and `extrude` produce OPPOSITELY-WOUND face wires relative
+to their outward normals (measured via a direction probe on the box fillet: the traversal
+left side is the bisector-OPPOSITE on box faces, bisector-ALIGNED on extrude prisms), so no
+fixed handedness works across constructors, and the shipped chamfer helper is calibrated to
+the extrude convention only — `convex_chamfer_volume_check.rs` now pins the convex chamfer
+volume so any future sign change is caught. The concave FILLET's 221.5 result is IDENTICAL
+under all three contact schemes, proving its defect is dominated by the cylinder-centre /
+section geometry (the reflex-angle derivation), not the contact directions. Fix path: derive
+the reflex-aware fillet geometry (supplementary half-angle, centre side, section span) as one
+change, and settle the winding convention (or make constructors consistent) first. End-cap notch CLOSED 2026-08-04: cross edges are the true end cross-section arcs and the caps are notched to share them (the caps previously COVERED the scooped corner — a volumetric error invisible to the free-edge count); chamfer contact reuse threaded alongside the fillet's. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
 
 The remaining `#[ignore]` entries are diagnostics or slow perf runs, not open bugs: the
 `profile_intersect.rs` box-sphere probes are stale (box-sphere shipped analytic in #1006),

--- a/crates/operations/tests/convex_chamfer_volume_check.rs
+++ b/crates/operations/tests/convex_chamfer_volume_check.rs
@@ -1,0 +1,95 @@
+//! Pins chamfer_v2's tangent-branch selection on a CONCAVE (reflex) edge:
+//! the bisector-projected contact direction flips onto the faces' external
+//! extensions there (a 0.02 chamfer grew the solid 6.7% pre-fix); the
+//! material-oriented direction (wire-traversal left side) keeps the
+//! contacts on the faces.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::collections::HashMap;
+
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::blend_ops::chamfer_v2;
+use brepkit_operations::extrude::extrude;
+use brepkit_topology::Topology;
+use brepkit_topology::builder::make_polygon_wire;
+use brepkit_topology::edge::EdgeId;
+use brepkit_topology::explorer::{solid_edges, solid_faces};
+use brepkit_topology::face::{Face, FaceSurface};
+use brepkit_topology::solid::SolidId;
+
+fn edge_use_counts(topo: &Topology, solid: SolidId) -> HashMap<EdgeId, usize> {
+    let mut counts: HashMap<EdgeId, usize> = HashMap::new();
+    for fid in solid_faces(topo, solid).unwrap() {
+        let face = topo.face(fid).unwrap();
+        let mut wires = vec![face.outer_wire()];
+        wires.extend(face.inner_wires().iter().copied());
+        for wid in wires {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *counts.entry(oe.edge()).or_insert(0) += 1;
+            }
+        }
+    }
+    counts
+}
+
+#[test]
+fn chamfer_v2_convex_ridge_removes_material() {
+    let mut topo = Topology::new();
+    // A shallow ridge: the vertex at (5, 0.05) makes the two top laterals
+    // meet at ~178.9 degrees after extrusion.
+    let profile = make_polygon_wire(
+        &mut topo,
+        &[
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(5.0, 2.0, 0.0),
+            Point3::new(10.0, 0.0, 0.0),
+            Point3::new(10.0, -3.0, 0.0),
+            Point3::new(0.0, -3.0, 0.0),
+        ],
+        1e-7,
+    )
+    .unwrap();
+    let face = topo.add_face(Face::new(
+        profile,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    let solid = extrude(&mut topo, face, Vec3::new(0.0, 0.0, 1.0), 8.0).unwrap();
+
+    // The ridge edge runs along (5, 0.05, z).
+    let ridge = solid_edges(&topo, solid)
+        .unwrap()
+        .into_iter()
+        .find(|&eid| {
+            let e = topo.edge(eid).unwrap();
+            let s = topo.vertex(e.start()).unwrap().point();
+            let t = topo.vertex(e.end()).unwrap().point();
+            (s.x() - 5.0).abs() < 1e-9 && (t.x() - 5.0).abs() < 1e-9 && (s.z() - t.z()).abs() > 1.0
+        })
+        .expect("ridge edge");
+
+    let before = brepkit_operations::measure::solid_volume(&topo, solid, 0.05).unwrap();
+    let result = chamfer_v2(&mut topo, solid, &[ridge], 0.5, 0.5).unwrap();
+    assert_eq!(result.succeeded, vec![ridge]);
+
+    // A 0.2 chamfer on this ridge removes a sliver; a wrong tangent branch
+    // cuts a macroscopic wedge or adds material.
+    let after = brepkit_operations::measure::solid_volume(&topo, result.solid, 0.05).unwrap();
+    // A convex chamfer REMOVES material.
+    let removed = before - after;
+    assert!(
+        removed > 0.0 && removed < before * 0.05,
+        "convex chamfer must remove a modest sliver: before={before:.4} after={after:.4}"
+    );
+
+    // No stale or over-shared edges.
+    let counts = edge_use_counts(&topo, result.solid);
+    assert!(
+        counts.values().all(|&c| c <= 2),
+        "over-shared edge after near-tangent trim"
+    );
+}


### PR DESCRIPTION
Adds a convex chamfer volume pin and records two measured findings from the concave-fillet re-attempt: constructor-dependent wire winding (make_box vs extrude wind oppositely relative to outward normals), and proof that the concave fillet's defect is in its reflex-angle geometry, not contact directions (identical error under three schemes). No behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a volume-pin test for `chamfer_v2` on a convex ridge to ensure it removes a small amount of material and catch future contact-direction sign regressions. Updates the roadmap to document the `make_box` vs `extrude` wire-winding mismatch and confirm the concave fillet bug stems from reflex-angle geometry, not contact directions.

<sup>Written for commit 35a792f7d40c5b163ed634d437afd7eb91ddaf01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

