### PR TITLE
perf(operations): spatial-hash the circle T-junction splice in solid tessellation

### DIFF
--- a/crates/io/examples/profile_export_tess.rs
+++ b/crates/io/examples/profile_export_tess.rs
@@ -1,0 +1,48 @@
+//! Profile export-tolerance tessellation on a captured tool solid (gh #1500).
+//!
+//! Usage: cargo run --release -p brepkit-io --example profile_export_tess -- <solid.bin> [deflection] [angular]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
+
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args.get(1).map_or("/tmp/perfbench/export-bin.bin", |s| s);
+    let deflection: f64 = args.get(2).map_or(0.01, |s| s.parse().unwrap());
+    let angular: f64 = args.get(3).map_or(5.0, |s| s.parse().unwrap());
+
+    let bytes = std::fs::read(path).unwrap();
+    let mut topo = brepkit_topology::Topology::new();
+    let solid = brepkit_io::arena_io::deserialize_solid(&bytes, &mut topo).unwrap();
+
+    let counts = brepkit_topology::explorer::solid_entity_counts(&topo, solid).unwrap();
+    println!(
+        "solid: faces={} edges={} vertices={}",
+        counts.0, counts.1, counts.2
+    );
+
+    for round in 0..3 {
+        let t = Instant::now();
+        let (mesh, offsets) =
+            brepkit_operations::tessellate::tessellate_solid_grouped_with_tolerance(
+                &topo, solid, deflection, angular,
+            )
+            .unwrap();
+        let mut h: u64 = 0;
+        for &i in &mesh.indices {
+            h = h.wrapping_mul(31).wrapping_add(u64::from(i));
+        }
+        for p in &mesh.positions {
+            for c in [p.x(), p.y(), p.z()] {
+                h = h.wrapping_mul(31).wrapping_add(c.to_bits());
+            }
+        }
+        println!(
+            "round {round}: {:.1}ms tris={} verts={} groups={} hash={h:x}",
+            t.elapsed().as_secs_f64() * 1e3,
+            mesh.indices.len() / 3,
+            mesh.positions.len(),
+            offsets.len()
+        );
+    }
+}

