### PR TITLE
perf(operations): resolve BK_TESS_TRACE once per process

### DIFF
--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -761,6 +761,14 @@ fn tessellate_solid_core(
     Ok((merged, tri_faces, all_faces.len()))
 }
 
+/// `BK_TESS_TRACE=1`: log each face's mesher-arm dispatch. Resolved ONCE per
+/// process — the dispatch runs per face and must not pay an env lookup each
+/// call.
+fn tess_trace() -> bool {
+    static TRACE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *TRACE.get_or_init(|| std::env::var("BK_TESS_TRACE").is_ok())
+}
+
 /// Tessellate a single face, reusing shared edge vertices from the global mesh.
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub(super) fn tessellate_face_with_shared_edges(
@@ -1109,7 +1117,7 @@ pub(super) fn tessellate_face_with_shared_edges(
                 point_to_global,
             );
             let cdt_produced_tris = cdt_ok.is_ok() && merged.indices.len() > idx_save;
-            if std::env::var("BK_TESS_TRACE").is_ok() {
+            if tess_trace() {
                 log::debug!(
                     "tess dispatch {face_id:?} {} rev={is_reversed} cdt_ok={cdt_produced_tris}",
                     face_data.surface().type_tag()


### PR DESCRIPTION
Follow-up to #1469 addressing the Copilot review finding that landed after automerge: the per-face dispatch trace paid an env lookup per face even when disabled. Resolved once via OnceLock, the same pattern as `ff_trace_x` in `phase_ff.rs`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve BK_TESS_TRACE once per process to avoid an env var lookup for every face during tessellation. Uses a OnceLock-backed helper to replace the inline check, reducing overhead when tracing is disabled.

<sup>Written for commit fc9146ad4b3d5e53391e9b9d2151660ac1ff3a39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

