### PR TITLE
test(operations): pin the tangent-wall fuse family as analytic

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -702,6 +702,11 @@ Measured A/B, same day, same tool commit, each overlay md5-verified through brep
   firing that helps against one that hurts.
 
 ## Closed: root cause + where the detail lives
+
+- **Cone/cylinder ∪ box tangent section circle** — the last primitive-boolean fallback; every
+  tangency count (0/1/2/4 walls) now fuses clean and analytic, closed as collateral of the
+  classifier conflict re-cast (#1357) and the SD cross-shell gate (#1360). Pinned ACTIVE with
+  exact face counts: `boolean::tests::tangent_wall_fuse_configurations_stay_analytic`.
 - **Kumiko lattice band fuse — CLOSED after 29 passes** (`kumiko_lattice_bands_fuse_closed`
   un-ignored and green). Final mechanism, all in the face splitter: (1) DEMAND-GATED outer-wire
   image expansion — a planar hole-free face expands a boundary edge's pave-split images only

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -6601,6 +6601,37 @@ fn diag_cone_box_tangency_sweep() {
 /// handled; two or more split it into a CHAIN of arcs that the quadric side
 /// fails to close — open at 2 walls, over-shared at 4.
 #[test]
+fn tangent_wall_fuse_configurations_stay_analytic() {
+    // Regression pin for the tangent-section-circle family (the last
+    // primitive-boolean fallback): a box wall exactly tangent to the
+    // cylinder used to break the section circle by tangency-point count
+    // (2 tangencies gave 4 free edges, 4 gave 4 non-manifold). All counts
+    // are clean since the classifier conflict re-cast and the SD
+    // cross-shell gate; this pins every configuration of the diagnostic
+    // sweep as watertight with its exact analytic face count.
+    use brepkit_math::mat::Mat4;
+    for &(label, xlo, xhi, ylo, yhi, expect_f) in &[
+        ("4 tangent walls", -4.0, 4.0, -4.0, 4.0, 15usize),
+        ("2 tangent walls (x only)", -4.0, 4.0, -9.0, 9.0, 11),
+        ("1 tangent wall  (x=+4)", -9.0, 4.0, -9.0, 9.0, 9),
+        ("0 tangent walls", -9.0, 9.0, -9.0, 9.0, 8),
+    ] {
+        let mut topo = Topology::new();
+        let cyl = crate::primitives::make_cylinder(&mut topo, 4.0, 12.0).unwrap();
+        let b = crate::primitives::make_box(&mut topo, xhi - xlo, yhi - ylo, 8.0).unwrap();
+        crate::transform::transform_solid(&mut topo, b, &Mat4::translation(xlo, ylo, 6.0)).unwrap();
+        let r = brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Fuse, cyl, b)
+            .unwrap_or_else(|e| panic!("{label}: fuse must not abort: {e}"));
+        let n = brepkit_topology::explorer::solid_faces(&topo, r)
+            .unwrap()
+            .len();
+        assert_eq!(n, expect_f, "{label}: analytic face count");
+        super::assembly::validate_boolean_result(&topo, r)
+            .unwrap_or_else(|e| panic!("{label}: result must validate: {e}"));
+    }
+}
+
+#[test]
 #[ignore = "diagnostic — how many tangency points break the section circle?"]
 fn diag_tangency_count() {
     use brepkit_math::mat::Mat4;


### PR DESCRIPTION
The roadmap's last primitive-boolean fallback (tangent section circles, keyed by tangency-point count) measures CLEAN on the current kernel across every configuration of the diagnostic sweep: 0/1/2/4 tangent walls all fuse watertight with exact analytic face counts (8/9/11/15). The closure is collateral of #1357 (ray-cast conflict re-cast) and #1360 (SD cross-shell gate) — the historical failure signatures were classification-driven.

The diagnostics were print-only, so nothing pinned the closure; this adds an active regression test asserting each configuration's face count and validated result, plus the roadmap closed-section entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test that pins the cylinder∪box tangent-wall fuse as analytic across 0/1/2/4 walls. It validates watertight results and exact face counts (8, 9, 11, 15), and updates the roadmap; test: `boolean::tests::tangent_wall_fuse_configurations_stay_analytic`.

<sup>Written for commit 0d43e054f5f0f529c5fbf73f437a39023753212c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

