### PR TITLE
fix(ci): stop the doc-paths check flaking on an EPIPE under pipefail

### DIFF
--- a/scripts/check-doc-paths.sh
+++ b/scripts/check-doc-paths.sh
@@ -54,12 +54,15 @@ for doc in "${DOCS[@]}"; do
     [ -z "$p" ] && continue
     is_allowlisted "$p" && continue
 
-    if ! echo "$FILE_LIST" | grep -qF "/${p}"; then
+    # Herestrings, not `echo | grep -q`: under pipefail, grep -q exiting at
+    # the first match can EPIPE the echo and flip the pipeline status to
+    # failure, reporting an existing file as a violation (a CI-only flake).
+    if ! grep -qF "/${p}" <<< "$FILE_LIST"; then
       echo "VIOLATION: $doc references '$p', which does not exist"
       # A split into a directory is the common case; point at it directly.
       dir="${p%.rs}"
-      if echo "$FILE_LIST" | grep -qE "/${dir}/[^/]+\.rs$"; then
-        members=$(echo "$FILE_LIST" | grep -oE "/${dir}/[^/]+\.rs$" | sed "s|.*/||; s|\.rs$||" | sort | tr '\n' ' ')
+      if grep -qE "/${dir}/[^/]+\.rs$" <<< "$FILE_LIST"; then
+        members=$(grep -oE "/${dir}/[^/]+\.rs$" <<< "$FILE_LIST" | sed "s|.*/||; s|\.rs$||" | sort | tr '\n' ' ')
         echo "           it is now a directory: ${dir}/ (${members% })"
       fi
       FAIL=1


### PR DESCRIPTION
PR #1357's Doc Paths job failed flagging `gridfinity_lipfuse_dividers_inmem.rs` as nonexistent. The file exists; the job log also shows `line 57: echo: write error: Broken pipe`.

Mechanism: `echo "$FILE_LIST" | grep -qF ...` under `set -o pipefail`. When grep -q finds its match early and exits, the echo can take EPIPE and return nonzero, and pipefail makes the whole pipeline nonzero even though grep matched. The `if !` then reports an existing file as a violation. It is timing-dependent, which is why the local run passes and CI intermittently does not.

Fix: feed grep with herestrings (no pipe, no EPIPE). Verified locally: the check passes and the failure branch still renders the directory-split hint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the Doc Paths CI check from flaking under `set -o pipefail` by avoiding EPIPE when `grep -q` exits early. This prevents false violations for existing files and keeps the directory-split hint.

- **Bug Fixes**
  - Replaced `echo "$FILE_LIST" | grep -q ...` with `grep ... <<< "$FILE_LIST"` to avoid EPIPE and pipeline failures.
  - Failure output and the directory members hint remain the same.

<sup>Written for commit e67608e7f83d16ce843a92d78faa7d3f2a070563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

