### PR TITLE
perf(operations): exact divergence-theorem volume for all-planar solids

### DIFF
--- a/crates/operations/src/measure/mod.rs
+++ b/crates/operations/src/measure/mod.rs
@@ -173,6 +173,37 @@ mod tests {
         assert_rel(vol, 1000.0, 1e-8, "10x10x10 box volume");
     }
 
+    /// Fuse of two overlapping boxes: all faces planar with Line edges, so
+    /// the exact polygon path applies. V = 2*1000 - 125 (5x5x5 overlap).
+    #[test]
+    fn box_fuse_volume_exact_via_planar_path() {
+        use crate::boolean::{BooleanOp, boolean};
+        use brepkit_math::mat::Mat4;
+        let mut topo = Topology::new();
+        let a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let b = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        crate::transform::transform_solid(&mut topo, b, &Mat4::translation(5.0, 5.0, 5.0)).unwrap();
+        let fused = boolean(&mut topo, BooleanOp::Fuse, a, b).unwrap();
+        let vol = solid_volume(&topo, fused, 0.1).unwrap();
+        assert_rel(vol, 1875.0, 1e-9, "overlapping box fuse volume");
+    }
+
+    /// A through-hole cut leaves top/bottom faces with inner wires; the
+    /// planar polygon path must subtract them. V = 1000 - 2*2*10.
+    #[test]
+    fn box_through_hole_volume_exact_via_planar_path() {
+        use crate::boolean::{BooleanOp, boolean};
+        use brepkit_math::mat::Mat4;
+        let mut topo = Topology::new();
+        let a = crate::primitives::make_box(&mut topo, 10.0, 10.0, 10.0).unwrap();
+        let tool = crate::primitives::make_box(&mut topo, 2.0, 2.0, 12.0).unwrap();
+        crate::transform::transform_solid(&mut topo, tool, &Mat4::translation(4.0, 4.0, -1.0))
+            .unwrap();
+        let cut = boolean(&mut topo, BooleanOp::Cut, a, tool).unwrap();
+        let vol = solid_volume(&topo, cut, 0.1).unwrap();
+        assert_rel(vol, 960.0, 1e-9, "box through-hole volume");
+    }
+
     /// Non-cube rectangular box: volume = dx * dy * dz.
     #[test]
     fn rectangular_box_volume_exact() {

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -225,6 +225,9 @@ fn all_planar_line_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> 
         for &iw in face.inner_wires() {
             face_area2 -= ring_area2(iw)?;
         }
+        if face_area2 < 0.0 {
+            return None;
+        }
         vol6 += sign * d_unit * face_area2;
     }
     Some((vol6 / 6.0).abs())

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -161,6 +161,75 @@ fn mesh_boundary_edge_count(mesh: &tessellate::TriangleMesh) -> usize {
     counts.values().filter(|&&c| c != 2).count()
 }
 
+/// Exact volume for a solid bounded entirely by planar faces with straight
+/// (`Line`) edges — boxes, box booleans, extruded polygons. On a plane the
+/// divergence integrand `x·n` is the constant plane offset, so the integral
+/// collapses to `d·A` per face with `A` the exact polygon area: no
+/// tessellation, no quadrature. Orientation comes from the face's effective
+/// normal alone (`|outer| − Σ|holes|` per face), matching the tessellation
+/// path's tolerance of mis-wound wires.
+fn all_planar_line_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
+    use brepkit_topology::edge::EdgeCurve;
+    use brepkit_topology::explorer::solid_faces;
+
+    let faces = solid_faces(topo, solid).ok()?;
+    if faces.is_empty() {
+        return None;
+    }
+    let mut vol6 = 0.0;
+    for &fid in &faces {
+        let face = topo.face(fid).ok()?;
+        let FaceSurface::Plane { normal, d } = face.surface() else {
+            return None;
+        };
+        let n_unit = normal.normalize().ok()?;
+        let d_unit = d / normal.length();
+        let sign = if face.is_reversed() { -1.0 } else { 1.0 };
+        // A skewed quad stored as a Plane (miter-sweep elbows) has vertices
+        // off the stored plane; x·n is then not constant and d·A is wrong.
+        // Bail to the tessellation pipeline on any planarity residual.
+        let planar_eps = 1e-6 * (1.0 + d_unit.abs());
+        let ring_area2 = |wid| -> Option<f64> {
+            let wire = topo.wire(wid).ok()?;
+            let edges = wire.edges();
+            if edges.len() < 3 {
+                return None;
+            }
+            let mut area2 = Vec3::new(0.0, 0.0, 0.0);
+            let mut first: Option<Vec3> = None;
+            let mut prev: Option<Vec3> = None;
+            for oe in edges {
+                let e = topo.edge(oe.edge()).ok()?;
+                if !matches!(e.curve(), EdgeCurve::Line) {
+                    return None;
+                }
+                let vid = if oe.is_forward() { e.start() } else { e.end() };
+                let p = topo.vertex(vid).ok()?.point();
+                let p = Vec3::new(p.x(), p.y(), p.z());
+                if (p.dot(n_unit) - d_unit).abs() > planar_eps {
+                    return None;
+                }
+                if let Some(q) = prev {
+                    area2 += q.cross(p);
+                } else {
+                    first = Some(p);
+                }
+                prev = Some(p);
+            }
+            if let (Some(last), Some(first)) = (prev, first) {
+                area2 += last.cross(first);
+            }
+            Some(area2.dot(n_unit).abs())
+        };
+        let mut face_area2 = ring_area2(face.outer_wire())?;
+        for &iw in face.inner_wires() {
+            face_area2 -= ring_area2(iw)?;
+        }
+        vol6 += sign * d_unit * face_area2;
+    }
+    Some((vol6 / 6.0).abs())
+}
+
 fn analytic_faces_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     use brepkit_topology::explorer::solid_faces;
 
