### PR TITLE
fix(algo): cut a cylinder band at the ring sections, not only at the notch

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -27,7 +27,7 @@ rg -n -A2 '#\[ignore' crates/    # filter the doc-comment false hits by hand
 ```
 
 **Inventory status (2026-08-10): ONE deferred-defect pin.**
-`lidpost_fuse_inmem::lidpost_fuse_is_closed_and_analytic` (#1517, see OPEN). Every
+`compartscoop_fuse_inmem::compartscoop_fuse_is_closed` (#1517 root a, see OPEN). Every
 other `#[ignore]` is an explicit diagnostic or a slow-test marker. Known stale-but-harmless:
 the `profile_intersect.rs` box-sphere probes (box-sphere shipped analytic in #1006),
 `staircase_fuse_with_cylinders` (~2 min perf run), the two `#696` dovetail entries and
@@ -125,9 +125,8 @@ that does not exist yet; without it, stop.
 
 | Item | Status / next step |
 |---|---|
-| **Tool geometric parity: 137 failed / 2550 passed (#1517)** | First end-to-end head-to-head; prior green numbers for that suite were all on the REFERENCE kernel. Perf LEADS (0.69x aggregate, faster on 24/26, 0 non-manifold scenarios vs the reference's 5). Two roots carry the tail: (a) the compartments+scoop graze fuse behind ~45 non-watertight exports, (b) a `hashbrown` capacity-overflow panic behind 1 panic + 4 reentrancy. Count is post-brepjs#2012 (compound meshing); the #1517 opening comment quotes the earlier 152/2535. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` in the tool; refresh `.brepkit.snap` baselines first or ~110 stale counts masquerade as defects |
+| **Tool geometric parity: 137 failed / 2550 passed (#1517)** | First end-to-end head-to-head; prior green numbers for that suite were all on the REFERENCE kernel. Perf LEADS (0.69x aggregate, faster on 24/26, 0 non-manifold scenarios vs the reference's 5). Two roots carry the tail: (a) the compartments+scoop graze fuse behind ~45 non-watertight exports, and (b) the lid magnet-post fuse behind the panic and the timeouts (CLOSED, see below). Re-measure the tool suite on a release carrying the root-b fix before quoting the failure count again. Count is post-brepjs#2012 (compound meshing); the #1517 opening comment quotes the earlier 152/2535. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` in the tool; refresh `.brepkit.snap` baselines first or ~110 stale counts masquerade as defects |
 | **Compartments+scoop graze fuse (#1517 root a)** | ORIENTATION-dominant: raw GFA keeps the analytic faces (12 cone/22 cyl) but emits 123 unmatched directed half-edges and only 34 free edges. Divider ramp faces are SLANTED and graze the body's vertical wall within 0.034mm, against a staircase of 0.1mm sliver faces. Same class as the #1365-#1404 orientation campaign; `detect_same_domain` reports 7 within-rank duplicates (usually 0) but SD has been wrongly blamed before. Repro `crates/io/tests/compartscoop_fuse_inmem.rs` (~700ms) |
-| **Lid magnet-post corner fuse (#1517 root b): the crash AND the 14 timeouts** | ONE root, not two symptoms. The lid is a plate from z=-0.800 to 0 over the full outer profile with a pocket the size of the x=+-122/y=+-80 octagon milled up from z=-5.793 to a ceiling at z=-0.800 (read it from `dump_solid`; volume 44005.4 pins it). A post cylinder (r=4 at (-118.5,76.5), z=-2.8..-0.7) hangs in that pocket at a corner and pokes through both pocket walls. Raw GFA stays analytic (47 faces) but leaves **6 free edges**, the gate rejects (euler=-1), mesh fallback turns 44 exact faces into 305 flat ones, the next ~24 post fuses compound the blob to 8852 faces, call 248 never returns and the kernel aborts after ~12 min. **The classifications are all CORRECT; the SPLIT is wrong.** `BK_SUBFACE_BOX` + `BK_SUBFACE_WIRE`: the kept cylinder sub-face spans z=-2.800..-0.700, i.e. the two exposed sectors AND the full-circumference band that sits inside the plate, as one piece — not classification-uniform, and its interior sample lands at 150 deg in the exposed sliver, so the band is kept too. Mechanism, localized 2026-08-10: `BK_SECEDGE` shows the ceiling and the cylinder get the SAME correct three (exposed) arcs, so FF and the section set are exonerated; the defect is inside `split_face_2d` on the cylinder. `BK_SPLIT_TRACE=44` (u = worldAngle-90, v=height) shows the face's own boundary and the sections unwrapped into DIFFERENT PERIODS: the bottom rim runs u=270..630 anchored at the seam, the top rim runs u=270..-90, and the section verticals/horizontals sit in u=28.955..331.045, so three of the four wall verticals have their v=0 endpoints a full 360 from the rim vertices they are the same point as. The caps then land on the two arcs FF dropped instead of the three it kept, and the band stays welded to the exposed sectors. `u_periodic` IS true and `build_wire_loops` quantizes vertices with `quantize_uv_periodic(u_period=TAU)`, so CONNECTIVITY is already period-aware and the orphaned endpoints do rejoin mod 2pi — the failure is downstream of that: the walker under-splits, `STRACE-LOOP` reports only 2 loops (n=12 mixing both periods, n=4), and the 3 sub-faces come out of the post-loop region logic. So look at the angular successor / region extraction in `split_face_2d_impl` after `build_wire_loops`, NOT at FF, classification, selection, or vertex matching. Expect the full foil suite to matter — this is the calibrated wire builder The control post at the opposite corner carries the SAME wrong split and passes only because its band rides a sub-face that classifies Inside and is dropped — so it is the specification, not a discriminant. Repro `crates/io/tests/lidpost_fuse_inmem.rs` (**5ms**, ignored pin `lidpost_fuse_is_closed_and_analytic`, active control `lidpost_control_post_fuses_closed_and_analytic`). RED HERRING: `plane_internal_line_loops` logs 'not strictly interior' at 2.8e-14/8.9e-16/0, correct behaviour since those sections do touch the boundary. CDT constraint recovery was separately found unbounded and hardened in #1520, but it was not this root |
 | **Mesh-boolean fallback emits OPEN meshes that are CONSUMED** | A product call, not just a fix: rejecting means the op fails outright. Mitigation shipped: `boolean::mesh_fallback_count()` + wasm `meshFallbackCount()` let pipelines snapshot-and-refuse |
 | **Export angular default (5°) vs the reference's coarser effective default** | Tolerance-parity product choice, not mesher waste: 5° forces 18 segments/quarter-arc on r=0.6 slot corners, ~1.7x triangles vs reference at fine deflection. Revisit only as a product decision |
 | **Kumiko corner-window roots (4, documented)** | Unshipped; the parked branch `fix/kumiko-corner-window-cut` is GONE from the remote with its fixtures. Re-attempting means re-capturing fixtures first |
@@ -139,6 +138,21 @@ that does not exist yet; without it, stop.
 
 One line each; the fixture/PR carries the story. Newest first.
 
+- **Lid magnet-post corner fuse (CLOSED 2026-08-10, #1517 root b)** —
+  `split_cylinder_band_by_arrangement` reconstructed the cut from the vertical wall
+  generators alone, pairing them from the seam into removed rectangles, and used the ring
+  sections only to confirm the cut was rectilinear. That models a box notch, where the
+  removed sector is the only place a horizontal cut exists. A partner plane that ENDS
+  inside the band cuts the arcs where it still exists — the sectors the notch KEEPS — so
+  nothing capped them, and everything above stayed welded to the material below. The fix
+  feeds the ring sections in as horizontals, taking their u-range from the exact 3D
+  projection with the arc midpoint picking the side. The lid fuse went from 47 faces with
+  6 free edges (rejected, then a 305-face mesh blob compounding across ~24 later fuses,
+  the crash and the 14 timeouts) to 49 faces, 0 free, exact. Fixture
+  `crates/io/tests/lidpost_fuse_inmem.rs`, pin un-ignored. Instruments that cracked it:
+  `BK_SECEDGE` (exonerated FF — both faces get the same correct sections),
+  `BK_SUBFACE_BOX` + `BK_SUBFACE_WIRE` (the kept piece spanned the whole band height),
+  `BK_SPLIT_TRACE`.
 - **Point classifier counted holes as crossings (CLOSED 2026-08-10)** —
   `classify_point` (both the `check` and `operations` copies) tested a ray hit against the
   face's OUTER wire only, so a ray leaving through the mouth of a pocket counted the ring

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -3238,6 +3238,7 @@ fn split_cylinder_band_by_arrangement(
     // used only to confirm the cut is rectilinear; the removed rectangles are
     // reconstructed from the generators, whose u/v are exact projections.
     let mut sec_pieces: Vec<(f64, f64, f64)> = Vec::new(); // (u_shift, v_lo, v_hi)
+    let mut sec_rings: Vec<(f64, f64, f64)> = Vec::new(); // (v, u_lo, u_hi)
     for (i, e) in all_edges.iter().enumerate() {
         match &e.curve_3d {
             EdgeCurve::Line => {
@@ -3288,6 +3289,34 @@ fn split_cylinder_band_by_arrangement(
                     e.end_3d,
                     &mut verts,
                 );
+                // A ring section over a sector the generators do NOT bound is a
+                // real cut too: a partner plane that ends inside the band cuts
+                // the arcs where it still exists, not only the sector the tool
+                // removed. Reconstructing from the generator pairs alone leaves
+                // those arcs uncut, and everything above them stays welded to
+                // the material below (the lid magnet-post band, #1517).
+                if i >= n_boundary_edges {
+                    let (t0, t1) = e.curve_3d.domain_with_endpoints(e.start_3d, e.end_3d);
+                    let mid = e.curve_3d.evaluate_with_endpoints(
+                        0.5_f64.mul_add(t1 - t0, t0),
+                        e.start_3d,
+                        e.end_3d,
+                    );
+                    let (um, _) = proj(mid);
+                    let a = snap_u((u0 - u_s).rem_euclid(TAU));
+                    let b = snap_u((u1 - u_s).rem_euclid(TAU));
+                    let m = (um - u_s).rem_euclid(TAU);
+                    // Endpoints alone leave the arc's side ambiguous; the
+                    // midpoint picks it. An arc running the far way round the
+                    // seam is emitted as its two strip pieces.
+                    let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                    if m > lo && m < hi {
+                        sec_rings.push((v0p, lo, hi));
+                    } else {
+                        sec_rings.push((v0p, 0.0, lo));
+                        sec_rings.push((v0p, hi, TAU));
+                    }
+                }
             }
             EdgeCurve::Ellipse(_) | EdgeCurve::NurbsCurve(_) => return None,
         }
@@ -3329,6 +3358,7 @@ fn split_cylinder_band_by_arrangement(
         return None;
     }
 
+    let cov = 1e-6;
     let mut verticals: Vec<(f64, f64, f64)> = Vec::new(); // (u_shift, v_lo, v_hi)
     let mut horizontals: Vec<(f64, f64, f64)> = Vec::new(); // (v, u_lo, u_hi)
 
@@ -3355,11 +3385,18 @@ fn split_cylinder_band_by_arrangement(
         }
     }
 
+    // The ring sections themselves, over whatever sectors they actually cover.
+    // Rings at the rims are already the band frame.
+    for &(v, u_lo, u_hi) in &sec_rings {
+        if v > v_bottom + tol && v < v_top - tol && u_hi - u_lo > cov {
+            horizontals.push((v, u_lo, u_hi));
+        }
+    }
+
     // Rectilinear split: cut each vertical at every horizontal ring's v that its
     // span brackets (and whose u-range covers the generator), and each horizontal
     // at every vertical generator's u interior to its span (whose v-range reaches
     // the ring). Emit undirected sub-segments; dedup collapses duplicates.
-    let cov = 1e-6;
     let mut sub: Vec<((i64, i64), (i64, i64))> = Vec::new();
 
     for &(u, v0, v1) in &verticals {

--- a/crates/io/tests/lidpost_fuse_inmem.rs
+++ b/crates/io/tests/lidpost_fuse_inmem.rs
@@ -1,6 +1,6 @@
-//! Captured-operand READY-REPRO for the lid retention-magnet post fuse (#1517).
+//! Captured-operand regression for the lid retention-magnet post fuse (#1517).
 //!
-//! This one boolean is the root of the tool's runaway cluster: the crash the
+//! This one boolean was the root of the tool's runaway cluster: the crash the
 //! issue records as `Hash table capacity overflow` plus the 14 scenario
 //! timeouts. It reproduces in ~5ms here against ~12 minutes in the tool.
 //!
@@ -18,10 +18,10 @@
 //! call  248  fuse(blob, post) never returns
 //! ```
 //!
-//! So the runaway is not a loop with a missing exit: it is one boolean losing
-//! its analytic surfaces, and then two dozen more booleans paying compound
-//! interest on the debris. Fixing the fuse below removes the blob, and with it
-//! both the crash and the timeouts.
+//! So the runaway was not a loop with a missing exit: it was one boolean
+//! losing its analytic surfaces, and then two dozen more booleans paying
+//! compound interest on the debris. That fuse now returns
+//! F=49 mix=[(cone,4),(cylinder,19),(plane,26)] with 0 free edges.
 //!
 //! # The geometry
 //!
@@ -46,34 +46,27 @@
 //! 118.955..151.045 and the big sector 208.955..61.045 through the seam at 0.
 //! The other two are buried in the wall material.
 //!
-//! # What the correct fuse looks like, and where this one diverges
+//! # The root
 //!
-//! The control gives it exactly: 48 faces = the lid's 44, plus the post's
-//! cylinder split into its two exposed sectors, the ceiling split in two, and
-//! the post's bottom cap. The post's top cap and its z=-0.800..-0.700 band are
-//! both buried in the plate and are dropped.
+//! Both operands are clean, the FF sections are right, and every sub-face
+//! classification is right. What was wrong was the SPLIT, in
+//! `split_cylinder_band_by_arrangement`: it reconstructed the cut from the
+//! vertical wall generators alone, pairing them from the seam into removed
+//! rectangles, and used the ring sections only to confirm the cut was
+//! rectilinear. That models a box notch, where the removed sector is the only
+//! place a horizontal cut exists. Here the ceiling plane ends inside the band
+//! and cuts the arcs where it still exists — the two EXPOSED sectors — so
+//! nothing capped them at z=-0.800 and the band from there up to the post's
+//! z=-0.700 rim stayed welded to material that is outside the lid. The kept
+//! piece spanned z=-2.800..-0.700 and was not classification-uniform: its
+//! interior sample landed at 150 degrees in the exposed sliver, so it was kept
+//! and dragged the buried band along, leaving that band's rim and the arcs the
+//! two surfaces did not share as six free edges.
 //!
-//! Every classification here is right, and `BK_SUBFACE_BOX` shows it: the
-//! ceiling splits into three with the post's footprint correctly dropped, and
-//! the cylinder's two buried wall sectors are correctly dropped. The defect is
-//! the SPLIT. The kept cylinder sub-face spans z=-2.800..-0.700, so it is the
-//! two exposed sectors AND the full-circumference band that sits inside the
-//! plate, as one piece. That piece is not classification-uniform; its interior
-//! sample lands at 150 degrees in the exposed sliver, so the whole thing is
-//! kept and drags the buried band along. The six free edges are that band's
-//! z=-0.700 rim plus the arcs the two surfaces did not share.
-//!
-//! `BK_SUBFACE_WIRE` names the mechanism. The cylinder's split at z=-0.800
-//! uses the two arcs the FF phase DROPPED as sections (`BK_FF_DUMP`: "drop
-//! closed-circle arc ... outside face pair", midpoints at 90 and 180 degrees),
-//! and does NOT use the three it kept. The kept arcs go to the ceiling plane
-//! alone, which is why they come out free. So the open question is why the
-//! cylinder is split against the complement of the section set.
-//!
-//! The control differs only in where the band ends up. Its seam at 0 degrees
-//! falls in a BURIED sector (crossings 28.955, 331.045, 241.045, 298.955), so
-//! the band-carrying piece samples at 14.5 degrees inside the wall, classifies
-//! Inside, and is dropped with the band. Same wrong split, right answer.
+//! The control passed on the same wrong split for a reason worth keeping: its
+//! seam at 0 degrees falls in a BURIED sector (crossings 28.955, 331.045,
+//! 241.045, 298.955), so the band-carrying piece sampled at 14.5 degrees
+//! inside the wall, classified Inside, and was dropped along with the band.
 //!
 //! Note `plane_internal_line_loops` logs three "not strictly interior"
 //! rejections here at distances 2.8e-14, 8.9e-16 and exactly 0. Those look
@@ -196,14 +189,9 @@ fn lid_classifies_its_plate_solid_and_its_pocket_empty() {
     }
 }
 
-/// The defect: GFA keeps the analytic surfaces but leaves the post's arcs
-/// single-sided, so the gate rejects the result and the mesh fallback replaces
-/// 44 exact faces with hundreds of flat ones.
-///
-/// Un-ignore when the fuse closes. The assertions below are the acceptance
-/// bar, not a description of current behaviour.
+/// The fuse stays exact and closed, so nothing downstream ever reaches the
+/// mesh fallback that used to turn 44 faces into 305 and compound from there.
 #[test]
-#[ignore = "#1517: post straddling a lid corner leaves 6 free edges, forcing the mesh fallback"]
 fn lidpost_fuse_is_closed_and_analytic() {
     let mut topo = Topology::new();
     let lid = load("lidpost_fuse_lid.bin", &mut topo);


### PR DESCRIPTION
Closes the crash and the 14 scenario timeouts on #1517 (root b).

## The defect

A partner plane that *ends inside* a cylindrical band cuts the band's arcs where it still exists. `split_cylinder_band_by_arrangement` reconstructed the cut from the vertical wall generators alone — pairing them from the seam into removed rectangles — and used the ring sections only to confirm the cut was rectilinear. That models a box notch, where the removed sector is the only place a horizontal cut exists.

So the sectors the notch **keeps** were never capped, and everything above them stayed welded to the material below.

On the lid magnet-post fuse that meant one sub-face spanning the full band height, z=-2.800..-0.700 — the two exposed sectors *and* the full-circumference band that sits inside the lid plate, as one piece. Not classification-uniform: its interior sample landed at 150° in the exposed sliver, so the whole thing was kept, dragging a buried band along, and the band's rim plus the arcs the two surfaces did not share came out as six free edges.

That rejected the fuse (euler=-1), fell back to mesh, turned 44 exact faces into 305 flat ones, and the next ~24 post fuses compounded the blob to 8852 faces until call 248 never returned and the kernel aborted.

## The fix

The ring sections become horizontals too, with their u-range taken from the exact 3D projection (not the stored pcurve UV, which the function already distrusts) and the arc midpoint choosing which side of the endpoints the arc runs. An arc running the far way round the seam is emitted as its two strip pieces.

```
before   F=47  mix=[(cone,4),(cylinder,17),(plane,26)]  free=6   -> rejected -> 305-face mesh blob
after    F=49  mix=[(cone,4),(cylinder,19),(plane,26)]  free=0   exact, watertight
```

## What ruled out everything else

- `BK_SECEDGE` — the ceiling plane and the post cylinder are handed the *same* three arcs, and they are the correct exposed ones. FF and the section set exonerated.
- `BK_SUBFACE_BOX` — every sub-face classification is right.
- `BK_SUBFACE_WIRE` — the kept piece's wire caps the buried sectors at z=-0.800 and runs the seam from z=-2.800 straight to z=-0.700 with no vertex between.
- `build_wire_loops` already quantizes periodically, so vertex matching was not it either.

The control post at the opposite corner was passing on the same wrong split: its seam falls in a buried sector, so the band-carrying piece sampled inside the wall, classified Inside, and was dropped along with the band. It stays in the fixture as a guard, and its result is unchanged (48 faces, 0 free).

## Verification

- `crates/io/tests/lidpost_fuse_inmem.rs` pin **un-ignored**; the deferred-defect inventory is down to root (a) alone
- `cargo test --workspace --exclude brepkit-render --no-fail-fast`: **2740 passed, 0 failed** — the whole face-splitter foil set (d4 gridfinity, honeycomb, divider-lip, groove-mouth, junction-disc, cylinder-slot, a1corner) included
- `approx_census`: no new fallbacks
- clippy clean

Root (a), the compartments+scoop graze fuse, is a different mechanism and still fails — verified, and its pin stays.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cylinder band splitting by cutting at the ring sections, not just at the notch. This removes the 6 free edges in the lid magnet‑post fuse and eliminates the crash/timeouts in #1517 (root b).

- **Bug Fixes**
  - Updated `split_cylinder_band_by_arrangement` to treat ring sections as horizontals, using u‑ranges from exact 3D projection and the arc midpoint to pick the side; seam‑spanning arcs are split into two pieces.
  - Keeps the existing rectilinear split logic; only adds the missing ring-driven cuts inside the band.
  - Result: lid fuse goes from 47 faces / 6 free edges (mesh fallback cascade) to 49 faces / 0 free, exact and watertight. The previously ignored test pin is now active; no new fallbacks; full suite passes.

<sup>Written for commit 42c5c9ca364147eb3a5cec04043c1d0f9bea66b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