--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -175,6 +175,16 @@ fn tessellate_solid_core(
 
     let all_faces = explorer::solid_faces(topo, solid)?;
     let edge_face_map = explorer::edge_to_face_map(topo, solid)?;
+    let mut phase_t = std::time::Instant::now();
+    let phase = |label: &str, t: &mut std::time::Instant| {
+        if tess_phases() {
+            log::debug!(
+                "TESS_PHASE {label}: {:.1}ms",
+                t.elapsed().as_secs_f64() * 1e3
+            );
+        }
+        *t = std::time::Instant::now();
+    };
 
     // The map is a std `HashMap`, so sort its keys into ID order before use —
     // keeping all downstream iteration deterministic regardless of
@@ -231,6 +241,7 @@ fn tessellate_solid_core(
         map
     };
 
+    phase("edge_sampling", &mut phase_t);
     // Synchronize circle edge samples with face grid density so a face's rim
     // points line up with its own analytic grid columns.
     {
@@ -304,6 +315,7 @@ fn tessellate_solid_core(
         }
     }
 
+    phase("circle_sync", &mut phase_t);
     let mut merged = TriangleMesh::default();
     let mut point_to_global: DetHashMap<(i64, i64, i64), u32> = DetHashMap::default();
     let mut edge_global_indices: DetHashMap<usize, Vec<u32>> = DetHashMap::default();
@@ -324,9 +336,58 @@ fn tessellate_solid_core(
         edge_global_indices.insert(edge_idx, global_ids);
     }
 
+    phase("edge_weld_pool", &mut phase_t);
     {
         let tol_linear = brepkit_math::tolerance::Tolerance::new().linear;
         let refine_tol = tol_linear * 10.0;
+
+        // Spatial hash over the shared edge-point pool. The T-junction splice
+        // below must find every pool point lying ON each circle edge; scanning
+        // the whole pool per circle is O(circle-edges × pool-points) and
+        // dominated a 1274-face export tessellation at 90% of its wall clock
+        // (gh #1500). Instead, bucket the pool once and walk each circle at
+        // cell-sized arc steps, inspecting the 3×3×3 neighborhood of each
+        // visited cell — sound because a candidate sits within
+        // `refine_tol + step/2 ≤ cell` of some walked sample, so its cell
+        // index differs by at most 1 per axis.
+        let (grid_cell, point_grid) = {
+            let mut lo = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+            let mut hi = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+            for p in &merged.positions {
+                lo = Point3::new(lo.x().min(p.x()), lo.y().min(p.y()), lo.z().min(p.z()));
+                hi = Point3::new(hi.x().max(p.x()), hi.y().max(p.y()), hi.z().max(p.z()));
+            }
+            let diag = (hi - lo).length();
+            let cell = if diag.is_finite() && diag > 0.0 {
+                (diag / 128.0).max(refine_tol * 4.0)
+            } else {
+                refine_tol.max(1e-3)
+            };
+            let inv = 1.0 / cell;
+            let key = |p: &Point3| -> (i64, i64, i64) {
+                #[allow(clippy::cast_possible_truncation)]
+                (
+                    (p.x() * inv).floor() as i64,
+                    (p.y() * inv).floor() as i64,
+                    (p.z() * inv).floor() as i64,
+                )
+            };
+            let mut grid: DetHashMap<(i64, i64, i64), Vec<u32>> = DetHashMap::default();
+            for (gid, p) in merged.positions.iter().enumerate() {
+                #[allow(clippy::cast_possible_truncation)]
+                grid.entry(key(p)).or_default().push(gid as u32);
+            }
+            (cell, grid)
+        };
+        let grid_inv = 1.0 / grid_cell;
+        let cell_of = |p: &Point3| -> (i64, i64, i64) {
+            #[allow(clippy::cast_possible_truncation)]
+            (
+                (p.x() * grid_inv).floor() as i64,
+                (p.y() * grid_inv).floor() as i64,
+                (p.z() * grid_inv).floor() as i64,
+            )
+        };
 
         for &edge_idx in &edge_indices {
             let Some(edge_id) = topo.edge_id_from_index(edge_idx) else {
@@ -357,10 +418,34 @@ fn tessellate_solid_core(
                 .unwrap_or_default();
             let existing_gids: DetHashSet<u32> = existing_gids_vec.iter().copied().collect();
 
+            let candidates: Vec<u32> = {
+                let steps = ((std::f64::consts::TAU * circle.radius() * grid_inv).ceil() as usize)
+                    .clamp(8, 8192);
+                let mut visited: DetHashSet<(i64, i64, i64)> = DetHashSet::default();
+                let mut cand: Vec<u32> = Vec::new();
+                #[allow(clippy::cast_precision_loss)]
+                for i in 0..steps {
+                    let t = std::f64::consts::TAU * (i as f64) / (steps as f64);
+                    let (cx, cy, cz) = cell_of(&circle.evaluate(t));
+                    for dx in -1..=1_i64 {
+                        for dy in -1..=1_i64 {
+                            for dz in -1..=1_i64 {
+                                let c = (cx + dx, cy + dy, cz + dz);
+                                if visited.insert(c)
+                                    && let Some(gids) = point_grid.get(&c)
+                                {
+                                    cand.extend_from_slice(gids);
+                                }
+                            }
+                        }
+                    }
+                }
+                cand
+            };
+
             let mut insertions: Vec<(f64, u32)> = Vec::new();
-            for (gid, pos) in merged.positions.iter().enumerate() {
-                #[allow(clippy::cast_possible_truncation)]
-                let gid32 = gid as u32;
+            for gid32 in candidates {
+                let pos = &merged.positions[gid32 as usize];
                 if existing_gids.contains(&gid32) {
                     continue;
                 }
@@ -412,6 +497,7 @@ fn tessellate_solid_core(
         }
     }
 
+    phase("circle_refine_scan", &mut phase_t);
     // When tracking, `tri_faces` runs parallel to the mesh triangles:
     // tri_faces[t] is the index (into `all_faces`) of the face that produced
     // triangle t. The ungrouped caller skips this bookkeeping entirely.
@@ -504,6 +590,7 @@ fn tessellate_solid_core(
         other_face_indices.push(fi);
     }
 
+    phase("cdt_job_prep", &mut phase_t);
     #[cfg(not(target_arch = "wasm32"))]
     let cdt_results: Vec<CdtResult> = if cdt_jobs.len() >= 2 {
         use rayon::prelude::*;
@@ -523,6 +610,7 @@ fn tessellate_solid_core(
         .map(|job| run_planar_cdt(&job.pts2d, job.outer_count, &job.inner_wire_ranges))
         .collect();
 
+    phase("cdt_run", &mut phase_t);
     for (job, result) in cdt_jobs.iter().zip(cdt_results) {
         let (tris, steiner) = result?;
 
@@ -651,6 +739,7 @@ fn tessellate_solid_core(
         }
     }
 
+    phase("planar_stitch", &mut phase_t);
     for &fi in &other_face_indices {
         if let Err(e) = tessellate_face_with_shared_edges(
             topo,
@@ -672,6 +761,7 @@ fn tessellate_solid_core(
         }
     }
 
+    phase("other_faces", &mut phase_t);
     let n_verts = merged.positions.len();
     let tri_count = merged.indices.len() / 3;
 
@@ -757,6 +847,7 @@ fn tessellate_solid_core(
         }
     }
 
+    phase("normals", &mut phase_t);
     weld_boundary_vertices(&mut merged, deflection, tri_faces.as_mut());
 
     // Drop coincident/cancelling triangles left by booleans that
@@ -764,8 +855,16 @@ fn tessellate_solid_core(
     // positions so position-coincident triangles with distinct vertex IDs
     // are still caught.
     dedupe_coincident_triangles(&mut merged, tri_faces.as_mut());
+    phase("weld_dedupe", &mut phase_t);
 
     Ok((merged, tri_faces, all_faces.len()))
+}
+
+/// `BK_TESS_PHASES` (any value): log per-phase wall clock of the solid
+/// tessellation pipeline. Resolved once per process.
+fn tess_phases() -> bool {
+    static PHASES: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *PHASES.get_or_init(|| std::env::var("BK_TESS_PHASES").is_ok())
 }
 
 /// `BK_TESS_TRACE` (any value): log each face's mesher-arm dispatch.


### PR DESCRIPTION
## Summary

Kernel-side root of #1500's warm re-export gap.

Profiling the tool's export path (kernel-call attribution via a timing proxy) put the warm 1292ms at: `tessellateSolidGroupedBinary` 870ms, one surviving `fuseWithEvolution` 390ms, everything else ~35ms. Native profiling of the tessellation on a captured arena .bin of the fused 6x6x4 bin (1274 faces / 2784 edges, export tolerance 0.01 / angular 5) attributed 355ms of 395ms — 90% — to the circle T-junction splice: for every circle edge, the pipeline scanned the entire shared edge-point pool, projecting each point onto the circle. O(circle-edges × pool-points).

## Change

Bucket the pool once into a uniform spatial hash (cell = bbox diag / 128). Walk each circle at cell-sized arc steps, collecting candidates from the 3×3×3 neighborhood of visited cells, then run the unchanged per-point splice logic on the candidates only.

Soundness of the neighborhood bound: a pool point within `refine_tol` of the circle lies within `refine_tol + step/2 ≤ cell` of some walked sample, so its cell index differs from the sample's by at most one per axis. The candidate set therefore equals the full-scan set and the output is unchanged.

## Numbers (native, captured bin)

| | before | after |
|---|---|---|
| circle_refine_scan | 355ms | 8.4ms |
| whole tessellation | 395ms | 48ms |
| mesh hash | `eaf6a88ec9414b8c` | `eaf6a88ec9414b8c` (identical) |

Projected warm re-export: the 870ms wasm tessellation should drop to roughly 150-200ms, putting brepkit's warm total well under the reference's 948ms. Tool-side verification on the released kernel to follow (local wasm builds are blocked in this sandbox).

## Verification

- Mesh output hash-identical on the capture (indices + positions), tris/verts/groups unchanged.
- `cargo nextest run -p brepkit-operations` (1036), `-p brepkit-io -p brepkit-wasm` (489): all green.
- Also adds the `profile_export_tess` example (replays a captured arena .bin at export tolerance) and a `BK_TESS_PHASES` env gate logging per-phase wall clock — the instrumentation that found this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up solid tessellation by spatial‑hashing the circle‑edge T‑junction splice, replacing an O(edges*points) scan. On the captured bin: circle scan 355ms→8.4ms, whole tessellation 395ms→48ms; mesh output is identical and warm wasm tessellation should drop to ~150–200ms.

- **New Features**
  - Added `profile_export_tess` example to replay a captured solid at export tolerance.
  - Added `BK_TESS_PHASES` env flag to log per‑phase tessellation timings.

<sup>Written for commit 41fd70956900db427e0d9ca3cde7a26c5d685f00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

