### PR TITLE
fix(algo): gate split-hole attachment on area dominance

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -126,7 +126,7 @@ that does not exist yet; without it, stop.
 |---|---|
 | **Tool geometric parity (#1517)** | MEASURED 2026-08-10 on released 3.2.22, stock pins, same-day same-catalog control. Generator suite 272 files / 2693 tests: **3.2.18 154 failed, 3.2.22 144 failed**; excluding stale per-kernel snapshots that is **153 -> 130 real**. The issue's old "137 failed / 2550 passed" DOES NOT REPRODUCE (3.2.18 measures 154 today) — the catalog grew, so only a same-day control is trustworthy. Head-to-head matrix: perf **0.63x** aggregate, faster on 24/26, **all 26 closed with 0 non-manifold** vs the reference's 5. Remaining 144 by class: 34 open-shell, **19 compound-capability (#1537 — 17 of them are the tool's stale `brepjs` pin at 18.124.2, fixed in brepjs 18.124.7; only the 2 compound-base `fuse` calls are a live gap, and it is brepjs-side)**, 15 timeout, 14 stale snapshot, 12 non-manifold, 2 reentrancy. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` |
 | **#1538 regressions from the band-split fixes** | Open-shell half CLOSED by #1540 (see Closed). Still open: 2 timeouts + 1 triangle-count invariant. The open-shell to mesh-fallback cascade is a plausible route to the timeouts but is NOT measured; #1530's ring-section horizontals are the other suspect (3.2.21 was already slow). Next step is a tool-side re-measure on a kernel carrying #1540, NOT another native dig |
-| **#1536 slotted no-lip loses its cavity** | LOCALIZED 2026-08-10 to the BODY OPERAND, not the fuse and not the measurement. `cavity_probe` on `slotted_nolip_body.bin`: outer shell +111351 (99.8% of its bbox), inner shell **-5263 against a 98783 bbox — 5.3% fill**. The cavity is present and correctly signed, it just encloses nothing; a correct one is ~-92000, exactly the 135237-vs-43129 gap. So GFA and every volume oracle are exonerated (per-shell sum, `oriented_solid_volume` and the fixture's own recorded numbers all agree). Next step is capturing one stage EARLIER than `crates/io/tests/data/slotted_nolip_body.bin` — the shell/cut chain that builds the body |
+| **#1536 slotted no-lip loses its cavity** | ROOT FIXED kernel-side 2026-08-12 (see Closed: "Slot cut closed the shelled bin's pocket"). Tool-side confirmation pending: needs a release carrying the fix, then the parity-matrix `2x2 slotted no-lip` row should read ~43129 (was 135221). Close the issue on that re-measure, not before |
 | **Mesh-boolean fallback emits OPEN meshes that are CONSUMED** | A product call, not just a fix: rejecting means the op fails outright. Mitigation shipped: `boolean::mesh_fallback_count()` + wasm `meshFallbackCount()` let pipelines snapshot-and-refuse |
 | **Export angular default (5°) vs the reference's coarser effective default** | Tolerance-parity product choice, not mesher waste: 5° forces 18 segments/quarter-arc on r=0.6 slot corners, ~1.7x triangles vs reference at fine deflection. Revisit only as a product decision |
 | **Kumiko corner-window roots (4, documented)** | Unshipped; the parked branch `fix/kumiko-corner-window-cut` is GONE from the remote with its fixtures. Re-attempting means re-capturing fixtures first |
@@ -138,6 +138,19 @@ that does not exist yet; without it, stop.
 
 One line each; the fixture/PR carries the story. Newest first.
 
+- **Slot cut closed the shelled bin's pocket (#1536 root, FIXED 2026-08-12)** —
+  the face splitter's first-vertex hole matching attached the rim annulus's woven
+  cavity-mouth loop to the tiny notch rectangle it shares two corners with
+  (first-match order + strict ray-cast jitter on an exactly-on-corner probe), so
+  the annulus lost its hole (emitted as a full disc) and the mouth re-emerged as a
+  same-sense coincident ceiling: closed, manifold, volume 6x. Arc-cornered rims
+  only — an all-line rim traces the mouth loop from a different first vertex. Fix:
+  area-dominance gate on hole-attach candidates (a hole cannot be carried by a
+  region smaller than itself), `builder/face_splitter/mod.rs` "Simple hole
+  matching". Regression `crates/operations/tests/shelled_bin_slot_cut.rs`; probes
+  `slot_cut_probe.rs` (operations example), `shell_face_census.rs` +
+  `cavity_probe.rs` (io examples). The ops-layer trivial-containment shortcut and
+  raw GFA both reproduced identically — the shortcut was a red herring.
 - **Rim-arc crossings took the short way round (CLOSED 2026-08-10, #1540, the #1538 open shells)** —
   `circle_arc_plane_crossings` (added by #1534) decided which part of a circle a
   boundary edge covers by taking the SHORTER way between its vertices. The kernel has
@@ -367,6 +380,13 @@ One line each; the fixture/PR carries the story. Newest first.
   high by the same amount. Print per-shell signed volume against each shell's own bbox
   (`cargo run --release --example cavity_probe -p brepkit-io`) before blaming either the
   boolean or the measurement (#1536).
+- **A hole can only be carried by a region larger than itself; a shared-corner probe
+  fakes containment.** The splitter's first-vertex hole matching + first-match order
+  handed a 6577-area mouth loop to a 1.26-area notch because the traced loop STARTED
+  at a shared corner and the strict ray-cast read it inside (#1536). When auditing
+  hole attachment, check area dominance before trusting any point probe. Per-face
+  signed-volume census (`shell_face_census`) is the cheap way to spot the resulting
+  same-sense doubled cover: one face's contribution has the wrong sign for its shell.
 - **Measurement and tessellation walk different face sets.** Tessellation uses
   `explorer::solid_faces` (outer + inner shells) so the MESH is complete, while several
   volume/area/CoM paths walked `outer_shell()` alone — closed, manifold and correctly

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -6714,9 +6714,18 @@ fn split_face_2d_impl(
         keys.sort_unstable();
         keys
     };
+    let loop_area_abs = |wl: &[OrientedPCurveEdge]| -> f64 {
+        let pts = if is_plane {
+            sampling::sample_wire_loop_uv_via_frame(wl, frame)
+        } else {
+            sample_wire_loop_uv(wl)
+        };
+        signed_area_2d(&pts).abs()
+    };
     for hole in holes {
         if let Some(first_pt) = hole.first().map(|e| e.start_uv) {
             let hole_key = loop_key(&hole);
+            let hole_area = loop_area_abs(&hole);
             let mut assigned = false;
             let mut fallback_idx: Option<usize> = None;
             for (i, sf) in sub_faces.iter_mut().enumerate() {
@@ -6731,6 +6740,18 @@ fn split_face_2d_impl(
                 if loop_key(&sf.outer_wire) == hole_key {
                     continue;
                 }
+                // A hole cannot be carried by a region smaller than itself.
+                // The first-vertex probe reads "inside" when the hole's traced
+                // loop happens to START at a vertex it shares with a small
+                // sibling region (a woven wall-notch rect shares its inner
+                // corners with the cavity-mouth loop on a shelled bin rim), and
+                // first-match order then hands the whole mouth to the notch —
+                // the containing disc loses its hole and the mouth re-emerges
+                // as a same-sense doubled cover (#1536). Area dominance is the
+                // one containment invariant the probe cannot fake.
+                if loop_area_abs(&sf.outer_wire) < hole_area * (1.0 - 1e-6) {
+                    continue;
+                }
                 if fallback_idx.is_none() {
                     fallback_idx = Some(i);
                 }
@@ -6741,8 +6762,25 @@ fn split_face_2d_impl(
                     break;
                 }
             }
-            if !assigned && let Some(i) = fallback_idx {
-                sub_faces[i].inner_wires.push(hole);
+            if !assigned {
+                // Last resort mirrors the pre-gate behaviour (never silently
+                // drop a hole): the first area-passing candidate, else the
+                // largest non-twin sub-face.
+                let idx = fallback_idx.or_else(|| {
+                    sub_faces
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, sf)| loop_key(&sf.outer_wire) != hole_key)
+                        .max_by(|(_, a), (_, b)| {
+                            loop_area_abs(&a.outer_wire)
+                                .partial_cmp(&loop_area_abs(&b.outer_wire))
+                                .unwrap_or(std::cmp::Ordering::Equal)
+                        })
+                        .map(|(i, _)| i)
+                });
+                if let Some(i) = idx {
+                    sub_faces[i].inner_wires.push(hole);
+                }
             }
         }
     }

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -6771,11 +6771,8 @@ fn split_face_2d_impl(
                         .iter()
                         .enumerate()
                         .filter(|(_, sf)| loop_key(&sf.outer_wire) != hole_key)
-                        .max_by(|(_, a), (_, b)| {
-                            loop_area_abs(&a.outer_wire)
-                                .partial_cmp(&loop_area_abs(&b.outer_wire))
-                                .unwrap_or(std::cmp::Ordering::Equal)
-                        })
+                        .map(|(i, sf)| (i, loop_area_abs(&sf.outer_wire)))
+                        .max_by(|(_, a), (_, b)| a.total_cmp(b))
                         .map(|(i, _)| i)
                 });
                 if let Some(i) = idx {

--- a/crates/io/examples/shell_face_census.rs
+++ b/crates/io/examples/shell_face_census.rs
@@ -1,0 +1,83 @@
+//! Per-face anatomy of one shell of a captured solid: surface type, AABB,
+//! area, and signed-volume contribution. Written for #1536, where the slotted
+//! no-lip body's inner shell is closed and correctly signed yet encloses only
+//! 5% of the space it spans — the per-face contributions show which faces
+//! cancel and what the void actually is.
+//!
+//! Usage: `cargo run --release --example shell_face_census -p brepkit-io -- \
+//!   <name.bin> [shell-index]`
+//! shell-index: 0 = outer (default), 1.. = inner shells in order.
+//! Names resolve against `crates/io/tests/data`; absolute paths are used as-is.
+#![allow(clippy::print_stdout, clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+use brepkit_io::arena_io::deserialize_solid;
+use brepkit_math::vec::Point3;
+use brepkit_topology::Topology;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let name = args
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "slotted_nolip_body.bin".to_string());
+    let shell_index: usize = args.get(1).map_or(0, |s| s.parse().unwrap());
+
+    let path = if Path::new(&name).is_absolute() {
+        PathBuf::from(&name)
+    } else {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data")
+            .join(&name)
+    };
+    let mut topo = Topology::new();
+    let sid = deserialize_solid(&std::fs::read(&path).unwrap(), &mut topo).unwrap();
+    let sd = topo.solid(sid).unwrap();
+    let shell = if shell_index == 0 {
+        sd.outer_shell()
+    } else {
+        sd.inner_shells()[shell_index - 1]
+    };
+
+    let origin = Point3::new(0.0, 0.0, 0.0);
+    let faces = topo.shell(shell).unwrap().faces().to_vec();
+    println!("{name} shell#{shell_index}: {} faces", faces.len());
+    let mut total = 0.0;
+    for fid in &faces {
+        let face = topo.face(*fid).unwrap();
+        let ty = face.surface().type_tag();
+        let mesh = brepkit_operations::tessellate::tessellate(&topo, *fid, 0.05).unwrap();
+        let (idx, pos) = (&mesh.indices, &mesh.positions);
+        let mut vol6 = 0.0;
+        let mut area2 = 0.0;
+        let (mut lo, mut hi) = (
+            Point3::new(f64::MAX, f64::MAX, f64::MAX),
+            Point3::new(f64::MIN, f64::MIN, f64::MIN),
+        );
+        for t in 0..idx.len() / 3 {
+            let a = pos[idx[t * 3] as usize];
+            let b = pos[idx[t * 3 + 1] as usize];
+            let c = pos[idx[t * 3 + 2] as usize];
+            vol6 += (a - origin).dot((b - origin).cross(c - origin));
+            area2 += (b - a).cross(c - a).length();
+            for p in [a, b, c] {
+                lo = Point3::new(lo.x().min(p.x()), lo.y().min(p.y()), lo.z().min(p.z()));
+                hi = Point3::new(hi.x().max(p.x()), hi.y().max(p.y()), hi.z().max(p.z()));
+            }
+        }
+        total += vol6 / 6.0;
+        println!(
+            "  {fid:>8?} {ty:<8} vol={:>10.1} area={:>8.1}  x[{:>7.2},{:>7.2}] y[{:>7.2},{:>7.2}] z[{:>6.2},{:>6.2}]",
+            vol6 / 6.0,
+            area2 / 2.0,
+            lo.x(),
+            hi.x(),
+            lo.y(),
+            hi.y(),
+            lo.z(),
+            hi.z()
+        );
+    }
+    println!("  shell signed volume = {total:.1}");
+}

--- a/crates/operations/examples/slot_cut_probe.rs
+++ b/crates/operations/examples/slot_cut_probe.rs
@@ -1,0 +1,291 @@
+//! #1536 repro probe: does cutting wall-slot boxes (tops coplanar with the
+//! bin rim plane) out of a shelled open-top bin body flip the z-top plane
+//! faces into a same-sense doubled cover?
+//!
+//! The captured `slotted_nolip_body.bin` shows the defect: the outer shell is
+//! the full box (top disc included), the inner shell is the complete
+//! cavity+slots void, and the cavity ceiling at the rim plane faces UP —
+//! same-sense with the outer top disc — so the enclosed void nearly cancels
+//! and the solid reads ~92k too big. This rebuilds the chain natively:
+//! rounded-rect box -> shell_op (open top) -> cut 6 wall slots.
+//!
+//! `cargo run --release --example slot_cut_probe -p brepkit-operations`
+#![allow(clippy::print_stdout, clippy::expect_used, clippy::unwrap_used)]
+
+use brepkit_math::curves::Circle3D;
+use brepkit_math::mat::Mat4;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::boolean::{self, BooleanOp};
+use brepkit_topology::Topology;
+use brepkit_topology::edge::{Edge, EdgeCurve};
+use brepkit_topology::face::{Face, FaceSurface};
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::vertex::Vertex;
+use brepkit_topology::wire::{OrientedEdge, Wire};
+
+const W: f64 = 83.6;
+const R: f64 = 3.75;
+const H: f64 = 21.0;
+const T: f64 = 1.25;
+const SLOT_DEPTH: f64 = 0.6;
+const SLOT_WIDTH: f64 = 2.1;
+const SLOT_EXT: f64 = 0.01;
+
+fn rounded_rect_box(topo: &mut Topology) -> SolidId {
+    let hw = W / 2.0;
+    let c = hw - R;
+    let t = 1e-7;
+    let z = Vec3::new(0.0, 0.0, 1.0);
+    let v = |topo: &mut Topology, x: f64, y: f64| {
+        topo.add_vertex(Vertex::new(Point3::new(x, y, 0.0), t))
+    };
+    let v0 = v(topo, hw, -c);
+    let v1 = v(topo, hw, c);
+    let v2 = v(topo, c, hw);
+    let v3 = v(topo, -c, hw);
+    let v4 = v(topo, -hw, c);
+    let v5 = v(topo, -hw, -c);
+    let v6 = v(topo, -c, -hw);
+    let v7 = v(topo, c, -hw);
+    let arc = |topo: &mut Topology, a, b, cx: f64, cy: f64| {
+        let circle = Circle3D::new(Point3::new(cx, cy, 0.0), z, R).unwrap();
+        topo.add_edge(Edge::new(a, b, EdgeCurve::Circle(circle)))
+    };
+    let edges = [
+        topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line)),
+        arc(topo, v1, v2, c, c),
+        topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line)),
+        arc(topo, v3, v4, -c, c),
+        topo.add_edge(Edge::new(v4, v5, EdgeCurve::Line)),
+        arc(topo, v5, v6, -c, -c),
+        topo.add_edge(Edge::new(v6, v7, EdgeCurve::Line)),
+        arc(topo, v7, v0, c, -c),
+    ];
+    let wire = Wire::new(
+        edges.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let fid = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    brepkit_operations::extrude::extrude(topo, fid, Vec3::new(0.0, 0.0, 1.0), H).unwrap()
+}
+
+fn report(topo: &Topology, sid: SolidId, label: &str) {
+    report_h(topo, sid, label, H);
+}
+
+fn report_h(topo: &Topology, sid: SolidId, label: &str, h: f64) {
+    let origin = Point3::new(0.0, 0.0, 0.0);
+    let sd = topo.solid(sid).unwrap();
+    let shells: Vec<_> = std::iter::once(("outer".to_string(), sd.outer_shell()))
+        .chain(
+            sd.inner_shells()
+                .iter()
+                .enumerate()
+                .map(|(i, &s)| (format!("inner{i}"), s)),
+        )
+        .collect();
+    println!("== {label}");
+    let mut total = 0.0;
+    for (name, shell) in &shells {
+        let faces = topo.shell(*shell).unwrap().faces().to_vec();
+        let mut vol = 0.0;
+        let mut top_up = 0usize;
+        let mut top_down = 0usize;
+        for fid in &faces {
+            let mesh = brepkit_operations::tessellate::tessellate(topo, *fid, 0.05).unwrap();
+            let (idx, pos) = (&mesh.indices, &mesh.positions);
+            let mut fvol = 0.0;
+            let mut at_top = !idx.is_empty();
+            let mut nz_sum = 0.0;
+            for tri in 0..idx.len() / 3 {
+                let a = pos[idx[tri * 3] as usize];
+                let b = pos[idx[tri * 3 + 1] as usize];
+                let c = pos[idx[tri * 3 + 2] as usize];
+                fvol += (a - origin).dot((b - origin).cross(c - origin));
+                nz_sum += (b - a).cross(c - a).z();
+                for p in [a, b, c] {
+                    if (p.z() - h).abs() > 1e-6 {
+                        at_top = false;
+                    }
+                }
+            }
+            vol += fvol / 6.0;
+            if at_top {
+                if nz_sum > 0.0 {
+                    top_up += 1;
+                } else {
+                    top_down += 1;
+                }
+            }
+        }
+        total += vol;
+        println!(
+            "  {name:<7} faces={:<4} signed={vol:>11.1}  z=H faces: {top_up} up, {top_down} down",
+            faces.len()
+        );
+    }
+    let ov = brepkit_operations::measure::oriented_solid_volume(topo, sid, 0.05).unwrap();
+    println!("  sum={total:.1}  oriented_solid_volume={ov:.1}");
+}
+
+fn slot_boxes(topo: &mut Topology) -> Vec<SolidId> {
+    let inner_wall = W / 2.0 - T;
+    let mut out = Vec::new();
+    for side in [1.0, -1.0] {
+        for yc in [-20.27_f64, 0.0, 20.27] {
+            let sid = brepkit_operations::primitives::make_box(
+                topo,
+                SLOT_DEPTH + SLOT_EXT,
+                SLOT_WIDTH,
+                H - T,
+            )
+            .unwrap();
+            let x0 = if side > 0.0 {
+                inner_wall - SLOT_EXT
+            } else {
+                -(inner_wall + SLOT_DEPTH)
+            };
+            let m = Mat4::translation(x0, yc - SLOT_WIDTH / 2.0, T);
+            brepkit_operations::transform::transform_solid(topo, sid, &m).unwrap();
+            out.push(sid);
+        }
+    }
+    out
+}
+
+fn shell_and_cut_one_slot(topo: &mut Topology, solid_box: SolidId, h: f64, label: &str) {
+    let top_faces: Vec<_> = {
+        let s = topo.solid(solid_box).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        sh.faces()
+            .iter()
+            .copied()
+            .filter(|&fid| {
+                matches!(
+                    topo.face(fid).unwrap().surface(),
+                    FaceSurface::Plane { normal, d }
+                        if normal.z() > 0.99 && (*d - h).abs() < 1e-6
+                )
+            })
+            .collect()
+    };
+    let hollow = brepkit_operations::shell_op::shell(topo, solid_box, T, &top_faces).unwrap();
+    report_h(topo, hollow, &format!("{label}: after shell_op"), h);
+    let bb = brepkit_operations::measure::solid_bounding_box(topo, hollow).unwrap();
+    let inner_wall_x = bb.max.x() - T;
+    let y_mid = f64::midpoint(bb.min.y(), bb.max.y());
+    let slot = brepkit_operations::primitives::make_box(topo, 0.61, 2.1, h - T).unwrap();
+    let m = Mat4::translation(inner_wall_x - 0.01, y_mid - 1.05, T);
+    brepkit_operations::transform::transform_solid(topo, slot, &m).unwrap();
+    let result = if std::env::var("BK_RAW_GFA").is_ok() {
+        brepkit_algo::gfa::boolean(topo, brepkit_algo::bop::BooleanOp::Cut, hollow, slot).unwrap()
+    } else {
+        boolean::boolean(topo, BooleanOp::Cut, hollow, slot).unwrap()
+    };
+    report_h(topo, result, &format!("{label}: after slot cut"), h);
+}
+
+fn minimal() {
+    let mut topo = Topology::new();
+    let solid_box = brepkit_operations::primitives::make_box(&mut topo, 20.0, 20.0, 10.0).unwrap();
+    let top_faces: Vec<_> = {
+        let s = topo.solid(solid_box).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        sh.faces()
+            .iter()
+            .copied()
+            .filter(|&fid| {
+                matches!(
+                    topo.face(fid).unwrap().surface(),
+                    FaceSurface::Plane { normal, d }
+                        if normal.z() > 0.99 && (*d - 10.0).abs() < 1e-6
+                )
+            })
+            .collect()
+    };
+    let hollow =
+        brepkit_operations::shell_op::shell(&mut topo, solid_box, 1.25, &top_faces).unwrap();
+    report_h(&topo, hollow, "min: after shell_op", 10.0);
+    let slot = brepkit_operations::primitives::make_box(&mut topo, 0.61, 2.1, 8.75).unwrap();
+    let m = Mat4::translation(20.0 - 1.25 - 0.01, 10.0 - 1.05, 1.25);
+    brepkit_operations::transform::transform_solid(&mut topo, slot, &m).unwrap();
+    let result = boolean::boolean(&mut topo, BooleanOp::Cut, hollow, slot).unwrap();
+    report_h(&topo, result, "min: after slot cut", 10.0);
+}
+
+fn main() {
+    env_logger::init();
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "seq".to_string());
+    if mode == "min" {
+        minimal();
+        return;
+    }
+    if mode == "rectfull" {
+        let mut topo = Topology::new();
+        let b = brepkit_operations::primitives::make_box(&mut topo, W, W, H).unwrap();
+        shell_and_cut_one_slot(&mut topo, b, H, "rectfull");
+        return;
+    }
+    if mode == "roundone" {
+        let mut topo = Topology::new();
+        let b = rounded_rect_box(&mut topo);
+        shell_and_cut_one_slot(&mut topo, b, H, "roundone");
+        return;
+    }
+
+    let mut topo = Topology::new();
+    let solid_box = rounded_rect_box(&mut topo);
+    report(&topo, solid_box, "solid box");
+
+    let top_faces: Vec<_> = {
+        let s = topo.solid(solid_box).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        sh.faces()
+            .iter()
+            .copied()
+            .filter(|&fid| {
+                matches!(
+                    topo.face(fid).unwrap().surface(),
+                    FaceSurface::Plane { normal, d }
+                        if normal.z() > 0.99 && (*d - H).abs() < 1e-6
+                )
+            })
+            .collect()
+    };
+    let hollow = brepkit_operations::shell_op::shell(&mut topo, solid_box, T, &top_faces).unwrap();
+    report(&topo, hollow, "after shell_op (open top)");
+
+    let slots = slot_boxes(&mut topo);
+    let before_fallbacks = boolean::mesh_fallback_count();
+
+    let result = if mode == "compound" {
+        boolean::compound_cut(
+            &mut topo,
+            hollow,
+            &slots,
+            boolean::BooleanOptions::default(),
+        )
+        .unwrap()
+    } else {
+        let mut cur = hollow;
+        for (i, s) in slots.iter().enumerate() {
+            cur = boolean::boolean(&mut topo, BooleanOp::Cut, cur, *s).unwrap();
+            report(&topo, cur, &format!("after slot cut {i}"));
+        }
+        cur
+    };
+    report(&topo, result, &format!("final ({mode})"));
+    println!(
+        "mesh fallbacks during cuts: {}",
+        boolean::mesh_fallback_count() - before_fallbacks
+    );
+}

