### PR TITLE
perf(algo): clip sampled plane-analytic section chains to the face-pair overlap

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -3142,7 +3142,7 @@ fn compute_raw_curves(
 
         (FaceSurface::Plane { normal, d }, other) if other.as_analytic().is_some() => {
             if let Some(analytic) = other.as_analytic() {
-                plane_analytic_intersection(*normal, *d, &analytic)
+                plane_analytic_intersection(*normal, *d, &analytic, bbox_a, bbox_b)
             } else {
                 Ok(Vec::new())
             }
@@ -3150,7 +3150,7 @@ fn compute_raw_curves(
 
         (other, FaceSurface::Plane { normal, d }) if other.as_analytic().is_some() => {
             if let Some(analytic) = other.as_analytic() {
-                plane_analytic_intersection(*normal, *d, &analytic)
+                plane_analytic_intersection(*normal, *d, &analytic, bbox_a, bbox_b)
             } else {
                 Ok(Vec::new())
             }
@@ -3405,10 +3405,83 @@ fn find_plane_plane_point(na: Vec3, da: f64, nb: Vec3, db: f64, dir: Vec3) -> Po
 }
 
 /// Plane-analytic surface intersection using exact curves.
+/// Split a sampled section chain into the runs that can reach the two faces'
+/// AABB overlap.
+///
+/// Downstream (the in-both sample filter and `restrict_curves_to_faces`)
+/// keeps only curve spans inside both faces' inflated AABBs, so chain points
+/// whose adjacent segments cannot touch the overlap contribute nothing but
+/// interpolation cost. Each segment is tested against the boxes expanded by
+/// its own chord length (absorbing sampling sagitta) plus a fixed guard; kept
+/// runs are dilated by two neighbors per side so a sub-pitch boundary
+/// crossing keeps enough support for the fit and the downstream refinement
+/// to find it.
+fn clip_chain_to_pair_boxes(pts: &[Point3], bbox_a: &Aabb3, bbox_b: &Aabb3) -> Vec<Vec<Point3>> {
+    const GUARD: f64 = 1e-3;
+    const DILATE: usize = 2;
+    let n = pts.len();
+    if n < 8 {
+        return vec![pts.to_vec()];
+    }
+    // A closed chain (sampled loop, first point repeated last) is circular:
+    // segment tests, dilation, and run extraction must wrap through the
+    // arbitrary chain start, or a kept span crossing it gets split into two
+    // open curves whose seam endpoints lie on no face boundary.
+    let closed = (pts[0] - pts[n - 1]).length() < 1e-9;
+    let m = if closed { n - 1 } else { n };
+    let seg_count = if closed { m } else { n - 1 };
+    let mut keep = vec![false; m];
+    for i in 0..seg_count {
+        let j = (i + 1) % m;
+        let (p, q) = (pts[i], pts[if closed { j } else { i + 1 }]);
+        let g = (q - p).length() + GUARD;
+        if segment_meets_both_boxes(p, q, bbox_a.expanded(g), bbox_b.expanded(g)) {
+            keep[i] = true;
+            keep[j] = true;
+        }
+    }
+    if !keep.iter().any(|&k| k) {
+        return Vec::new();
+    }
+    // A closed section loop stays whole: the band splitters downstream
+    // consume the closed curve (seam handling, tube severing), and open
+    // sub-arcs with endpoints on no face boundary break them. The win is
+    // still the common one — a loop that never reaches the overlap is
+    // dropped above, and unbounded conic branches (the expensive 512-point
+    // chains) are open and get clipped below.
+    if closed {
+        return vec![pts.to_vec()];
+    }
+    let mut dilated = keep.clone();
+    for (i, d) in dilated.iter_mut().enumerate() {
+        if !*d {
+            *d = (1..=DILATE).any(|off| keep[i.saturating_sub(off)] || keep[(i + off).min(m - 1)]);
+        }
+    }
+    if dilated.iter().all(|&k| k) {
+        return vec![pts.to_vec()];
+    }
+    let mut runs: Vec<Vec<Point3>> = Vec::new();
+    let mut current: Vec<Point3> = Vec::new();
+    for (i, &k) in dilated.iter().enumerate() {
+        if k {
+            current.push(pts[i]);
+        } else if !current.is_empty() {
+            runs.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        runs.push(current);
+    }
+    runs
+}
+
 fn plane_analytic_intersection(
     normal: Vec3,
     d: f64,
     analytic: &analytic_intersection::AnalyticSurface<'_>,
+    bbox_a: &Aabb3,
+    bbox_b: &Aabb3,
 ) -> Result<Vec<RawCurve>, AlgoError> {
     let exact_curves = analytic_intersection::exact_plane_analytic(*analytic, normal, d)?;
 
@@ -3442,45 +3515,58 @@ fn plane_analytic_intersection(
                 });
             }
             analytic_intersection::ExactIntersectionCurve::Points(pts) => {
-                // A tangential contact can sample as one point repeated N
-                // times (adjacent half-socket corner cylinders touching the
-                // body wall): interpolation through duplicate points is
-                // singular and used to abort the whole boolean into the mesh
-                // fallback. Deduplicate first; fewer than 2 distinct points
-                // is a point contact, not a section curve — skip it (point
-                // interferences are EE/EF/VF territory).
-                let mut pts_dedup: Vec<Point3> = Vec::with_capacity(pts.len());
-                for &p in &pts {
-                    if pts_dedup.last().is_none_or(|&q| {
-                        (p - q).length() > brepkit_math::tolerance::Tolerance::new().linear
-                    }) {
-                        pts_dedup.push(p);
+                // The sampled chain spans the UNBOUNDED section conic (a
+                // hyperbola from a wall plane grazing a taper cone covers
+                // 8x the vertex radius), while everything downstream keeps
+                // only spans inside both faces' inflated AABBs. Fitting the
+                // full chain feeds `interpolate`'s dense O(n^3) solve with
+                // ~512 points per pair — the whole baseplate fuse budget
+                // (#1488). Clip to the segments that can reach the pair's
+                // AABB overlap first (with neighbor padding so boundary
+                // crossings keep local shape support) and fit per run.
+                for pts in clip_chain_to_pair_boxes(&pts, bbox_a, bbox_b) {
+                    // A tangential contact can sample as one point repeated N
+                    // times (adjacent half-socket corner cylinders touching the
+                    // body wall): interpolation through duplicate points is
+                    // singular and used to abort the whole boolean into the mesh
+                    // fallback. Deduplicate first; fewer than 2 distinct points
+                    // is a point contact, not a section curve — skip it (point
+                    // interferences are EE/EF/VF territory).
+                    let mut pts_dedup: Vec<Point3> = Vec::with_capacity(pts.len());
+                    for &p in &pts {
+                        if pts_dedup.last().is_none_or(|&q| {
+                            (p - q).length() > brepkit_math::tolerance::Tolerance::new().linear
+                        }) {
+                            pts_dedup.push(p);
+                        }
                     }
+                    // Fewer than 3 distinct survivors from a dense sample means
+                    // the whole "curve" spans tolerance scale — a chord through
+                    // 2 barely-distinct points would only mint micro edges.
+                    if pts_dedup.len() < 3 {
+                        continue;
+                    }
+                    let pts = pts_dedup;
+                    crate::perf::bump_section_fit_points(pts.len() as u64);
+                    // Fit a degree-3 NURBS curve through the sampled points
+                    let nurbs =
+                        brepkit_math::nurbs::fitting::interpolate(&pts, 3.min(pts.len() - 1))
+                            .map_err(|e| {
+                                AlgoError::IntersectionFailed(format!("NURBS fit failed: {e}"))
+                            })?;
+                    let t_range = nurbs.domain();
+                    let bbox = Aabb3::try_from_points(pts.iter().copied()).ok_or_else(|| {
+                        AlgoError::IntersectionFailed("empty points for NURBS fit".into())
+                    })?;
+                    let end_pt = pts[pts.len() - 1];
+                    results.push(RawCurve {
+                        curve: EdgeCurve::NurbsCurve(nurbs),
+                        bbox,
+                        t_range,
+                        p_start: pts[0],
+                        p_end: end_pt,
+                    });
                 }
-                // Fewer than 3 distinct survivors from a dense sample means
-                // the whole "curve" spans tolerance scale — a chord through
-                // 2 barely-distinct points would only mint micro edges.
-                if pts_dedup.len() < 3 {
-                    continue;
-                }
-                let pts = pts_dedup;
-                // Fit a degree-3 NURBS curve through the sampled points
-                let nurbs = brepkit_math::nurbs::fitting::interpolate(&pts, 3.min(pts.len() - 1))
-                    .map_err(|e| {
-                    AlgoError::IntersectionFailed(format!("NURBS fit failed: {e}"))
-                })?;
-                let t_range = nurbs.domain();
-                let bbox = Aabb3::try_from_points(pts.iter().copied()).ok_or_else(|| {
-                    AlgoError::IntersectionFailed("empty points for NURBS fit".into())
-                })?;
-                let end_pt = pts[pts.len() - 1];
-                results.push(RawCurve {
-                    curve: EdgeCurve::NurbsCurve(nurbs),
-                    bbox,
-                    t_range,
-                    p_start: pts[0],
-                    p_end: end_pt,
-                });
             }
         }
     }

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -3524,6 +3524,7 @@ fn plane_analytic_intersection(
                 // (#1488). Clip to the segments that can reach the pair's
                 // AABB overlap first (with neighbor padding so boundary
                 // crossings keep local shape support) and fit per run.
+                let lin_tol = brepkit_math::tolerance::Tolerance::new().linear;
                 for pts in clip_chain_to_pair_boxes(&pts, bbox_a, bbox_b) {
                     // A tangential contact can sample as one point repeated N
                     // times (adjacent half-socket corner cylinders touching the
@@ -3534,9 +3535,7 @@ fn plane_analytic_intersection(
                     // interferences are EE/EF/VF territory).
                     let mut pts_dedup: Vec<Point3> = Vec::with_capacity(pts.len());
                     for &p in &pts {
-                        if pts_dedup.last().is_none_or(|&q| {
-                            (p - q).length() > brepkit_math::tolerance::Tolerance::new().linear
-                        }) {
+                        if pts_dedup.last().is_none_or(|&q| (p - q).length() > lin_tol) {
                             pts_dedup.push(p);
                         }
                     }

--- a/crates/algo/src/perf.rs
+++ b/crates/algo/src/perf.rs
@@ -34,6 +34,8 @@ static RAY_GEOM_BUILDS: AtomicU64 = AtomicU64::new(0);
 static FACE_SPLIT_PROBES: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "perf-counters")]
 static LOCAL_VERTEX_INSERTS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-counters")]
+static SECTION_FIT_POINTS: AtomicU64 = AtomicU64::new(0);
 
 /// Count one pave-vertex distance comparison (per candidate examined while
 /// snapping an intersection endpoint to a coincident vertex). Crate-internal:
@@ -87,6 +89,20 @@ pub(crate) fn bump_local_vertex_insert() {
     LOCAL_VERTEX_INSERTS.fetch_add(1, Ordering::Relaxed);
 }
 
+/// Count the points fed to a section-curve NURBS interpolation in the FF
+/// phase's sampled plane-analytic path. The sampled chain spans the unbounded
+/// section conic; `clip_chain_to_pair_boxes` keeps only the runs that can
+/// reach the face pair's AABB overlap, so a tangent graze fits a handful of
+/// points. Reverting the clip feeds the full ~512-point chain to the dense
+/// O(n^3) solve per grazing pair — the baseplate fuse regression (#1488).
+/// Crate-internal.
+#[inline]
+#[allow(clippy::used_underscore_binding)]
+pub(crate) fn bump_section_fit_points(_n: u64) {
+    #[cfg(feature = "perf-counters")]
+    SECTION_FIT_POINTS.fetch_add(_n, Ordering::Relaxed);
+}
+
 /// A snapshot of every work counter since the last [`reset`]. Only available
 /// with `perf-counters`.
 #[cfg(feature = "perf-counters")]
@@ -103,6 +119,8 @@ pub struct PerfSnapshot {
     pub face_split_probes: u64,
     /// Sub-face-local vertex materializations in `build_topology_face`.
     pub local_vertex_inserts: u64,
+    /// Points fed to section-curve NURBS interpolation in the FF phase.
+    pub section_fit_points: u64,
 }
 
 /// Reset all counters to zero. Only available with `perf-counters`.
@@ -113,6 +131,7 @@ pub fn reset() {
     RAY_GEOM_BUILDS.store(0, Ordering::Relaxed);
     FACE_SPLIT_PROBES.store(0, Ordering::Relaxed);
     LOCAL_VERTEX_INSERTS.store(0, Ordering::Relaxed);
+    SECTION_FIT_POINTS.store(0, Ordering::Relaxed);
 }
 
 /// Every work counter since the last [`reset`]. Only available with
@@ -126,5 +145,6 @@ pub fn snapshot() -> PerfSnapshot {
         ray_geom_builds: RAY_GEOM_BUILDS.load(Ordering::Relaxed),
         face_split_probes: FACE_SPLIT_PROBES.load(Ordering::Relaxed),
         local_vertex_inserts: LOCAL_VERTEX_INSERTS.load(Ordering::Relaxed),
+        section_fit_points: SECTION_FIT_POINTS.load(Ordering::Relaxed),
     }
 }

--- a/crates/operations/examples/plate_probe.rs
+++ b/crates/operations/examples/plate_probe.rs
@@ -1,0 +1,200 @@
+//! Native probe for issue #1488: plain rectangular baseplate pocket cuts.
+//!
+//! Mirrors the gridfinity baseplate export path: a slab cut by one tapered
+//! pocket loft per cell via `compound_cut`. Pocket walls at the top band are
+//! exactly coplanar with their neighbors (INSET_TOP = 0) and with the slab
+//! perimeter, which is the suspected super-linear coincident-face path.
+#![allow(
+    clippy::print_stdout,
+    clippy::unwrap_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::significant_drop_tightening
+)]
+
+use std::time::Instant;
+
+use brepkit_math::curves::Circle3D;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::{boolean, loft, measure, primitives};
+use brepkit_topology::Topology;
+use brepkit_topology::edge::{Edge, EdgeCurve};
+use brepkit_topology::face::{Face, FaceId, FaceSurface};
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::vertex::Vertex;
+use brepkit_topology::wire::{OrientedEdge, Wire};
+
+const CELL: f64 = 42.0;
+const SOCKET_HEIGHT: f64 = 5.0;
+const COPLANAR_MARGIN: f64 = 1.0;
+
+fn rounded_rect_face(topo: &mut Topology, cx: f64, cy: f64, w: f64, r: f64, z: f64) -> FaceId {
+    let tol_val = 1e-7;
+    let c = w / 2.0 - r;
+    let corners = [
+        (cx + c, cy + c, 0.0_f64),
+        (cx - c, cy + c, 90.0),
+        (cx - c, cy - c, 180.0),
+        (cx + c, cy - c, 270.0),
+    ];
+    let pt = |kx: f64, ky: f64, deg: f64| {
+        let a = deg.to_radians();
+        Point3::new(kx + r * a.cos(), ky + r * a.sin(), z)
+    };
+    let mut vids = Vec::new();
+    for &(kx, ky, a0) in &corners {
+        vids.push(topo.add_vertex(Vertex::new(pt(kx, ky, a0), tol_val)));
+        vids.push(topo.add_vertex(Vertex::new(pt(kx, ky, a0 + 90.0), tol_val)));
+    }
+    let mut oes = Vec::new();
+    for (k, &(kx, ky, _)) in corners.iter().enumerate() {
+        let circle = Circle3D::new(Point3::new(kx, ky, z), Vec3::new(0.0, 0.0, 1.0), r).unwrap();
+        let arc = topo.add_edge(Edge::new(
+            vids[2 * k],
+            vids[2 * k + 1],
+            EdgeCurve::Circle(circle),
+        ));
+        oes.push(OrientedEdge::new(arc, true));
+        let line = topo.add_edge(Edge::new(
+            vids[2 * k + 1],
+            vids[(2 * k + 2) % 8],
+            EdgeCurve::Line,
+        ));
+        oes.push(OrientedEdge::new(line, true));
+    }
+    let wid = topo.add_wire(Wire::new(oes, true).unwrap());
+    topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: z,
+        },
+    ))
+}
+
+fn pocket(topo: &mut Topology, cx: f64, cy: f64, z_top: f64) -> SolidId {
+    // (z offset from slab top, inset): the export 5-section socket profile
+    // plus the +1 coplanar-margin cap and the -1 through-cut extension.
+    let sections = [
+        (COPLANAR_MARGIN, 0.0),
+        (0.0, 0.0),
+        (-0.25, 0.0),
+        (-2.4, 2.15),
+        (-4.2, 2.15),
+        (-SOCKET_HEIGHT, 2.95),
+        (-SOCKET_HEIGHT - COPLANAR_MARGIN, 2.95),
+    ];
+    let profs: Vec<FaceId> = sections
+        .iter()
+        .map(|&(dz, inset)| {
+            let w = CELL - 2.0 * inset;
+            let r = (4.0_f64 - inset).max(0.1);
+            rounded_rect_face(topo, cx, cy, w, r, z_top + dz)
+        })
+        .collect();
+    loft::loft(topo, &profs).unwrap()
+}
+
+struct StampLogger {
+    clock: std::sync::Mutex<(Option<Instant>, Option<Instant>)>,
+}
+
+impl log::Log for StampLogger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record) {
+        let now = Instant::now();
+        let (total_us, delta_us) = {
+            let mut clock = self.clock.lock().unwrap();
+            let start = *clock.0.get_or_insert(now);
+            let delta = clock.1.map_or(0, |l| now.duration_since(l).as_micros());
+            clock.1 = Some(now);
+            (now.duration_since(start).as_micros(), delta)
+        };
+        if delta_us > 5000 {
+            let msg = format!("{}", record.args());
+            let msg = &msg[..msg.len().min(110)];
+            println!("[{total_us:>8}us +{delta_us:>7}us] {msg}");
+        }
+    }
+    fn flush(&self) {}
+}
+
+fn main() {
+    if std::env::var("PLATE_TRACE").is_ok() {
+        let logger = Box::leak(Box::new(StampLogger {
+            clock: std::sync::Mutex::new((None, None)),
+        }));
+        log::set_logger(logger).unwrap();
+        log::set_max_level(log::LevelFilter::Trace);
+    }
+    let grids: Vec<(usize, usize)> = std::env::args().nth(1).map_or_else(
+        || vec![(1, 1), (2, 2), (3, 3), (4, 4), (6, 4)],
+        |s| {
+            let (a, b) = s.split_once('x').unwrap();
+            vec![(a.parse().unwrap(), b.parse().unwrap())]
+        },
+    );
+
+    for (n, m) in grids {
+        let mut topo = Topology::new();
+        let slab = primitives::make_box(&mut topo, CELL * n as f64, CELL * m as f64, SOCKET_HEIGHT)
+            .unwrap();
+        let mut pockets = Vec::new();
+        for i in 0..n {
+            for j in 0..m {
+                let cx = CELL / 2.0 + CELL * i as f64;
+                let cy = CELL / 2.0 + CELL * j as f64;
+                pockets.push(pocket(&mut topo, cx, cy, SOCKET_HEIGHT));
+            }
+        }
+        let split_stages = std::env::var("PLATE_STAGES").is_ok();
+        if split_stages {
+            let t0 = Instant::now();
+            let fused = brepkit_algo::gfa::fuse_n(&mut topo, &pockets).unwrap();
+            let fuse_ms = t0.elapsed().as_secs_f64() * 1000.0;
+            let fused_faces =
+                brepkit_topology::explorer::solid_faces(&topo, fused).map_or(0, |f| f.len());
+            let t1 = Instant::now();
+            let result = boolean::boolean(&mut topo, boolean::BooleanOp::Cut, slab, fused);
+            let cut_ms = t1.elapsed().as_secs_f64() * 1000.0;
+            match result {
+                Ok(solid) => {
+                    let faces = brepkit_topology::explorer::solid_faces(&topo, solid)
+                        .map_or(0, |f| f.len());
+                    println!(
+                        "{n}x{m}: fuse={fuse_ms:>8.1}ms (tool faces={fused_faces})  cut={cut_ms:>8.1}ms  faces={faces}"
+                    );
+                }
+                Err(e) => println!("{n}x{m}: fuse={fuse_ms:>8.1}ms  cut ERROR {e}"),
+            }
+            continue;
+        }
+        let t = Instant::now();
+        let result = boolean::compound_cut(
+            &mut topo,
+            slab,
+            &pockets,
+            boolean::BooleanOptions::default(),
+        );
+        let elapsed = t.elapsed();
+        match result {
+            Ok(solid) => {
+                let faces =
+                    brepkit_topology::explorer::solid_faces(&topo, solid).map_or(0, |f| f.len());
+                let vol = measure::solid_volume(&topo, solid, 0.1).unwrap_or(f64::NAN);
+                println!(
+                    "{n}x{m}: {:>8.1}ms  faces={faces}  volume={vol:.1}",
+                    elapsed.as_secs_f64() * 1000.0
+                );
+            }
+            Err(e) => println!(
+                "{n}x{m}: {:>8.1}ms  ERROR {e}",
+                elapsed.as_secs_f64() * 1000.0
+            ),
+        }
+    }
+}

