### PR TITLE
fix(operations): false trivial-containment on thin revolved cutters + untrimmed-arc volume misreads

### DIFF
--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -2250,6 +2250,33 @@ fn detect_trivial_relation(
             inside_inner && outside_outer
         };
 
+    // Volume witness for the AABB-only fallback: `inner ⊆ outer` implies
+    // `vol(inner) ≤ vol(outer)`, so a decisively larger inner volume proves
+    // non-containment. This catches what `center_outside` cannot: the AABB
+    // expansion for partial cylinder/cone faces is a conservative full-circle
+    // bound, so a thin angular wedge's box balloons to the whole cylinder
+    // footprint and can "strictly contain" a much bigger solid's box, while
+    // the bigger solid's own AABB center sits in its annular hole and
+    // disables the center witness (gh #1499, the kumiko corner cutter).
+    // Volumes are immune to that inflation. The 1.05 factor absorbs
+    // deflection under-counting on curved faces so a true containment is
+    // never rejected; errors fall through to "no refutation" (shortcut
+    // soundness is then up to the remaining witnesses, as before).
+    let volume_refutes = |topo: &Topology, inner: SolidId, outer: SolidId| -> bool {
+        let defl = |bb: &Option<(Point3, Point3)>| {
+            let Some((lo, hi)) = *bb else { return 1e-3 };
+            let (dx, dy, dz) = (hi.x() - lo.x(), hi.y() - lo.y(), hi.z() - lo.z());
+            (dx.mul_add(dx, dy.mul_add(dy, dz * dz)).sqrt() * 0.01).max(1e-6)
+        };
+        let (Ok(vi), Ok(vo)) = (
+            crate::measure::solid_volume(topo, inner, defl(&aabb_a).min(defl(&aabb_b))),
+            crate::measure::solid_volume(topo, outer, defl(&aabb_a).min(defl(&aabb_b))),
+        ) else {
+            return false;
+        };
+        vi > vo * 1.05
+    };
+
     // Bidirectional vertex check via the analytic classifier — the
     // primary signal for identical/containment classification. A vertex
     // classifying as inside-or-on (None within tolerance band counts
@@ -2282,10 +2309,14 @@ fn detect_trivial_relation(
     // with the `center_outside` witness — sound for every path because it
     // only fires on proven non-containment (see the lemma above).
     let b_in_a = ((all_b_verts_in_a && aabb_encloses(&aabb_b, &aabb_a))
-        || (ca.is_none() && aabb_strictly_contains(&aabb_b, &aabb_a)))
+        || (ca.is_none()
+            && aabb_strictly_contains(&aabb_b, &aabb_a)
+            && !volume_refutes(topo, b, a)))
         && !center_outside(topo, b, a, &aabb_b);
     let a_in_b = ((all_a_verts_in_b && aabb_encloses(&aabb_a, &aabb_b))
-        || (cb.is_none() && aabb_strictly_contains(&aabb_a, &aabb_b)))
+        || (cb.is_none()
+            && aabb_strictly_contains(&aabb_a, &aabb_b)
+            && !volume_refutes(topo, a, b)))
         && !center_outside(topo, a, b, &aabb_a);
 
     TrivialRelation {

--- a/crates/operations/src/boolean/mod.rs
+++ b/crates/operations/src/boolean/mod.rs
@@ -2268,9 +2268,10 @@ fn detect_trivial_relation(
             let (dx, dy, dz) = (hi.x() - lo.x(), hi.y() - lo.y(), hi.z() - lo.z());
             (dx.mul_add(dx, dy.mul_add(dy, dz * dz)).sqrt() * 0.01).max(1e-6)
         };
+        let d = defl(&aabb_a).min(defl(&aabb_b));
         let (Ok(vi), Ok(vo)) = (
-            crate::measure::solid_volume(topo, inner, defl(&aabb_a).min(defl(&aabb_b))),
-            crate::measure::solid_volume(topo, outer, defl(&aabb_a).min(defl(&aabb_b))),
+            crate::measure::solid_volume(topo, inner, d),
+            crate::measure::solid_volume(topo, outer, d),
         ) else {
             return false;
         };

--- a/crates/operations/src/boolean/tests.rs
+++ b/crates/operations/src/boolean/tests.rs
@@ -7548,3 +7548,103 @@ fn tangent_graze_section_fit_is_clipped() {
         "grazing-pocket fuse fit {graze} section points — the chain clip regressed"
     );
 }
