### PR TITLE
fix(measure): count cavity shells in volume, area and centre of mass

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -124,9 +124,9 @@ that does not exist yet; without it, stop.
 
 | Item | Status / next step |
 |---|---|
-| **Tool geometric parity (#1517)** | MEASURED 2026-08-10 on released 3.2.22, stock pins, same-day same-catalog control. Generator suite 272 files / 2693 tests: **3.2.18 154 failed, 3.2.22 144 failed**; excluding stale per-kernel snapshots that is **153 -> 130 real**. The issue's old "137 failed / 2550 passed" DOES NOT REPRODUCE (3.2.18 measures 154 today) — the catalog grew, so only a same-day control is trustworthy. Head-to-head matrix: perf **0.63x** aggregate, faster on 24/26, **all 26 closed with 0 non-manifold** vs the reference's 5. Remaining 144 by class: 34 open-shell, **19 compound-capability (#1537, the biggest single lever — drives the ~48-test text cluster)**, 15 timeout, 14 stale snapshot, 12 non-manifold, 2 reentrancy. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` |
-| **#1538 regressions from the band-split fixes** | 2 deterministic open shells (compartments+insert 16 bnd, solid-mode cutout 20 bnd) + 2 timeouts + 1 triangle-count invariant, all introduced between 3.2.18 and 3.2.22. Suspects #1530/#1534. Next step is operand capture + `replay_pair`, NOT another tool run |
-| **#1536 slotted no-lip loses its cavity** | volume 135221 vs the reference's 43129 (3.13x, 92% of its own bbox) yet CLOSED and MANIFOLD, so every watertightness gate passes and only volume catches it. Pre-existing (identical on 3.2.18). Sibling scenarios agree to 0.02% |
+| **Tool geometric parity (#1517)** | MEASURED 2026-08-10 on released 3.2.22, stock pins, same-day same-catalog control. Generator suite 272 files / 2693 tests: **3.2.18 154 failed, 3.2.22 144 failed**; excluding stale per-kernel snapshots that is **153 -> 130 real**. The issue's old "137 failed / 2550 passed" DOES NOT REPRODUCE (3.2.18 measures 154 today) — the catalog grew, so only a same-day control is trustworthy. Head-to-head matrix: perf **0.63x** aggregate, faster on 24/26, **all 26 closed with 0 non-manifold** vs the reference's 5. Remaining 144 by class: 34 open-shell, **19 compound-capability (#1537 — 17 of them are the tool's stale `brepjs` pin at 18.124.2, fixed in brepjs 18.124.7; only the 2 compound-base `fuse` calls are a live gap, and it is brepjs-side)**, 15 timeout, 14 stale snapshot, 12 non-manifold, 2 reentrancy. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` |
+| **#1538 regressions from the band-split fixes** | Open-shell half CLOSED by #1540 (see Closed). Still open: 2 timeouts + 1 triangle-count invariant. The open-shell to mesh-fallback cascade is a plausible route to the timeouts but is NOT measured; #1530's ring-section horizontals are the other suspect (3.2.21 was already slow). Next step is a tool-side re-measure on a kernel carrying #1540, NOT another native dig |
+| **#1536 slotted no-lip loses its cavity** | LOCALIZED 2026-08-10 to the BODY OPERAND, not the fuse and not the measurement. `cavity_probe` on `slotted_nolip_body.bin`: outer shell +111351 (99.8% of its bbox), inner shell **-5263 against a 98783 bbox — 5.3% fill**. The cavity is present and correctly signed, it just encloses nothing; a correct one is ~-92000, exactly the 135237-vs-43129 gap. So GFA and every volume oracle are exonerated (per-shell sum, `oriented_solid_volume` and the fixture's own recorded numbers all agree). Next step is capturing one stage EARLIER than `crates/io/tests/data/slotted_nolip_body.bin` — the shell/cut chain that builds the body |
 | **Mesh-boolean fallback emits OPEN meshes that are CONSUMED** | A product call, not just a fix: rejecting means the op fails outright. Mitigation shipped: `boolean::mesh_fallback_count()` + wasm `meshFallbackCount()` let pipelines snapshot-and-refuse |
 | **Export angular default (5°) vs the reference's coarser effective default** | Tolerance-parity product choice, not mesher waste: 5° forces 18 segments/quarter-arc on r=0.6 slot corners, ~1.7x triangles vs reference at fine deflection. Revisit only as a product decision |
 | **Kumiko corner-window roots (4, documented)** | Unshipped; the parked branch `fix/kumiko-corner-window-cut` is GONE from the remote with its fixtures. Re-attempting means re-capturing fixtures first |
@@ -138,6 +138,17 @@ that does not exist yet; without it, stop.
 
 One line each; the fixture/PR carries the story. Newest first.
 
+- **Rim-arc crossings took the short way round (CLOSED 2026-08-10, #1540, the #1538 open shells)** —
+  `circle_arc_plane_crossings` (added by #1534) decided which part of a circle a
+  boundary edge covers by taking the SHORTER way between its vertices. The kernel has
+  one definition and it is not that: `EdgeCurve::domain_with_endpoints` reads an open
+  circle edge as the CCW span start->end, a MAJOR arc whenever a band keeps more than
+  half its circumference. On a major arc the two readings are complements, so the
+  predicate swaps its accept and reject sets — it drops the crossings on the edge and
+  returns ones where the edge never goes. The invented crossing is the damaging half:
+  it splits a section where no face boundary passes, and the existing midpoint test then
+  drops a piece that should have been kept. Regressions
+  `phase_ff::tests::{major,minor}_rim_arc_*`. Durable lesson in Recurring traps.
 - **Compartments+scoop graze fuse (CLOSED 2026-08-10, #1517 root a)** —
   a thin planar tread meeting a corner cylinder takes a dedicated path,
   `trim_ellipse_to_boundary_crossings`, because the in-both arc is a sub-millimetre
@@ -347,6 +358,20 @@ One line each; the fixture/PR carries the story. Newest first.
 
 ## Recurring traps (the distilled, expensive lessons)
 
+- **A circular edge has ONE canonical span and it is not the short one.**
+  `EdgeCurve::domain_with_endpoints` is the CCW range from start vertex to end vertex,
+  routinely a major arc. Any new "which part of the circle does this edge cover" test
+  must call it or reproduce it exactly (#1540). Taking the short way does not merely
+  lose crossings, it invents them on the complement.
+- **A whole-solid volume cannot tell a MISSING cavity from a COLLAPSED one** — both read
+  high by the same amount. Print per-shell signed volume against each shell's own bbox
+  (`cargo run --release --example cavity_probe -p brepkit-io`) before blaming either the
+  boolean or the measurement (#1536).
+- **Measurement and tessellation walk different face sets.** Tessellation uses
+  `explorer::solid_faces` (outer + inner shells) so the MESH is complete, while several
+  volume/area/CoM paths walked `outer_shell()` alone — closed, manifold and correctly
+  bounded, with the cavity silently absent from the number. Fixed for volume, area and
+  centre of mass; when adding a solid-scoped measurement, use `solid_faces`.
 - **Marched/fitted section geometry is good to ~1e-6; every exact-tol (1e-7) gate it
   meets needs a weld-scale (100·tol) band.** Four separate gaps in one family were this.
 - **A sampled proxy gated at an exactness tolerance** is the single most common defect

--- a/crates/check/src/properties/mod.rs
+++ b/crates/check/src/properties/mod.rs
@@ -48,7 +48,7 @@ pub fn bounding_box(topo: &Topology, solid: SolidId) -> Result<Aabb3, CheckError
 /// Compute the volume of a solid via face integration.
 ///
 /// Uses the divergence theorem: V = (1/3) sum of integral P dot N dA
-/// over all faces of the outer shell.
+/// over every face of the solid, cavity shells included.
 ///
 /// # Errors
 ///
@@ -58,11 +58,8 @@ pub fn solid_volume(
     solid: SolidId,
     options: &PropertiesOptions,
 ) -> Result<f64, CheckError> {
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total_volume = 0.0;
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let contrib = face_integrator::integrate_face(topo, fid, options.gauss_order)?;
         total_volume += contrib.volume;
     }
@@ -71,7 +68,7 @@ pub fn solid_volume(
 
 /// Compute the total surface area of a solid.
 ///
-/// Sums the area of each face in the solid's outer shell.
+/// Sums the area of every face of the solid, cavity shells included.
 ///
 /// # Errors
 ///
@@ -81,11 +78,8 @@ pub fn solid_area(
     solid: SolidId,
     options: &PropertiesOptions,
 ) -> Result<f64, CheckError> {
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total_area = 0.0;
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let contrib = face_integrator::integrate_face(topo, fid, options.gauss_order)?;
         total_area += contrib.area;
     }
@@ -107,15 +101,12 @@ pub fn center_of_mass(
     solid: SolidId,
     options: &PropertiesOptions,
 ) -> Result<Point3, CheckError> {
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total_volume = 0.0;
     let mut mx = 0.0;
     let mut my = 0.0;
     let mut mz = 0.0;
 
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let contrib = face_integrator::integrate_face(topo, fid, options.gauss_order)?;
         total_volume += contrib.volume;
         mx += contrib.volume_moment_x;

--- a/crates/io/examples/cavity_probe.rs
+++ b/crates/io/examples/cavity_probe.rs
@@ -1,0 +1,107 @@
+//! Per-shell signed volume of a captured solid.
+//!
+//! A whole-solid volume cannot distinguish "the cavity is missing from the
+//! measurement" from "the cavity is in the measurement but encloses nothing".
+//! Both read high by the same amount. This prints each shell separately with
+//! its face count, bounding box and signed divergence volume, which separates
+//! them: compare a shell's signed volume against the volume of its own bbox.
+//!
+//! ```sh
+//! cargo run --release --example cavity_probe -p brepkit-io -- <name.bin> ...
+//! ```
+//!
+//! Names resolve against `crates/io/tests/data`; absolute paths are used as-is.
+//! With no arguments it reads the #1536 slotted no-lip operands, where the body
+//! reports `inner0 signed=-5263` against a bbox of ~98800 — the cavity is there,
+//! correctly signed, and hollow by only 5% of the space it spans.
+#![allow(clippy::print_stdout, clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+use brepkit_io::arena_io::deserialize_solid;
+use brepkit_math::aabb::Aabb3;
+use brepkit_math::vec::Point3;
+use brepkit_topology::Topology;
+use brepkit_topology::shell::ShellId;
+use brepkit_topology::solid::SolidId;
+
+const DEFLECTION: f64 = 0.05;
+
+fn shell_signed_volume(topo: &Topology, shell: ShellId, defl: f64) -> (f64, Aabb3, usize) {
+    let origin = Point3::new(0.0, 0.0, 0.0);
+    let mut total = 0.0;
+    let mut pts = Vec::new();
+    let faces = topo.shell(shell).unwrap().faces().to_vec();
+    for fid in &faces {
+        let mesh = brepkit_operations::tessellate::tessellate(topo, *fid, defl).unwrap();
+        let (idx, pos) = (&mesh.indices, &mesh.positions);
+        for t in 0..idx.len() / 3 {
+            let a = pos[idx[t * 3] as usize];
+            let b = pos[idx[t * 3 + 1] as usize];
+            let c = pos[idx[t * 3 + 2] as usize];
+            total += (a - origin).dot((b - origin).cross(c - origin));
+            pts.extend_from_slice(&[a, b, c]);
+        }
+    }
+    (total / 6.0, Aabb3::from_points(pts), faces.len())
+}
+
+fn report(topo: &Topology, sid: SolidId, name: &str) {
+    let sd = topo.solid(sid).unwrap();
+    println!("{name}");
+    let mut sum = 0.0;
+    let shells = std::iter::once(("outer".to_string(), sd.outer_shell())).chain(
+        sd.inner_shells()
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| (format!("inner{i}"), s)),
+    );
+    for (label, shell) in shells {
+        let (v, bb, n) = shell_signed_volume(topo, shell, DEFLECTION);
+        sum += v;
+        let d = bb.max - bb.min;
+        let bbox_vol = d.x() * d.y() * d.z();
+        println!(
+            "  {label:<7} faces={n:<4} signed={v:>12.1}  bbox_vol={bbox_vol:>12.1}  fill={:>5.1}%",
+            if bbox_vol > 0.0 {
+                100.0 * v.abs() / bbox_vol
+            } else {
+                0.0
+            }
+        );
+    }
+    println!("  shell sum             = {sum:>12.1}");
+    println!(
+        "  oriented_solid_volume = {:>12.1}",
+        brepkit_operations::measure::oriented_solid_volume(topo, sid, DEFLECTION).unwrap()
+    );
+    println!(
+        "  measure::solid_volume = {:>12.1}",
+        brepkit_operations::measure::solid_volume(topo, sid, DEFLECTION).unwrap()
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "slotted_nolip_body.bin".to_string(),
+            "slotted_socket_assembly.bin".to_string(),
+        ]
+    } else {
+        args
+    };
+
+    let mut topo = Topology::new();
+    for name in &names {
+        let path = if Path::new(name).is_absolute() {
+            PathBuf::from(name)
+        } else {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/data")
+                .join(name)
+        };
+        let sid = deserialize_solid(&std::fs::read(&path).unwrap(), &mut topo).unwrap();
+        report(&topo, sid, name);
+    }
+}

--- a/crates/io/examples/cavity_probe.rs
+++ b/crates/io/examples/cavity_probe.rs
@@ -43,7 +43,14 @@ fn shell_signed_volume(topo: &Topology, shell: ShellId, defl: f64) -> (f64, Aabb
             pts.extend_from_slice(&[a, b, c]);
         }
     }
-    (total / 6.0, Aabb3::from_points(pts), faces.len())
+    // A shell whose faces all tessellate to nothing still has a signed volume
+    // and a face count worth printing, so an empty point set is a zero bbox
+    // rather than a panic.
+    let bb = Aabb3::try_from_points(pts).unwrap_or(Aabb3 {
+        min: origin,
+        max: origin,
+    });
+    (total / 6.0, bb, faces.len())
 }
 
 fn report(topo: &Topology, sid: SolidId, name: &str) {

--- a/crates/operations/src/measure/volume.rs
+++ b/crates/operations/src/measure/volume.rs
@@ -784,6 +784,11 @@ fn try_analytic_solid_volume(topo: &Topology, solid: SolidId) -> Option<f64> {
     use std::f64::consts::PI;
 
     let solid_data = topo.solid(solid).ok()?;
+    // A closed-form primitive formula describes the outer shell alone, so a
+    // solid carrying a cavity has to go the long way round.
+    if !solid_data.inner_shells().is_empty() {
+        return None;
+    }
     let shell = topo.shell(solid_data.outer_shell()).ok()?;
 
     let mut sphere_r: Option<f64> = None;
@@ -1279,16 +1284,14 @@ pub fn solid_volume(
     // use direct per-face tessellation with signed-volume summation.
     // tessellate() handles face reversal (flips winding + normals), so raw
     // signed tets are correct even without a globally watertight mesh.
-    let needs_direct_tessellation = {
-        let s = topo.solid(solid)?;
-        let sh = topo.shell(s.outer_shell())?;
-        sh.faces().iter().any(|&fid| {
+    let needs_direct_tessellation = brepkit_topology::explorer::solid_faces(topo, solid)?
+        .into_iter()
+        .any(|fid| {
             topo.face(fid).is_ok_and(|f| {
                 !f.inner_wires().is_empty()
                     || (f.is_reversed() && !matches!(f.surface(), FaceSurface::Plane { .. }))
             })
-        })
-    };
+        });
     if needs_direct_tessellation {
         return volume_from_direct_face_tessellation(topo, solid, deflection);
     }
@@ -1373,11 +1376,8 @@ fn volume_from_per_face_tessellation(
     solid: SolidId,
     deflection: f64,
 ) -> Result<f64, crate::OperationsError> {
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total: f64 = 0.0;
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let mesh = tessellate::tessellate(topo, fid, deflection)?;
         let idx = &mesh.indices;
         if vol_trace_enabled() {
@@ -2152,11 +2152,8 @@ pub fn volume_from_direct_face_tessellation(
     solid: SolidId,
     deflection: f64,
 ) -> Result<f64, crate::OperationsError> {
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total: f64 = 0.0;
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let face = topo.face(fid)?;
 
         // Use exact analytical volume for analytic surface faces.
@@ -2235,13 +2232,10 @@ pub fn solid_volume_from_faces(
     use brepkit_topology::edge::EdgeCurve;
     use brepkit_topology::face::FaceSurface;
 
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total = 0.0;
     let mut all_planar_triangles = true;
 
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let face = topo.face(fid)?;
 
         // Only use the fast path for planar faces with exactly 3 line edges.
@@ -2314,15 +2308,12 @@ pub fn solid_center_of_mass(
 
     // tessellate() already handles face reversal (flips winding),
     // so signed tetrahedra sum is correct without winding heuristics.
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total_vol: f64 = 0.0;
     let mut cx = 0.0;
     let mut cy = 0.0;
     let mut cz = 0.0;
 
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let mesh = tessellate::tessellate(topo, fid, deflection)?;
         let idx = &mesh.indices;
         let pos = &mesh.positions;
@@ -2371,15 +2362,12 @@ fn center_of_mass_from_faces(
     use brepkit_topology::edge::EdgeCurve;
     use brepkit_topology::face::FaceSurface;
 
-    let solid_data = topo.solid(solid)?;
-    let shell = topo.shell(solid_data.outer_shell())?;
-
     let mut total_vol = 0.0;
     let mut cx = 0.0;
     let mut cy = 0.0;
     let mut cz = 0.0;
 
-    for &fid in shell.faces() {
+    for fid in brepkit_topology::explorer::solid_faces(topo, solid)? {
         let face = topo.face(fid)?;
         if !matches!(face.surface(), FaceSurface::Plane { .. }) {
             return Err(crate::OperationsError::InvalidInput {
@@ -2438,6 +2426,70 @@ mod regression_tests {
     use super::*;
     use brepkit_topology::builder::{make_face_from_wire, make_polygon_wire};
     use brepkit_topology::face::FaceSurface;
+
+    /// A fully enclosed void makes the cavity a SEPARATE inner shell, which a
+    /// volume path walking `outer_shell()` alone silently skips — the result is
+    /// closed, manifold and correctly bounded, so only the volume shows it.
+    #[test]
+    fn enclosed_cavity_is_subtracted_from_solid_volume() {
+        use brepkit_math::mat::Mat4;
+
+        let mut topo = Topology::new();
+        let outer = crate::primitives::make_box(&mut topo, 40.0, 40.0, 10.0).unwrap();
+        // Off-centre on every axis, so the cavity moves the centre of mass too
+        // and a CoM that ignores it cannot pass by symmetry.
+        let void = crate::primitives::make_box(&mut topo, 20.0, 20.0, 4.0).unwrap();
+        crate::transform::transform_solid(&mut topo, void, &Mat4::translation(5.0, 5.0, 2.0))
+            .unwrap();
+        let hollow =
+            crate::boolean::boolean(&mut topo, crate::boolean::BooleanOp::Cut, outer, void)
+                .unwrap();
+
+        assert_eq!(
+            topo.solid(hollow).unwrap().inner_shells().len(),
+            1,
+            "the enclosed void must come back as an inner shell"
+        );
+
+        let v = solid_volume(&topo, hollow, 0.05).unwrap();
+        assert!(
+            (v - 14_400.0).abs() < 1.0,
+            "40x40x10 minus an enclosed 20x20x4 void is 14400, got {v}"
+        );
+
+        // The tessellating paths are reached whenever the analytic ones above
+        // decline, so they need the cavity too — they are not a slower route to
+        // the same answer if they integrate a different set of faces.
+        let direct = volume_from_direct_face_tessellation(&topo, hollow, 0.05).unwrap();
+        assert!(
+            (direct - 14_400.0).abs() < 1.0,
+            "direct face tessellation must see the cavity, got {direct}"
+        );
+
+        // `check` measures the same solid through its own accumulator.
+        let opts = brepkit_check::properties::PropertiesOptions::default();
+        let checked = brepkit_check::properties::solid_volume(&topo, hollow, &opts).unwrap();
+        assert!(
+            (checked - 14_400.0).abs() < 1.0,
+            "check::properties must see the cavity, got {checked}"
+        );
+
+        // 16000 at (20,20,5) minus 1600 at (15,15,4).
+        let com = solid_center_of_mass(&topo, hollow, 0.05).unwrap();
+        let want = Point3::new(20.555_555, 20.555_555, 5.111_111);
+        assert!(
+            (com - want).length() < 1e-3,
+            "centre of mass must shift with the cavity, got {com:?}"
+        );
+
+        // Surface area is the whole boundary, cavity walls included:
+        // 2*40*40 + 4*40*10 = 4800 outside, 2*20*20 + 4*20*4 = 1120 inside.
+        let area = brepkit_check::properties::solid_area(&topo, hollow, &opts).unwrap();
+        assert!(
+            (area - 5920.0).abs() < 1.0,
+            "surface area must include the cavity walls, got {area}"
+        );
+    }
 
     fn unit_square_extrude_volume() -> (f64, bool) {
         let mut topo = Topology::new();


### PR DESCRIPTION
## The defect

Tessellation walks `explorer::solid_faces` — outer shell plus inner (cavity) shells. Seven measurement paths walked `outer_shell()` alone, so they integrated a **different set of faces than the mesh they claim to describe**.

That combination is why it is silent. The mesh of a hollow solid is complete: closed, manifold, correctly bounded. Every watertightness, manifold and bbox gate passes. Only the number is wrong, and it is wrong by exactly the cavity.

## Proof

A 40×40×10 box with an enclosed, off-centre 20×20×4 void:

```
volume_from_direct_face_tessellation  ->  16000     (answer: 14400)
```

The plain `solid_volume` entry point happened to be right, which is what makes this easy to miss — an analytic fast path above already used `solid_faces`, so a naive box-with-a-void probe reports no bug. The tessellating paths beneath are reached by anything those fast paths decline, which includes **any solid with an inner wire on a face**.

## Fixed

`operations::measure::volume`
- `volume_from_direct_face_tessellation`, `volume_from_per_face_tessellation`, `solid_volume_from_faces`
- both centre-of-mass paths (`solid_center_of_mass` and `center_of_mass_from_faces`)
- the `needs_direct_tessellation` predicate, which decided from outer-shell faces only
- `try_analytic_solid_volume` now declines a solid with inner shells outright — a closed-form primitive formula describes the outer shell alone

`check::properties`
- `solid_volume`, `solid_area`, `center_of_mass`

Surface area now includes cavity walls, which is the boundary integral its own doc comment describes.

The regression asserts volume, direct-tessellation volume, `check::properties` volume, centre of mass and surface area on one solid. The void is off-centre on every axis so the CoM assertion cannot pass by symmetry.

## New probe

`cargo run --release --example cavity_probe -p brepkit-io -- [<name.bin> ...]`

Reports per-shell signed volume against **each shell's own bounding box**. That ratio is the thing a whole-solid volume cannot give you: a cavity missing from the measurement and a cavity present but enclosing nothing both read high by the same amount.

## On #1536 — this is not that root

I found this while investigating #1536 and it is worth being explicit that it does not close it. Run on the captured operand:

```
slotted_nolip_body.bin
  outer   faces=10   signed=    111351.3  bbox_vol=    111556.0  fill= 99.8%
  inner0  faces=46   signed=     -5263.1  bbox_vol=     98783.0  fill=  5.3%
  shell sum             =     106088.2
  oriented_solid_volume =     106088.2
```

The cavity is present, correctly signed, and included — it just encloses nothing. A correct one is about −92000, which is exactly the gap between brepkit's 135237 and the reference's 43129. Per-shell sum, `oriented_solid_volume` and the fixture's own recorded numbers all agree to the digit, so GFA and every volume oracle are exonerated. #1536 stays open against the chain that builds the body operand, one stage earlier than the capture.

## Verification

- `cargo test --workspace --exclude brepkit-render --no-fail-fast`: **2745 passed, 0 failed**
- roadmap skill updated: #1536 row re-pointed at the operand, #1538 row split, three new entries under Recurring traps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes volume, area, and center-of-mass to include cavity shells so measurements match tessellation and are correct for hollow solids. Adds `cavity_probe` to report per-shell signed volume and now handles shells that tessellate to nothing.

- **Bug Fixes**
  - All measurement paths now iterate `brepkit_topology::explorer::solid_faces` (outer + inner shells) in `brepkit_operations` and `brepkit_check`.
  - Updated paths: direct/per-face tessellation volume, `solid_volume_from_faces`, both CoM paths, and `check::properties::{solid_volume, solid_area, center_of_mass}`.
  - `try_analytic_solid_volume` declines solids with inner shells; primitive formulas describe only the outer shell.
  - The “needs direct tessellation” predicate inspects all faces, not just the outer shell.
  - Regression: box-with-void — volume subtracts the cavity, area includes cavity walls, CoM shifts.

- **New Features**
  - New `crates/io` example `cavity_probe`: prints per-shell signed volume and each shell’s bbox volume to distinguish missing vs collapsed cavities. Usage: `cargo run --release --example cavity_probe -p brepkit-io -- <name.bin> ...`.
  - Robustness: if a shell tessellates to nothing, `cavity_probe` still reports it (zero bbox, no panic). Related to #1536 — confirms the captured body has a collapsed cavity; this PR does not close the issue.

<sup>Written for commit f383dc870d0d1baeb9eee219e2ae0f96426f95c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