@@ -1109,6 +1178,15 @@ pub fn solid_volume(
     if let Some(v) = try_analytic_solid_volume(topo, solid) {
         if std::env::var("BK_VOL_TRACE").is_ok() {
             log::debug!("VOL_TRACE try_analytic -> {v}");
+        }
+        return Ok(v);
+    }
+
+    // Fast path: all faces planar with straight edges — exact polygon
+    // divergence integral, no tessellation.
+    if let Some(v) = all_planar_line_solid_volume(topo, solid) {
+        if std::env::var("BK_VOL_TRACE").is_ok() {
+            log::debug!("VOL_TRACE all_planar_line -> {v}");
         }
         return Ok(v);
     }


### PR DESCRIPTION
## Summary

`solid_volume` on a plain box fell through every fast path (the primitive recognizer has no box arm; the analytic-faces integrator requires a bored quadric) and went to tessellation: **25.6 µs per call** on `make_box(10,10,10)`. On a planar face the divergence integrand `x·n` is the constant plane offset, so the integral collapses to `d·A` with `A` the exact polygon area — no tessellation, no quadrature.

The new path covers any solid bounded entirely by planar faces with straight (`Line`) edges: boxes, box booleans, extruded polygons.

## Numbers

| bench | before | after |
|---|---|---|
| `volume x100` (box) | 2.56 ms | 58.4 µs (**44x**, 0.58 µs/call, exact) |

## Design notes

- Orientation comes from the face's **effective normal** alone (`|outer| − Σ|holes|` per face), matching the tessellation path's tolerance of mis-wound wires (the `make_unit_cube_non_manifold` fixture's back face is deliberately mis-wound and stays correct).
- A planarity residual guard (`|p·n − d| ≤ 1e-6·(1+|d|)`) bails skewed quads stored as planes — the L-miter sweep's elbow quad — back to the tessellation pipeline; caught by `sweep_miter_l_shaped_volume_correct` during development.
- New pins: `box_fuse_volume_exact_via_planar_path` (overlapping fuse = 1875 exact), `box_through_hole_volume_exact_via_planar_path` (inner-wire subtraction = 960 exact).

## Verification

- operations 1019 passed (incl. all existing volume pins now routing through the exact path), io 244, wasm gridfinity canary 27, clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an exact volume path in `solid_volume` for solids with all-planar faces and line edges. It skips tessellation and makes box volume 44× faster (0.58 µs/call), with exact results.

- **New Features**
  - Uses divergence theorem on planes (per-face d·A) with effective normals; subtracts inner wires.
  - Applies to boxes, box booleans, and extruded polygons.
  - Guards: bails to tessellation on planarity residuals and when hole area exceeds the outer ring.
  - Added tests for overlapping fuse (1875) and through-hole cut (960).

<sup>Written for commit 0dea2bfcb4fe9246b590b92fd760f1a59a718e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