+
+/// gh #1499: an annular wedge (partial revolve) about the Z axis.
+///
+/// Profile rectangle r0..r1 × z0..z1 in the y=0 plane, revolved by `angle`,
+/// then rotated so its angular span starts at `start_angle`.
+fn make_annular_wedge(
+    topo: &mut Topology,
+    r0: f64,
+    r1: f64,
+    z0: f64,
+    z1: f64,
+    angle: f64,
+    start_angle: f64,
+) -> SolidId {
+    use brepkit_topology::builder::make_polygon_wire;
+
+    let wire = make_polygon_wire(
+        topo,
+        &[
+            Point3::new(r0, 0.0, z0),
+            Point3::new(r1, 0.0, z0),
+            Point3::new(r1, 0.0, z1),
+            Point3::new(r0, 0.0, z1),
+        ],
+        1e-7,
+    )
+    .unwrap();
+    let face = topo.add_face(Face::new(
+        wire,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 1.0, 0.0),
+            d: 0.0,
+        },
+    ));
+    let solid = crate::revolve::revolve(
+        topo,
+        face,
+        Point3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+        angle,
+    )
+    .unwrap();
+    if start_angle != 0.0 {
+        crate::transform::transform_solid(
+            topo,
+            solid,
+            &brepkit_math::mat::Mat4::rotation_z(start_angle),
+        )
+        .unwrap();
+    }
+    solid
+}
+
+#[test]
+fn cut_wedge_by_thin_radial_strut_is_not_empty() {
+    // gh #1499: the kumiko corner cutter. A wide annular wedge cut by a thin
+    // radial strut that pokes through it (wider radially and axially, but a
+    // fraction of the angular span — 3.4× smaller by volume). The strut can
+    // NOT contain the wedge, yet the trivial-containment shortcut declared
+    // "target fully contained in tool" and returned EmptyResult:
+    //  - neither operand builds an analytic classifier (two different-radius
+    //    cylinders), so containment fell to the AABB-only fallback;
+    //  - `solid_bounding_box` expands partial cylinder faces to the FULL
+    //    circle, so the thin strut's box ballooned to ±r1 and strictly
+    //    contained the wedge's box in all three dims;
+    //  - the `center_outside` witness was disabled because the wedge's AABB
+    //    center sits in its own annular hole.
+    use crate::measure::solid_volume;
+
+    let mut topo = Topology::new();
+    // Faithful to the failing tool call: base vol ≈ 175.7, tool vol ≈ 52.1,
+    // tool AABB ⊋ base AABB by just over 10% in every dim.
+    let base = make_annular_wedge(&mut topo, 2.85, 4.75, 2.7, 13.8, 2.2, 0.0);
+    let tool = make_annular_wedge(&mut topo, 2.8, 5.25, 2.1, 14.4, 0.44, 0.88);
+
+    let base_vol = solid_volume(&topo, base, 0.01).unwrap();
+    let tool_vol = solid_volume(&topo, tool, 0.01).unwrap();
+    assert!(
+        base_vol > tool_vol * 3.0,
+        "precondition: tool ({tool_vol}) must be much smaller than base ({base_vol})"
+    );
+
+    let result = boolean(&mut topo, BooleanOp::Cut, base, tool)
+        .expect("cut must not be trivially empty: the tool cannot contain the base");
+    let cut_vol = solid_volume(&topo, result, 0.01).unwrap();
+
+    // Volume invariant: vol(A−B) + vol(A∩B) = vol(A).
+    let overlap = boolean(&mut topo, BooleanOp::Intersect, base, tool)
+        .expect("operands overlap, intersect must not be empty");
+    let overlap_vol = solid_volume(&topo, overlap, 0.01).unwrap();
+    assert!(
+        overlap_vol > 1.0,
+        "the strut pokes through the wedge, overlap must be substantial, got {overlap_vol}"
+    );
+    assert!(
+        (cut_vol + overlap_vol - base_vol).abs() / base_vol < 0.01,
+        "vol(A−B) + vol(A∩B) = vol(A) violated: {cut_vol} + {overlap_vol} ≠ {base_vol}"
+    );
+}

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -1160,6 +1160,12 @@ fn volume_tessellation_deflection(topo: &Topology, solid: SolidId, requested: f6
     requested.min((diag * 5e-5).max(1e-9))
 }
 
+/// Whether `BK_VOL_TRACE` diagnostics are enabled, checked once per process.
+fn vol_trace_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("BK_VOL_TRACE").is_ok())
+}
+
 /// Compute the volume of a solid using the signed tetrahedra method
 /// (divergence theorem on a surface tessellation).
 ///
