### PR TITLE
fix(algo): cross a band's rim arcs when trimming a faceted-ramp section

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -26,9 +26,8 @@ The `#[ignore]` inventory is the load-bearing artifact. Before quoting any
 rg -n -A2 '#\[ignore' crates/    # filter the doc-comment false hits by hand
 ```
 
-**Inventory status (2026-08-10): ONE deferred-defect pin.**
-`compartscoop_fuse_inmem::compartscoop_fuse_is_closed` (#1517 root a, see OPEN). Every
-other `#[ignore]` is an explicit diagnostic or a slow-test marker. Known stale-but-harmless:
+**Inventory status (2026-08-10): ZERO deferred-defect pins.**
+Every remaining `#[ignore]` is an explicit diagnostic or a slow-test marker. Known stale-but-harmless:
 the `profile_intersect.rs` box-sphere probes (box-sphere shipped analytic in #1006),
 `staircase_fuse_with_cylinders` (~2 min perf run), the two `#696` dovetail entries and
 `diverge_first_cut` (print-only).
@@ -125,8 +124,7 @@ that does not exist yet; without it, stop.
 
 | Item | Status / next step |
 |---|---|
-| **Tool geometric parity: 137 failed / 2550 passed (#1517)** | First end-to-end head-to-head; prior green numbers for that suite were all on the REFERENCE kernel. Perf LEADS (0.69x aggregate, faster on 24/26, 0 non-manifold scenarios vs the reference's 5). Two roots carry the tail: (a) the compartments+scoop graze fuse behind ~45 non-watertight exports, and (b) the lid magnet-post fuse behind the panic and the timeouts (CLOSED, see below). Re-measure the tool suite on a release carrying the root-b fix before quoting the failure count again. Count is post-brepjs#2012 (compound meshing); the #1517 opening comment quotes the earlier 152/2535. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` in the tool; refresh `.brepkit.snap` baselines first or ~110 stale counts masquerade as defects |
-| **Compartments+scoop graze fuse (#1517 root a)** | Raw GFA keeps the analytic faces (12 cone/22 cyl) but leaves 34 free edges (over=0), so the gate rejects and the mesh fallback emits an OPEN shell behind ~45 non-watertight exports. Re-measured 2026-08-10, unchanged by #1526/#1530. All 34 sit in the two FRONT CORNERS, 17 per side and exact mirror images, where BOTH operands carry a chorded scoop front wall and those walls are COINCIDENT — that is the source of the 7 within-rank SD duplicates, and it is visible directly: body Id(120)/divider Id(165), Id(121)/Id(164), Id(122)/Id(163) (mirrored Id(137)/Id(166), Id(138)/Id(167)) receive IDENTICAL `BK_SECEDGE` and `BK_CLIP` lines. MECHANISM (2026-08-10): the body's corner is a cylinder Id(101) (z=1.200..**13.300**) topped by a cone Id(80) (z=13.300..14.700), and divider facet Id(121) (z=12.879..13.912) STRADDLES that junction. `phase_ff`'s mutual-overlap trim — including its exact v-window clip against a banded partner — is gated on `if !matches!(raw.curve, EdgeCurve::Line) { return Some(raw); }`, so a plane cutting a cylinder at an angle keeps its FULL ellipse (`BK_FF_DUMP` bb z=-7.67..23.22). It is then clipped to the FACET's boundary instead of the cylinder's, landing at z=13.912 — 0.612 past the cylinder's own top — so the two faces bound the same region along different curves. FIRST ATTEMPT (reverted, see the #1517 thread): the conic band clip DOES close the 0.687mm gap, but the edges stay free — the partner cylinder face still does not keep the matching curve, so this is one of at least two problems. Two traps: keeping the longest in-band run gives 34->27 free but over 0->2, because a conic that re-enters the band must become TWO curves and the trim sits in a `filter_map`; and trimming only the unambiguous single-run case gives 34->**36**, worse than baseline, which points at the sinusoid sampling — `phase_ff` has two `evaluate` conventions in play (`ParametricCurve::evaluate` vs `evaluate_with_endpoints`) and `RawCurve::t_range` follows the former. VERIFY THE CONVENTION BEFORE WRITING ANY CONIC TRIM. `clip_line_to_face_boundary` is NOT involved (every `BK_CLIP` call is at the inner divider walls x=+-0.400). The old 'ORIENTATION-dominant / 123 unmatched half-edges' framing came from a pass that predates the #1525 classifier fix — re-derive it before relying on it. Repro `crates/io/tests/compartscoop_fuse_inmem.rs` (42ms raw fuse) |
+| **Tool geometric parity: 137 failed / 2550 passed (#1517)** | First end-to-end head-to-head; prior green numbers for that suite were all on the REFERENCE kernel. Perf LEADS (0.69x aggregate, faster on 24/26, 0 non-manifold scenarios vs the reference's 5). Both roots are now CLOSED (see below): (a) the compartments+scoop graze fuse behind ~45 non-watertight exports, and (b) the lid magnet-post fuse behind the panic and the timeouts. NEXT STEP IS MEASUREMENT, not more digging — run the tool suite against a release carrying both before quoting any failure count. Count is post-brepjs#2012 (compound meshing); the #1517 opening comment quotes the earlier 152/2535. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` in the tool; refresh `.brepkit.snap` baselines first or ~110 stale counts masquerade as defects |
 | **Mesh-boolean fallback emits OPEN meshes that are CONSUMED** | A product call, not just a fix: rejecting means the op fails outright. Mitigation shipped: `boolean::mesh_fallback_count()` + wasm `meshFallbackCount()` let pipelines snapshot-and-refuse |
 | **Export angular default (5°) vs the reference's coarser effective default** | Tolerance-parity product choice, not mesher waste: 5° forces 18 segments/quarter-arc on r=0.6 slot corners, ~1.7x triangles vs reference at fine deflection. Revisit only as a product decision |
 | **Kumiko corner-window roots (4, documented)** | Unshipped; the parked branch `fix/kumiko-corner-window-cut` is GONE from the remote with its fixtures. Re-attempting means re-capturing fixtures first |
@@ -138,6 +136,23 @@ that does not exist yet; without it, stop.
 
 One line each; the fixture/PR carries the story. Newest first.
 
+- **Compartments+scoop graze fuse (CLOSED 2026-08-10, #1517 root a)** —
+  a thin planar tread meeting a corner cylinder takes a dedicated path,
+  `trim_ellipse_to_boundary_crossings`, because the in-both arc is a sub-millimetre
+  sliver the generic sampled filters drop. It crossed only `EdgeCurve::Line` boundary
+  edges, so it split the section at the tread's boundary lines and the analytic face's
+  SEAM lines but never at its RIM arcs. Nothing split the section where the band ends,
+  and the single over-long arc kept its midpoint inside the extent's boundary margin, so
+  the whole thing survived: tread and cylinder then bounded the same region along curves
+  0.687mm apart and the shell came back open (34 free edges, ~45 non-watertight exports).
+  Crossing the rim arcs too splits it at the rim and the existing midpoint test drops the
+  rest — no keep/drop logic changed. 178 faces, 12 cone / 24 cyl, 0 free. Fixture
+  `crates/io/tests/compartscoop_fuse_inmem.rs`, pin un-ignored. REFUTED on the way: the
+  "orientation-dominant / 145 same-sense pairs" framing (predated the #1525 classifier
+  fix), same-domain (the coincident scoop walls are real but not the cause), and
+  `clip_line_to_face_boundary`. Also refuted: adding a conic band clip in the FF
+  mutual-overlap trim — it closes the gap but the edges stay free, because the section
+  never reached that clip at all. `BK_RESTRICT=1` is what showed the bypass.
 - **Lid magnet-post corner fuse (CLOSED 2026-08-10, #1517 root b)** —
   `split_cylinder_band_by_arrangement` reconstructed the cut from the vertical wall
   generators alone, pairing them from the seam into removed rectangles, and used the ring
@@ -429,7 +444,9 @@ One line each; the fixture/PR carries the story. Newest first.
   received-10x-above is a defect.
 - **Durable native probes/instruments** (env-gated, grep for them before writing new
   ones): `BK_FF_DUMP` / `BK_FF_TRACE` / `BK_RAWC` (phase_ff), `BK_SD_SETS`
-  (same_domain), `BK_OPEN_SHELL` / `BK_SHELLS` (builder_solid shell grouping),
+  (same_domain), `BK_RESTRICT` (phase_ff — the in-both window each section is trimmed to, and
+  crucially whether a section reached that clip at all: a special-case emitter that bypasses
+  it looks exactly like a window computed wrong), `BK_OPEN_SHELL` / `BK_SHELLS` (builder_solid shell grouping),
   `BK_SUBFACE_SRC` / `BK_SUBFACE_BOX` (builder — note BOX tests face VERTICES only) and
   `BK_SUBFACE_WIRE` (adds each sub-face's wire with per-edge curve MIDPOINTS, the only way
   to tell a short arc from the long one sharing its endpoints on a periodic wall),

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -2361,11 +2361,15 @@ fn circle_arc_plane_crossings(
     if amp <= 1e-12 {
         return Vec::new(); // circle parallel to the plane (or lying in it)
     }
+    // A tangency lands exactly on |ratio| = 1, where rounding can put it a
+    // hair outside and drop a real (doubled) crossing. Admit the epsilon band
+    // and clamp before `acos`; the duplicate root the tangent case yields is
+    // collapsed by the caller's dedup.
     let ratio = -c / amp;
-    if ratio.abs() > 1.0 {
+    if ratio.abs() > 1.0 + 1e-9 {
         return Vec::new();
     }
-    let (phase, delta) = (b.atan2(a), ratio.acos());
+    let (phase, delta) = (b.atan2(a), ratio.clamp(-1.0, 1.0).acos());
 
     // Arc membership: the shorter way round from the start vertex to the end
     // vertex, which is how every downstream consumer reads an open circle edge.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1288,6 +1288,11 @@ fn restrict_curves_to_faces(
     };
 
     const N: usize = 24;
+    // `BK_RESTRICT=1`: the in-both window each section is trimmed to. Reports
+    // whether a curve reached this clip at all, which is what separates "the
+    // window was computed wrong" from "a special-case path emitted the section
+    // and skipped the clip entirely".
+    let trace_restrict = std::env::var("BK_RESTRICT").is_ok();
     let mut out = Vec::with_capacity(raw_curves.len());
     for raw in raw_curves {
         // Lines are clipped downstream by `clip_line_to_face`; only the
@@ -1353,6 +1358,13 @@ fn restrict_curves_to_faces(
         // back via the curve's periodic parameterization).
         let closed = (raw.p_start - raw.p_end).length() < 1e-7;
         let (b0, b1) = longest_inboth_run(&inb, closed);
+        if trace_restrict {
+            log::debug!(
+                "RESTRICT fa={fa:?} fb={fb:?} kind={} closed={closed} b0={b0} b1={b1} N={N} inb={}",
+                raw.curve.type_tag(),
+                inb.iter().filter(|v| **v).count()
+            );
+        }
         // An in-both run spanning fewer than two segments (b1-b0 < 2, i.e. at
         // most two consecutive in-both samples) is a tangency/grazing point —
         // such a curve never splits either face, so drop it.
@@ -2203,18 +2215,35 @@ fn trim_ellipse_to_boundary_crossings(
             let Ok(edge) = topo.edge(oe.edge()) else {
                 continue;
             };
-            if !matches!(edge.curve(), EdgeCurve::Line) {
-                continue;
-            }
             let Ok(sv) = topo.vertex(edge.start()) else {
                 continue;
             };
             let Ok(ev) = topo.vertex(edge.end()) else {
                 continue;
             };
-            if let Some(p) = line_segment_plane_crossing(sv.point(), ev.point(), *plane_n, *plane_d)
-            {
-                push_crossing(p, &mut crossings);
+            match edge.curve() {
+                EdgeCurve::Line => {
+                    if let Some(p) =
+                        line_segment_plane_crossing(sv.point(), ev.point(), *plane_n, *plane_d)
+                    {
+                        push_crossing(p, &mut crossings);
+                    }
+                }
+                // The band's RIM is where the face ends, exactly as its seam
+                // is. Without a crossing here the arc is never split at the
+                // rim, and one over-long arc reaching past it can still have
+                // its midpoint inside the extent's boundary margin — so the
+                // whole thing is kept and the two faces end up bounding the
+                // same region along different curves (#1517 root a: a corner
+                // cylinder ending at z=13.300 kept a section to z=13.912).
+                EdgeCurve::Circle(c) => {
+                    for p in
+                        circle_arc_plane_crossings(c, sv.point(), ev.point(), *plane_n, *plane_d)
+                    {
+                        push_crossing(p, &mut crossings);
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -2299,6 +2328,66 @@ fn trim_ellipse_to_boundary_crossings(
     }
 
     if arcs.is_empty() { None } else { Some(arcs) }
+}
+
+/// Crossings of a circular boundary ARC with the plane `normal·p = d`.
+///
+/// `normal·evaluate(t)` is a sinusoid in the circle's own parameter, so three
+/// evaluations pin it exactly and the crossings are a closed-form
+/// `a cos t + b sin t = c` solve. Points outside the arc actually spanned by
+/// `[sp, ep]` are discarded; a closed edge (coincident endpoints) spans all of
+/// it. The caller re-validates every point against the section curve, so a
+/// spurious root cannot survive.
+fn circle_arc_plane_crossings(
+    circle: &brepkit_math::curves::Circle3D,
+    sp: Point3,
+    ep: Point3,
+    normal: Vec3,
+    d: f64,
+) -> Vec<Point3> {
+    use std::f64::consts::{FRAC_PI_2, PI, TAU};
+
+    let f = |t: f64| -> f64 {
+        let p = circle.evaluate(t);
+        normal
+            .x()
+            .mul_add(p.x(), normal.y().mul_add(p.y(), normal.z() * p.z()))
+            - d
+    };
+    let (f0, fq, fp) = (f(0.0), f(FRAC_PI_2), f(PI));
+    let c = 0.5 * (f0 + fp);
+    let (a, b) = (0.5 * (f0 - fp), fq - c);
+    let amp = a.hypot(b);
+    if amp <= 1e-12 {
+        return Vec::new(); // circle parallel to the plane (or lying in it)
+    }
+    let ratio = -c / amp;
+    if ratio.abs() > 1.0 {
+        return Vec::new();
+    }
+    let (phase, delta) = (b.atan2(a), ratio.acos());
+
+    // Arc membership: the shorter way round from the start vertex to the end
+    // vertex, which is how every downstream consumer reads an open circle edge.
+    let closed = (sp - ep).length() < 1e-9;
+    let ts = circle.project(sp).rem_euclid(TAU);
+    let te = circle.project(ep).rem_euclid(TAU);
+    let fwd = (te - ts).rem_euclid(TAU);
+    let (arc_lo, arc_span) = if fwd <= PI {
+        (ts, fwd)
+    } else {
+        (te, TAU - fwd)
+    };
+
+    let mut out = Vec::new();
+    for root in [phase + delta, phase - delta] {
+        let t = root.rem_euclid(TAU);
+        if !closed && (t - arc_lo).rem_euclid(TAU) > arc_span + 1e-9 {
+            continue;
+        }
+        out.push(circle.evaluate(t));
+    }
+    out
 }
 
 /// Crossing of a line SEGMENT `[sp, ep]` with the plane `normal·p = d`.

--- a/crates/io/tests/compartscoop_fuse_inmem.rs
+++ b/crates/io/tests/compartscoop_fuse_inmem.rs
@@ -2,10 +2,11 @@
 //!
 //! This one boolean is the root of the tool's largest parity cluster: ~45
 //! "export mesh is not watertight" failures across unrelated features. The
-//! chain is `fuse(scooped bin body, compartment divider assembly)` ->  GFA is
+//! chain was `fuse(scooped bin body, compartment divider assembly)` ->  GFA
 //! rejected -> `operations::boolean` pays for the mesh fallback -> the fallback
 //! emits an OPEN shell (650 all-planar faces, 4 free edges) -> every downstream
-//! op and the export inherit it.
+//! op and the export inherit it. The fuse now returns 178 faces,
+//! 12 cone / 24 cylinder / 142 plane, 0 free edges.
 //!
 //! Both operands are well-formed going in, which is what makes this a genuine
 //! engine defect rather than a poisoned capture:
@@ -15,11 +16,26 @@
 //! B: F=110 mix=[(plane,110)]                          free=0 over=0 vol=9471.817
 //! ```
 //!
-//! Raw GFA on those produces 34 boundary edges, 145 shared edges with
-//! inconsistent face orientations, and Euler -5. The orientation count is the
-//! striking part: 145 same-sense pairs on a fuse whose inputs are both clean
-//! points at the assembler's face-orientation emission rather than at the
-//! intersection phases.
+//! # The root
+//!
+//! The body's front corner is a cylinder (z=1.200..**13.300**) topped by a
+//! cone, and the divider's chorded scoop wall has a facet spanning
+//! z=12.879..13.912 — so the facet straddles that junction.
+//!
+//! A thin planar tread meeting a corner cylinder takes a dedicated path,
+//! `trim_ellipse_to_boundary_crossings`, because the in-both arc is a
+//! sub-millimetre sliver the generic sampled filters drop. That path split the
+//! section at the tread's boundary lines and at the analytic face's SEAM
+//! lines, but not at its RIM arcs — it only crossed `EdgeCurve::Line` boundary
+//! edges. So nothing split the section at z=13.300 where the cylinder ends,
+//! and the single over-long arc reaching to z=13.912 kept its midpoint
+//! (z~13.40) inside the extent's 0.121 boundary margin, so the whole thing
+//! survived. The tread then bounded the region along one curve and the
+//! cylinder along another, 0.687mm apart on the tread's top edge, and the
+//! shell came back open.
+//!
+//! Crossing the rim arcs too splits the section at z=13.300, and the existing
+//! midpoint test drops the piece above it with no other change.
 //!
 //! Bisection from the tool: compartments alone and scoop alone both export
 //! watertight; only the combination fails. The sibling cluster (0.4mm walls,
@@ -88,7 +104,6 @@ fn compartscoop_operands_are_well_formed() {
 }
 
 #[test]
-#[ignore = "#1517: fuse(scooped body, dividers) emits 34 free edges and 145 same-sense pairs, forcing the mesh fallback that opens the export"]
 fn compartscoop_fuse_is_closed() {
     let mut topo = Topology::new();
     let body = load("compartscoop_fuse_body.bin", &mut topo);


### PR DESCRIPTION
Closes the last root on #1517 (root a) — the ~45 non-watertight exports.

## The defect

A thin planar tread meeting a corner cylinder takes a dedicated path, `trim_ellipse_to_boundary_crossings`, because the in-both arc is a sub-millimetre sliver that the generic sampled filters drop. That path collects exact crossings from the tread's boundary lines and from the analytic face's **seam** lines — but its loop over the analytic face's boundary reads

```rust
if !matches!(edge.curve(), EdgeCurve::Line) { continue; }
```

so it never crosses the band's **rim** arcs, which is where the face actually ends.

On the compartments+scoop fuse the body's front corner is a cylinder ending at z=13.300 and the divider's chorded scoop wall has a facet spanning z=12.879..13.912, straddling that junction. Nothing split the section at z=13.300, and the single over-long arc reaching to z=13.912 kept its midpoint (z≈13.40) inside the extent's 0.121 boundary margin — so the whole thing survived. The tread then bounded the region along one curve and the cylinder along another, **0.687mm apart** on the tread's top edge, and the shell came back open.

## The fix

Cross the rim arcs too. `normal·evaluate(t)` is a sinusoid in the circle's own parameter, so three evaluations pin it exactly and the crossings are a closed-form `a cos t + b sin t = c` solve; points outside the arc actually spanned by the edge are discarded, and the caller re-validates every crossing against the section curve.

That splits the section at the rim, and **the existing midpoint test drops the piece beyond it** — no keep/drop logic changed.

```
before   F=176  free=34  (rejected -> mesh fallback -> 650 all-planar faces, open shell)
after    F=178  mix=[(cone,12),(cylinder,24),(plane,142)]  free=0  over=0
```

## Refuted along the way

- **"Orientation-dominant, 145 same-sense pairs"** — that framing predated the #1525 classifier fix and did not survive re-derivation.
- **Same-domain** — the coincident scoop walls are real (three face pairs receive identical section lists, which is where the 7 within-rank duplicates come from), but they are not what leaves the boundary open.
- **`clip_line_to_face_boundary`** — every one of its calls is at the inner divider walls.
- **Adding a conic band clip to the FF mutual-overlap trim** (my first attempt, in the issue thread) — it does close the 0.687mm gap, but the edges stay free, because the section never reaches that clip at all. `BK_RESTRICT=1`, added here, is what showed the bypass: no trace line ever appeared for the pair.

## Verification

- `compartscoop_fuse_inmem::compartscoop_fuse_is_closed` **un-ignored** — the deferred-defect `#[ignore]` inventory is now **zero**
- `cargo test --workspace --exclude brepkit-render --no-fail-fast`: **2741 passed, 0 failed**, full face-splitter foil set included
- `approx_census`: no new fallbacks
- clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes faceted-ramp section trimming by crossing rim arcs so sections split at the analytic face boundary and the shell closes. Also handles rim tangencies robustly. Resolves the ~45 non‑watertight exports reported in #1517.

- **Bug Fixes**
  - `trim_ellipse_to_boundary_crossings` now crosses rim `EdgeCurve::Circle` arcs, not just boundary lines and seams.
  - Added closed-form plane/arc solve `circle_arc_plane_crossings`, discarding points outside the spanned arc.
  - Admits rim-arc tangency by clamping the acos input (epsilon band) to avoid dropping real doubled crossings.
  - Fuse result: 178 faces (12 cone / 24 cylinder / 142 plane), 0 free edges.

- **New Features**
  - `BK_RESTRICT=1` debug trace to log the in-both clip window and whether a section reached the clip.

<sup>Written for commit fd29315c247df3bb8eb90f22dc2df6b1699ee931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

