### PR TITLE
build(release): retry rate limits, add a semver check and a stability policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,27 @@ jobs:
       # tarball. Publishes nothing.
       - run: cargo publish --workspace --dry-run
 
+  # Advisory, not a gate: deliberately absent from `ci-pass`. brepkit's crates
+  # are published at 2.x but the kernel's internals still move, and adding a
+  # `FaceSurface` or `EdgeCurve` variant is a semver-major change that is also
+  # on the roadmap. Making this blocking would force a major bump across all
+  # 13 crates on a routine change. It runs to make breakage visible; the
+  # policy for acting on it lives in STABILITY.md.
+  semver:
+    name: SemVer Check (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.62.30
+        with:
+          tool: cargo-semver-checks
+      # Baselines against the newest version of each crate on crates.io.
+      - run: cargo semver-checks --workspace
+
   machete:
     name: Unused Dependencies
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,6 +605,9 @@ workspace-inherited relative readme path does not resolve), an entry in
 `[workspace.dependencies]` **with a version**, a matching jsonpath in
 `release-please-config.json`, and its name in `scripts/publish-crates.sh`.
 
+Per-crate API stability and the semver policy live in `STABILITY.md`; the
+`SemVer Check` CI job is advisory and deliberately not part of `CI Pass`.
+
 A brand-new crate name must be published manually once
 (`CARGO_REGISTRY_TOKEN=<token> ./scripts/publish-crates.sh`) before crates.io
 will accept a trusted-publisher config for it. Releases after that are

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Solid modeling kernel for Rust and WebAssembly.
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org/) [![unsafe denied](https://img.shields.io/badge/unsafe-denied-success.svg)](#why-a-cad-kernel)
 
-**[Architecture](#architecture)** · **[Performance](#performance)** · **[Getting Started](#getting-started)** · **[Known Limitations](#known-limitations)** · **[Contributing](./CONTRIBUTING.md)**
+**[Architecture](#architecture)** · **[Performance](#performance)** · **[Getting Started](#getting-started)** · **[Known Limitations](#known-limitations)** · **[Stability](./STABILITY.md)** · **[Contributing](./CONTRIBUTING.md)**
 
 </div>
 
@@ -65,6 +65,8 @@ The geometry is exact. Booleans run on analytic and NURBS surfaces and keep thos
 ## Status
 
 brepkit is in active development. Core modeling is solid. Each feature below is marked stable, beta, planned, or experimental, and [Known Limitations](#known-limitations) covers the gaps.
+
+The table below rates *features*. For *API* stability per crate, and what the shared `2.x` version does and does not promise, see [STABILITY.md](./STABILITY.md).
 
 | Category                | Feature                                                                      | Status       |
 | ----------------------- | ---------------------------------------------------------------------------- | ------------ |
@@ -213,30 +215,13 @@ cargo add brepkit-io       # optional: STEP, STL, 3MF, OBJ, PLY, glTF
 
 `brepkit-operations` is the entry point for modeling. It pulls in the geometry,
 topology, and algorithm crates it needs, so most projects want it plus
-`brepkit-topology` for the `Topology` arena that every operation takes:
+`brepkit-topology`, which owns the `Topology` arena that every operation takes.
+Add `brepkit-io` for import and export.
 
-```toml
-[dependencies]
-brepkit-topology = "2.129"
-brepkit-operations = "2.129"
-brepkit-io = "2.129"       # optional
-```
-
-Every crate publishes at the same version from the same commit, so pinning one
-minor line across all of them is always consistent. The individual crates are
-useful on their own when you need less than the whole kernel:
-
-| Crate | Add it directly when you need |
-| --------------------- | ----------------------------------------------------------- |
-| `brepkit-math` | NURBS, predicates, CDT, or convex hull without any B-Rep |
-| `brepkit-geometry` | Curve sampling, extrema, or analytic-to-NURBS conversion |
-| `brepkit-topology` | The `Topology` arena and B-Rep types (required in practice) |
-| `brepkit-operations` | Booleans, sweeps, blends, measurement, tessellation |
-| `brepkit-io` | Import and export |
-| `brepkit-check` | Validation, mass properties, or distance without operations |
-| `brepkit-heal` | Repairing imported geometry |
-| `brepkit-sketch` | The 2D constraint solver on its own (no workspace deps) |
-| `brepkit-render` | Offscreen GPU rendering. Pulls in wgpu, so it is opt-in |
+Every crate publishes at the same version from the same commit, so a single
+minor line works across all of them. To depend on something more specific, the
+[Architecture](#architecture) table lists what each crate does, and
+[STABILITY.md](./STABILITY.md) says which are meant to be depended on directly.
 
 ### Building from source
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,80 @@
+# Stability Policy
+
+brepkit publishes its crates to crates.io at a shared `2.x` version. That number
+comes from the `brepkit-wasm` npm release line, which the crates were unified
+onto so there is one version across the workspace. **It is not a claim that the
+Rust APIs have settled.** This document says what the version actually promises.
+
+## What the shared version means
+
+Every crate ships at the same version from the same commit, so pinning one minor
+line across all of them is always consistent. Use `cargo add`, which resolves the
+current version rather than one written down here.
+
+The consequence of lockstep: a breaking change in *any* crate bumps *all* of
+them, including `brepkit-wasm` and the npm package. There is no way to break one
+crate's API without moving the whole line.
+
+## Which crates are meant to be depended on
+
+Stability follows the layer architecture rather than a per-crate list, so this
+does not drift as crates change. The layer table in
+[CLAUDE.md](./CLAUDE.md#layer-dependency-rules) is the source of truth for which
+crate sits where, and `scripts/check-boundaries.sh` enforces it in CI.
+
+**Consumer surface.** `brepkit-operations`, `brepkit-io`, `brepkit-topology`,
+`brepkit-math`, `brepkit-sketch`, and `brepkit-wasm`. These are what a
+downstream project should name in its `Cargo.toml`. Breaking changes are
+possible but not routine, and land with a CHANGELOG entry.
+
+**Internal, published only because the dependency graph requires it.** Every
+other L1/L2 crate. They are published so that `brepkit-operations` resolves from
+crates.io, not because their APIs are meant to be called directly. Depend on
+`brepkit-operations` instead; treat these as private and expect breakage on any
+release.
+
+**Experimental.** Anything the [README status table](./README.md#status) marks
+Experimental, currently including `brepkit-render`. The API is real and tested
+but its shape is still open. That table is the single place feature maturity is
+recorded; this document does not repeat it.
+
+## The known upcoming break
+
+`FaceSurface` and `EdgeCurve` (both in `brepkit-topology`) are exhaustive enums
+with no `_ =>` wildcards, so **any code that matches on them exhaustively will
+fail to compile when a variant is added**. Adding variants is on the roadmap:
+surface-of-revolution and surface-of-linear-extrusion are needed for STEP files
+that today fail to import. That will be a semver-major change for every
+downstream matcher.
+
+If you match on these enums, prefer the delegate methods on each type rather
+than matching variants directly. Code that goes through a delegate keeps
+compiling when a variant is added. The delegates are defined in
+`crates/math/src/traits.rs`; the ripple-effect checklists in
+[CLAUDE.md](./CLAUDE.md#ripple-effect-checklists) explain the pattern and how to
+enumerate the current match sites.
+
+## Semver enforcement
+
+CI runs `cargo semver-checks` on every PR as an **advisory** check. It reports
+API breakage against the published baseline but does not block the merge, and it
+is not part of the required `CI Pass` gate.
+
+That is deliberate. The kernel is under active development and the enum change
+above is planned, so a blocking gate would force major bumps on routine work
+before there is a deprecation process to justify them. The check exists to make
+breakage visible and deliberate rather than accidental.
+
+When it reports a break, the options are: rework the change to be additive,
+accept it and note it in the PR, or take a major bump. Promoting this check to
+blocking is the right move once `brepkit-topology` stops moving.
+
+## What is not covered
+
+- Behavioral changes that keep the same signature. Geometry algorithms are
+  improved continuously; face counts, tessellation output, and numerical results
+  can change between patch versions. Pin an exact version if you keep golden
+  files.
+- `#[doc(hidden)]` items, and anything reachable only through an internal crate.
+- The `test-utils` feature on `brepkit-topology`, which exists for this
+  workspace's own tests.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -56,6 +56,41 @@ fi
 
 echo "Publishing brepkit crates at $VERSION"
 
+# crates.io allows a burst of 5 NEW crate names then one per 10 minutes. New
+# versions of existing crates have a far higher allowance, so this only bites
+# when crates are added to the workspace. Retrying is bounded: a run that adds
+# more names than this should be finished by re-running the script rather than
+# holding a CI runner idle for an hour.
+MAX_RETRIES=${PUBLISH_MAX_RETRIES:-3}
+RETRY_WAIT=${PUBLISH_RETRY_WAIT:-630}
+
+publish_one() {
+  local crate="$1" attempt=0 out status
+  while :; do
+    # Capture rather than stream so the 429 can be recognised; the output is
+    # echoed either way so nothing is hidden. The `|| status=$?` form is load
+    # bearing: a bare assignment from a failing command substitution trips
+    # `set -e` before the status can be inspected.
+    status=0
+    out=$(cargo publish -p "$crate" 2>&1) || status=$?
+    echo "$out"
+    [ "$status" -eq 0 ] && return 0
+
+    if ! grep -q '429 Too Many Requests' <<<"$out"; then
+      return $status
+    fi
+    attempt=$((attempt + 1))
+    if [ "$attempt" -gt "$MAX_RETRIES" ]; then
+      echo "❌ Still rate-limited after $MAX_RETRIES retries."
+      echo "   Crates published so far are safe. Re-run this script to resume;"
+      echo "   it skips everything already on crates.io."
+      return 1
+    fi
+    echo "  rate-limited on $crate, waiting ${RETRY_WAIT}s (retry $attempt/$MAX_RETRIES)"
+    sleep "$RETRY_WAIT"
+  done
+}
+
 for crate in "${CRATES[@]}"; do
   if curl -sf -o /dev/null -H 'User-Agent: brepkit-release' \
        "https://crates.io/api/v1/crates/$crate/$VERSION"; then
@@ -65,7 +100,7 @@ for crate in "${CRATES[@]}"; do
   echo "  publishing $crate@$VERSION"
   # cargo blocks until the new version appears in the index, so the next
   # crate in the list can resolve it.
-  cargo publish -p "$crate"
+  publish_one "$crate"
 done
 
 echo "✅ All crates at $VERSION."


### PR DESCRIPTION
Follow-ups from the crates.io bootstrap, which hit crates.io's new-crate rate limit (a burst of 5, then one per 10 minutes) partway through publishing and needed an out-of-repo wrapper script to finish.

## Retry on 429

`publish-crates.sh` now handles the rate limit itself. The retry is bounded (`PUBLISH_MAX_RETRIES`, default 3): a run that adds more crate names than the cap should be finished by re-running the script rather than holding a CI runner idle for an hour, and the skip-if-published check makes resuming free. A non-429 failure still aborts immediately with no retries.

Verified against a stubbed `cargo` for all three paths:

| Path | Result |
|---|---|
| Two 429s then success | exits 0, publishes everything |
| Retries exhausted | exits 1 with a resume message |
| Non-429 error | exits immediately, zero retries |

One subtlety worth noting for future edits: the `out=$(cargo publish ...) \|\| status=$?` form is load bearing. A bare assignment from a failing command substitution trips `set -e` before the status can be inspected, which silently defeats the retry.

## SemVer check (advisory)

`cargo semver-checks` runs on every PR but is **deliberately absent from `CI Pass`**.

The crates publish at 2.x while the kernel's internals still move, and adding a `FaceSurface` or `EdgeCurve` variant is both semver-major and on the roadmap (surface-of-revolution and surface-of-linear-extrusion are needed for STEP files that currently fail to import). A blocking gate would force a major bump across all crates on routine work, before there is a deprecation process to justify it. The check makes breakage visible and deliberate; the policy for acting on it is in STABILITY.md.

## STABILITY.md

Says what the shared 2.x version does and does not promise. The number came from the npm release line, not from the Rust APIs having settled, and nothing said so until now.

Written specifically to resist going stale:

- Stability is stated **per layer**, deferring to the boundary table that `scripts/check-boundaries.sh` already enforces in CI, rather than as a hand-maintained per-crate list that nobody would update.
- Variant counts and delegate-method names are **referenced, not copied**. An earlier draft hardcoded "six variants and four", which CLAUDE.md already tells you to derive with `rg`.
- Feature maturity defers to the README status table rather than repeating it.
- No version numbers; `cargo add` resolves them.

For the same reason this drops the README's per-crate dependency table, which duplicated the Architecture table a few sections above it.

## Verification

Scripts shellcheck clean. Boundaries, doc-paths, version check, and taplo all green. Both new CLAUDE.md anchors resolve.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the release process: retries crates.io 429 rate limits during publish, adds an advisory `cargo semver-checks` job in CI, and documents our API stability policy. This reduces failed publishes and clarifies what `2.x` guarantees.

- New Features
  - Release: `scripts/publish-crates.sh` now retries 429s with bounded attempts (`PUBLISH_MAX_RETRIES`, `PUBLISH_RETRY_WAIT`), resumes safely on re-run, and still fails fast on non-429 errors.
  - CI: Adds an advisory `SemVer Check` job using `cargo semver-checks` against the latest crates.io baselines; it runs on PRs but is not part of `CI Pass`.
  - Docs: Adds `STABILITY.md` describing per-layer stability, the shared `2.x` policy, and the upcoming `FaceSurface`/`EdgeCurve` variant addition risk; updates README to link it and removes a duplicate per-crate table; notes policy in `CLAUDE.md`.

<sup>Written for commit ed7f0a70ad8117d4186b6b0af839a2037398d764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

