### PR TITLE
fix(algo): span a rim arc the way the kernel defines it, not the short way

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -2371,22 +2371,23 @@ fn circle_arc_plane_crossings(
     }
     let (phase, delta) = (b.atan2(a), ratio.clamp(-1.0, 1.0).acos());
 
-    // Arc membership: the shorter way round from the start vertex to the end
-    // vertex, which is how every downstream consumer reads an open circle edge.
+    // Arc membership follows the kernel's one convention for an open circular
+    // edge (`EdgeCurve::domain_with_endpoints`): the CCW span from the start
+    // vertex to the end vertex, which is routinely a MAJOR arc. Reading it as
+    // the shorter way round instead is wrong in both directions — it drops
+    // real crossings on the arc AND invents them on the complement, and an
+    // invented crossing splits a section where no face boundary exists.
     let closed = (sp - ep).length() < 1e-9;
-    let ts = circle.project(sp).rem_euclid(TAU);
-    let te = circle.project(ep).rem_euclid(TAU);
-    let fwd = (te - ts).rem_euclid(TAU);
-    let (arc_lo, arc_span) = if fwd <= PI {
-        (ts, fwd)
-    } else {
-        (te, TAU - fwd)
+    let ts = circle.project(sp);
+    let span = {
+        let fwd = (circle.project(ep) - ts).rem_euclid(TAU);
+        if fwd < 1e-12 { TAU } else { fwd }
     };
 
     let mut out = Vec::new();
     for root in [phase + delta, phase - delta] {
         let t = root.rem_euclid(TAU);
-        if !closed && (t - arc_lo).rem_euclid(TAU) > arc_span + 1e-9 {
+        if !closed && (t - ts).rem_euclid(TAU) > span + 1e-9 {
             continue;
         }
         out.push(circle.evaluate(t));
@@ -5105,6 +5106,57 @@ mod tests {
             ])
         };
         (mk(a), mk(b))
+    }
+
+    fn unit_circle_xy() -> brepkit_math::curves::Circle3D {
+        // `new` picks u_axis from a derived frame; pin it to +X so the test can
+        // name parameters and points interchangeably.
+        brepkit_math::curves::Circle3D::new_with_ref(
+            Point3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            1.0,
+            Vec3::new(1.0, 0.0, 0.0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn major_rim_arc_crosses_its_own_span_not_the_complement() {
+        // A rim arc is an ordinary major arc whenever the band keeps more than
+        // half its circumference. Reading it as the shorter way round fails in
+        // both directions at once, so one plane pins both: y = -0.5 meets the
+        // unit circle at 210° and 330°, and a CCW edge from 0° to 270° spans
+        // the first and not the second.
+        let circle = unit_circle_xy();
+        let hits = circle_arc_plane_crossings(
+            &circle,
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, -1.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            -0.5,
+        );
+        assert_eq!(hits.len(), 1, "got {hits:?}");
+        let expected = circle.evaluate(std::f64::consts::PI * 7.0 / 6.0);
+        assert!(
+            (hits[0] - expected).length() < 1e-9,
+            "crossing landed on the complement: {:?}",
+            hits[0]
+        );
+    }
+
+    #[test]
+    fn minor_rim_arc_still_discards_the_crossing_beyond_it() {
+        // The guard the span check exists for: the same plane, but an edge
+        // that really does stop short of either root.
+        let circle = unit_circle_xy();
+        let hits = circle_arc_plane_crossings(
+            &circle,
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 1.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            -0.5,
+        );
+        assert!(hits.is_empty(), "got {hits:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes the two deterministic open shells on #1538.

## The defect

`circle_arc_plane_crossings`, added in #1534 so a faceted-ramp section is split at a band's rim, decided which part of the circle a boundary edge covers by taking the **shorter way round** between its vertices.

The kernel has one definition of that and it is not this one. `EdgeCurve::domain_with_endpoints` (`crates/topology/src/edge.rs:85`) reads an open circle edge as the **CCW span from start vertex to end vertex**:

```rust
let a0 = c.project(start);
let delta = (c.project(end) - a0).rem_euclid(TAU);
(a0, a0 + delta)
```

That is a major arc whenever a band keeps more than half its circumference, which is the common case, not the exotic one.

On a major arc the two readings are exact complements, so the predicate does not merely lose crossings — it **swaps the accept and reject sets**. It discards the crossings that lie on the edge and returns ones that lie where the edge never goes.

That direction is the damaging one. A missing crossing reproduces the pre-#1534 behaviour: the section stays over-long. A returned crossing splits the section at a point that **no face boundary passes through**, and the existing midpoint keep/drop test then discards a piece that should have been kept. The result is free edges — the 16- and 20-boundary-edge open shells reported on #1538.

## The fix

Use the kernel's span. Three lines.

## Verification

The regression pins both halves with a single plane: `y = -0.5` meets the unit circle at 210° and 330°, and a CCW edge from 0° to 270° spans the first and not the second. Reverted to the old logic the test reports

```
crossing landed on the complement: Position([0.866, -0.500, 0.0])
```

— the 330° point, with the real 210° one dropped.

- `cargo test --workspace --exclude brepkit-render --no-fail-fast`: **2744 passed, 0 failed**
- The full face-splitter foil set is in that run, including the three fixtures #1530 and #1534 were written for: `compartscoop_fuse_is_closed`, `lidpost_fuse_is_closed_and_analytic`, `labelbracket_fuse_closes_the_back_wall` — all still close.

## Not covered here

#1538 also lists two timeouts and a triangle-count change. The open-shell to mesh-fallback cascade is a plausible route to those timeouts, but I have not measured it tool-side, so I am not claiming them. The issue stays open for that half.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rim-arc span to match the kernel’s rule (CCW from start to end), not the short way. This corrects plane/circle crossing selection, preventing false splits and closing the two deterministic open shells in #1538.

- **Bug Fixes**
  - Use the kernel’s `EdgeCurve::domain_with_endpoints` span (CCW start→end), treating near-zero as a full circle.
  - Check roots against that span; handle closed arcs correctly.
  - Add regression tests for major and minor rim arcs to prove correct crossing selection.

<sup>Written for commit e30c57b2293fe00762c4997e28a207ac1c952d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

