### PR TITLE
docs(io): correct the O-shape suspect to dropped upper faces over B's rims

### DIFF
--- a/crates/io/tests/oshape_socket_fuse_inmem.rs
+++ b/crates/io/tests/oshape_socket_fuse_inmem.rs
@@ -27,13 +27,16 @@
 //! z=-2.6): the quarter-socket NURBS pieces fail to pair with their plane
 //! neighbours after selection.
 //!
-//! The unpaired edges are the bin's four corner CHAMFER-BAND arcs: Circle
-//! edges (len 5.30) at z=0 and z=0.7 plus the slanted 1.21-length corner
-//! connectors between them. Operand A carries these as Circle edges; the
-//! suspect is that B's quarter-socket side carries coincident twins in a
-//! different representation (NURBS or different segmentation), the
-//! mismatched-representation coincident-boundary class that endpoint-pair
-//! edge merging cannot reconcile by design.
+//! The unpaired edges are operand B's OWN corner rims: the top rims of its
+//! four corner cylinders (Circle arcs, len 5.30, at z=0, faces Id 17/19/21/
+//! 23 spanning z -1.2..0) plus matching rims at z=0.7 and the slanted 1.21
+//! connectors. Operand A has NO geometry at the corner radius (nothing at
+//! x or y near 23.85), so this is not a coincident-twin mismatch between
+//! operands: the fuse drops or fails to select the B faces ABOVE those rims
+//! (or their split pieces), leaving B's rim edges single-used in the
+//! assembled shell. Next: account for the sub-faces of B's corner-adjacent
+//! upper faces through the splitter and classifier (the wedge campaign's
+//! BK_CLS3/BK_SPLITW recipes apply directly).
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 


### PR DESCRIPTION
Measured correction to #1354's suspect: operand A has NO geometry at the corner radius (nothing near x/y = 23.85), so the free arcs are not mismatched coincident twins between operands. They are operand B's OWN corner-cylinder top rims (z=0, faces Id 17/19/21/23) and 0.7-chamfer rims, left single-used because the B faces above them — or their split pieces — are dropped during the fuse.

The dig's entry point is sub-face accounting for B's corner-adjacent upper faces through the splitter and classifier; the wedge campaign's `BK_CLS3`/`BK_SPLITW` recipes apply directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the O-shape fuse analysis: the free arcs are operand B’s own corner-cylinder top and chamfer rims, left single-used because the faces above them are dropped during the fuse, not a coincident-twin mismatch with operand A.

Updates the doc comment in crates/io/tests/oshape_socket_fuse_inmem.rs to reflect this and note next steps for sub-face accounting via the splitter/classifier (BK_CLS3/BK_SPLITW).

<sup>Written for commit 6e2b16840dbd83ccaedae4edacbbfe980eefba3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