--- a/crates/operations/examples/plate_probe.rs
+++ b/crates/operations/examples/plate_probe.rs
@@ -116,7 +116,8 @@ impl log::Log for StampLogger {
         };
         if delta_us > 5000 {
             let msg = format!("{}", record.args());
-            let msg = &msg[..msg.len().min(110)];
+            let cut = msg.char_indices().nth(110).map_or(msg.len(), |(i, _)| i);
+            let msg = &msg[..cut];
             println!("[{total_us:>8}us +{delta_us:>7}us] {msg}");
         }
     }

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -7342,3 +7342,123 @@ fn mesh_fallback_counter_records_fallbacks() {
         "edge-touching fuse should route through the mesh fallback and increment the counter"
     );
 }
+
+/// A gridfinity-style baseplate pocket: a ruled loft of rounded-rect
+/// sections, full cell size at the top (walls land exactly on the cell
+/// boundary) tapering inward below. At pitch == cell size, adjacent pockets'
+/// wall planes are coplanar and each wall plane is tangent to the neighbor's
+/// corner cones — the #1488 grazing configuration.
+#[cfg(feature = "perf-counters")]
+fn make_plate_pocket(topo: &mut Topology, cx: f64, cy: f64) -> SolidId {
+    let cell = 42.0;
+    let sections = [
+        (1.0, 0.0),
+        (0.0, 0.0),
+        (-0.25, 0.0),
+        (-2.4, 2.15),
+        (-4.2, 2.15),
+        (-5.0, 2.95),
+        (-6.0, 2.95),
+    ];
+    let profs: Vec<brepkit_topology::face::FaceId> = sections
+        .iter()
+        .map(|&(z, inset): &(f64, f64)| {
+            let w = cell - 2.0 * inset;
+            let r = (4.0_f64 - inset).max(0.1);
+            make_offset_rounded_rect_face(topo, cx, cy, w, r, z)
+        })
+        .collect();
+    crate::loft::loft(topo, &profs).unwrap()
+}
+
+#[cfg(feature = "perf-counters")]
+fn make_offset_rounded_rect_face(
+    topo: &mut Topology,
+    cx: f64,
+    cy: f64,
+    w: f64,
+    r: f64,
+    z: f64,
+) -> brepkit_topology::face::FaceId {
+    use brepkit_math::curves::Circle3D;
+    let tol_val = 1e-7;
+    let c = w / 2.0 - r;
+    let corners = [
+        (cx + c, cy + c, 0.0_f64),
+        (cx - c, cy + c, 90.0),
+        (cx - c, cy - c, 180.0),
+        (cx + c, cy - c, 270.0),
+    ];
+    let pt = |kx: f64, ky: f64, deg: f64| {
+        let a = deg.to_radians();
+        Point3::new(kx + r * a.cos(), ky + r * a.sin(), z)
+    };
+    let mut vids = Vec::new();
+    for &(kx, ky, a0) in &corners {
+        vids.push(topo.add_vertex(Vertex::new(pt(kx, ky, a0), tol_val)));
+        vids.push(topo.add_vertex(Vertex::new(pt(kx, ky, a0 + 90.0), tol_val)));
+    }
+    let mut oes = Vec::new();
+    for (k, &(kx, ky, _)) in corners.iter().enumerate() {
+        let circle = Circle3D::new(Point3::new(kx, ky, z), Vec3::new(0.0, 0.0, 1.0), r).unwrap();
+        let arc = topo.add_edge(Edge::new(
+            vids[2 * k],
+            vids[2 * k + 1],
+            EdgeCurve::Circle(circle),
+        ));
+        oes.push(OrientedEdge::new(arc, true));
+        let line = topo.add_edge(Edge::new(
+            vids[2 * k + 1],
+            vids[(2 * k + 2) % 8],
+            EdgeCurve::Line,
+        ));
+        oes.push(OrientedEdge::new(line, true));
+    }
+    let wid = topo.add_wire(Wire::new(oes, true).unwrap());
+    topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: z,
+        },
+    ))
+}
+
+/// Complexity guard for the #1488 baseplate regression: a wall plane grazing
+/// a neighbor pocket's taper cone samples the section hyperbola across the
+/// UNBOUNDED cone; without `clip_chain_to_pair_boxes` the full ~512-point
+/// chain feeds the dense O(n³) interpolation per grazing pair (~60ms each,
+/// the whole plate fuse budget). Counting fit points keeps the guard
+/// deterministic. Bounds calibrated on the fixed path; reverting the clip
+/// sends the grazing count into the thousands.
+#[cfg(feature = "perf-counters")]
+#[test]
+fn tangent_graze_section_fit_is_clipped() {
+    // Two pockets at exact cell pitch: coplanar walls, tangent cones.
+    let mut topo = Topology::new();
+    let a = make_plate_pocket(&mut topo, 21.0, 21.0);
+    let b = make_plate_pocket(&mut topo, 63.0, 21.0);
+    brepkit_algo::perf::reset();
+    brepkit_algo::gfa::fuse_n(&mut topo, &[a, b]).unwrap();
+    let graze = brepkit_algo::perf::snapshot().section_fit_points;
+
+    // Same pockets genuinely overlapping: real plane×cone crossings must
+    // still fit their (clipped) sections, proving the counter is live.
+    let mut topo = Topology::new();
+    let a = make_plate_pocket(&mut topo, 21.0, 21.0);
+    let b = make_plate_pocket(&mut topo, 51.0, 21.0);
+    brepkit_algo::perf::reset();
+    brepkit_algo::gfa::fuse_n(&mut topo, &[a, b]).unwrap();
+    let overlap = brepkit_algo::perf::snapshot().section_fit_points;
+
+    eprintln!("section_fit_points: graze={graze} overlap={overlap}");
+    assert!(
+        overlap > 0,
+        "overlapping-pocket fuse should exercise the sampled section-fit path"
+    );
+    assert!(
+        graze < 600,
+        "grazing-pocket fuse fit {graze} section points — the chain clip regressed"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses the dominant cost in #1488 (baseplate generation 4-27x behind the reference): the N-way fuse of touching baseplate pockets spent its entire budget in the FF phase's sampled plane-analytic path.

## Root

A pocket wall plane grazing a neighbor pocket's taper cone hits the hyperbola branch of `exact_plane_cone`, which samples the section across the UNBOUNDED cone (~512 points, capped at 8x the vertex radius) and feeds the whole chain to `interpolate`'s dense O(n³) Gauss solve — ~30ms per grazing face pair, measured via a temporary per-pair timer (fit = 360ms of the 376ms plane-cone total at 2x2). A plain rectangular plate has two such pairs per pocket adjacency (INSET_TOP = 0 puts every wall exactly on the cell boundary) plus the slab-perimeter walls, and the pair count grows with adjacency, which is the issue's super-linear signature.

## Fix

Everything downstream of `compute_raw_curves` keeps only spans inside both faces' inflated AABBs (the in-both sample filter and `restrict_curves_to_faces`), so chain points that cannot reach the pair's AABB overlap contribute nothing but interpolation cost. `clip_chain_to_pair_boxes` keeps the runs whose segments meet both boxes (expanded by chord length to absorb sampling sagitta, dilated by two neighbors so sub-pitch crossings keep fit support) and fits per run.

Closed section loops stay whole or drop whole: the band splitters consume closed curves, and open sub-arcs whose seam endpoints lie on no face boundary break them (`cut_torus_by_box_notch_is_analytic_watertight` caught this — it now passes).

## Measured

`plate_probe` (new example mirroring the issue's plain-plate workload: slab + tapered cell pockets via `compound_cut`), native release:

| Grid | before | after |
|------|--------|-------|
| 1x1 | 38ms | 6ms |
| 2x2 | 478ms | 81ms |
| 3x3 | 1294ms | 255ms |
| 4x4 | 2538ms | 564ms |
| 6x4 | 4080ms | 1009ms |

Face counts and volumes identical before/after on every grid. `boolean_tracking` vs main baseline: no change outside noise (intersect_box_box −3.5%).

## Guard

New deterministic work counter `section_fit_points` (perf-counters feature) + `tangent_graze_section_fit_is_clipped`: two tangent pockets fuse at 72 fit points (bound 600); with the clip reverted it explodes to 2648 and the test fails. An overlapping-pocket fuse asserts the counter stays live (336 > 0).

Workspace suite green in both feature configs.

Part of #1488 — tool-side re-measurement on a released kernel still pending; the remaining FF/EF time is linear in pocket adjacencies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clip sampled plane–analytic intersection chains to the face-pair AABB overlap to avoid fitting unbounded sections, addressing the dominant cost in #1488. This cuts baseplate fuse time by 4–6x+ with identical geometry.

- **Performance**
  - Added `clip_chain_to_pair_boxes` in the sampled plane–analytic path and fit NURBS per kept run; closed loops stay whole. Prevents sending ~512-point chains into the O(n^3) interpolator.
  - Results (compound_cut, ms): 1x1 38→6, 2x2 478→81, 3x3 1294→255, 4x4 2538→564, 6x4 4080→1009. Face counts and volumes unchanged.

- **Tests and Guards**
  - New perf counter `section_fit_points` (feature `perf-counters`) and test `tangent_graze_section_fit_is_clipped` (graze ≈72 fit points; bound 600; overlapping case >0), ensuring the clip stays effective.
  - Added native example `crates/operations/examples/plate_probe.rs` (logger truncates on char boundaries). Hoisted the dedup tolerance in the fit path for clarity.

<sup>Written for commit f7b77b6823d46da0b3d401fa7117a237f9941eac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