--- a/crates/operations/tests/shelled_bin_slot_cut.rs
+++ b/crates/operations/tests/shelled_bin_slot_cut.rs
@@ -1,0 +1,173 @@
+//! #1536: cutting wall-slot boxes out of a shelled open-top rounded bin must
+//! keep the pocket open, not re-encode it as an enclosed void.
+//!
+//! The face splitter's first-vertex hole matching attached the bin's whole
+//! cavity-mouth loop to the tiny woven notch rectangle it shares two corners
+//! with (first-match order + a strict ray-cast reading an exactly-on-corner
+//! probe as inside). The rim annulus then lost its hole and was emitted as a
+//! full disc, with the mouth re-emerging as a same-sense coincident ceiling —
+//! a closed, manifold solid that reads ~6x its true volume (the tool's
+//! "2x2 slotted no-lip bin loses its cavity" defect). The trigger needs the
+//! rim's corner arcs: an all-line rim traces its mouth loop from a different
+//! first vertex and never mis-attached.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+
+use brepkit_math::curves::Circle3D;
+use brepkit_math::mat::Mat4;
+use brepkit_math::vec::{Point3, Vec3};
+use brepkit_operations::boolean::{self, BooleanOp};
+use brepkit_topology::Topology;
+use brepkit_topology::edge::{Edge, EdgeCurve, EdgeId};
+use brepkit_topology::explorer::solid_faces;
+use brepkit_topology::face::{Face, FaceSurface};
+use brepkit_topology::solid::SolidId;
+use brepkit_topology::vertex::Vertex;
+use brepkit_topology::wire::{OrientedEdge, Wire};
+
+const W: f64 = 83.6;
+const R: f64 = 3.75;
+const H: f64 = 21.0;
+const T: f64 = 1.25;
+const SLOT_DEPTH: f64 = 0.6;
+const SLOT_WIDTH: f64 = 2.1;
+const SLOT_EXT: f64 = 0.01;
+
+fn rounded_rect_box(topo: &mut Topology) -> SolidId {
+    let hw = W / 2.0;
+    let c = hw - R;
+    let t = 1e-7;
+    let z = Vec3::new(0.0, 0.0, 1.0);
+    let v = |topo: &mut Topology, x: f64, y: f64| {
+        topo.add_vertex(Vertex::new(Point3::new(x, y, 0.0), t))
+    };
+    let v0 = v(topo, hw, -c);
+    let v1 = v(topo, hw, c);
+    let v2 = v(topo, c, hw);
+    let v3 = v(topo, -c, hw);
+    let v4 = v(topo, -hw, c);
+    let v5 = v(topo, -hw, -c);
+    let v6 = v(topo, -c, -hw);
+    let v7 = v(topo, c, -hw);
+    let arc = |topo: &mut Topology, a, b, cx: f64, cy: f64| {
+        let circle = Circle3D::new(Point3::new(cx, cy, 0.0), z, R).unwrap();
+        topo.add_edge(Edge::new(a, b, EdgeCurve::Circle(circle)))
+    };
+    let edges = [
+        topo.add_edge(Edge::new(v0, v1, EdgeCurve::Line)),
+        arc(topo, v1, v2, c, c),
+        topo.add_edge(Edge::new(v2, v3, EdgeCurve::Line)),
+        arc(topo, v3, v4, -c, c),
+        topo.add_edge(Edge::new(v4, v5, EdgeCurve::Line)),
+        arc(topo, v5, v6, -c, -c),
+        topo.add_edge(Edge::new(v6, v7, EdgeCurve::Line)),
+        arc(topo, v7, v0, c, -c),
+    ];
+    let wire = Wire::new(
+        edges.iter().map(|&e| OrientedEdge::new(e, true)).collect(),
+        true,
+    )
+    .unwrap();
+    let wid = topo.add_wire(wire);
+    let fid = topo.add_face(Face::new(
+        wid,
+        vec![],
+        FaceSurface::Plane {
+            normal: Vec3::new(0.0, 0.0, 1.0),
+            d: 0.0,
+        },
+    ));
+    brepkit_operations::extrude::extrude(topo, fid, Vec3::new(0.0, 0.0, 1.0), H).unwrap()
+}
+
+fn shelled_bin(topo: &mut Topology) -> SolidId {
+    let solid_box = rounded_rect_box(topo);
+    let top_faces: Vec<_> = {
+        let s = topo.solid(solid_box).unwrap();
+        let sh = topo.shell(s.outer_shell()).unwrap();
+        sh.faces()
+            .iter()
+            .copied()
+            .filter(|&fid| {
+                matches!(
+                    topo.face(fid).unwrap().surface(),
+                    FaceSurface::Plane { normal, d }
+                        if normal.z() > 0.99 && (*d - H).abs() < 1e-6
+                )
+            })
+            .collect()
+    };
+    brepkit_operations::shell_op::shell(topo, solid_box, T, &top_faces).unwrap()
+}
+
+fn slot_boxes(topo: &mut Topology) -> Vec<SolidId> {
+    let inner_wall = W / 2.0 - T;
+    let mut out = Vec::new();
+    for side in [1.0, -1.0] {
+        for yc in [-20.27_f64, 0.0, 20.27] {
+            let sid = brepkit_operations::primitives::make_box(
+                topo,
+                SLOT_DEPTH + SLOT_EXT,
+                SLOT_WIDTH,
+                H - T,
+            )
+            .unwrap();
+            let x0 = if side > 0.0 {
+                inner_wall - SLOT_EXT
+            } else {
+                -(inner_wall + SLOT_DEPTH)
+            };
+            let m = Mat4::translation(x0, yc - SLOT_WIDTH / 2.0, T);
+            brepkit_operations::transform::transform_solid(topo, sid, &m).unwrap();
+            out.push(sid);
+        }
+    }
+    out
+}
+
+fn edge_health(topo: &Topology, sid: SolidId) -> (usize, usize) {
+    let mut uses: HashMap<EdgeId, usize> = HashMap::new();
+    for fid in solid_faces(topo, sid).unwrap() {
+        let face = topo.face(fid).unwrap();
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *uses.entry(oe.edge()).or_default() += 1;
+            }
+        }
+    }
+    let free = uses.values().filter(|&&c| c == 1).count();
+    let over = uses.values().filter(|&&c| c > 2).count();
+    (free, over)
+}
+
+#[test]
+fn slot_cut_on_shelled_rounded_bin_keeps_the_open_pocket() {
+    let mut topo = Topology::new();
+    let hollow = shelled_bin(&mut topo);
+    let vol_hollow =
+        brepkit_operations::measure::oriented_solid_volume(&topo, hollow, 0.05).unwrap();
+
+    let mut cur = hollow;
+    for slot in slot_boxes(&mut topo) {
+        cur = boolean::boolean(&mut topo, BooleanOp::Cut, cur, slot).unwrap();
+    }
+
+    let sd = topo.solid(cur).unwrap();
+    assert!(
+        sd.inner_shells().is_empty(),
+        "slot cut must not close the pocket into an enclosed void, got {} inner shell(s)",
+        sd.inner_shells().len()
+    );
+    let (free, over) = edge_health(&topo, cur);
+    assert_eq!((free, over), (0, 0), "result must stay closed and manifold");
+
+    // Each slot removes exactly its in-wall material: 0.6 x 2.1 x (H - T).
+    let removed = 6.0 * SLOT_DEPTH * SLOT_WIDTH * (H - T);
+    let vol = brepkit_operations::measure::oriented_solid_volume(&topo, cur, 0.05).unwrap();
+    assert!(
+        (vol - (vol_hollow - removed)).abs() < 0.5,
+        "volume {vol:.1} must be the hollow body {vol_hollow:.1} minus the slots {removed:.1}"
+    );
+}


