### PR TITLE
build(release): publish the workspace to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,23 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  publish-dry-run:
+    name: Publish Dry Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # Fails fast on version drift between the workspace and the inter-crate
+      # dep requirements before spending the dry-run's build time.
+      - run: ./scripts/check-versions.sh
+      # Catches manifest faults that would otherwise only surface at release
+      # time: a path dep missing its version, a package over the 10 MiB limit,
+      # a dependency cycle, or a crate that fails to build from its packaged
+      # tarball. Publishes nothing.
+      - run: cargo publish --workspace --dry-run
+
   machete:
     name: Unused Dependencies
     runs-on: ubuntu-latest
@@ -268,7 +285,8 @@ jobs:
   ci-pass:
     name: CI Pass
     if: always()
-    needs: [fmt, clippy, test, coverage, msrv, wasm, boundaries, deny, audit, docs, machete, taplo]
+    needs:
+      [fmt, clippy, test, coverage, msrv, wasm, boundaries, deny, audit, docs, publish-dry-run, machete, taplo]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,12 +180,21 @@ jobs:
       contents: read
       id-token: write
     environment: crates-io
+    env:
+      TAG_NAME: ${{ github.event.release.tag_name || needs.release-please.outputs.tag_name || format('v{0}', github.event.inputs.publish_version) }}
     steps:
+      # Pinned to the tag rather than the default branch: a delayed
+      # `release:created` event or a manual dispatch would otherwise publish
+      # whatever main has advanced to instead of what was tagged.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.TAG_NAME }}
 
       # rust-toolchain.toml provides the pinned Rust version
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      # Belt and braces now that the checkout is tag-pinned: catches a tag whose
+      # Cargo.toml somehow disagrees with the tag name.
       - name: Verify workspace version matches the tag
         run: |
           WS_VERSION=$(cargo metadata --no-deps --format-version 1 \
@@ -195,8 +204,6 @@ jobs:
             exit 1
           fi
           echo "Publishing brepkit crates at $WS_VERSION"
-        env:
-          TAG_NAME: ${{ github.event.release.tag_name || needs.release-please.outputs.tag_name || format('v{0}', github.event.inputs.publish_version) }}
 
       # Trusted publishing: mints a short-lived crates.io token from the
       # workflow's OIDC identity, so there is no long-lived registry secret to

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,3 +163,51 @@ jobs:
           }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Publishes the Rust crates. Separate from the WASM job so a crates.io outage
+  # cannot block the npm release (brepjs pins the npm package, not the crates).
+  publish-crates:
+    name: Publish to crates.io
+    needs: [release-please]
+    if: >-
+      always() && (
+        github.event_name == 'release' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.release-please.outputs.release_created == 'true'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # rust-toolchain.toml provides the pinned Rust version
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Verify workspace version matches the tag
+        run: |
+          WS_VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "brepkit-math") | .version')
+          if [ "$WS_VERSION" != "${TAG_NAME#v}" ]; then
+            echo "::error::Version mismatch: workspace=$WS_VERSION tag=${TAG_NAME#v}"
+            exit 1
+          fi
+          echo "Publishing brepkit crates at $WS_VERSION"
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name || needs.release-please.outputs.tag_name || format('v{0}', github.event.inputs.publish_version) }}
+
+      # Trusted publishing: mints a short-lived crates.io token from the
+      # workflow's OIDC identity, so there is no long-lived registry secret to
+      # rotate or leak. Configured on crates.io per crate under Settings ->
+      # Trusted Publishing.
+      - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+        id: auth
+
+      # Same script a human runs to bootstrap a new crate name, so the release
+      # path and the manual path cannot drift.
+      - name: Publish crates (skip any already published)
+        run: ./scripts/publish-crates.sh
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -592,7 +592,23 @@ cargo fmt --all                            # Format
 cargo build -p brepkit-wasm --target wasm32-unknown-unknown  # WASM
 ./scripts/check-boundaries.sh              # Verify layer deps
 ./scripts/check-doc-paths.sh               # Verify doc file paths still resolve
