### PR TITLE
docs(io): characterize both new abort fixtures' failing shells

### DIFF
--- a/crates/io/tests/oshape_socket_fuse_inmem.rs
+++ b/crates/io/tests/oshape_socket_fuse_inmem.rs
@@ -20,6 +20,12 @@
 //!
 //! Operands captured 2026-08-05 via the kernel-test boolean monkey-patch
 //! (call 006 of the export chain; call 007 is its downstream collateral).
+//!
+//! BK_OPEN_SHELL characterization: the open 45-face growth shell has
+//! POSITIVE volume 3628.8 and is the socket ring itself — alternating plane
+//! and NURBS faces at the ring positions (x,y around +-18.7/+-22.45,
+//! z=-2.6): the quarter-socket NURBS pieces fail to pair with their plane
+//! neighbours after selection.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/crates/io/tests/slotted_nolip_fuse_inmem.rs
+++ b/crates/io/tests/slotted_nolip_fuse_inmem.rs
@@ -14,6 +14,12 @@
 //!
 //! Operands captured 2026-08-05 via the kernel-test boolean monkey-patch on
 //! the failing export scenario (call 009 of 10).
+//!
+//! BK_OPEN_SHELL characterization: the aborting 45-face shell has signed
+//! volume -51259 and is built from the BODY's own faces (src 10-13, the
+//! outer walls and corner cylinders) — the fuse classifies a body-sized
+//! chunk as a hole shell, the "no outer shell / misgrouped interior" family
+//! rather than a small-fragment drop.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 


### PR DESCRIPTION
BK_OPEN_SHELL dumps on the two new drift fixtures, appended to their headers:

- **Slotted no-lip**: the aborting 45-face shell has signed volume -51259 and is built from the BODY's own outer walls and corner cylinders — the fuse classifies a body-sized chunk as a hole shell (the no-outer-shell / misgrouped-interior family), not a small-fragment drop.
- **O-shape sockets**: the open 45-face growth shell has POSITIVE volume 3628.8 and is the socket ring itself — alternating plane and NURBS faces at the ring positions; the quarter-socket NURBS pieces fail to pair with their plane neighbours after selection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added BK_OPEN_SHELL characterizations to `crates/io/tests/slotted_nolip_fuse_inmem.rs` and `crates/io/tests/oshape_socket_fuse_inmem.rs` to explain the failing shells. Slotted no-lip: 45-face abort shell with signed volume -51259 built from the body’s outer walls and corner cylinders and misclassified as a hole shell; O-shape sockets: 45-face open growth shell with positive volume 3628.8 representing the socket ring with alternating plane and NURBS faces where quarter-socket NURBS pieces do not pair with adjacent planes.

<sup>Written for commit 5f137256ba86102ebe0c50976a41da5a6d98302c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