### PR DESCRIPTION
Closes the kernel side of #1536 (2x2 slotted no-lip bin loses its cavity, volume 3.13x, silent because closed and manifold).

## Root cause

The face splitter's simple hole matching (`builder/face_splitter/mod.rs`) attaches each hole loop to the first sub-face whose outer polygon contains the hole's **first vertex**. Splitting a shelled bin's rim annulus by a woven wall-slot notch, the notched cavity-mouth loop's trace starts at a corner it **shares** with the tiny notch rectangle; the strict ray-cast reads that on-corner probe as inside, and first-match order hands the 6,577-area mouth to the 1.26-area notch. The annulus loses its hole (emitted as a full disc) and the mouth re-emerges as a same-sense coincident ceiling. Every watertightness gate passes; only volume catches it.

Arc-cornered rims only: an all-line rim traces the mouth loop from a different first vertex, which is why the plain sibling bins were exact while every slotted variant lost its cavity (measured: plain-rect control at full bin dimensions correct, rounded reproduces).

## Fix

A hole cannot be carried by a region smaller than itself — skip attach candidates smaller than the hole (area sampled arc-true via the plane frame). This is the one containment invariant a point probe cannot fake. The documented BoundaryCoincident calibrations are untouched: those holes attach to the larger surrounding region, which passes the gate; the last-resort fallback still never drops a hole.

