### PR TITLE
fix(operations): make the tessellation phase timer a wasm no-op

### DIFF
--- a/crates/operations/src/tessellate/solid.rs
+++ b/crates/operations/src/tessellate/solid.rs
@@ -175,16 +175,8 @@ fn tessellate_solid_core(
 
     let all_faces = explorer::solid_faces(topo, solid)?;
     let edge_face_map = explorer::edge_to_face_map(topo, solid)?;
-    let mut phase_t = std::time::Instant::now();
-    let phase = |label: &str, t: &mut std::time::Instant| {
-        if tess_phases() {
-            log::debug!(
-                "TESS_PHASE {label}: {:.1}ms",
-                t.elapsed().as_secs_f64() * 1e3
-            );
-        }
-        *t = std::time::Instant::now();
-    };
+    let mut phase_t = PhaseTimer::start();
+    let phase = |label: &str, t: &mut PhaseTimer| t.lap(label);
 
     // The map is a std `HashMap`, so sort its keys into ID order before use —
     // keeping all downstream iteration deterministic regardless of
@@ -862,9 +854,45 @@ fn tessellate_solid_core(
 
 /// `BK_TESS_PHASES` (any value): log per-phase wall clock of the solid
 /// tessellation pipeline. Resolved once per process.
+#[cfg(not(target_arch = "wasm32"))]
 fn tess_phases() -> bool {
     static PHASES: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *PHASES.get_or_init(|| std::env::var("BK_TESS_PHASES").is_ok())
+}
+
+/// Per-phase wall-clock lap timer for `BK_TESS_PHASES` diagnostics.
+///
+/// `std::time::Instant::now()` PANICS on wasm32-unknown-unknown (no time
+/// source), and this runs inside every solid tessellation — the timer must
+/// compile to a no-op there (3.2.15 aborted every wasm solid tessellation
+/// through this call).
+struct PhaseTimer {
+    #[cfg(not(target_arch = "wasm32"))]
+    t: std::time::Instant,
+}
+
+impl PhaseTimer {
+    fn start() -> Self {
+        Self {
+            #[cfg(not(target_arch = "wasm32"))]
+            t: std::time::Instant::now(),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn lap(&mut self, label: &str) {
+        if tess_phases() {
+            log::debug!(
+                "TESS_PHASE {label}: {:.1}ms",
+                self.t.elapsed().as_secs_f64() * 1e3
+            );
+        }
+        self.t = std::time::Instant::now();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[allow(clippy::unused_self)]
+    fn lap(&mut self, _label: &str) {}
 }
 
 /// `BK_TESS_TRACE` (any value): log each face's mesher-arm dispatch.


### PR DESCRIPTION
## Summary

**Release regression in 3.2.15, wasm only.** The `BK_TESS_PHASES` lap timer added in #1502 calls `std::time::Instant::now()` unconditionally inside `tessellate_solid_core`, and `Instant::now()` panics on wasm32-unknown-unknown (no time source). On the released 3.2.15 wasm package every solid tessellation aborts with `RuntimeError: unreachable` — observed tool-side through `tessellateSolidGrouped` (exportCache) and through `compoundCut`'s containment volume witness (kumikoProfile). Native is unaffected, which is why the Rust suite and CI stayed green; the wasm CI job builds but does not execute.

The gridfinity tool still pins 3.2.13, so nothing consuming is broken; this needs to ship before any pin bump.

## Fix

The timer becomes a `PhaseTimer` struct whose `Instant` field and lap body compile only off-wasm, matching the existing `timer_now()` convention in `boolean/mod.rs` (same panic, same cure, documented there). Audited the workspace for other `Instant::now()` uses reachable from wasm: none (remaining hits are the cfg'd boolean timer, native tests, and native-only examples).

## Verification

- Repro chain: captured the panicking `compoundCut` operands from the tool (arena .bin), native replay succeeds — isolating the failure to a wasm-only difference; the only wasm-divergent code on the path is the timer.
- `cargo build -p brepkit-wasm --target wasm32-unknown-unknown`: clean.
- `cargo nextest run -p brepkit-operations` tessellation filter: 75 passed; clippy clean.
- Tool-side re-verification of kumikoProfile + exportCache on the released fix to follow (that loop is what caught this).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wasm-only crash by making the tessellation phase timer a no-op on `wasm32-unknown-unknown`. Restores solid tessellation by removing unconditional `Instant::now()` calls on wasm.

- **Bug Fixes**
  - Added `PhaseTimer`: uses `std::time::Instant` and logs only off-wasm; no-op on wasm.
  - Replaced inline timer in `tessellate_solid_core` with `PhaseTimer::start()` and `lap(...)`.
  - Gated `tess_phases()` behind non-wasm cfg; audited for other wasm-reachable `Instant::now()` calls — none.

<sup>Written for commit 23605bba3470547c04df8d6278857d46c60df09b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