@@ -1179,7 +1185,7 @@ pub fn solid_volume(
 ) -> Result<f64, crate::OperationsError> {
     // Fast path: exact analytic formula for known primitives.
     if let Some(v) = try_analytic_solid_volume(topo, solid) {
-        if std::env::var("BK_VOL_TRACE").is_ok() {
+        if vol_trace_enabled() {
             log::debug!("VOL_TRACE try_analytic -> {v}");
         }
         return Ok(v);
@@ -1188,7 +1194,7 @@ pub fn solid_volume(
     // Fast path: all faces planar with straight edges — exact polygon
     // divergence integral, no tessellation.
     if let Some(v) = all_planar_line_solid_volume(topo, solid) {
-        if std::env::var("BK_VOL_TRACE").is_ok() {
+        if vol_trace_enabled() {
             log::debug!("VOL_TRACE all_planar_line -> {v}");
         }
         return Ok(v);
@@ -1201,7 +1207,7 @@ pub fn solid_volume(
     // tessellation paths below suffer on bored quadrics (e.g. a cylinder
     // drilled through a sphere).
     if let Some(v) = analytic_faces_solid_volume(topo, solid) {
-        if std::env::var("BK_VOL_TRACE").is_ok() {
+        if vol_trace_enabled() {
             log::debug!("VOL_TRACE analytic_faces -> {v}");
         }
         return Ok(v);
@@ -1214,7 +1220,7 @@ pub fn solid_volume(
     // does NOT catch boolean results that merely happen to have arc-bounded
     // planar faces (rounded-rect caps, arc-frame lips).
     if let Some(v) = analytic_revolution_solid_volume(topo, solid) {
-        if std::env::var("BK_VOL_TRACE").is_ok() {
+        if vol_trace_enabled() {
             log::debug!("VOL_TRACE revolution -> {v}");
         }
         return Ok(v);
@@ -1374,7 +1380,7 @@ fn volume_from_per_face_tessellation(
     for &fid in shell.faces() {
         let mesh = tessellate::tessellate(topo, fid, deflection)?;
         let idx = &mesh.indices;
-        if std::env::var("BK_VOL_TRACE").is_ok() {
+        if vol_trace_enabled() {
             log::debug!("VOL_TRACE direct plane face {fid:?} tris={}", idx.len() / 3);
         }
         let pos = &mesh.positions;
@@ -1498,7 +1504,7 @@ fn analytic_cylinder_signed_volume(
     let (sin1, cos1) = u1.sin_cos();
     let (sin2, cos2) = u2.sin_cos();
 
-    if std::env::var("BK_VOL_TRACE").is_ok() {
+    if vol_trace_enabled() {
         log::debug!(
             "VOL_TRACE cyl {face_id:?} u_vals={u_vals:?} u_range=({u1},{u2}) h={h} r={r} ox={ox} oy={oy}"
         );
@@ -2157,7 +2163,7 @@ pub fn volume_from_direct_face_tessellation(
         match face.surface() {
             FaceSurface::Cylinder(_) => {
                 let v = analytic_cylinder_signed_volume(topo, fid)? * 6.0;
-                if std::env::var("BK_VOL_TRACE").is_ok() {
+                if vol_trace_enabled() {
                     log::debug!("VOL_TRACE direct cyl face {:?} -> {}", fid, v / 6.0);
                 }
                 total += v;
@@ -2196,7 +2202,7 @@ pub fn volume_from_direct_face_tessellation(
             face_total += a.dot(b.cross(c));
         }
 
-        if std::env::var("BK_VOL_TRACE").is_ok() {
+        if vol_trace_enabled() {
             log::debug!(
                 "VOL_TRACE direct planar face {:?} -> {} (tris={})",
                 fid,

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -1463,10 +1463,14 @@ fn analytic_cylinder_signed_volume(
             // `EdgeCurve::Circle`. Sample its domain midpoint too, or a partial
             // (sub-2π) band has only its two endpoint angles, `compute_angular_range`
             // falls back to the full 2π, and the band over-counts (gh #968).
+            // Use the endpoint-trimmed sub-span: a boolean-split edge shares its
+            // parent curve, whose full-domain midpoint lies outside the edge and
+            // widens the angular range (gh #1499).
             if !edge.is_closed()
                 && let brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
             {
-                let (t0, t1) = nc.domain();
+                let (t0, t1) = edge.curve().domain_with_endpoints(sv.point(), ev.point());
                 let (u, _) = cyl.project_point(nc.evaluate(f64::midpoint(t0, t1)));
                 u_vals.push(u);
             }
@@ -1494,6 +1498,11 @@ fn analytic_cylinder_signed_volume(
     let (sin1, cos1) = u1.sin_cos();
     let (sin2, cos2) = u2.sin_cos();
 
+    if std::env::var("BK_VOL_TRACE").is_ok() {
+        log::debug!(
+            "VOL_TRACE cyl {face_id:?} u_vals={u_vals:?} u_range=({u1},{u2}) h={h} r={r} ox={ox} oy={oy}"
+        );
+    }
     let vol = (r / 3.0) * h * (ox * (sin2 - sin1) + oy * (-cos2 + cos1) + r * (u2 - u1));
 
     Ok(if face.is_reversed() { -vol } else { vol })
@@ -1749,11 +1758,13 @@ fn analytic_cone_signed_volume(
             }
             // Sample NURBS revolution-band arcs too (see the cylinder case, #968).
             // Skip an arc that degenerates to the apex (v ≈ 0), where u is
-            // undefined.
+            // undefined. Endpoint-trimmed sub-span for boolean-split edges
+            // sharing a parent curve (gh #1499).
             if !edge.is_closed()
                 && let brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) = edge.curve()
+                && let (Ok(sv), Ok(ev)) = (topo.vertex(edge.start()), topo.vertex(edge.end()))
             {
-                let (t0, t1) = nc.domain();
+                let (t0, t1) = edge.curve().domain_with_endpoints(sv.point(), ev.point());
                 let (u, v) = cone.project_point(nc.evaluate(f64::midpoint(t0, t1)));
                 if v.abs() > 1e-9 {
                     u_vals.push(u);
@@ -1997,7 +2008,7 @@ fn analytic_torus_signed_volume(
                         Some(circle.evaluate(mid_t))
                     }
                     brepkit_topology::edge::EdgeCurve::NurbsCurve(nc) => {
-                        let (t0, t1) = nc.domain();
+                        let (t0, t1) = edge.curve().domain_with_endpoints(sv.point(), ev.point());
                         Some(nc.evaluate(f64::midpoint(t0, t1)))
                     }
                     _ => None,
@@ -2185,6 +2196,14 @@ pub fn volume_from_direct_face_tessellation(
             face_total += a.dot(b.cross(c));
         }
 
+        if std::env::var("BK_VOL_TRACE").is_ok() {
+            log::debug!(
+                "VOL_TRACE direct planar face {:?} -> {} (tris={})",
+                fid,
+                face_total / 6.0,
+                tri_count
+            );
+        }
         total += face_total;
     }
 

--- a/crates/operations/src/tessellate/planar.rs
+++ b/crates/operations/src/tessellate/planar.rs
@@ -357,14 +357,23 @@ pub(super) fn tessellate_planar(
                 );
             }
             EdgeCurve::NurbsCurve(nurbs) => {
+                // Endpoint-trimmed convention (see `sample_edge`): a validated
+                // sub-span samples only the edge's own piece of a shared parent
+                // curve. Sampling the full knot domain traces the whole parent
+                // arc and drags the boundary through the split-away region —
+                // a cap wire then self-crosses and the CDT folds (gh #1499).
+                let sp = topo.vertex(edge.start())?.point();
+                let ep = topo.vertex(edge.end())?.point();
+                let (t0, t1) = edge.curve().domain_with_endpoints(sp, ep);
                 let (u0, u1) = nurbs.domain();
+                let is_subspan = (t0 - u0).abs() > 1e-12 || (t1 - u1).abs() > 1e-12;
                 let n_spans = nurbs
                     .control_points()
                     .len()
                     .saturating_sub(nurbs.degree())
                     .max(1);
                 let coarse_n = (n_spans * 4).clamp(8, 128);
-                let max_dev = measure_max_chord_deviation(nurbs, u0, u1, coarse_n);
+                let max_dev = measure_max_chord_deviation(nurbs, t0, t1, coarse_n);
                 #[allow(clippy::cast_sign_loss)]
                 let n_samples = if max_dev <= deflection {
                     coarse_n
@@ -372,12 +381,18 @@ pub(super) fn tessellate_planar(
                     ((coarse_n as f64) * (max_dev / deflection).sqrt()).ceil() as usize
                 }
                 .clamp(8, 4096);
-                let forward = oe.is_forward()
-                    != super::edge_sampling::nurbs_runs_end_to_start(topo, edge, nurbs)?;
+                // A sub-span is already endpoint-ordered (start→end); only a
+                // full-domain curve may run end→start.
+                let forward = if is_subspan {
+                    oe.is_forward()
+                } else {
+                    oe.is_forward()
+                        != super::edge_sampling::nurbs_runs_end_to_start(topo, edge, nurbs)?
+                };
                 #[allow(clippy::cast_precision_loss)]
                 sample_curve(
                     &|t| nurbs.evaluate(t),
-                    &|i| u0 + (u1 - u0) * (i as f64) / (n_samples as f64),
+                    &|i| t0 + (t1 - t0) * (i as f64) / (n_samples as f64),
                     n_samples,
                     forward,
                     &mut positions,


### PR DESCRIPTION
## Summary

Fixes the kernel side of #1499 (the kumiko corner cutter chain).

The reported symptom (`cutAll requires a solid, got compound`) traces to a kernel `cut` that wrongly threw `empty result: Cut with target fully contained in tool` for a wedge 3.4x larger than the strut cutting it. The brepjs adapter converts that empty-result error to an empty compound, which the next loop iteration feeds back into `cutAll`, which throws.

## Root 1: AABB-only containment fallback trusts inflated boxes

`detect_trivial_relation`'s no-classifier fallback claims containment from `aabb_strictly_contains` alone. The solid bounding box is a conservative outer bound: partial cylinder faces expand to the full circle, so a thin angular strut's box balloons to the whole cylinder footprint (±r squares) and strictly contains a much larger wedge's box in all three dims. The `center_outside` witness is disabled exactly here, because the wedge's AABB center sits in its own annular hole (the documented incompleteness).

Fix: a volume witness on that arm. `inner ⊆ outer ⇒ vol(inner) ≤ vol(outer)`, so `vol(inner) > 1.05·vol(outer)` refutes containment, and volumes are immune to AABB inflation. Gated behind the rare fallback arm, so no hot-path cost.

## Root 2: consumers reading the parent curve's domain on split edges

Boolean-split edges share their parent NURBS curve, with vertices marking the sub-span (`domain_with_endpoints` is the sanctioned accessor, and `sample_edge` already warns about this). Four consumers still read the parent extent:

- `analytic_cylinder_signed_volume`, `analytic_cone_signed_volume`, and the torus arm sampled `nc.domain()` midpoints, pushing angles outside the face and widening `compute_angular_range` (a 0.22-rad band integrated as 0.55 rad).
- `planar.rs`'s NURBS boundary sampling walked the full knot domain, dragging cap wires through the split-away region: self-crossed CDT input, folded triangles, sector caps over-counting area by 9-16%.

The result solids from cut/intersect of two annular wedges were geometrically correct all along (mesh signed volume matches closed form to 4 decimal places); only these measurements lied.

## Verification

- New regression `cut_wedge_by_thin_radial_strut_is_not_empty` with faithful geometry from the failing tool call (base vol 175.7, tool 52.1, tool box ⊋ base box by just over 10% in every dim): fails with EmptyResult before, passes with correct cut volume after.
- `cargo nextest run -p brepkit-operations`: 1037 passed.
- Full workspace suite green except the pre-existing GPU SIGSEGV in brepkit-render compute-mesh tests (fails identically on clean main in this sandbox).

Closes nothing on its own: #1499 also wants the adapter to accept compound bases (composability), which is a brepjs-side follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false empty cuts with thin revolved cutters by adding a volume-based check to the AABB-only containment fallback. Also fixes volume and planar tessellation errors by sampling NURBS edges using their endpoint-trimmed domain. Addresses the kernel side of #1499.

- **Bug Fixes**
  - Containment shortcut: add a volume witness that rejects fallback containment when `vol(inner) > 1.05 * vol(outer)`; avoids AABB inflation on partial cylinder/cone faces.
  - Volume integrals: in cylinder, cone, and torus paths, use `domain_with_endpoints` for boolean-split NURBS edges to prevent widened angular ranges and over-counted volumes.
  - Planar tessellation: sample only the edge’s sub-span and keep start→end ordering for sub-spans; prevents self-crossing cap wires and CDT folding. Adds regression `cut_wedge_by_thin_radial_strut_is_not_empty`.

- **Refactors**
  - Cache `BK_VOL_TRACE` via a process-level gate to avoid repeated env reads.
  - In the containment volume witness, compute a shared deflection once from the operands’ AABBs to reduce duplicate work.

<sup>Written for commit ad8636b303a07d32640aacaaf24d86aa6dd7a9cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

