### PR TITLE
fix(blend): fill concave edges on the correct side of the analytic fillet

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -125,43 +125,7 @@ doc comment — read that, not this.**
 | **Mesh-boolean fallback emits OPEN meshes that are CONSUMED** (open since 2026-07-16) | operations | `mesh_boolean_fallback` warns its output is not a closed 2-manifold and uses it anyway; there is no further fallback, so rejecting means the op fails outright. A product call, not just a fix |
 | **Divider residual geometry** (3 cases, re-confirmed 2026-08-01 with the compound + shell fixes overlaid: 3 failed / 12 passed, 820 s) | algo/GFA | `mitsukude lattice on dividers` (**boundary 6** — was non-manifold 4 before the shell fix, so the signature MOVED), `kumiko dividers perforate the compartment walls`, `dividers + scoops keep the ramp footings solid` (boundary 4). The first two are the SAME 2x2x6 mitsukude bin with 2x1 compartments differing only in `dividers: true/false`, which argues against the divider carry-through being the cause; `__kernel-tests__/mitsukudeNmProbe.test.ts` isolates pattern vs compartments vs footprint |
 | **snapClip 0.6 mm-nozzle export chain** breaks at op-cut-3 (posBad=10, analytic but leaky) | algo/GFA | Root is marched FF sections on curved faces carrying `pave_block_id=None`, bypassing the pave machinery. Canonical altitude is pave-block attachment at phase-FF/make_blocks; every face-splitter-level attempt broke calibrated chains |
