### PR TITLE
docs(roadmap): night sweep — ignore inventory clean, ready queue empty

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -24,6 +24,14 @@ The `#[ignore]` inventory below is the load-bearing artifact. Before quoting any
 rg -n -A2 '#\[ignore' crates/    # filter the 3 doc-comment false hits by hand
 ```
 
+**Inventory status (2026-08-08 night sweep): CLEAN.** Every remaining `#[ignore]` is an
+explicit diagnostic or a slow-test marker — zero deferred-defect pins. The ready queue is
+EMPTY: every row below is CLOSED, parked with rationale, TERMINAL, or Andy-gated (#1424
+crates.io publishing, the mesh-fallback open-mesh product call, the export angular-default
+parity choice, GTM). The next session should look for NEW signal (fresh issues, CI
+regressions, tool-side re-measures on new releases) or open a genuinely new frontier
+rather than re-scanning these rows.
+
 ## When to use
 
 - Starting a session with no assigned task and needing to pick high-value work.


### PR DESCRIPTION
The maintenance sweep after the day's campaigns: every remaining `#[ignore]` is an explicit diagnostic or slow-test marker (zero deferred-defect pins), and every roadmap row is closed, parked with rationale, terminal, or owner-gated. Records that state so the next session hunts new signal instead of re-scanning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `SKILL.md` with the 2026-08-08 night sweep: the `#[ignore]` inventory is clean (only diagnostics/slow-test markers) and the ready queue is empty. Directs the next session to hunt new signal (fresh issues, CI regressions, tool re-measures) instead of re-scanning parked rows.

<sup>Written for commit ffd1528731c70066bff371d294d8f6dfb6ce01a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

