### PR TITLE
test(io): localize the double-flipped faces to the 1u top half-socket

### DIFF
--- a/crates/io/examples/fuse_orient.rs
+++ b/crates/io/examples/fuse_orient.rs
@@ -145,6 +145,34 @@ fn main() {
                 }
             }
             if votes_in > votes_out && votes_in >= 2 {
+                let mut lo = [f64::MAX; 3];
+                let mut hi = [f64::MIN; 3];
+                for wid in
+                    std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
+                {
+                    for oe in topo.wire(wid).unwrap().edges() {
+                        let e = topo.edge(oe.edge()).unwrap();
+                        for vid in [e.start(), e.end()] {
+                            let p = topo.vertex(vid).unwrap().point();
+                            let c = [p.x(), p.y(), p.z()];
+                            for k in 0..3 {
+                                lo[k] = lo[k].min(c[k]);
+                                hi[k] = hi[k].max(c[k]);
+                            }
+                        }
+                    }
+                }
+                println!(
+                    "  inverted {fid:?} {} rev={} votes={votes_in}-{votes_out} x[{:.2},{:.2}] y[{:.2},{:.2}] z[{:.2},{:.2}]",
+                    face.surface().type_tag(),
+                    face.is_reversed(),
+                    lo[0],
+                    hi[0],
+                    lo[1],
+                    hi[1],
+                    lo[2],
+                    hi[2]
+                );
                 inverted.push((
                     fid,
                     face.surface().type_tag(),

--- a/crates/io/examples/fuse_orient.rs
+++ b/crates/io/examples/fuse_orient.rs
@@ -162,8 +162,9 @@ fn main() {
                         }
                     }
                 }
+                // Vertex-based extents: arcs can bulge past their endpoints.
                 println!(
-                    "  inverted {fid:?} {} rev={} votes={votes_in}-{votes_out} x[{:.2},{:.2}] y[{:.2},{:.2}] z[{:.2},{:.2}]",
+                    "  inverted {fid:?} {} rev={} votes={votes_in}-{votes_out} vbox x[{:.2},{:.2}] y[{:.2},{:.2}] z[{:.2},{:.2}]",
                     face.surface().type_tag(),
                     face.is_reversed(),
                     lo[0],

--- a/crates/io/tests/mixed_socket_tess_inmem.rs
+++ b/crates/io/tests/mixed_socket_tess_inmem.rs
@@ -80,10 +80,21 @@
 //! readings that need a careful pass — offsets near thin webs can cross
 //! legitimately-close material). So the winding root is UPSTREAM in the
 //! body's construction chain (per-cell quarter-socket dispatch), in a
-//! class NO existing validation detects. Next altitudes: (a) find the
-//! construction op minting double-flipped faces (per-stage outwardness
-//! audit of a fresh chain capture, or a native socket-construction
-//! repro); (b) add a geometric outwardness check beside the combinatorial
+//! class NO existing validation detects.
+//!
+//! GEOMETRIC LOCALIZATION (2026-08-07, bbox audit): the body's 3 inverted
+//! cylinders are the three stacked profile bands of ONE feature — the 1u
+//! mixed cell's TOP half-socket at its interior corner (x 18-24.5,
+//! y -24.5..-18, z 19.7-25.3; radii ~3.75/1.85/1.15) — so the emitting op
+//! is the chain's top-socket boolean, not the base. SECOND SUB-ROOT
+//! suspected in the fuse itself: the result adds unanimously-inverted
+//! cones/cylinders at z 0-5 in the region where A and B COINCIDE (the
+//! socket nest, e.g. z breaks 0.8/2.6/4.75) though both operands audit
+//! clean standalone — the same-domain kept-face orientation choice.
+//! Next altitudes: (a) find the construction op minting double-flipped
+//! faces (per-stage outwardness audit of a fresh chain capture, or a
+//! native top-socket-cut repro); (b) audit the fuse's SD-kept coincident
+//! faces; (c) add a geometric outwardness check beside the combinatorial
 //! one in validate. Probes: `crates/io/examples/orient_scan.rs` and
 //! `fuse_orient.rs` (fuse + per-face half-edge attribution + the
 //! majority-vote outwardness audit of both operands and the result).


### PR DESCRIPTION
Follow-up to #1399: the outwardness audit now prints each inverted face's bbox.

- The body's 3 inverted cylinders are the three stacked profile bands of ONE feature — the mixed 1u cell's **top half-socket** at its interior corner (z 19.7-25.3, radii ~3.75/1.85/1.15). The emitting op is the chain's top-socket boolean, not the base.
- The fuse result additionally shows unanimously-inverted cones/cylinders at z 0-5 exactly where the operands **coincide** (the socket nest, profile breaks 0.8/2.6/4.75) though both operands audit clean standalone — pointing at the **same-domain kept-face orientation choice** in the fuse as a second sub-root.

Fixture header records both; probe-and-docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add vertex-based bbox logging to `fuse_orient.rs`’s outwardness audit, printing each inverted face’s bounds. Update test notes to localize the three inverted cylinders to the mixed 1u cell’s top half-socket and to flag a suspected same-domain kept-face orientation issue in the fuse where operands coincide.

<sup>Written for commit edbf87ab3f635c18b15bdf9eba2459ff64ca9bce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

