### PR TITLE
fix(operations): centralize the sphere-patch plane thresholds on kernel tolerance

### DIFF
--- a/crates/operations/src/classify.rs
+++ b/crates/operations/src/classify.rs
@@ -343,10 +343,11 @@ fn nonplanar_sphere_arc_halfspaces(
     // Non-planar means the arcs span at least two DISTINCT planes. The
     // sampled polygon cannot decide this (a three-arc patch samples only
     // its three coplanar corners).
+    let tol = brepkit_math::tolerance::Tolerance::new();
     let (c0, n0) = planes[0];
     let coplanar = planes
         .iter()
-        .all(|&(c, n)| n.cross(n0).length() <= 1e-9 && (c - c0).dot(n0).abs() <= 1e-9);
+        .all(|&(c, n)| n.cross(n0).length() <= 1e-9 && (c - c0).dot(n0).abs() <= tol.linear);
     if coplanar {
         return None;
     }
@@ -370,7 +371,7 @@ fn nonplanar_sphere_arc_halfspaces(
     let mut out = Vec::with_capacity(planes.len());
     for (c, n) in planes {
         let side = (p_ref - c).dot(n);
-        if side.abs() <= 1e-9 {
+        if side.abs() <= tol.linear {
             return None;
         }
         out.push((c, n, side.signum()));

--- a/crates/operations/src/classify.rs
+++ b/crates/operations/src/classify.rs
@@ -343,7 +343,7 @@ fn nonplanar_sphere_arc_halfspaces(
     // Non-planar means the arcs span at least two DISTINCT planes. The
     // sampled polygon cannot decide this (a three-arc patch samples only
     // its three coplanar corners).
-    let tol = brepkit_math::tolerance::Tolerance::new();
+    let tol = Tolerance::new();
     let (c0, n0) = planes[0];
     let coplanar = planes
         .iter()


### PR DESCRIPTION
Follow-up to #1408's review finding (it auto-merged before this landed): the non-planar sphere-patch containment's plane-offset checks now use `Tolerance::new().linear` instead of a hard-coded 1e-9, so nearly-coplanar arc planes stay on the calibrated planar path. The direction-parallelism cross check keeps 1e-9 (sin-angle scale). Repro and classify tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hard-coded 1e-9 plane-offset checks in non-planar sphere-patch classification with `Tolerance::linear` to keep nearly coplanar arc planes on the planar path and improve robustness. Also switched to the module-level `Tolerance` import; the direction-parallelism cross-check still uses 1e-9 (sin-angle scale).

<sup>Written for commit 5151ad2416dddf1bdd22a3f9b26504454ab3baa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