+./scripts/check-versions.sh                # Verify all crates share one version
+cargo publish --workspace --dry-run        # Verify the workspace is publishable
 ```
+
+### Publishing
+
+All crates share one version, inherited from `[workspace.package] version` and
+bumped by release-please. Adding a crate means: `version.workspace = true` plus
+the inherited metadata keys, a `readme = "../../README.md"` line (a
+workspace-inherited relative readme path does not resolve), an entry in
+`[workspace.dependencies]` **with a version**, a matching jsonpath in
+`release-please-config.json`, and its name in `scripts/publish-crates.sh`.
+
+A brand-new crate name must be published manually once
+(`CARGO_REGISTRY_TOKEN=<token> ./scripts/publish-crates.sh`) before crates.io
+will accept a trusted-publisher config for it. Releases after that are
+automatic.
 
 ### Profiling
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,16 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
+categories = ["graphics", "mathematics", "science"]
 edition = "2024"
+homepage = "https://github.com/andymai/brepkit"
+keywords = ["cad", "brep", "geometry", "solid-modeling", "nurbs"]
 license = "MIT OR Apache-2.0"
-repository = "git+https://github.com/andymai/brepkit.git"
+repository = "https://github.com/andymai/brepkit"
 rust-version = "1.88"
+# Every crate inherits this via `version.workspace = true`. release-please
+# rewrites it, and the `[workspace.dependencies]` versions below, in lockstep.
+version = "2.129.15"
 
 [workspace.dependencies]
 # Math
@@ -45,18 +51,19 @@ criterion = {version = "0.8", features = ["html_reports"]}
 quick-xml = "0.41"
 zip = {version = "8", default-features = false, features = ["deflate"]}
 
-# Workspace crates
-brepkit-algo = {path = "crates/algo"}
-brepkit-blend = {path = "crates/blend"}
-brepkit-check = {path = "crates/check"}
-brepkit-geometry = {path = "crates/geometry"}
-brepkit-heal = {path = "crates/heal"}
-brepkit-io = {path = "crates/io"}
-brepkit-math = {path = "crates/math"}
-brepkit-offset = {path = "crates/offset"}
-brepkit-operations = {path = "crates/operations"}
-brepkit-sketch = {path = "crates/sketch"}
-brepkit-topology = {path = "crates/topology"}
+# Workspace crates. The `version` is what consumers resolve from crates.io;
+# `path` only overrides it for in-workspace builds and is stripped on publish.
+brepkit-algo = {path = "crates/algo", version = "2.129.15"}
+brepkit-blend = {path = "crates/blend", version = "2.129.15"}
+brepkit-check = {path = "crates/check", version = "2.129.15"}
+brepkit-geometry = {path = "crates/geometry", version = "2.129.15"}
+brepkit-heal = {path = "crates/heal", version = "2.129.15"}
+brepkit-io = {path = "crates/io", version = "2.129.15"}
+brepkit-math = {path = "crates/math", version = "2.129.15"}
+brepkit-offset = {path = "crates/offset", version = "2.129.15"}
+brepkit-operations = {path = "crates/operations", version = "2.129.15"}
+brepkit-sketch = {path = "crates/sketch", version = "2.129.15"}
+brepkit-topology = {path = "crates/topology", version = "2.129.15"}
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Solid modeling kernel for Rust and WebAssembly.
 
 [![CI](https://github.com/andymai/brepkit/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/brepkit/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/brepkit-operations?label=crates.io)](https://crates.io/crates/brepkit-operations)
 [![npm](https://img.shields.io/npm/v/brepkit-wasm)](https://www.npmjs.com/package/brepkit-wasm)
 [![Last release](https://img.shields.io/github/release-date/andymai/brepkit?label=last%20release)](https://github.com/andymai/brepkit/releases)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/andymai/brepkit?label=commits%2Fmonth)](https://github.com/andymai/brepkit/commits/main)
@@ -182,6 +183,8 @@ Mesh formats export tessellated triangles. glTF is binary `.glb`, with no materi
 
 ## Getting Started
 
+The Rust crates require Rust 1.88 or newer. The WASM package has no toolchain requirement.
+
 ### As a WASM package
 
 ```bash