## Verification

- New regression `crates/operations/tests/shelled_bin_slot_cut.rs`: shelled rounded bin + 6 slot cuts stays a single open-pocket shell, watertight, volume = shell − slots (0.32s).
- Repro instrument `crates/operations/examples/slot_cut_probe.rs` (modes: seq / compound / min / rectfull / roundone, `BK_RAW_GFA=1` to bypass the ops shortcuts), plus `crates/io/examples/shell_face_census.rs` (per-face signed-volume census that makes a same-sense doubled cover visible at a glance).
- Before: one slot cut on the shelled rounded bin gave 108,706 (full-box outer +146,499 with an up-facing cavity ceiling in an inner shell). After: 16,687.0 = shell − slot exactly; the 6-slot chain 16,562.6, identical across raw GFA, sequential cuts and `compound_cut`, zero mesh fallbacks.
- Full workspace 2739/2739 passed (render excluded per the known SIGSEGV), including all splitter foil fixtures and `brepkit-wasm --lib gridfinity` 27/27.

Tool-side confirmation (parity-matrix slotted row reading ~43,129) happens after release; #1536 stays open until then.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hole attachment in the face splitter by gating on area dominance so a hole never attaches to a smaller region. This stops rim‑mouth loops from snapping to tiny slot notches and closing the bin pocket; the slotted no‑lip bin now reports the correct cavity (addresses #1536).

- **Bug Fixes**
  - Added an area-based filter to simple hole matching in `builder/face_splitter/mod.rs`; skip sub-faces whose outer area is smaller than the hole (arc-true area via the plane frame).
  - Kept existing `BoundaryCoincident` behavior; fallback is now deterministic and single-pass: pick the first area-passing candidate, else the largest non-twin by precomputed area (ordered via `total_cmp`), so holes are never dropped.
  - Added regression test for a shelled rounded bin with 6 slots and two examples to inspect per-face volume and slot-cut behavior; result stays watertight and volume equals shell minus slots.

<sup>Written for commit 449fe4ebaf423930539fc97c00c2ab66e7f5da78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

