### PR TITLE
perf(blend): O(E) sense lookup in orientation propagation

### DIFF
--- a/crates/blend/src/builder_utils.rs
+++ b/crates/blend/src/builder_utils.rs
@@ -1032,24 +1032,30 @@ pub(crate) fn propagate_orientation(
     use brepkit_topology::edge::EdgeId;
     use std::collections::{HashMap, HashSet, VecDeque};
 
-    let face_senses = |topo: &Topology, fid: FaceId| -> Result<Vec<(EdgeId, bool)>, BlendError> {
+    // Raw wire senses are immutable during propagation; only the reversal
+    // bit changes on a flip. Precompute per-face raw senses and track
+    // reversal in a map so the BFS stays O(E) instead of re-walking wires
+    // per visited edge.
+    let mut raw_senses: HashMap<FaceId, Vec<(EdgeId, bool)>> = HashMap::new();
+    let mut revs: HashMap<FaceId, bool> = HashMap::new();
+    for &fid in faces {
         let face = topo.face(fid)?;
-        let rev = face.is_reversed();
+        revs.insert(fid, face.is_reversed());
         let mut v = Vec::new();
         let mut wires = vec![face.outer_wire()];
         wires.extend_from_slice(face.inner_wires());
         for wid in wires {
             for oe in topo.wire(wid)?.edges() {
-                v.push((oe.edge(), oe.is_forward() ^ rev));
+                v.push((oe.edge(), oe.is_forward()));
             }
         }
-        Ok(v)
-    };
+        raw_senses.insert(fid, v);
+    }
 
     let mut edge_users: HashMap<EdgeId, Vec<FaceId>> = HashMap::new();
-    for &fid in faces {
-        for (eid, _) in face_senses(topo, fid)? {
-            edge_users.entry(eid).or_default().push(fid);
+    for (&fid, senses) in &raw_senses {
+        for (eid, _) in senses {
+            edge_users.entry(*eid).or_default().push(fid);
         }
     }
 
@@ -1071,8 +1077,10 @@ pub(crate) fn propagate_orientation(
 
     let mut flipped = 0usize;
     while let Some(fid) = queue.pop_front() {
-        let senses = face_senses(topo, fid)?;
-        for (eid, my_sense) in senses {
+        let my_rev = revs.get(&fid).copied().unwrap_or(false);
+        let senses = raw_senses.get(&fid).cloned().unwrap_or_default();
+        for (eid, raw) in senses {
+            let my_sense = raw ^ my_rev;
             let Some(users) = edge_users.get(&eid) else {
                 continue;
             };
@@ -1083,13 +1091,16 @@ pub(crate) fn propagate_orientation(
                 if other == fid || visited.contains(&other) {
                     continue;
                 }
-                let other_senses = face_senses(topo, other)?;
-                let Some(&(_, other_sense)) = other_senses.iter().find(|(e, _)| *e == eid) else {
+                let other_rev = revs.get(&other).copied().unwrap_or(false);
+                let Some(&(_, other_raw)) = raw_senses
+                    .get(&other)
+                    .and_then(|v| v.iter().find(|(e, _)| *e == eid))
+                else {
                     continue;
                 };
-                if other_sense == my_sense {
-                    let cur = topo.face(other)?.is_reversed();
-                    topo.face_mut(other)?.set_reversed(!cur);
+                if other_raw ^ other_rev == my_sense {
+                    topo.face_mut(other)?.set_reversed(!other_rev);
+                    revs.insert(other, !other_rev);
                     flipped += 1;
                 }
                 visited.insert(other);

--- a/crates/io/examples/replay_fillet_variable.rs
+++ b/crates/io/examples/replay_fillet_variable.rs
@@ -31,6 +31,39 @@ fn census(topo: &Topology, solid: SolidId, label: &str) {
     }
     let free = uses.values().filter(|&&c| c == 1).count();
     let over = uses.values().filter(|&&c| c > 2).count();
+    if let Ok(spec) = std::env::var("DUMP_NEAR") {
+        let v: Vec<f64> = spec.split(',').map(|x| x.parse().unwrap()).collect();
+        let target = Point3::new(v[0], v[1], v[2]);
+        let r = v[3];
+        for fid in brepkit_topology::explorer::solid_faces(topo, solid).unwrap() {
+            let face = topo.face(fid).unwrap();
+            let tag = face.surface().type_tag();
+            let mut wires = vec![face.outer_wire()];
+            wires.extend_from_slice(face.inner_wires());
+            for wid in wires {
+                for oe in topo.wire(wid).unwrap().edges() {
+                    let e = topo.edge(oe.edge()).unwrap();
+                    let (a, b) = (
+                        topo.vertex(e.start()).unwrap().point(),
+                        topo.vertex(e.end()).unwrap().point(),
+                    );
+                    if (a - target).length() < r || (b - target).length() < r {
+                        println!(
+                            "  NEAR e{} {} ({:.4},{:.4},{:.4})->({:.4},{:.4},{:.4}) on {fid:?}:{tag}",
+                            oe.edge().index(),
+                            e.curve().type_tag(),
+                            a.x(),
+                            a.y(),
+                            a.z(),
+                            b.x(),
+                            b.y(),
+                            b.z()
+                        );
+                    }
+                }
+            }
+        }
+    }
     if std::env::var("ORIENT").is_ok() {
         let mut senses: HashMap<usize, Vec<(String, bool)>> = HashMap::new();
         for fid in brepkit_topology::explorer::solid_faces(topo, solid).unwrap() {


### PR DESCRIPTION
Follow-up to #1466 addressing the Copilot review finding that landed after automerge: `propagate_orientation` re-walked each face's wires for every adjacent edge and neighbor, making the BFS quadratic on larger fillet outputs. Raw wire senses are immutable during propagation and only the reversal bit changes on a flip, so raw senses are now precomputed per face and reversal tracked in a map (effective = raw XOR reversal on demand).

Behavior identical: all six captured grouped-scoop cases measure the same (brep same-sense 0; tess boundary 153/72/77/59/0/3); blend + io suites 356 passed / 0 failed; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make orientation propagation in blends O(E) by precomputing raw wire senses per face and tracking reversals, eliminating redundant wire walks. Behavior is unchanged; improves performance on large fillets.

- **Refactors**
  - Precompute per-face raw edge senses and store in a `raw_senses` map; track per-face reversal in `revs` and compute effective sense as raw XOR rev during BFS.
  - Build `edge_users` once from `raw_senses` to avoid repeated wire traversals while visiting neighbors.
  - Tests unchanged (blend + io suites pass).

- **New Features**
  - `replay_fillet_variable` example: add `DUMP_NEAR=x,y,z,r` env var to print edges near a point for easier debugging.

<sup>Written for commit e60509adfe6ab1030f01bff860ce6954dd47edf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