@@ -199,15 +202,39 @@ For a higher-level TypeScript API, see [brepjs](https://github.com/andymai/brepj
 
 ### As a Rust dependency
 
-Not yet published to crates.io. Use git dependencies for now:
+Requires Rust 1.88 or newer.
+
+```bash
+cargo add brepkit-topology brepkit-operations
+cargo add brepkit-io       # optional: STEP, STL, 3MF, OBJ, PLY, glTF
+```
+
+`brepkit-operations` is the entry point for modeling. It pulls in the geometry,
+topology, and algorithm crates it needs, so most projects want it plus
+`brepkit-topology` for the `Topology` arena that every operation takes:
 
 ```toml
 [dependencies]
-brepkit-math = { git = "https://github.com/andymai/brepkit" }
-brepkit-topology = { git = "https://github.com/andymai/brepkit" }
-brepkit-operations = { git = "https://github.com/andymai/brepkit" }
-brepkit-io = { git = "https://github.com/andymai/brepkit" }        # optional
+brepkit-topology = "2.129"
+brepkit-operations = "2.129"
+brepkit-io = "2.129"       # optional
 ```
+
+Every crate publishes at the same version from the same commit, so pinning one
+minor line across all of them is always consistent. The individual crates are
+useful on their own when you need less than the whole kernel:
+
+| Crate | Add it directly when you need |
+| --------------------- | ----------------------------------------------------------- |
+| `brepkit-math` | NURBS, predicates, CDT, or convex hull without any B-Rep |
+| `brepkit-geometry` | Curve sampling, extrema, or analytic-to-NURBS conversion |
+| `brepkit-topology` | The `Topology` arena and B-Rep types (required in practice) |
+| `brepkit-operations` | Booleans, sweeps, blends, measurement, tessellation |
+| `brepkit-io` | Import and export |
+| `brepkit-check` | Validation, mass properties, or distance without operations |
+| `brepkit-heal` | Repairing imported geometry |
+| `brepkit-sketch` | The 2D constraint solver on its own (no workspace deps) |
+| `brepkit-render` | Offscreen GPU rendering. Pulls in wgpu, so it is opt-in |
 
 ### Building from source
 

--- a/crates/algo/Cargo.toml
+++ b/crates/algo/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "GFA boolean algorithm engine for brepkit"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-algo"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 brepkit-math.workspace = true

--- a/crates/blend/Cargo.toml
+++ b/crates/blend/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "Walking-based fillet and chamfer engine for brepkit"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-blend"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 brepkit-math.workspace = true

--- a/crates/check/Cargo.toml
+++ b/crates/check/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "Topology algorithms: classification, validation, properties, distance"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-check"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 brepkit-geometry.workspace = true

--- a/crates/geometry/Cargo.toml
+++ b/crates/geometry/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "Geometry algorithms: sampling, extrema, conversion"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-geometry"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 brepkit-math.workspace = true

--- a/crates/heal/Cargo.toml
+++ b/crates/heal/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "Shape healing (analysis, fixing, upgrading) for brepkit B-Rep models"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-heal"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 bitflags.workspace = true

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -1,11 +1,18 @@
 [package]
+categories.workspace = true
 description = "Multi-format B-Rep data exchange for brepkit (STEP, IGES, STL, 3MF, OBJ, PLY, glTF)"
 edition.workspace = true
+# `tests/data` holds 11 MB of captured STEP and arena fixtures, over the 10 MiB
+# crates.io package limit. They are regression inputs, not consumer-facing.
+exclude = ["tests/data/"]
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-io"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 brepkit-math = {workspace = true, features = ["serde"]}

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -1,11 +1,18 @@
 [package]
+categories.workspace = true
 description = "Vector math, transforms, NURBS, and geometric predicates for brepkit"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-math"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 log.workspace = true

--- a/crates/offset/Cargo.toml
+++ b/crates/offset/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "Solid offset engine for brepkit"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-offset"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 brepkit-geometry.workspace = true
@@ -16,7 +20,10 @@ log.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-brepkit-operations.workspace = true
+# Path-only on purpose: brepkit-operations depends on this crate, so a
+# versioned dev-dep would deadlock `cargo publish` (each waiting for the
+# other). Cargo drops version-less dev-deps when packaging.
+brepkit-operations = {path = "../operations"}
 brepkit-topology = {workspace = true, features = ["test-utils"]}
 
 [lints]

--- a/crates/operations/Cargo.toml
+++ b/crates/operations/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "CAD modeling operations (booleans, fillets, extrusions) for brepkit"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-operations"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [features]
 # Pass-through to brepkit-algo's deterministic work counters, enabled by the

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "Offscreen GPU renderer for brepkit B-Rep solids"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-render"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [features]
 default = []

--- a/crates/sketch/Cargo.toml
+++ b/crates/sketch/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
+categories.workspace = true
 description = "2D parametric constraint solver (GCS) for brepkit sketch mode"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-sketch"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/topology/Cargo.toml
+++ b/crates/topology/Cargo.toml
@@ -1,11 +1,18 @@
 [package]
+categories.workspace = true
 description = "B-Rep topological data structures for brepkit"
 edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
 license.workspace = true
 name = "brepkit-topology"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 brepkit-math.workspace = true

--- a/crates/wasm-macros/Cargo.toml
+++ b/crates/wasm-macros/Cargo.toml
@@ -3,9 +3,11 @@ description = "Proc macros for brepkit-wasm binding generation"
 edition.workspace = true
 license.workspace = true
 name = "brepkit-wasm-macros"
+# Not wired into brepkit-wasm yet; keep it off crates.io until it is.
+publish = false
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.0"
+version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -2,12 +2,14 @@
 categories = ["wasm", "mathematics", "science"]
 description = "WebAssembly bindings for brepkit — browser-native B-Rep solid modeling"
 edition.workspace = true
+homepage.workspace = true
 keywords = ["cad", "brep", "wasm", "geometry", "solid-modeling"]
 license.workspace = true
 name = "brepkit-wasm"
+readme = "../../README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "2.129.15"
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,11 +7,18 @@
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        {
-          "type": "toml",
-          "path": "crates/wasm/Cargo.toml",
-          "jsonpath": "$.package.version"
-        }
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.package.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-algo.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-blend.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-check.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-geometry.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-heal.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-io.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-math.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-offset.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-operations.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-sketch.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.brepkit-topology.version" }
       ],
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -10,8 +10,20 @@ set -euo pipefail
 # older crate from crates.io instead of the sibling in this workspace. This
 # check makes that drift fail on the release PR rather than at publish time.
 