-| **v2 trimmer residuals** (3 remaining) | blend | CLOSED 2026-08-04: `create_blend_face` duplicate contact edges — the blend face now REUSES the trimmers' contact edges when endpoints match within weld (regress bnd 22 → 7, pin tightened to <= 7). Remaining: keep-side selection degenerate under tangency — NOW WITH A STABLE PRIMITIVE REPRO
-(`regress_blend_keepside_tangency.rs`, ignored: a 0.02-radius fillet on a 178.9° extruded
-ridge loses 12% of the solid, 242 → 212.4). MEASURED REFUTATION on record: an in-plane
-cross-contact side discriminant (keep the side of the contact line opposite the projected
-other-contact direction) flipped the CALIBRATED box case while leaving the 12% loss
-UNCHANGED — so the loss is at least partly in the trim geometry itself at shallow incidence,
-not only the side dot; separate the two sub-defects before re-attempting. `chamfer_v2` external tangent branch CLOSED
-2026-08-04: on a concave edge the bisector-projected contact direction flips onto the faces'
-extensions (0.02 chamfer grew a notched prism 6.7%); the chamfer's plane-plane path now uses
-the material-oriented direction (effective-normal × wire-traversal tangent), bisector as
-fallback. `regress_chamfer_obtuse_ridge.rs`. The FILLET
-plane-plane path DOES share a concave defect but milder and DIFFERENT (probed 2026-08-04,
-`regress_fillet_concave_notch.rs` ignored ready-repro: a 0.02 fillet on the reflex notch
-REMOVES 0.077 instead of adding the sliver). REFUTED (now THREE times, with the root
-identified): transplanting the chamfer's material-oriented contacts fails under every sign
-scheme tried — unconditional `n x t` (breaks convex fillet pins), Newell-winding-calibrated
-(breaks the concave CHAMFER pin), and an in-polygon containment probe (same). GROUND TRUTH
-DISCOVERED on the way: `make_box` and `extrude` produce OPPOSITELY-WOUND face wires relative
-to their outward normals (measured via a direction probe on the box fillet: the traversal
-left side is the bisector-OPPOSITE on box faces, bisector-ALIGNED on extrude prisms), so no
-fixed handedness works across constructors, and the shipped chamfer helper is calibrated to
-the extrude convention only — `convex_chamfer_volume_check.rs` now pins the convex chamfer
-volume so any future sign change is caught. The concave FILLET's 221.5 result is IDENTICAL
-under all three contact schemes, proving its defect is dominated by the cylinder-centre /
-section geometry (the reflex-angle derivation), not the contact directions. Fix path SHARPENED by a
-worked example (the notch with perpendicular wall normals): the bisector CONTACTS and the
-CENTRE formula are PROVABLY CORRECT there (centre r*sqrt(2) up the bisector, contacts r along
-the walls toward material — the bisector projection lands right for this concave case), so
-"supplementary half-angle" is NOT the defect. The concave failure is strictly DOWNSTREAM of
-the contact/centre computation: the section-arc span (must bow toward the vertex, the ball's
-notch-side arc), the blend-face surface orientation, or the trimmer keep-side mapping
-(worked example: n·(centre − p1) > 0 → Right; verify Right is the away-from-vertex chain for
-the trimmer's direction convention). Also note the shipped 0.077 removal vs the 10.5 removal
-under material contacts differ only in contact SIGN — meaning the shipped concave contacts
-land on the extensions and the trim barely does anything, while corrected contacts make the
-wrong downstream machinery bite harder. Instrument the section arc and kept chains on the
-notch repro first. End-cap notch CLOSED 2026-08-04: cross edges are the true end cross-section arcs and the caps are notched to share them (the caps previously COVERED the scooped corner — a volumetric error invisible to the free-edge count); chamfer contact reuse threaded alongside the fillet's. `crates/operations/tests/regress_blend_trim_neighbor_split.rs` |
+| **v2 trimmer residuals** (1 remaining) | blend | Remaining: keep-side/trim geometry degenerate under tangency (`regress_blend_keepside_tangency.rs`, ignored: a 0.02 fillet on a 178.9° extruded ridge loses 12%, 242 → 212.4; UNCHANGED by the 2026-08-04 concave fixes, and a measured refutation on record shows the loss is at least partly in the trim geometry at shallow incidence, not only the side dot — separate the two sub-defects before re-attempting). CLOSED 2026-08-04: duplicate contact edges (blend face reuses trimmer contacts, bnd 22 → 7), end-cap notch (caps share the true end cross-section arcs), `chamfer_v2` external tangent branch (material-oriented contact direction, `regress_chamfer_obtuse_ridge.rs`), and the CONCAVE FILLET (`regress_fillet_concave_notch.rs`, now un-ignored and green): two roots — the analytic plane-plane fillet placed its cross-section down the inward bisector because inward normals alone cannot distinguish convex from concave (fixed with a face-extent material witness that flips the bisector), and the trim keep-side keyed on which side of the PLANE the ball centre sits, which flips for concave edges though the in-plane keep side does not (fixed with `TrimKeep::AwayFrom(spine point)`, resolved INSIDE the trimmer because its Left/Right frame follows each face's wire traversal and is unknowable to callers — the same frame-fragility that produced three refuted external sign schemes; their record and the constructor-winding ground truth live in the fixture doc comments and `convex_chamfer_volume_check.rs`) |
 
 The remaining `#[ignore]` entries are diagnostics or slow perf runs, not open bugs: the
 `profile_intersect.rs` box-sphere probes are stale (box-sphere shipped analytic in #1006),

--- a/crates/blend/src/analytic.rs
+++ b/crates/blend/src/analytic.rs
@@ -436,6 +436,34 @@ fn midpoint_3d(a: Point3, b: Point3) -> Point3 {
 /// # Errors
 /// Returns `BlendError` if topology lookups or math operations fail.
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+/// Signed extent of `face`'s vertices against another plane's inward normal
+/// `n_other`, measured from the spine point `p`. The extreme-magnitude vertex
+/// is the witness: positive means the face reaches into the material side of
+/// the other plane (convex edge), negative means the void side (concave).
+fn material_side_witness(
+    topo: &Topology,
+    face: FaceId,
+    n_other: Vec3,
+    p: Point3,
+) -> Result<f64, BlendError> {
+    let f = topo.face(face)?;
+    let mut wires = vec![f.outer_wire()];
+    wires.extend(f.inner_wires().iter().copied());
+    let mut extreme = 0.0_f64;
+    for wid in wires {
+        for oe in topo.wire(wid)?.edges() {
+            let e = topo.edge(oe.edge())?;
+            for vid in [e.start(), e.end()] {
+                let s = n_other.dot(topo.vertex(vid)?.point() - p);
+                if s.abs() > extreme.abs() {
+                    extreme = s;
+                }
+            }
+        }
+    }
+    Ok(extreme)
+}
+
 fn plane_plane_fillet(
     spine: &Spine,
     topo: &Topology,
@@ -460,6 +488,21 @@ fn plane_plane_fillet(
 
     let (bisector, _cross_dir) = section_basis(n1, n2, tangent);
 
+    // The inward normals alone cannot distinguish a convex edge from a
+    // concave (notch) one — both wedges share the same bounding planes.
+    // The tie-breaker is the faces' extent: a convex neighbour face lies on
+    // the material (inward) side of the other plane, a concave one on the
+    // void side. On a concave edge the fillet centre and contacts sit up the
+    // OUTWARD bisector, and the in-plane contact projections then follow the
+    // real walls instead of their extensions.
+    let w1 = material_side_witness(topo, face1, n2, p_start)?;
+    let w2 = material_side_witness(topo, face2, n1, p_start)?;
+    let bisector = if w1 < -ANALYTIC_TOL_LIN && w2 < -ANALYTIC_TOL_LIN {
+        -bisector
+    } else {
+        bisector
+    };
+
     let center_offset = radius / sin_half;
 
     let cyl_origin = p_start + bisector * center_offset;
@@ -477,7 +520,6 @@ fn plane_plane_fillet(
     let c1_end = p_end + contact_dir1 * contact_offset;
     let c2_start = p_start + contact_dir2 * contact_offset;
     let c2_end = p_end + contact_dir2 * contact_offset;
-
     let contact1 = nurbs_line(c1_start, c1_end)?;
     let contact2 = nurbs_line(c2_start, c2_end)?;
 

--- a/crates/blend/src/chamfer_builder.rs
+++ b/crates/blend/src/chamfer_builder.rs
@@ -16,7 +16,7 @@ use crate::analytic;
 use crate::builder_utils::sample_nurbs_endpoints;
 use crate::spine::Spine;
 use crate::stripe::StripeResult;
-use crate::trimmer::{self, TrimSide};
+use crate::trimmer::{self, TrimKeep, TrimSide};
 use crate::{BlendError, BlendResult};
 
 /// Internal representation of a chamfer edge set with its distance parameters.
@@ -238,7 +238,7 @@ impl<'a> ChamferBuilder<'a> {
                 current_face1,
                 &contact1_pts,
                 &[(0.0, 0.0), (1.0, 0.0)],
-                keep_side1,
+                TrimKeep::Side(keep_side1),
             );
 
             match trim1 {
@@ -263,7 +263,7 @@ impl<'a> ChamferBuilder<'a> {
                 current_face2,
                 &contact2_pts,
                 &[(0.0, 0.0), (1.0, 0.0)],
-                keep_side2,
+                TrimKeep::Side(keep_side2),
             );
 
             match trim2 {

--- a/crates/blend/src/fillet_builder.rs
+++ b/crates/blend/src/fillet_builder.rs
@@ -23,7 +23,7 @@ use crate::corner;
 use crate::radius_law::RadiusLaw;
 use crate::spine::Spine;
 use crate::stripe::{Stripe, StripeResult};
-use crate::trimmer::{self, TrimSide};
+use crate::trimmer;
 use crate::walker::{Walker, WalkerConfig, approximate_blend_surface};
 use crate::{BlendError, BlendResult};
 
@@ -191,39 +191,21 @@ impl<'a> FilletBuilder<'a> {
             let contact1_pts = sample_nurbs_endpoints(&stripe.contact1);
             let contact2_pts = sample_nurbs_endpoints(&stripe.contact2);
 
-            // Compute which side to keep: the side AWAY from the blend ball center.
-            // Use the first section's ball center to determine direction relative
-            // to each face normal. If center is on the normal side, keep Right
-            // (away from center); otherwise keep Left.
-            let keep_side1 =
-                if let (Some(sec), Ok(face)) = (stripe.sections.first(), topo.face(stripe.face1)) {
-                    let n = face.surface().normal(0.0, 0.0);
-                    if n.dot(sec.center - sec.p1) > 0.0 {
-                        TrimSide::Right
-                    } else {
-                        TrimSide::Left
-                    }
-                } else {
-                    TrimSide::Right
-                };
-            let keep_side2 =
-                if let (Some(sec), Ok(face)) = (stripe.sections.first(), topo.face(stripe.face2)) {
-                    let n = face.surface().normal(0.0, 0.0);
-                    if n.dot(sec.center - sec.p2) > 0.0 {
-                        TrimSide::Right
-                    } else {
-                        TrimSide::Left
-                    }
-                } else {
-                    TrimSide::Right
-                };
+            // Keep the side of the contact line AWAY from the spine edge: the
+            // strip between the contact line and the old edge is what the
+            // blend face replaces. The side is resolved inside the trimmer,
+            // whose Left/Right frame follows each face's wire traversal and
+            // cannot be predicted here; a ball-centre plane-side test flips
+            // for concave edges even though the in-plane keep side does not.
+            let spine_pt = stripe.spine.evaluate(topo, 0.0)?;
+            let keep = trimmer::TrimKeep::AwayFrom(spine_pt);
 
             // Trim face 1 — use current replacement if face was already trimmed.
             let current_face1 = face_replacements
                 .get(&stripe.face1)
                 .copied()
                 .unwrap_or(stripe.face1);
-            let trim1 = trimmer::trim_face_general(topo, current_face1, &contact1_pts, keep_side1);
+            let trim1 = trimmer::trim_face_general(topo, current_face1, &contact1_pts, keep);
 
             match trim1 {
                 Ok(tr) if tr.trimmed_face != current_face1 => {
@@ -244,7 +226,7 @@ impl<'a> FilletBuilder<'a> {
                 .get(&stripe.face2)
                 .copied()
                 .unwrap_or(stripe.face2);
-            let trim2 = trimmer::trim_face_general(topo, current_face2, &contact2_pts, keep_side2);
+            let trim2 = trimmer::trim_face_general(topo, current_face2, &contact2_pts, keep);
 
             match trim2 {
                 Ok(tr) if tr.trimmed_face != current_face2 => {

--- a/crates/blend/src/trimmer.rs
+++ b/crates/blend/src/trimmer.rs
@@ -26,6 +26,21 @@ pub enum TrimSide {
     Right,
 }
 
+/// How to choose the kept side of the contact curve.
+///
+/// `Side` is interpreted against the trimmer's internal hit order, which
+/// follows the face's wire traversal; callers outside the trimmer cannot
+/// predict that frame, so `AwayFrom` names a 3D point (typically a spine
+/// point on the edge being blended) and the trimmer keeps the chain on the
+/// opposite side, resolved in its own frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TrimKeep {
+    /// Keep an explicit side in the trimmer's own frame.
+    Side(TrimSide),
+    /// Keep the side of the contact curve away from this point.
+    AwayFrom(Point3),
+}
+
 /// Result of trimming a face along a contact curve.
 #[derive(Debug, Clone)]
 pub struct TrimResult {
@@ -77,7 +92,7 @@ pub fn trim_face(
     face_id: FaceId,
     contact_3d: &[Point3],
     contact_uv: &[(f64, f64)],
-    keep_side: TrimSide,
+    keep: TrimKeep,
 ) -> Result<TrimResult, BlendError> {
     let face = topo.face(face_id)?;
     if !face.surface().is_planar() {
@@ -262,6 +277,18 @@ pub fn trim_face(
     let to_sample = sample_pt - hit_a.point_3d;
     let cross = contact_dir.cross(to_sample);
     let chain1_is_left = face_normal.dot(cross) > 0.0;
+
+    let keep_side = match keep {
+        TrimKeep::Side(side) => side,
+        TrimKeep::AwayFrom(p) => {
+            let p_is_left = face_normal.dot(contact_dir.cross(p - hit_a.point_3d)) > 0.0;
+            if p_is_left {
+                TrimSide::Right
+            } else {
+                TrimSide::Left
+            }
+        }
+    };
 
     // chain1 runs va→…→vb, so the contact edge (va→vb) closes it REVERSED;
     // chain2 runs vb→…→va and closes with the contact edge forward.
@@ -530,7 +557,7 @@ pub fn trim_face_general(
     topo: &mut Topology,
     face_id: FaceId,
     contact_3d: &[Point3],
-    keep_side: TrimSide,
+    keep: TrimKeep,
 ) -> Result<TrimResult, BlendError> {
     if contact_3d.len() < 2 {
         return Err(BlendError::TrimmingFailure { face: face_id });
@@ -569,7 +596,7 @@ pub fn trim_face_general(
             })
             .collect();
 
-        return trim_face(topo, face_id, contact_3d, &contact_uv, keep_side);
+        return trim_face(topo, face_id, contact_3d, &contact_uv, keep);
     }
 
     // Non-planar path: project to UV space
@@ -688,6 +715,39 @@ pub fn trim_face_general(
     right_edges.push(OrientedEdge::new(ea_pre, true));
     right_edges.push(OrientedEdge::new(contact_eid, true));
 
+    let keep_side = match keep {
+        TrimKeep::Side(side) => side,
+        TrimKeep::AwayFrom(p) => {
+            let face_normal = match &surface {
+                FaceSurface::Plane { normal, .. } => {
+                    if reversed {
+                        -*normal
+                    } else {
+                        *normal
+                    }
+                }
+                _ => return Err(BlendError::TrimmingFailure { face: face_id }),
+            };
+            let contact_dir = hit_b.point_3d - hit_a.point_3d;
+            let left_sample = (idx_a..idx_b).rev().find_map(|i| {
+                let oe = oriented_edges[i];
+                let e = topo.edge(oe.edge()).ok()?;
+                let vid = if oe.is_forward() { e.end() } else { e.start() };
+                let q = topo.vertex(vid).ok()?.point();
+                let side = face_normal.dot(contact_dir.cross(q - hit_a.point_3d));
+                (side.abs() > 1e-12).then_some(side > 0.0)
+            });
+            let Some(left_chain_is_left) = left_sample else {
+                return Err(BlendError::TrimmingFailure { face: face_id });
+            };
+            let p_is_left = face_normal.dot(contact_dir.cross(p - hit_a.point_3d)) > 0.0;
+            if p_is_left == left_chain_is_left {
+                TrimSide::Right
+            } else {
+                TrimSide::Left
+            }
+        }
+    };
     let (keep_edges, _contact_forward) = match keep_side {
         TrimSide::Left => (left_edges, false),
         TrimSide::Right => (right_edges, true),
@@ -786,8 +846,14 @@ mod tests {
         let contact_3d = vec![Point3::new(0.5, 0.0, 0.0), Point3::new(0.5, 1.0, 0.0)];
         let contact_uv = vec![(0.5, 0.0), (0.5, 1.0)];
 
-        let result = trim_face(&mut topo, face_id, &contact_3d, &contact_uv, TrimSide::Left)
-            .expect("trim should succeed");
+        let result = trim_face(
+            &mut topo,
+            face_id,
+            &contact_3d,
+            &contact_uv,
+            TrimKeep::Side(TrimSide::Left),
+        )
+        .expect("trim should succeed");
 
         // The trimmed face should have a new wire.
         let trimmed_face = topo.face(result.trimmed_face).unwrap();
@@ -883,8 +949,14 @@ mod tests {
         // neighbor) and e2 (unshared).
         let contact_3d = vec![Point3::new(0.5, 0.0, 0.0), Point3::new(0.5, 1.0, 0.0)];
         let contact_uv = vec![(0.5, 0.0), (0.5, 1.0)];
-        let result = trim_face(&mut topo, face_id, &contact_3d, &contact_uv, TrimSide::Left)
-            .expect("trim should succeed");
+        let result = trim_face(
+            &mut topo,
+            face_id,
+            &contact_3d,
+            &contact_uv,
+            TrimKeep::Side(TrimSide::Left),
+        )
+        .expect("trim should succeed");
 
         // The neighbor must no longer reference the stale unsplit edge.
         let neighbor_wire = topo
@@ -972,7 +1044,13 @@ mod tests {
 
         let contact_3d = vec![Point3::new(0.5, -1.0, 0.0), Point3::new(0.5, 1.0, 0.0)];
         let contact_uv = vec![(0.5, -1.0), (0.5, 1.0)];
-        let result = trim_face(&mut topo, face_id, &contact_3d, &contact_uv, TrimSide::Left);
+        let result = trim_face(
+            &mut topo,
+            face_id,
+            &contact_3d,
+            &contact_uv,
+            TrimKeep::Side(TrimSide::Left),
+        );
         assert!(
             matches!(result, Err(BlendError::TrimmingFailure { .. })),
             "two hits on one repeated edge must be rejected"
@@ -1006,8 +1084,14 @@ mod tests {
 
         let contact_3d = vec![Point3::new(0.5, 0.0, 0.0), Point3::new(0.5, 1.0, 0.0)];
         let contact_uv = vec![(0.5, 0.0), (0.5, 1.0)];
-        trim_face(&mut topo, face_id, &contact_3d, &contact_uv, TrimSide::Left)
-            .expect("trim should succeed");
+        trim_face(
+            &mut topo,
+            face_id,
+            &contact_3d,
+            &contact_uv,
+            TrimKeep::Side(TrimSide::Left),
+        )
+        .expect("trim should succeed");
 
         assert!(
             !topo.pcurves().contains(edges[0], neighbor),
@@ -1028,7 +1112,7 @@ mod tests {
             face_id,
             &contact_3d,
             &contact_uv,
-            TrimSide::Right,
+            TrimKeep::Side(TrimSide::Right),
         )
         .expect("trim should succeed");
 
@@ -1083,8 +1167,14 @@ mod tests {
         let contact_3d = vec![Point3::new(0.5, 0.0, 0.0), Point3::new(0.5, 1.0, 0.0)];
         let contact_uv = vec![(0.5, 0.0), (0.5, 1.0)];
 
-        let result = trim_face(&mut topo, face_id, &contact_3d, &contact_uv, TrimSide::Left)
-            .expect("should return untrimmed result");
+        let result = trim_face(
+            &mut topo,
+            face_id,
+            &contact_3d,
+            &contact_uv,
+            TrimKeep::Side(TrimSide::Left),
+        )
+        .expect("should return untrimmed result");
 
         // Untrimmed: same face, no new topology.
         assert_eq!(result.trimmed_face, face_id);

--- a/crates/operations/tests/regress_fillet_concave_notch.rs
+++ b/crates/operations/tests/regress_fillet_concave_notch.rs
@@ -1,6 +1,12 @@
-//! Probe: does the FILLET's plane-plane path share the chamfer's concave
-//! tangent-branch defect? Its contact directions still come from the
-//! bisector projection.
+//! A fillet on a CONCAVE (reflex-notch) edge must fill the corner with a
+//! small sliver, not carve material. Two roots closed here: the analytic
+//! plane-plane fillet placed its whole cross-section down the inward-normal
+//! bisector (the material side; a convex and a concave edge are
+//! indistinguishable from the inward normals alone, so a face-extent witness
+//! supplies the missing bit), and the trim keep-side keyed on which side of
+//! the PLANE the ball centre sits, which flips for concave edges even though
+//! the in-plane keep side does not (now resolved inside the trimmer via
+//! TrimKeep::AwayFrom, since its Left/Right frame follows wire traversal).
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
@@ -32,11 +38,6 @@ fn edge_use_counts(topo: &Topology, solid: SolidId) -> HashMap<EdgeId, usize> {
 }
 
 #[test]
-#[ignore = "ready repro: a 0.02 fillet on a reflex notch REMOVES 0.077 instead of adding the \
-            blend sliver. REFUTED: swapping only the contact directions to the \
-            material-oriented form (the chamfer fix) makes it WORSE (removes 10.5) and breaks \
-            the calibrated convex pins — the fillet's concave case needs the full geometry \
-            (cylinder centre side, section orientation, keep-side) treated together."]
 fn fillet_v2_concave_notch_adds_only_the_fillet_sliver() {
     let mut topo = Topology::new();
     // A shallow ridge: the vertex at (5, 0.05) makes the two top laterals


### PR DESCRIPTION
## Root causes

A 0.02 fillet on a reflex-notch edge removed material instead of adding the corner sliver (`regress_fillet_concave_notch.rs`, previously an ignored ready-repro). Instrumenting the analytic fillet found two independent roots:

1. **The analytic plane-plane fillet always placed its cross-section down the inward-normal bisector.** Inward normals alone cannot distinguish a convex edge from a concave one: both wedges share the same bounding planes and give the same dihedral. The missing bit is the faces' extent: a convex neighbour face lies on the material side of the other plane, a concave one on the void side. A face-extent witness now flips the bisector on concave edges, which also lands the in-plane contact projections on the real walls instead of their extensions.

2. **The trim keep-side keyed on which side of the PLANE the ball centre sits.** The centre-to-contact vector is perpendicular to the face plane, so that test only measures which side of the plane the centre is on, and it flips for concave edges even though the correct in-plane keep side (away from the spine edge) does not. The fillet path now passes `TrimKeep::AwayFrom(spine point)` and the trimmer resolves the side in its own frame. Resolving externally is impossible in principle: the trimmer's Left/Right frame follows each face's wire traversal order, which callers cannot predict; this frame-fragility is what broke all three previously refuted external sign schemes.

## Validation

- `regress_fillet_concave_notch.rs` un-ignored and green (fillet adds the sliver).
- Calibrated pins unchanged: `regress_blend_trim_neighbor_split` (bnd <= 7), `regress_chamfer_obtuse_ridge`, `convex_chamfer_volume_check`.
- Full suites green: blend 96, operations 1010, io 231, algo 209.
- `regress_blend_keepside_tangency` (separate near-tangent defect) unchanged, stays ignored.

Roadmap updated in the same PR: v2 trimmer residuals down to 1 (keep-side/trim geometry under tangency).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concave plane-plane fillets so they add the corner sliver instead of carving material on reflex-notch edges. Chooses the correct bisector and keep side; the concave-notch repro is green and convex cases are unchanged.

- **Bug Fixes**
  - Bisector selection: added a face-extent material witness to detect concave edges and flip to the outward bisector, so contact projections land on the real walls.
  - Keep-side resolution: fillet now passes `TrimKeep::AwayFrom(spine point)` and the `trimmer` resolves Left/Right in its own frame (replacing the plane-side-of-center heuristic); updated `trim_face`/`trim_face_general` to accept `TrimKeep`.

<sup>Written for commit 0a12b6920eec24463deefbd30a103e1cd2b832ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

