### PR TITLE
ci(publish): publish only from the release event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,21 +62,20 @@ jobs:
           echo "Enabling auto-merge for PR #$PR_NUMBER"
           gh pr merge "$PR_NUMBER" --auto --squash --repo "$GITHUB_REPOSITORY"
 
-  # Publish triggers on three events:
-  # 1. release:created — fired when release-please creates a GitHub release
-  #    (works even if release-please crashes afterward trying to comment on
-  #    the locked/merged PR, which was preventing release_created from being set)
-  # 2. release_created output — belt-and-suspenders if release-please succeeds fully
-  # 3. workflow_dispatch — manual publish for a specific version
+  # Publish triggers on two events:
+  # 1. release:created — release-please creates the GitHub release with the bot
+  #    app token, so this event always fires (default-GITHUB_TOKEN suppression
+  #    does not apply) even if release-please crashes afterward trying to
+  #    comment on the locked/merged PR. The push run must NOT also publish via
+  #    the release_created output: when release-please succeeds fully, both
+  #    runs race the registries and the loser turns main red with
+  #    already-published errors.
+  # 2. workflow_dispatch — manual publish for a specific version
   publish:
     name: Build WASM & Publish
-    needs: [release-please]
     if: >-
-      always() && (
-        github.event_name == 'release' ||
-        github.event_name == 'workflow_dispatch' ||
-        needs.release-please.outputs.release_created == 'true'
-      )
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -143,7 +142,7 @@ jobs:
           fi
           echo "Publishing brepkit-wasm@$PKG_VERSION"
         env:
-          TAG_NAME: ${{ github.event.release.tag_name || needs.release-please.outputs.tag_name || format('v{0}', github.event.inputs.publish_version) }}
+          TAG_NAME: ${{ github.event.release.tag_name || format('v{0}', github.event.inputs.publish_version) }}
 
       - name: Publish to npm (skip if already published)
         working-directory: crates/wasm/pkg
@@ -168,20 +167,16 @@ jobs:
   # cannot block the npm release (brepjs pins the npm package, not the crates).
   publish-crates:
     name: Publish to crates.io
-    needs: [release-please]
     if: >-
-      always() && (
-        github.event_name == 'release' ||
-        github.event_name == 'workflow_dispatch' ||
-        needs.release-please.outputs.release_created == 'true'
-      )
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     environment: crates-io
     env:
-      TAG_NAME: ${{ github.event.release.tag_name || needs.release-please.outputs.tag_name || format('v{0}', github.event.inputs.publish_version) }}
+      TAG_NAME: ${{ github.event.release.tag_name || format('v{0}', github.event.inputs.publish_version) }}
     steps:
       # Pinned to the tag rather than the default branch: a delayed
       # `release:created` event or a manual dispatch would otherwise publish


### PR DESCRIPTION
## Why main went red on v3.2.10

Every release triggers publish.yml twice: the push of the release-please merge commit, and the `release: created` event fired seconds later. When release-please succeeds fully on the push run, its `release_created` output makes that run publish too, so two publishers race the registries.

On v3.2.10 the push run lost both races and turned main red:
- npm: E403 "cannot publish over 3.2.10" (the release-event run published first), and the race-condition `npm view` fallback still saw nothing due to registry read-after-write lag.
- crates.io: "crate version 3.2.10 is already uploaded" for brepkit-math.

For 3.2.4 through 3.2.9 the push run stayed green only because release-please crashed before setting `release_created`, so the push run skipped publishing by accident.

## Fix

Drop the `release_created` fallback from both publish jobs. release-please creates the GitHub release with the bot app token, so the `release: created` event always fires (default-token event suppression does not apply) and that run is the single publisher. `workflow_dispatch` stays as the manual escape hatch.

Push runs to main now only run release-please and auto-merge; the publish jobs are skipped.

## Not fixed here

The release-event run itself still fails at `brepkit-topology` with 403 "token not valid for crate": crates.io trusted publishing is configured for math + geometry only. That is #1424 and needs registry-side web UI config. npm 3.2.10 and math/geometry 3.2.10 are published; re-running the crates job after #1424 finishes the batch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish only from the GitHub Release event (or manual dispatch) to stop double publishes that race and fail. This makes publishing deterministic and prevents npm/crates.io “already published” errors.

- **Bug Fixes**
  - Removed the `release_created` fallback and `needs.release-please` from both publish jobs in `.github/workflows/publish.yml`.
  - Publish now triggers only on `release: created` or `workflow_dispatch`; push runs no longer publish.
  - Simplified `TAG_NAME` resolution by dropping `needs.release-please.outputs.tag_name`.

<sup>Written for commit 457dc45bca9452590d5e1cb6d3ca4b61e20a0dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