+for tool in cargo jq; do
+  command -v "$tool" >/dev/null || {
+    echo "❌ $tool is required but not installed."
+    exit 1
+  }
+done
+
 WS_VERSION=$(cargo metadata --no-deps --format-version 1 \
   | jq -r '.packages[] | select(.name == "brepkit-math") | .version')
+
+if [ -z "$WS_VERSION" ]; then
+  echo "❌ Could not read the workspace version from cargo metadata."
+  exit 1
+fi
 
 FAIL=0
 

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -39,6 +39,17 @@ done < <(cargo metadata --no-deps --format-version 1 \
            | select(.kind != "dev")
            | "\(.name) \(.req)"' | sort -u)
 
+# Every publishable member must be listed in the publish script. Without this,
+# adding a crate and forgetting the script means it silently never reaches
+# crates.io while everything else keeps releasing.
+while read -r name; do
+  if ! grep -qx "  $name" scripts/publish-crates.sh; then
+    echo "❌ $name is publishable but missing from scripts/publish-crates.sh"
+    FAIL=1
+  fi
+done < <(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.publish != []) | .name')
+
 if [ $FAIL -ne 0 ]; then
   echo "❌ Version check failed. Reconcile Cargo.toml with release-please-config.json."
   exit 1

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify every crate and every inter-crate dependency sits at one version.
+#
+# release-please bumps `[workspace.package] version` and each
+# `[workspace.dependencies] brepkit-*.version` through separate jsonpath
+# entries in release-please-config.json. If one of those entries is dropped or
+# stops matching, the versions drift silently and `cargo publish` resolves an
+# older crate from crates.io instead of the sibling in this workspace. This
+# check makes that drift fail on the release PR rather than at publish time.
+
+WS_VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name == "brepkit-math") | .version')
+
+FAIL=0
+
+# Every workspace member must be at the shared version (they all use
+# `version.workspace = true`, so a mismatch means one opted out).
+while read -r name version; do
+  if [ "$version" != "$WS_VERSION" ]; then
+    echo "❌ crate $name is at $version, expected $WS_VERSION"
+    FAIL=1
+  fi
+done < <(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | "\(.name) \(.version)"')
+
+# Every brepkit-to-brepkit dependency must request the shared version.
+while read -r line; do
+  dep=${line%% *}
+  req=${line#* }
+  if [ "$req" != "^$WS_VERSION" ]; then
+    echo "❌ workspace dependency $dep requests '$req', expected '^$WS_VERSION'"
+    FAIL=1
+  fi
+done < <(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[].dependencies[]
+           | select(.name | startswith("brepkit-"))
+           | select(.kind != "dev")
+           | "\(.name) \(.req)"' | sort -u)
+
+if [ $FAIL -ne 0 ]; then
+  echo "❌ Version check failed. Reconcile Cargo.toml with release-please-config.json."
+  exit 1
+fi
+
+echo "✅ All crates and inter-crate deps at $WS_VERSION."

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish every publishable crate to crates.io, in dependency order, skipping
+# any already at this version.
+#
+# Used two ways:
+#   - `.github/workflows/publish.yml` runs it on each release, authenticating
+#     via OIDC trusted publishing.
+#   - A human runs it once per crate name to bootstrap. crates.io only accepts
+#     a trusted-publisher config for a crate that already exists, so the FIRST
+#     version of each crate must be pushed manually with an API token:
+#       CARGO_REGISTRY_TOKEN=<token> ./scripts/publish-crates.sh
+#
+# Skipping already-published crates is what makes a re-run after a partial
+# failure safe, and it is why this does not just call
+# `cargo publish --workspace` (which aborts the batch on the first crate that
+# already exists).
+#
+# Order is cargo's own topological order; `cargo package --workspace` prints
+# it. brepkit-wasm-macros is `publish = false` and is deliberately absent.
+CRATES=(
+  brepkit-math
+  brepkit-geometry
+  brepkit-topology
+  brepkit-check
+  brepkit-algo
+  brepkit-blend
+  brepkit-heal
+  brepkit-offset
+  brepkit-sketch
+  brepkit-operations
+  brepkit-io
+  brepkit-render
+  brepkit-wasm
+)
+
+VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name == "brepkit-math") | .version')
+
+echo "Publishing brepkit crates at $VERSION"
+
+for crate in "${CRATES[@]}"; do
+  if curl -sf -o /dev/null -H 'User-Agent: brepkit-release' \
+       "https://crates.io/api/v1/crates/$crate/$VERSION"; then
+    echo "  $crate@$VERSION already published, skipping"
+    continue
+  fi
+  echo "  publishing $crate@$VERSION"
+  # cargo blocks until the new version appears in the index, so the next
+  # crate in the list can resolve it.
+  cargo publish -p "$crate"
+done
+
+echo "✅ All crates at $VERSION."

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -35,8 +35,24 @@ CRATES=(
   brepkit-wasm
 )
 
+for tool in cargo jq curl; do
+  command -v "$tool" >/dev/null || {
+    echo "❌ $tool is required but not installed."
+    exit 1
+  }
+done
+
 VERSION=$(cargo metadata --no-deps --format-version 1 \
   | jq -r '.packages[] | select(.name == "brepkit-math") | .version')
+
+# An empty VERSION is not cosmetic: it would turn the existence check below
+# into a request for the crate's base endpoint, which answers 200 for any
+# published crate. Every crate would then "already exist", the loop would skip
+# all of them, and the script would exit 0 having published nothing.
+if [ -z "$VERSION" ]; then
+  echo "❌ Could not read the workspace version from cargo metadata."
+  exit 1
+fi
 
 echo "Publishing brepkit crates at $VERSION"
 

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,6 +1,10 @@
 # Taplo — TOML formatter and linter
 # https://taplo.tamasfe.dev/configuration/
 
+# `cargo package` writes rewritten manifests under target/package/. They are
+# cargo's output, not sources, and are not formatted to this config.
+exclude = ["target/**"]
+
 [formatting]
 align_entries = false
 array_trailing_comma = true


### PR DESCRIPTION
Makes every crate publishable and wires crates.io into the existing release flow. All 14 names are currently free on crates.io.

## What was blocking `cargo publish`

| Blocker | Fix |
|---|---|
| Workspace path deps carried no `version`, which crates.io rejects | `version` added alongside each `path` in `[workspace.dependencies]` |
| `repository = "git+https://..."` is not a valid Cargo repository URL | Plain `https://github.com/andymai/brepkit` |
| `crates/io/tests/data` is 11 MB, over the 10 MiB package limit | `exclude`, taking the package from 11 MB to 721 KB |
| `brepkit-offset` dev-depends on `brepkit-operations`, which depends back on it | That dev-dep is path-only; cargo drops version-less dev-deps when packaging |

## Versioning

All crates share one version via `version.workspace = true`, bumped by release-please through 12 jsonpath entries on `Cargo.toml` (the workspace version plus 11 inter-crate dependency versions). The libraries move from `0.1.0` to the current `2.129.15` line so there is a single number across the workspace and the npm package.

That jsonpath list is the one soft spot: if an entry stops matching, a dependency version freezes while the crate version advances and `cargo publish` would resolve an older sibling from crates.io instead of the one in the workspace. `scripts/check-versions.sh` asserts every crate and every inter-crate requirement sits at one version, and that every publishable member is listed in the publish script, so neither kind of drift can reach a release. It runs in CI.

## Publishing

`scripts/publish-crates.sh` publishes in dependency order and skips versions already on crates.io, which is what makes a re-run after a partial failure safe. This is why it does not just call `cargo publish --workspace`, which aborts the batch on the first crate that already exists. The release workflow and the manual bootstrap both call it, so the two paths cannot drift.

Authentication is OIDC trusted publishing via `rust-lang/crates-io-auth-action`, so there is no long-lived registry token. The checkout is pinned to the release tag rather than the default branch, so a delayed `release:created` event or a manual dispatch publishes what was tagged. The job is separate from the WASM job so a crates.io outage cannot block the npm release.

## Also

- `publish-dry-run` CI job runs the version check then `cargo publish --workspace --dry-run`, catching manifest faults on the PR instead of at release time.
- Per-crate `readme = "../../README.md"` so each crates.io page renders. A workspace-inherited relative readme path gets re-resolved against the crate dir and fails, so it is spelled out per crate.
- `[package.metadata.docs.rs] all-features = true` on `brepkit-math` and `brepkit-topology`, whose public API is feature-gated.
- `brepkit-wasm-macros` is `publish = false`; no crate references it yet.
- `taplo.toml` excludes `target/**`. `cargo package` writes rewritten manifests there and `taplo fmt --check` was failing on them.
- README: crates.io badge, `cargo add` instructions, and a per-crate table for picking less than the whole kernel.

## Verification

`cargo publish --workspace --dry-run` passes: all 13 publishable crates build from their packaged tarballs. `cargo nextest run -p brepkit-offset` passes (38/38), covering the dev-dependency change. Boundaries, doc-paths, taplo, and the new version check are all green.

## Follow-up needed before the first release

crates.io only accepts a trusted-publisher config for a crate that already exists, so the first version of each has to be pushed manually with an API token. A `crates-io` GitHub environment also needs creating.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish all Rust crates in the workspace to crates.io and integrate publishing into the release workflow. Adds CI checks and scripts to keep one shared version and make releases safe to re-run.

- **New Features**
  - Fixed publish blockers: added `version` to workspace path deps, corrected `repository` URL, excluded `crates/io/tests/data`, and made `brepkit-offset`’s dev-dep on `brepkit-operations` path-only to avoid a cycle.
  - Unified versioning via `[workspace.package] version`, with release-please updating both the workspace version and inter-crate requirements. `scripts/check-versions.sh` enforces no drift and fails if any publishable crate is missing from `scripts/publish-crates.sh`.
  - Added `publish-dry-run` CI job to run the version check and `cargo publish --workspace --dry-run`.
  - Release workflow now tag-pins the checkout and verifies the tag matches the workspace version; publishes via OIDC trusted publishing using `scripts/publish-crates.sh` (dependency order, skips already-published versions).
  - Hardened scripts: preflight required tools and guard an empty version to avoid silently skipping all publishes.
  - Per-crate `readme` paths and docs.rs `all-features` for `brepkit-math` and `brepkit-topology`; `brepkit-wasm-macros` remains `publish = false`. README adds a crates.io badge and `cargo add` examples.

- **Migration**
  - First release requires a one-time manual bootstrap: publish the initial version of each crate with a crates.io API token and create the `crates-io` GitHub environment.
  - After bootstrap, releases are automatic via the workflow.

<sup>Written for commit 681837ef8d3785bef17c95a09f287c0af81972ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Review fixes

Copilot raised three findings; one was a real defect. An empty `VERSION` in the publish script would have turned the existence check into a request for the crate's base endpoint, which answers 200 for any published crate: every crate would read as already published, the loop would skip all of them, and the script would exit 0 having published nothing. Now guarded, along with tag-pinned checkout and tool preflights in both scripts.

cubic did not substantively review this PR (it reported "AI review line limit reached" on the first push and skipped the rest), so the diff was self-reviewed. That pass is what found the missing-crate hole the publish-list guard now covers.
