### PR TITLE
docs(readme): refresh head-to-head numbers from the public bench harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,25 +147,30 @@ Layered Cargo workspace. Each crate depends only on the same or lower layers, an
 
 ## Performance
 
-Median times from the [brepjs benchmark suite](https://github.com/andymai/brepjs/tree/main/benchmarks) (5 iterations, Node.js, Linux x86_64). WASM is single-threaded. Native benchmarks use criterion.
+Median times from [brepkit-bench](https://github.com/andymai/brepkit-bench), the public repro harness (5 iterations, Node.js, Linux x86_64). WASM is single-threaded. Native benchmarks use criterion. Reproduce the WASM columns yourself:
+
+```bash
+git clone https://github.com/andymai/brepkit-bench && cd brepkit-bench
+npm install && npm run bench
+```
 
 | Operation                | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
 | ------------------------ | -------------- | ----------- | ------- | ---------------- |
-| fuse(box, box) (×10)     | 0.5 ms         | 43.7 ms     | 87x     | 122 µs           |
-| cut(box, cylinder) (×10) | 28.3 ms        | 64.3 ms     | 2.3x    | 9.3 ms           |
-| box + chamfer            | 0.2 ms         | 5.4 ms      | 27x     | 46 µs            |
-| box + fillet             | 0.3 ms         | 6.2 ms      | 21x     | 127 µs           |
-| intersect(box, sphere) (×10) | 0.6 ms     | 69.6 ms     | 117x    | 98 µs            |
-| multi-boolean (16 holes) | 4.7 ms         | 30.1 ms     | 6.4x    | 2.8 ms           |
-| mesh sphere (tol=0.01)   | 7.1 ms         | 51.9 ms     | 7.3x    | 6.0 ms           |
-| volume (box) (×100)      | 0.18 ms        | 8.3 ms      | 47x     | 56 µs            |
-| exportSTEP (×10)         | 0.9 ms         | 14.3 ms     | 16x     | n/a              |
+| fuse(box, box) (×10)     | 0.4 ms         | 44.9 ms     | 103x    | 122 µs           |
+| cut(box, cylinder) (×10) | 19.2 ms        | 64.9 ms     | 3.4x    | 9.3 ms           |
+| box + chamfer            | 0.1 ms         | 5.6 ms      | 55x     | 46 µs            |
+| box + fillet             | 0.3 ms         | 6.1 ms      | 18x     | 127 µs           |
+| intersect(box, sphere) (×10) | 0.2 ms     | 59.1 ms     | 252x    | 98 µs            |
+| multi-boolean (16 holes) | 4.6 ms         | 30.3 ms     | 6.6x    | 2.8 ms           |
+| mesh sphere (tol=0.01)   | 6.2 ms         | 49.4 ms     | 7.9x    | 6.0 ms           |
+| volume (box) (×100)      | 0.18 ms        | 9.8 ms      | 54x     | 56 µs            |
+| exportSTEP (×10)         | 0.9 ms         | 14.3 ms     | 17x     | n/a              |
 
-Every quoted row is output-verified before timing is compared: fuse, chamfer, and sphere volumes match exactly; cut, fillet, and multi-boolean volumes agree within 0.004%; the intersect result matches the closed-form spherical-octant volume (pinned by a regression test). The sphere mesh densities are comparable at equal tolerance (9,800 triangles vs 10,176).
+Every row is output-verified before timing, enforced by the harness itself: it refuses to time a row whose result is wrong. Fuse, chamfer, and box volumes must match exactly; cut, fillet, and multi-boolean volumes are checked against closed-form or cross-kernel values (measured fillet agreement: 0.004%); the intersect result must match the closed-form spherical-octant volume (also pinned by a regression test); exported STEP must re-import to the correct volume. The sphere mesh densities are comparable at equal tolerance (9,800 triangles vs 10,176).
 
 Booleans preserve analytic surfaces, so face counts stay low across chained operations. A nine-step compound boolean settles at 72 faces while a mesh-based approach would reach roughly 7,000. The same holds for blends: a straight edge filleted between two planar faces keeps an exact cylindrical wall rather than a NURBS approximation of one.
 
-> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js. Boolean and `exportSTEP` rows are timed as batches of ten operations. WASM figures are medians of `kernel-comparison.bench.test.ts` (5 iterations) against a local `cargo xtask wasm-build` package, hash-verified at the require path. Native figures: `cargo bench -p brepkit-operations --bench cad_operations`, except the mesh-sphere row, which is measured at the same parameters as the WASM row (`tessellate_solid_with_tolerance`, deflection 0.01, angular 0.1 rad) via `crates/operations/examples/perf_probe.rs` — the criterion suite's sphere case meshes per-face and is not comparable. Full benchmark source: [brepjs/benchmarks](https://github.com/andymai/brepjs/tree/main/benchmarks). Boolean and measurement rows measured 2026-08-07 on the released 2.129.13/2.129.14 packages (npm tarball overlay, hash-verified at the require path); the remaining rows are the 2026-08-06 measurements on brepkit main post-2.129.8.
+> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js through the same [brepjs](https://github.com/andymai/brepjs) adapter layer, so adapter overhead is identical on both sides. Boolean and `exportSTEP` rows are timed as batches of ten operations. WASM figures measured 2026-08-07 via [brepkit-bench](https://github.com/andymai/brepkit-bench) on the released npm packages, exact-pinned in its lockfile: `brepkit-wasm` 3.0.0, `occt-wasm` 3.8.3, `brepjs` 18.120.0. Native figures: `cargo bench -p brepkit-operations --bench cad_operations`, except the mesh-sphere row, which is measured at the same parameters as the WASM row (`tessellate_solid_with_tolerance`, deflection 0.01, angular 0.1 rad) via `crates/operations/examples/perf_probe.rs` — the criterion suite's sphere case meshes per-face and is not comparable.
 
 ## Data Exchange
 

--- a/README.md
+++ b/README.md
@@ -151,26 +151,26 @@ Median times from [brepkit-bench](https://github.com/andymai/brepkit-bench), the
 
 ```bash
 git clone https://github.com/andymai/brepkit-bench && cd brepkit-bench
-npm install && npm run bench
+npm ci && npm run bench
 ```
 
 | Operation                | brepkit (WASM) | OCCT (WASM) | Speedup | brepkit (native) |
 | ------------------------ | -------------- | ----------- | ------- | ---------------- |
-| fuse(box, box) (×10)     | 0.4 ms         | 44.9 ms     | 103x    | 122 µs           |
+| fuse(box, box) (×10)     | 0.43 ms        | 44.9 ms     | 103x    | 122 µs           |
 | cut(box, cylinder) (×10) | 19.2 ms        | 64.9 ms     | 3.4x    | 9.3 ms           |
-| box + chamfer            | 0.1 ms         | 5.6 ms      | 55x     | 46 µs            |
-| box + fillet             | 0.3 ms         | 6.1 ms      | 18x     | 127 µs           |
-| intersect(box, sphere) (×10) | 0.2 ms     | 59.1 ms     | 252x    | 98 µs            |
+| box + chamfer            | 0.10 ms        | 5.6 ms      | 55x     | 46 µs            |
+| box + fillet             | 0.33 ms        | 6.1 ms      | 18x     | 127 µs           |
+| intersect(box, sphere) (×10) | 0.23 ms    | 59.1 ms     | 252x    | 98 µs            |
 | multi-boolean (16 holes) | 4.6 ms         | 30.3 ms     | 6.6x    | 2.8 ms           |
 | mesh sphere (tol=0.01)   | 6.2 ms         | 49.4 ms     | 7.9x    | 6.0 ms           |
 | volume (box) (×100)      | 0.18 ms        | 9.8 ms      | 54x     | 56 µs            |
-| exportSTEP (×10)         | 0.9 ms         | 14.3 ms     | 17x     | n/a              |
+| exportSTEP (×10)         | 0.85 ms        | 14.3 ms     | 17x     | n/a              |
 
 Every row is output-verified before timing, enforced by the harness itself: it refuses to time a row whose result is wrong. Fuse, chamfer, and box volumes must match exactly; cut, fillet, and multi-boolean volumes are checked against closed-form or cross-kernel values (measured fillet agreement: 0.004%); the intersect result must match the closed-form spherical-octant volume (also pinned by a regression test); exported STEP must re-import to the correct volume. The sphere mesh densities are comparable at equal tolerance (9,800 triangles vs 10,176).
 
 Booleans preserve analytic surfaces, so face counts stay low across chained operations. A nine-step compound boolean settles at 72 faces while a mesh-based approach would reach roughly 7,000. The same holds for blends: a straight edge filleted between two planar faces keeps an exact cylindrical wall rather than a NURBS approximation of one.
 
-> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js through the same [brepjs](https://github.com/andymai/brepjs) adapter layer, so adapter overhead is identical on both sides. Boolean and `exportSTEP` rows are timed as batches of ten operations. WASM figures measured 2026-08-07 via [brepkit-bench](https://github.com/andymai/brepkit-bench) on the released npm packages, exact-pinned in its lockfile: `brepkit-wasm` 3.0.0, `occt-wasm` 3.8.3, `brepjs` 18.120.0. Native figures: `cargo bench -p brepkit-operations --bench cad_operations`, except the mesh-sphere row, which is measured at the same parameters as the WASM row (`tessellate_solid_with_tolerance`, deflection 0.01, angular 0.1 rad) via `crates/operations/examples/perf_probe.rs` — the criterion suite's sphere case meshes per-face and is not comparable.
+> The OCCT comparison uses [occt-wasm](https://www.npmjs.com/package/occt-wasm), an OpenCASCADE build compiled to WebAssembly. Both kernels run single-threaded in Node.js through the same [brepjs](https://github.com/andymai/brepjs) adapter layer, so adapter overhead is identical on both sides. Boolean and `exportSTEP` rows are timed as batches of ten operations. Speedups are computed from unrounded medians. WASM figures measured 2026-08-07 via [brepkit-bench](https://github.com/andymai/brepkit-bench) on the released npm packages, exact-pinned in its lockfile: `brepkit-wasm` 3.0.0, `occt-wasm` 3.8.3, `brepjs` 18.120.0. Native figures: `cargo bench -p brepkit-operations --bench cad_operations`, except the mesh-sphere row, which is measured at the same parameters as the WASM row (`tessellate_solid_with_tolerance`, deflection 0.01, angular 0.1 rad) via `crates/operations/examples/perf_probe.rs` — the criterion suite's sphere case meshes per-face and is not comparable.
 
 ## Data Exchange
 


### PR DESCRIPTION
Re-measures the WASM head-to-head table via brepkit-bench (https://github.com/andymai/brepkit-bench), the new public repro harness, on the released packages (brepkit-wasm 3.0.0, occt-wasm 3.8.3, brepjs 18.120.0, exact-pinned in its lockfile), and links the harness with a clone-and-run snippet in the Performance section.

Row changes from the previous table: fuse 87x -> 103x, cut 2.3x -> 3.4x, chamfer 27x -> 55x, fillet 21x -> 18x, intersect 117x -> 252x, multi-boolean 6.4x -> 6.6x, mesh sphere 7.3x -> 7.9x, volume 47x -> 54x, exportSTEP 16x -> 17x. Native column unchanged (same kernel code as 2.129.15; criterion figures still current).

Verification is now enforced structurally: the harness refuses to time any row whose output check fails (closed-form volumes, cross-kernel agreement, STEP round-trip). Its verification pass independently reproduced the published claims, including the 0.004% fillet agreement and the exact 9,800 vs 10,176 sphere mesh densities. The three local runs agreed within normal variance; the quoted run is results.json from the canonical measurement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the README performance table using the public `brepkit-bench` harness on current released packages, updating WASM vs native/OCCT numbers.
Adds a clone-and-run snippet (`npm ci && npm run bench`), clarifies harness-enforced result checks and equal adapter overhead, and notes speedups are computed from unrounded medians with two-decimal displays.

<sup>Written for commit f6ff087f420efbb33a72dbc5ac22102ace53d17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

