### PR TITLE
docs(roadmap): record the tool-side confirmation for #1510

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -141,12 +141,13 @@ One line each; the fixture/PR carries the story. Newest first.
   section on an arc-cornered holed face stopped a sagitta short of the boundary and could not
   separate the piece beyond it (the bin annulus's outer corner chord meets y=40.550 at 39.200
   where the arc meets it at 40.7495). 121 all-planar fallback faces in 34ms became 58 keeping all
-  8 cylinders in 11ms, watertight. Tool-side on released 3.2.18: the row went 1.60x SLOWER to
-  **1.74x faster** than the reference (104ms->39ms vs its 68ms), 1510->1072 triangles, and it is the
-  ONLY one of the 22 scenarios whose triangle count moved; brepkit reads 0 non-manifold edges where
+  8 cylinders in 11ms, watertight. Tool-side on released 3.2.18 the row moved from 1.60x slower than
+  the reference to 1.74x faster (104ms to 39ms against its 68ms) at 1510 to 1072 triangles, the only
+  one of the 22 scenarios whose triangle count moved; brepkit reads 0 non-manifold edges there where
   the reference reads 147. Fixture `crates/io/tests/labelbracket_fuse_inmem.rs`;
-  instruments `BK_SECEDGE` (per-face clipped section extents) and `BK_CLIPTRACE` (chord vs
-  true-arc crossings) — reach for those first when a section survives FF but the split is wrong.
+  instruments `BK_SECEDGE` (per-face clipped section extents) and `BK_CLIP` (chord vs true-arc
+  crossings, with 3D points) — reach for those first when a section survives FF but the split is
+  wrong.
 - **4x4 mag no-lip bin row (CLOSED 2026-08-09 at parity on 3.2.16, report #1510)** —
   396 vs 398ms in-suite, 393 vs 400ms cold median against a same-session reference run; moved by the
   #1502 splice spatial hash (magnet-hole-circle-heavy tessellation), no bin-targeted work involved.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -141,7 +141,10 @@ One line each; the fixture/PR carries the story. Newest first.
   section on an arc-cornered holed face stopped a sagitta short of the boundary and could not
   separate the piece beyond it (the bin annulus's outer corner chord meets y=40.550 at 39.200
   where the arc meets it at 40.7495). 121 all-planar fallback faces in 34ms became 58 keeping all
-  8 cylinders in 11ms, watertight. Fixture `crates/io/tests/labelbracket_fuse_inmem.rs`;
+  8 cylinders in 11ms, watertight. Tool-side on released 3.2.18: the row went 1.60x SLOWER to
+  **1.74x faster** than the reference (104ms->39ms vs its 68ms), 1510->1072 triangles, and it is the
+  ONLY one of the 22 scenarios whose triangle count moved; brepkit reads 0 non-manifold edges where
+  the reference reads 147. Fixture `crates/io/tests/labelbracket_fuse_inmem.rs`;
   instruments `BK_SECEDGE` (per-face clipped section extents) and `BK_CLIPTRACE` (chord vs
   true-arc crossings) — reach for those first when a section survives FF but the split is wrong.
 - **4x4 mag no-lip bin row (CLOSED 2026-08-09 at parity on 3.2.16, report #1510)** —


### PR DESCRIPTION
Closes the loop on #1510 with the scenario re-probe the roadmap makes mandatory after a GFA change.

On released 3.2.18 with stock pins and a same-session reference control, the 2x2 label bracket row went from 1.60x slower than the reference to **1.74x faster** (104ms to 39ms against its 68ms). It is the only one of the 22 scenarios whose triangle count moved, so the change is surgical.

The count dropping (1510 to 1072) is the analytic result rather than lost geometry, asserted rather than assumed: watertight, **0 non-manifold edges against the reference kernel's 147 on the same scenario**, volume within 0.03%, and an Euler characteristic that matches the plain 2x2 baseline exactly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update roadmap doc (`SKILL.md`) to record tool-side confirmation for #1510 and fix a stale instrument name. On 3.2.18, the 2x2 label bracket row improved from 104ms to 39ms (1.74x faster than the 68ms reference); triangles dropped 1510→1072 with watertight geometry and 0 non‑manifold edges (only scenario with a triangle-count change), and `BK_CLIPTRACE` is now `BK_CLIP`.

<sup>Written for commit 17bc27cea6e2f729888e2f11327a51f6c920f6d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

