### PR TITLE
ci: allowlist web-flow and bot committers in the CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,4 +24,7 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/andymai/brepkit/blob/main/.github/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'andymai,dependabot[bot],github-actions[bot],brepkit[bot]'
+          # web-flow is GitHub's web-UI committer identity; release-please PR
+          # commits carry it as the committer, so it must be allowlisted or
+          # every release PR fails the CLA check.
+          allowlist: 'andymai,web-flow,dependabot[bot],github-actions[bot],brepkit[bot],*[bot]'


### PR DESCRIPTION
The CLA check failed on release PR #1417: release-please commits carry GitHub's web-UI identity (web-flow) as the committer, and the contributor-assistant action requires signatures from committers as well as authors. Allowlists web-flow and adds a *[bot] wildcard so bot-authored PRs (release-please, dependabot) never trip the CLA gate. Also covered by this PR's own run, which exercises the changed workflow from the base branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allowlisted GitHub `web-flow` and any `*[bot]` committers in the CLA workflow to prevent release-please and other bot PRs from failing the CLA check.

<sup>Written for commit 10d512cfa592ed8078396e72f599199765c2f694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

