### PR TITLE
docs(io): the O-shape unpaired edges are the corner chamfer-band arcs

### DIFF
--- a/crates/io/tests/oshape_socket_fuse_inmem.rs
+++ b/crates/io/tests/oshape_socket_fuse_inmem.rs
@@ -26,6 +26,14 @@
 //! and NURBS faces at the ring positions (x,y around +-18.7/+-22.45,
 //! z=-2.6): the quarter-socket NURBS pieces fail to pair with their plane
 //! neighbours after selection.
+//!
+//! The unpaired edges are the bin's four corner CHAMFER-BAND arcs: Circle
+//! edges (len 5.30) at z=0 and z=0.7 plus the slanted 1.21-length corner
+//! connectors between them. Operand A carries these as Circle edges; the
+//! suspect is that B's quarter-socket side carries coincident twins in a
+//! different representation (NURBS or different segmentation), the
+//! mismatched-representation coincident-boundary class that endpoint-pair
+//! edge merging cannot reconcile by design.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 


### PR DESCRIPTION
Free-edge map of the O-shape fixture's failing shell: the unpaired edges are the bin's four corner CHAMFER-BAND arcs — Circle edges (length 5.30) at z=0 and z=0.7 plus the slanted 1.21 connectors between them. Operand A carries these as Circle edges; the suspect is that the quarter-socket side carries coincident twins in a different representation (NURBS or different segmentation) — the mismatched-representation coincident-boundary class that endpoint-pair edge merging cannot reconcile by design (the frontier's original eighth-vs-quarter statement, now in Circle-vs-NURBS form). Appended to the fixture header as the dig's entry point.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the failing edges in the O-shape socket fuse test. Notes the four corner chamfer-band Circle arcs at z=0 and z=0.7 and their slanted connectors as unpaired, and documents the suspected Circle vs NURBS/segmentation mismatch that blocks endpoint-pair merging.

<sup>Written for commit 0d700bba1a37ba33e2f5da389aab74fcf575b5bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

