### PR TITLE
fix(operations): cover constraint-recovery Steiner vertices in the CDT lift

### DIFF
--- a/crates/operations/src/tessellate/nonplanar.rs
+++ b/crates/operations/src/tessellate/nonplanar.rs
@@ -1980,6 +1980,13 @@ pub(super) fn tessellate_nonplanar_cdt(
     let cdt_verts = cdt.vertices();
     let triangles = cdt.triangles();
 
+    // Constraint recovery can mint Steiner vertices (crossing splits,
+    // bisection backstop) whose ids the insert calls above never returned;
+    // cover them so the lift below assigns them global ids.
+    if cdt_to_global.len() < cdt_verts.len() {
+        cdt_to_global.resize(cdt_verts.len(), None);
+    }
+
     let mut final_global_ids: Vec<u32> = vec![0; cdt_to_global.len()];
 
     for i in 0..cdt_to_global.len() {

--- a/crates/operations/src/tessellate/tests.rs
+++ b/crates/operations/src/tessellate/tests.rs
@@ -2251,3 +2251,62 @@ fn pinched_ledge_prism_is_watertight() {
         }
     }
 }
+
+/// #1487: constraint recovery can mint Steiner vertices the caller's
+/// `cdt_to_global` never tracked. Pre-#1478 the interior-grid resize masked
+/// the gap; with the curvature floor off, developable faces insert no
+/// interior points and the vote loop indexed past `final_global_ids`.
+/// A bowtie boundary in UV forces the constrained-crossing split, the
+/// deterministic way to mint an untracked Steiner vertex.
+#[test]
+fn cdt_covers_steiner_vertices_from_constraint_recovery() {
+    use brepkit_math::surfaces::CylindricalSurface;
+
+    let mut topo = Topology::new();
+    let cyl =
+        CylindricalSurface::new(Point3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0), 1.0).unwrap();
+    let u1 = 1.0_f64;
+    let pts = [
+        Point3::new(1.0, 0.0, 0.0),
+        Point3::new(u1.cos(), u1.sin(), 1.0),
+        Point3::new(u1.cos(), u1.sin(), 0.0),
+        Point3::new(1.0, 0.0, 1.0),
+    ];
+    let verts: Vec<_> = pts
+        .iter()
+        .map(|&p| topo.add_vertex(Vertex::new(p, 1e-7)))
+        .collect();
+    let edges: Vec<_> = (0..4)
+        .map(|i| topo.add_edge(Edge::new(verts[i], verts[(i + 1) % 4], EdgeCurve::Line)))
+        .collect();
+    let wire = Wire::new(
+        edges.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let face = topo.add_face(Face::new(wid, vec![], FaceSurface::Cylinder(cyl)));
+
+    let face_data = topo.face(face).unwrap().clone();
+    let edge_global_indices: DetHashMap<usize, Vec<u32>> = DetHashMap::default();
+    let mut merged = TriangleMesh::default();
+    let mut point_to_global: DetHashMap<(i64, i64, i64), u32> = DetHashMap::default();
+
+    let result = super::nonplanar::tessellate_nonplanar_cdt(
+        &topo,
+        face,
+        &face_data,
+        0.1,
+        brepkit_math::chord::DEFAULT_ANGULAR_TOL,
+        false,
+        &edge_global_indices,
+        &mut merged,
+        &mut point_to_global,
+    );
+    assert!(result.is_ok(), "CDT tessellation failed: {result:?}");
+
+    let n = merged.positions.len() as u32;
+    for &idx in &merged.indices {
+        assert!(idx < n, "triangle index {idx} out of bounds (len {n})");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1487, the 3.2.9 tessellation panic (`index out of bounds`) that aborts the wasm instance and poisons the kernel on the 36-hole hex-array bin.

## Root

`tessellate_nonplanar_cdt` sized `cdt_to_global` from the ids returned by its own `insert_points_hilbert` calls. But `insert_constraint`'s edge recovery can mint extra Steiner vertices the caller never sees: the constrained-crossing split and the bisection backstop both call `insert_point` internally (`crates/math/src/cdt/constraints.rs`).

The bookkeeping gap is old, but the always-on interior-grid insertion (which runs after constraint insertion and resizes to its own max id) covered the Steiner ids by accident. #1478 made developable faces skip interior points on the display path, so a cylinder/cone face whose boundary needed recovery indexed past `final_global_ids` in the winding-vote loop and panicked.

## Fix

Size `cdt_to_global` from `cdt.vertices().len()` before the lift. Untracked Steiner vertices then take the existing surface-eval lift branch (evaluate at their UV, merge into the shared pool), the same treatment they got pre-#1478 when the interior resize happened to cover them. Paths where no Steiner vertices are minted are untouched, so the boolean path (floor on) stays bit-identical.

## Test

New regression test `cdt_covers_steiner_vertices_from_constraint_recovery`: a cylinder face whose UV boundary is a bowtie, forcing the constrained-crossing split deterministically. Panics at the exact issue line before the fix; passes after. Full operations suite green (821 lib + integration), clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1487 by preventing a tessellation panic caused by untracked Steiner vertices from CDT constraint recovery. Resizes `cdt_to_global` to the CDT’s vertex count so the lift assigns ids to all vertices and avoids out-of-bounds on developable faces.

- **Bug Fixes**
  - Resize `cdt_to_global` to `cdt.vertices().len()` before the lift to cover Steiner vertices created by crossing splits/backstop.
  - Add regression test `cdt_covers_steiner_vertices_from_constraint_recovery` that forces a constrained-crossing split on a cylindrical face; fails before the fix, passes now.

<sup>Written for commit 1ebd7c3abb36ed25bb37978f40cc0c6eb4919860. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

