### PR TITLE
fix(math): guard CDT constrained-crossing split against welded intersection vertices

### DIFF
--- a/crates/math/proptest-regressions/cdt/tests.txt
+++ b/crates/math/proptest-regressions/cdt/tests.txt
@@ -1,0 +1,4 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+cc 02a6b8c38da78b1d5c8fd2170635d7129fb3d7b413fc6a684a67b6e388d12113

--- a/crates/math/src/cdt/constraints.rs
+++ b/crates/math/src/cdt/constraints.rs
@@ -32,6 +32,9 @@ impl Cdt {
     /// becomes an edge).
     #[allow(clippy::too_many_lines)]
     fn recover_edge_depth(&mut self, v0: usize, v1: usize, depth: usize) -> Result<(), MathError> {
+        if v0 == v1 {
+            return Ok(());
+        }
         let max_iter = self.triangles.len() * 4 + 100;
 
         for _ in 0..max_iter {
@@ -56,11 +59,27 @@ impl Cdt {
                     let q0 = self.vertices[e0];
                     let q1 = self.vertices[e1];
                     if let Some(mid_pt) = segment_intersection_point(p0, p1, q0, q1) {
+                        // `insert_point` welds onto an existing vertex when the
+                        // intersection lands within snap distance of one, so
+                        // `mid` can come back as any of the four endpoints.
+                        // Recursing with a degenerate pair (v0 == mid) spins
+                        // the flip loop and dead-ends in the bisect backstop
+                        // (its midpoint snaps straight back to the vertex), so
+                        // every recursion and constraint below is guarded.
                         let mid = self.insert_point(mid_pt)?;
-                        // Replace old constraint (e0,e1) with two sub-constraints.
-                        self.constraints.remove(&sorted_pair(e0, e1));
-                        self.constraints.insert(sorted_pair(e0, mid));
-                        self.constraints.insert(sorted_pair(mid, e1));
+                        if mid != e0 && mid != e1 {
+                            // Replace old constraint (e0,e1) with two sub-constraints.
+                            self.constraints.remove(&sorted_pair(e0, e1));
+                            self.constraints.insert(sorted_pair(e0, mid));
+                            self.constraints.insert(sorted_pair(mid, e1));
+                        }
+                        if mid == v0 || mid == v1 {
+                            // The crossing degenerated onto one of our own
+                            // endpoints: the crossed constraint (if any) was
+                            // split there, so it no longer properly crosses
+                            // this segment. Retry the flip loop.
+                            continue;
+                        }
                         // Recover the two halves of the original edge.
                         self.recover_edge(v0, mid)?;
                         self.constraints.insert(sorted_pair(v0, mid));

--- a/crates/math/src/cdt/tests.rs
+++ b/crates/math/src/cdt/tests.rs
@@ -766,6 +766,40 @@ proptest! {
     }
 }
 
+/// Deterministic replay of the proptest seed 23358 CI failure: the fifth
+/// constraint's recovery returned `ConvergenceFailure { iterations: 288 }`
+/// on this 20-point, 5-constraint arrangement.
+#[test]
+fn cdt_seed_23358_constraints_converge() {
+    // The proptest body computes `seed | 1`, so 23358 becomes 23359.
+    let mut rng_state: u64 = 23359;
+    let n = 20;
+    let mut pts = Vec::with_capacity(n);
+    for _ in 0..n {
+        pts.push(Point2::new(
+            rand_f64(&mut rng_state, 0.0, 100.0),
+            rand_f64(&mut rng_state, 0.0, 100.0),
+        ));
+    }
+    let mut cdt = Cdt::new((Point2::new(-10.0, -10.0), Point2::new(110.0, 110.0)));
+    let mut ids = Vec::with_capacity(n);
+    for pt in &pts {
+        ids.push(cdt.insert_point(*pt).unwrap());
+    }
+    for k in 0..5 {
+        let a = (xorshift64(&mut rng_state) as usize) % n;
+        let b = (xorshift64(&mut rng_state) as usize) % n;
+        if a != b {
+            let result = cdt.insert_constraint(ids[a], ids[b]);
+            assert!(
+                result.is_ok(),
+                "constraint {k} ({a},{b}) failed: {result:?}"
+            );
+        }
+    }
+    assert!(!cdt.triangles().is_empty());
+}
+
 /// Collinear vertex splitting: a constraint from v0→v3 should split through
 /// collinear intermediate vertices v1 and v2, producing three sub-constraints.
 #[test]


### PR DESCRIPTION
## Summary

CI on #1389 hit a random-seed proptest failure: `cdt_random_constraints_no_panic` seed 23358, `ConvergenceFailure { iterations: 288 }`. Replayed deterministically: on a 20-point, 5-constraint arrangement, the constrained-crossing split inside `recover_edge` computed an intersection that `insert_point` welded onto an existing vertex, and the recursive `recover_edge(v0, mid)` ran with `v0 == mid`. A degenerate self-recovery finds no edge and no crossing, falls to the bisection backstop, whose midpoint snaps straight back onto the vertex — guaranteed ConvergenceFailure.

## Fix

Guards on the split path (the bisect path already had them):
- `mid == e0 || mid == e1` (crossed constraint's own endpoint): skip the constraint replacement — a degenerate `(e0, e0)` pair must never enter the constraint set.
- `mid == v0 || mid == v1` (our own endpoint): retry the flip loop — the crossed constraint was split at that vertex, so it no longer properly crosses this segment.
- `recover_edge_depth` returns early on identical endpoints as a safety net.

## Pins

- The CI seed committed to `proptest-regressions/cdt/tests.txt` (proptest replays it before generating new cases).
- A deterministic replay unit test (`cdt_seed_23358_constraints_converge`) with the exact failing arrangement.

math + operations + io suites green (1,740 tests), gridfinity wasm canary 27/27.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CDT convergence failures by guarding constrained-crossing splits when intersections snap to existing vertices. Adds endpoint guards and an early return, and pins the failing `proptest` seed with a deterministic replay test.

- **Bug Fixes**
  - Skip constraint replacement when `mid` equals crossed-constraint endpoints (`e0` or `e1`).
  - Retry the flip loop when `mid` equals our own endpoints (`v0` or `v1`).
  - Early return in `recover_edge_depth` when `v0 == v1`.
  - Pin the failing seed in `proptest-regressions/cdt/tests.txt` and add `cdt_seed_23358_constraints_converge` to replay the case.

<sup>Written for commit 0a8c3bfe842f3f8f5b4767a5140a07f7e1316f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

