### PR TITLE
ci(semver): scope the advisory check to the consumer-surface crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,17 @@ jobs:
         with:
           tool: cargo-semver-checks
       # Baselines against the newest version of each crate on crates.io.
-      - run: cargo semver-checks --workspace
+      # Scoped to STABILITY.md's consumer-surface crates: the internal L1/L2
+      # crates are published only so the graph resolves and promise no API
+      # stability, so checking them reports breaks the policy already permits.
+      - run: >
+          cargo semver-checks
+          --package brepkit-math
+          --package brepkit-topology
+          --package brepkit-sketch
+          --package brepkit-operations
+          --package brepkit-io
+          --package brepkit-wasm
 
   machete:
     name: Unused Dependencies

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -56,9 +56,11 @@ enumerate the current match sites.
 
 ## Semver enforcement
 
-CI runs `cargo semver-checks` on every PR as an **advisory** check. It reports
-API breakage against the published baseline but does not block the merge, and it
-is not part of the required `CI Pass` gate.
+CI runs `cargo semver-checks` on every PR as an **advisory** check, scoped to
+the consumer-surface crates above (the internal crates promise no stability, so
+checking them only reports breaks this policy already permits). It reports API
+breakage against the published baseline but does not block the merge, and it is
+not part of the required `CI Pass` gate.
 
 That is deliberate. The kernel is under active development and the enum change
 above is planned, so a blocking gate would force major bumps on routine work


### PR DESCRIPTION
## Summary

The `SemVer Check (advisory)` failed on the 3.2.12 release PR (#1492): `constructible_struct_adds_field` on `brepkit-algo`'s `PerfSnapshot.section_fit_points` (the perf counter added in #1490).

That is a break STABILITY.md already permits: `brepkit-algo` is in the internal tier — published only so the dependency graph resolves, "treat these as private and expect breakage on any release". Running the check with `--workspace` makes it report breaks the policy does not govern, so routine internal-crate evolution shows a red X on release PRs.

## Fix

Scope the check to the documented consumer surface (`brepkit-math`, `brepkit-topology`, `brepkit-sketch`, `brepkit-operations`, `brepkit-io`, `brepkit-wasm`) and note the scoping in STABILITY.md's semver-enforcement section. The check stays advisory and outside `CI Pass`, unchanged.

The 3.2.12 red X itself is historical (the release shipped; the field is now in the published baseline, so it would not re-fire regardless).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the advisory `cargo-semver-checks` job to the consumer-surface crates so internal crate changes don’t trigger false failures on release PRs. Also documents this in STABILITY.md; the check stays non-blocking.

- `cargo semver-checks` now runs only for: `brepkit-math`, `brepkit-topology`, `brepkit-sketch`, `brepkit-operations`, `brepkit-io`, `brepkit-wasm`

<sup>Written for commit d33ac2eabaa3bec5f13b1d8230d7ed0b807ea70b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

