### PR TITLE
ci(cla): stop locking merged PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,6 +24,12 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/andymai/brepkit/blob/main/.github/CLA.md'
           branch: 'cla-signatures'
+          # The default (true) locks every merged PR within seconds. On a
+          # release PR that races release-please's post-merge comment: if the
+          # lock wins, the autorelease label is never flipped to "tagged" and
+          # every later run retries the old release instead of opening the
+          # next release PR (masked green by continue-on-error in publish.yml).
+          lock-pullrequest-aftermerge: false
           # web-flow is GitHub's web-UI committer identity; release-please PR
           # commits carry it as the committer, so it must be allowlisted or
           # every release PR fails the CLA check.


### PR DESCRIPTION
The CLA action's `lock-pullrequest-aftermerge` defaults to true, so `github-actions[bot]` locks every merged PR seconds after merge. On a release PR that lock races release-please's post-merge flow: when the lock lands first (v3.2.22, locked 8s before the comment call), release-please dies on "Unable to create comment because issue is locked" and never flips `autorelease: pending` to `autorelease: tagged`. Every subsequent push run then retries creating the already-existing release, fails, and never opens the next release PR. `continue-on-error: true` in publish.yml shows all of it green.

That is exactly how #1540 and #1541 sat unreleased with no release PR open. Recovery this time was manual: flip the label on #1535, rerun the Release Please job (release PR #1542 opened).

Locking merged PRs buys nothing here, so turn it off rather than teaching the release flow to fight it.

Verification: the lock event on merged PRs (`gh api repos/andymai/brepkit/issues/<n>/timeline`, actor `github-actions[bot]`) should stop appearing for PRs merged after this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned off post-merge PR locking in the CLA workflow to stop `release-please` from failing on locked issues and stalling the release flow. Merged PRs will no longer be locked by `github-actions[bot]`, so the autorelease label flips to tagged and the next release PR opens as expected.

<sup>Written for commit b3de01f3471080989ec8f931ad775f7ec431569d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

