### PR TITLE
ci: pin contributor-assistant to its release commit and state per-repo signing

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event_name == 'issue_comment' && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
     steps:
-      - uses: contributor-assistant/github-action@v2.6.1
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 All contributors must sign our [CLA](.github/CLA.md) before their first PR
 can be merged. When you open a PR, a bot will prompt you to sign by posting
 a comment. You sign once per repository: brepkit and brepjs keep separate
-signature stores, and the agreement terms are identical in both.
+signature stores.
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@
 
 All contributors must sign our [CLA](.github/CLA.md) before their first PR
 can be merged. When you open a PR, a bot will prompt you to sign by posting
-a comment. This is a one-time requirement.
+a comment. You sign once per repository: brepkit and brepjs keep separate
+signature stores, and the agreement terms are identical in both.
 
 ## Getting Started
 


### PR DESCRIPTION
Mirrors two review findings from the brepjs CLA PR: pins contributor-assistant to the immutable commit for v2.6.1 (this pull_request_target workflow holds four write scopes, so a repointed tag would run attacker code with them; SHA verified against the upstream tag ref), and clarifies in CONTRIBUTING that signing is per repository since brepkit and brepjs keep separate signature stores.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `contributor-assistant/github-action` to its v2.6.1 commit to harden the `pull_request_target` CLA workflow. Updates `CONTRIBUTING.md` to state CLA signing is per repository (brepkit and brepjs keep separate stores) and removes the “one-time” wording.

- **Dependencies**
  - Pin `contributor-assistant/github-action` to `ca4a40a7d1004f18d9960b404b97e5f30a505a08` (v2.6.1) in `.github/workflows/cla.yml`.

<sup>Written for commit bca321a67dcabb0469dc78a376bdfc73de0341b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

