### PR TITLE
fix(algo): decide closed-edge winding by curve direction, not convention

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -125,7 +125,7 @@ that does not exist yet; without it, stop.
 | Item | Status / next step |
 |---|---|
 | **Tool geometric parity (#1517)** | MEASURED 2026-08-10 on released 3.2.22, stock pins, same-day same-catalog control. Generator suite 272 files / 2693 tests: **3.2.18 154 failed, 3.2.22 144 failed**; excluding stale per-kernel snapshots that is **153 -> 130 real**. The issue's old "137 failed / 2550 passed" DOES NOT REPRODUCE (3.2.18 measures 154 today) — the catalog grew, so only a same-day control is trustworthy. Head-to-head matrix: perf **0.63x** aggregate, faster on 24/26, **all 26 closed with 0 non-manifold** vs the reference's 5. Remaining 144 by class: 34 open-shell, **19 compound-capability (#1537 — 17 of them are the tool's stale `brepjs` pin at 18.124.2, fixed in brepjs 18.124.7; only the 2 compound-base `fuse` calls are a live gap, and it is brepjs-side)**, 15 timeout, 14 stale snapshot, 12 non-manifold, 2 reentrancy. Harness `kernelParityMatrix.test.ts` + `scripts/compare-kernel-parity.ts` |
-| **#1538 tail: the coplanar-interface holed-cap fuse family** | RE-MEASURED 2026-08-12 on 3.2.24 + brepjs 18.124.8 (worktree `pinbump-3223`, both pins bumped, patch re-targeted). FIXED tool-side: label-tab split timeout, the text cluster (30/30), slotted cavity (#1536). STILL FAILING: `edgeCases` circle-insert / deep-cutout / cornerRadius, `combinedFeatures` compartments+insert (22 bnd) and the 26-minute 4x4 label-bracket+half-sockets row, lid text timeouts. Deep-cutout cut root FIXED (expand_edge, see Closed). The remaining family: FUSE across a coplanar interface whose face carries a HOLE (circle pocket mouth at z=5, through-cut at z=0) emits 27-60 free edges — ready-repros `circleinsert_interface_fuse_inmem.rs` + `deepcutout_cut_inmem.rs` (ignored strict pins; captured operands in tests/data). Winding residue: the pocket cuts mint 8-9 same-direction shared edges (validator sees them, free/over census does not). The `radius` case's booleans all replay clean — its failure is in uncaptured traffic (executeBatch) or meshing; capture that next. Probe: `__kernel-tests__/edgeCaseCapture.test.ts` in the worktree (untracked, budget to re-write) |
+| **#1538 tail: the coplanar-interface family, DECOMPOSED** | Dug 2026-08-12 with synthetic clean-input probes (`interface_fuse_probe.rs`): the family is WINDING emitters, not one fuse defect. THREE ROOTS FIXED (see Closed: "Closed-edge winding direction"): internal-loops frame-area inversion on down-facing planes, merge never flipping closed edges, CB rebuild degenerating to forward=true on closed rims. Rect and circle through-hole chains (cut + interface fuse) now strictly valid end-to-end. REMAINING sub-classes, each pinned: (a) coincident-cap pocket rim, 1 edge, cylinder-band rim emission suspect (`interface_fuse_winding.rs` ignored pin); (b) deepcutout 9 same-direction LINE edges (`deepcutout_cut_inmem.rs` strict pin); (c) captured circleinsert fuse free=60, arc-cornered (`circleinsert_interface_fuse_inmem.rs`); (d) the 26-min 4x4 label-bracket row, unattributed; (e) the tool's `cornerRadius` scenario — booleans replay clean, capture executeBatch traffic next |
 | **Tool pin bump** | gridfinity-layout-tool#3441 open: brepjs 18.124.8 + brepkit-wasm 3.2.24, intersectCurves patch re-targeted. #1536 CLOSED on the 3.2.24 re-measure (slotted row 43119.91 vs reference 43129, Euler 10, 24ms; full 26-row matrix 0 bnd / 0 nm) |
 | **Mesh-boolean fallback emits OPEN meshes that are CONSUMED** | A product call, not just a fix: rejecting means the op fails outright. Mitigation shipped: `boolean::mesh_fallback_count()` + wasm `meshFallbackCount()` let pipelines snapshot-and-refuse |
 | **Export angular default (5°) vs the reference's coarser effective default** | Tolerance-parity product choice, not mesher waste: 5° forces 18 segments/quarter-arc on r=0.6 slot corners, ~1.7x triangles vs reference at fine deflection. Revisit only as a product decision |
@@ -138,7 +138,20 @@ that does not exist yet; without it, stop.
 
 One line each; the fixture/PR carries the story. Newest first.
 
-- **Kept-face wire imaging emitted CommonBlock sub-edges backwards (FIXED 2026-08-12)** —
+- **Closed-edge winding direction, three emitters (FIXED 2026-08-12, the #1538 interface family's core)** —
+  synthetic clean-input probes (`crates/operations/examples/interface_fuse_probe.rs`)
+  showed even cut(box, box) through-hole mints same-direction shared edges. Three
+  independent roots, all invisible to the free/over census: (1) the internal-loops
+  splitter normalized disc/hole winding via a signed area in the surface's own
+  parameterization, inverted vs the local frame on a DOWN-facing plane
+  (`special_cases.rs`, now frame-projected 3D areas); (2) `merge_duplicate_edges`
+  "never flip closed edges" — two coincident circles can parameterize opposite ways
+  (quarter-point comparison added; this is the merge's orientation MAP, not the
+  terminal merge-key); (3) `rebuild_face_with_cb_edges` collapsed to forward=true
+  for a closed rim swapped to its CommonBlock circle (same comparison). Regressions
+  `crates/operations/tests/interface_fuse_winding.rs` (rect + circle chains strictly
+  valid; coincident-cap pocket pinned ignored). The probe's BK_WINDING=1/2 prints
+  per-edge effective directions with owning faces — the fast winding instrument.
   `expand_edge` (fill_images_faces) assumed every image sub-edge of a split boundary
   edge is minted in the parent's direction, but a CommonBlock split_edge is shared
   with the coincident partner solid and keeps THAT solid's direction. A deep corner

--- a/crates/algo/src/builder/builder_solid.rs
+++ b/crates/algo/src/builder/builder_solid.rs
@@ -2660,10 +2660,37 @@ fn merge_duplicate_edges(topo: &mut Topology, face_ids: &mut [FaceId]) -> Result
             let dup_qs = quantize_point(topo.vertex(dup_edge.start())?.point(), tol);
             let dup_qe = quantize_point(topo.vertex(dup_edge.end())?.point(), tol);
             // Detect reversed vertex order. For closed edges (start == end),
-            // qs == qe for both canonical and duplicate, so the flip condition
-            // would be trivially true. Never flip closed edges.
+            // qs == qe for both canonical and duplicate, so the vertex-order
+            // condition is useless — but two coincident CLOSED edges can still
+            // parameterize in opposite directions (a section-minted circle vs
+            // a kept operand rim whose axis points the other way; the #1538
+            // pocket ring). Decide by comparing quarter points of the actual
+            // curves: same direction lands on the same point, opposite lands
+            // on the mirrored parameter.
             let is_closed = canon_qs == canon_qe;
-            let needs_flip = !is_closed && dup_qs == canon_qe && dup_qe == canon_qs;
+            let needs_flip = if is_closed {
+                let canon_edge = topo.edge(canonical)?;
+                let cs = topo.vertex(canon_edge.start())?.point();
+                let ce = topo.vertex(canon_edge.end())?.point();
+                let ds = topo.vertex(dup_edge.start())?.point();
+                let de = topo.vertex(dup_edge.end())?.point();
+                let (c0, c1) = canon_edge.curve().domain_with_endpoints(cs, ce);
+                let (d0, d1) = dup_edge.curve().domain_with_endpoints(ds, de);
+                let cq = canon_edge
+                    .curve()
+                    .evaluate_with_endpoints(c0 + (c1 - c0) * 0.25, cs, ce);
+                let dq_same =
+                    dup_edge
+                        .curve()
+                        .evaluate_with_endpoints(d0 + (d1 - d0) * 0.25, ds, de);
+                let dq_flip =
+                    dup_edge
+                        .curve()
+                        .evaluate_with_endpoints(d0 + (d1 - d0) * 0.75, ds, de);
+                (cq - dq_flip).length() < (cq - dq_same).length()
+            } else {
+                dup_qs == canon_qe && dup_qe == canon_qs
+            };
             replacements.insert(dup, (canonical, needs_flip));
         }
     }

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1611,11 +1611,22 @@ pub(super) fn split_face_with_internal_loops(
     // the hole plus the hole pieces inside the loop.
     let mut consumed_holes: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let mut union_hole_by_loop: Vec<Option<Vec<OrientedPCurveEdge>>> = vec![None; loops.len()];
-    if let FaceSurface::Plane { normal, .. } = surface {
-        // Stored UVs on hole wires can be fitted in a foreign frame; build ONE
-        // local frame and project every 3D endpoint through it for all 2D
-        // tests (the pcurve-convention lesson).
-        let frame = PlaneFrame::from_plane_face(*normal, wire_pts);
+    // Stored UVs on section and hole wires can be fitted in a foreign frame;
+    // build ONE local frame and project every 3D endpoint through it for all
+    // 2D tests (the pcurve-convention lesson). This frame also decides the
+    // disc/hole winding normalization below: stored UVs from the FF phase
+    // live in the surface's own parameterization, whose handedness disagrees
+    // with the local frame on a down-facing plane, and a signed area taken in
+    // the wrong frame inverts the winding verdict (the z-interface pocket
+    // ring of #1538: the bottom cap's hole wound backwards while the top
+    // cap's was correct).
+    let plane_frame = if let FaceSurface::Plane { normal, .. } = surface {
+        Some(PlaneFrame::from_plane_face(*normal, wire_pts))
+    } else {
+        None
+    };
+    if let Some(frame) = plane_frame.as_ref() {
+        let frame = frame.clone();
         for (li, loop_edges) in loops.iter_mut().enumerate() {
             let mut hit: Option<usize> = None;
             for (hi, hole) in original_inner_wires.iter().enumerate() {
@@ -1656,7 +1667,40 @@ pub(super) fn split_face_with_internal_loops(
         // Compute signed area in UV. For single-edge closed curves
         // (circles), sample points along the pcurve since start_uv ~= end_uv
         // gives zero area with just the endpoints.
-        let signed_area = if loop_edges.len() == 1 {
+        // On a plane, take the area in the LOCAL frame from 3D points: the
+        // stored UVs come from the surface's own parameterization, whose
+        // handedness can disagree with the frame on a down-facing plane and
+        // invert this verdict. Non-planar faces keep the stored-UV area the
+        // periodic machinery is calibrated to.
+        let signed_area = if let Some(frame) = plane_frame.as_ref() {
+            let mut area = 0.0;
+            for edge in loop_edges.iter() {
+                let (t0, t1) = edge
+                    .curve_3d
+                    .domain_with_endpoints(edge.start_3d, edge.end_3d);
+                let n = if matches!(edge.curve_3d, EdgeCurve::Line) {
+                    1
+                } else {
+                    32
+                };
+                for k in 0..n {
+                    #[allow(clippy::cast_precision_loss)]
+                    let ta = t0 + (t1 - t0) * (k as f64 / n as f64);
+                    #[allow(clippy::cast_precision_loss)]
+                    let tb = t0 + (t1 - t0) * ((k + 1) as f64 / n as f64);
+                    let a3 = edge
+                        .curve_3d
+                        .evaluate_with_endpoints(ta, edge.start_3d, edge.end_3d);
+                    let b3 = edge
+                        .curve_3d
+                        .evaluate_with_endpoints(tb, edge.start_3d, edge.end_3d);
+                    let a = frame.project(a3);
+                    let b = frame.project(b3);
+                    area += (b.x() - a.x()) * (b.y() + a.y());
+                }
+            }
+            area
+        } else if loop_edges.len() == 1 {
             // For single-edge closed curves (circles), sample UV points
             // along the 3D curve and project to UV. The pcurve evaluation
             // gives proper UV coordinates for the full circle.
@@ -1771,11 +1815,21 @@ pub(super) fn split_face_with_internal_loops(
         let hole: Vec<OrientedPCurveEdge> = if let Some(u) = union_hole_by_loop[li].take() {
             // Normalize to hole winding: effective-CW about the effective
             // normal, i.e. stored CW (positive trapezoid area) for an
-            // unreversed parent, stored CCW for a reversed one.
-            let area: f64 = u
-                .iter()
-                .map(|e| (e.end_uv.x() - e.start_uv.x()) * (e.end_uv.y() + e.start_uv.y()))
-                .sum();
+            // unreversed parent, stored CCW for a reversed one. Same local
+            // frame as the disc normalization — stored UVs can be foreign.
+            let area: f64 = if let Some(frame) = plane_frame.as_ref() {
+                u.iter()
+                    .map(|e| {
+                        let a = frame.project(e.start_3d);
+                        let b = frame.project(e.end_3d);
+                        (b.x() - a.x()) * (b.y() + a.y())
+                    })
+                    .sum()
+            } else {
+                u.iter()
+                    .map(|e| (e.end_uv.x() - e.start_uv.x()) * (e.end_uv.y() + e.start_uv.y()))
+                    .sum()
+            };
             let mut u = u;
             if (area < 0.0) != reversed {
                 u.reverse();

--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -1160,13 +1160,43 @@ fn rebuild_face_with_cb_edges(
             if let Some(&cb_edge) = cb_qpair_edges.get(&key)
                 && cb_edge != eid
             {
-                let oriented_start_q = if fwd { qs } else { qe };
-                // If we can't look up the CB edge's start position,
-                // preserve the original orientation rather than
-                // guessing `false`.
-                let new_fwd = cb_start_qs
-                    .get(&cb_edge)
-                    .map_or(fwd, |&cs| cs == oriented_start_q);
+                let new_fwd = if qs == qe {
+                    // Closed rim replaced by the CB circle: endpoints cannot
+                    // orient it (start == end makes the position test read
+                    // "same start" for either traversal), and the CB curve
+                    // can parameterize opposite the original rim (the #1538
+                    // pocket ring: a kept wall's own rim vs the section
+                    // circle). Compare quarter points of the two curves and
+                    // carry the original traversal across the direction map.
+                    let same_dir = (|| {
+                        let orig_curve = curve.as_ref()?;
+                        let sp = topo.vertex(sv).ok()?.point();
+                        let ep = topo.vertex(ev).ok()?.point();
+                        let cbe = topo.edge(cb_edge).ok()?;
+                        let cs3 = topo.vertex(cbe.start()).ok()?.point();
+                        let ce3 = topo.vertex(cbe.end()).ok()?.point();
+                        let (o0, o1) = orig_curve.domain_with_endpoints(sp, ep);
+                        let (b0, b1) = cbe.curve().domain_with_endpoints(cs3, ce3);
+                        let oq = orig_curve.evaluate_with_endpoints(o0 + (o1 - o0) * 0.25, sp, ep);
+                        let bq_same =
+                            cbe.curve()
+                                .evaluate_with_endpoints(b0 + (b1 - b0) * 0.25, cs3, ce3);
+                        let bq_flip =
+                            cbe.curve()
+                                .evaluate_with_endpoints(b0 + (b1 - b0) * 0.75, cs3, ce3);
+                        Some((oq - bq_same).length() <= (oq - bq_flip).length())
+                    })()
+                    .unwrap_or(true);
+                    if same_dir { fwd } else { !fwd }
+                } else {
+                    let oriented_start_q = if fwd { qs } else { qe };
+                    // If we can't look up the CB edge's start position,
+                    // preserve the original orientation rather than
+                    // guessing `false`.
+                    cb_start_qs
+                        .get(&cb_edge)
+                        .map_or(fwd, |&cs| cs == oriented_start_q)
+                };
                 oes.push(OrientedEdge::new(cb_edge, new_fwd));
                 continue;
             }

--- a/crates/operations/examples/interface_fuse_probe.rs
+++ b/crates/operations/examples/interface_fuse_probe.rs
@@ -1,0 +1,182 @@
+//! #1538 coplanar-interface fuse family probe: fuse a plate carrying a
+//! through-hole onto a block below it, sharing the interface plane. The
+//! plate's interface face has a hole; the block's top face is full. The
+//! correct fuse is a solid with a blind pocket whose floor is part of the
+//! block's top plane.
+//!
+//! Modes: `circle` (round hole), `rect` (rectangular hole), `pocket`
+//! (blind pocket in the plate reaching exactly the interface — the
+//! circle-insert configuration). SYNTHETIC inputs only: both operands are
+//! validation-clean, which splits "the interface fuse is broken" from "the
+//! captured operands carry winding taint".
+//!
+//! `cargo run --release --example interface_fuse_probe -p brepkit-operations -- <mode>`
+#![allow(
+    clippy::print_stdout,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{self, BooleanOp};
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+fn report(topo: &Topology, sid: SolidId, label: &str) {
+    let faces = brepkit_topology::explorer::solid_faces(topo, sid).unwrap();
+    let mut mix: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+    let mut uses: std::collections::HashMap<brepkit_topology::edge::EdgeId, usize> =
+        std::collections::HashMap::new();
+    for &fid in &faces {
+        let face = topo.face(fid).unwrap();
+        *mix.entry(face.surface().type_tag()).or_default() += 1;
+        for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied()) {
+            for oe in topo.wire(wid).unwrap().edges() {
+                *uses.entry(oe.edge()).or_default() += 1;
+            }
+        }
+    }
+    let free = uses.values().filter(|&&c| c == 1).count();
+    let over = uses.values().filter(|&&c| c > 2).count();
+    if std::env::var("BK_WINDING").is_ok() {
+        // Per shared edge: the directed uses from each face. Same direction
+        // twice = the winding defect the census cannot see.
+        let mut dir_uses: std::collections::HashMap<
+            brepkit_topology::edge::EdgeId,
+            Vec<(brepkit_topology::face::FaceId, bool, bool)>,
+        > = std::collections::HashMap::new();
+        for &fid in &faces {
+            let face = topo.face(fid).unwrap();
+            let wires: Vec<_> = std::iter::once((face.outer_wire(), true))
+                .chain(face.inner_wires().iter().map(|&w| (w, false)))
+                .collect();
+            for (wid, is_outer) in wires {
+                for oe in topo.wire(wid).unwrap().edges() {
+                    dir_uses.entry(oe.edge()).or_default().push((
+                        fid,
+                        oe.is_forward() != face.is_reversed(),
+                        is_outer,
+                    ));
+                }
+            }
+        }
+        for (eid, us) in &dir_uses {
+            let closed = topo.edge(*eid).is_ok_and(|e| e.start() == e.end());
+            if us.len() == 2
+                && (us[0].1 == us[1].1
+                    || (closed && std::env::var("BK_WINDING").is_ok_and(|v| v == "2")))
+            {
+                let e = topo.edge(*eid).unwrap();
+                let a = topo.vertex(e.start()).unwrap().point();
+                let b = topo.vertex(e.end()).unwrap().point();
+                if let brepkit_topology::edge::EdgeCurve::Circle(c) = e.curve() {
+                    println!(
+                        "    axis=({:.2},{:.2},{:.2})",
+                        c.normal().x(),
+                        c.normal().y(),
+                        c.normal().z()
+                    );
+                }
+                println!(
+                    "  SAMEDIR {eid:?} ({:.1},{:.1},{:.1})->({:.1},{:.1},{:.1}) uses={us:?}",
+                    a.x(),
+                    a.y(),
+                    a.z(),
+                    b.x(),
+                    b.y(),
+                    b.z()
+                );
+                for (fid, _, _) in us {
+                    let f = topo.face(*fid).unwrap();
+                    println!(
+                        "    {fid:?} {} reversed={} inner_wires={}",
+                        f.surface().type_tag(),
+                        f.is_reversed(),
+                        f.inner_wires().len()
+                    );
+                }
+            }
+        }
+    }
+    let vol = brepkit_operations::measure::oriented_solid_volume(topo, sid, 0.05).unwrap();
+    let report = brepkit_operations::validate::validate_solid(topo, sid).unwrap();
+    println!(
+        "{label}: F={} mix={mix:?} free={free} over={over} vol={vol:.3} valid={} {:?}",
+        faces.len(),
+        report.is_valid(),
+        report.issues
+    );
+}
+
+fn main() {
+    env_logger::init();
+    let mode = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "circle".to_string());
+    let mut topo = Topology::new();
+
+    // Plate: 80 x 80 x 5 spanning z 5..10.
+    let plate = brepkit_operations::primitives::make_box(&mut topo, 80.0, 80.0, 5.0).unwrap();
+    brepkit_operations::transform::transform_solid(
+        &mut topo,
+        plate,
+        &Mat4::translation(0.0, 0.0, 5.0),
+    )
+    .unwrap();
+
+    let plate = match mode.as_str() {
+        "circle" => {
+            // Through-hole: cylinder r=10 through the plate.
+            let hole = brepkit_operations::primitives::make_cylinder(&mut topo, 10.0, 7.0).unwrap();
+            brepkit_operations::transform::transform_solid(
+                &mut topo,
+                hole,
+                &Mat4::translation(40.0, 40.0, 4.0),
+            )
+            .unwrap();
+            boolean::boolean(&mut topo, BooleanOp::Cut, plate, hole).unwrap()
+        }
+        "rect" => {
+            let hole =
+                brepkit_operations::primitives::make_box(&mut topo, 20.0, 20.0, 7.0).unwrap();
+            brepkit_operations::transform::transform_solid(
+                &mut topo,
+                hole,
+                &Mat4::translation(30.0, 30.0, 4.0),
+            )
+            .unwrap();
+            boolean::boolean(&mut topo, BooleanOp::Cut, plate, hole).unwrap()
+        }
+        "pocket" => {
+            // Blind pocket from the plate top reaching EXACTLY the interface
+            // plane z=5 (the circle-insert configuration: cutDepth == floor).
+            let hole = brepkit_operations::primitives::make_cylinder(&mut topo, 10.0, 6.0).unwrap();
+            brepkit_operations::transform::transform_solid(
+                &mut topo,
+                hole,
+                &Mat4::translation(40.0, 40.0, 5.0),
+            )
+            .unwrap();
+            boolean::boolean(&mut topo, BooleanOp::Cut, plate, hole).unwrap()
+        }
+        other => panic!("unknown mode {other}"),
+    };
+    report(&topo, plate, "plate with hole");
+
+    // Block below: 80 x 80 x 5 spanning z 0..5, sharing the z=5 plane.
+    let block = brepkit_operations::primitives::make_box(&mut topo, 80.0, 80.0, 5.0).unwrap();
+    report(&topo, block, "block");
+
+    let before = boolean::mesh_fallback_count();
+    let ops_result = boolean::boolean(&mut topo, BooleanOp::Fuse, plate, block).unwrap();
+    report(&topo, ops_result, "ops fuse");
+    println!("fallbacks: {}", boolean::mesh_fallback_count() - before);
+
+    // GFA deep-copies operands into its own store, so the same solids can be
+    // replayed raw in the same topology.
+    let raw =
+        brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Fuse, plate, block)
+            .unwrap();
+    report(&topo, raw, "raw GFA fuse");
+}

--- a/crates/operations/tests/interface_fuse_winding.rs
+++ b/crates/operations/tests/interface_fuse_winding.rs
@@ -1,0 +1,93 @@
+//! #1538 coplanar-interface family: cutting a through-hole out of a plate and
+//! fusing the plate onto a block across the shared plane must produce strictly
+//! valid winding (the free/over census cannot see same-direction shared
+//! edges; only `validate_solid`'s orientation check can).
+//!
+//! Three winding emitters have failed here, each invisible to watertightness:
+//! - the internal-loops splitter normalized disc/hole loops with a signed
+//!   area taken in the surface's own parameterization, which inverts the
+//!   verdict on a down-facing plane (fixed: local-frame areas);
+//! - `merge_duplicate_edges` never flipped closed edges, silently reversing
+//!   winding when two coincident circles parameterize opposite ways (fixed:
+//!   quarter-point direction comparison);
+//! - `rebuild_face_with_cb_edges` degenerated to `forward=true` for a closed
+//!   rim replaced by its CommonBlock circle (fixed: same comparison).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use brepkit_math::mat::Mat4;
+use brepkit_operations::boolean::{self, BooleanOp};
+use brepkit_topology::Topology;
+use brepkit_topology::solid::SolidId;
+
+fn plate_and_block(topo: &mut Topology) -> (SolidId, SolidId) {
+    let plate = brepkit_operations::primitives::make_box(topo, 80.0, 80.0, 5.0).unwrap();
+    brepkit_operations::transform::transform_solid(topo, plate, &Mat4::translation(0.0, 0.0, 5.0))
+        .unwrap();
+    let block = brepkit_operations::primitives::make_box(topo, 80.0, 80.0, 5.0).unwrap();
+    (plate, block)
+}
+
+fn assert_strictly_valid(topo: &Topology, sid: SolidId, label: &str) {
+    let report = brepkit_operations::validate::validate_solid(topo, sid).unwrap();
+    assert!(report.is_valid(), "{label} must validate: {report:?}");
+}
+
+#[test]
+fn rect_through_hole_cut_and_interface_fuse_have_valid_winding() {
+    let mut topo = Topology::new();
+    let (plate, block) = plate_and_block(&mut topo);
+    let hole = brepkit_operations::primitives::make_box(&mut topo, 20.0, 20.0, 7.0).unwrap();
+    brepkit_operations::transform::transform_solid(
+        &mut topo,
+        hole,
+        &Mat4::translation(30.0, 30.0, 4.0),
+    )
+    .unwrap();
+    let holed = boolean::boolean(&mut topo, BooleanOp::Cut, plate, hole).unwrap();
+    assert_strictly_valid(&topo, holed, "rect through-hole cut");
+
+    let fused = boolean::boolean(&mut topo, BooleanOp::Fuse, holed, block).unwrap();
+    assert_strictly_valid(&topo, fused, "rect interface fuse");
+    let vol = brepkit_operations::measure::oriented_solid_volume(&topo, fused, 0.05).unwrap();
+    assert!((vol - 62000.0).abs() < 0.5, "fuse volume {vol:.3}");
+}
+
+#[test]
+fn circle_through_hole_cut_and_interface_fuse_have_valid_winding() {
+    let mut topo = Topology::new();
+    let (plate, block) = plate_and_block(&mut topo);
+    let hole = brepkit_operations::primitives::make_cylinder(&mut topo, 10.0, 7.0).unwrap();
+    brepkit_operations::transform::transform_solid(
+        &mut topo,
+        hole,
+        &Mat4::translation(40.0, 40.0, 4.0),
+    )
+    .unwrap();
+    let holed = boolean::boolean(&mut topo, BooleanOp::Cut, plate, hole).unwrap();
+    assert_strictly_valid(&topo, holed, "circle through-hole cut");
+
+    let fused = boolean::boolean(&mut topo, BooleanOp::Fuse, holed, block).unwrap();
+    assert_strictly_valid(&topo, fused, "circle interface fuse");
+}
+
+/// READY-REPRO: a cutter whose bottom cap is COINCIDENT with the plate's
+/// bottom plane (the circle-insert cutDepth == floor configuration) still
+/// mints one same-direction shared edge at the rim — the cylinder-band
+/// split's rim emission in the coincident-cap case, the family's remaining
+/// sub-class.
+#[test]
+#[ignore = "coincident-cap pocket cut mints one same-direction rim edge; see #1538"]
+fn coincident_cap_pocket_cut_has_valid_winding() {
+    let mut topo = Topology::new();
+    let (plate, _block) = plate_and_block(&mut topo);
+    let hole = brepkit_operations::primitives::make_cylinder(&mut topo, 10.0, 6.0).unwrap();
+    brepkit_operations::transform::transform_solid(
+        &mut topo,
+        hole,
+        &Mat4::translation(40.0, 40.0, 5.0),
+    )
+    .unwrap();
+    let holed = boolean::boolean(&mut topo, BooleanOp::Cut, plate, hole).unwrap();
+    assert_strictly_valid(&topo, holed, "coincident-cap pocket cut");
+}


### PR DESCRIPTION
Digs the #1538 coplanar-interface family to its core: synthetic clean-input probes showed the family is three independent WINDING emitters, not one fuse defect. Even `cut(box, box)` through-hole minted 4 same-direction shared edges — invisible to the free-edge census, caught only by the validator's orientation check, and paid for downstream as open exported shells.

## The three roots

1. **`split_face_with_internal_loops`** normalized disc/hole loops with a signed area from **stored UVs** (the surface's own parameterization). On a down-facing plane that winds opposite the local frame the convention reasons in, inverting the verdict: the bottom cap's hole wire wound backwards while the top cap's was correct. Areas now come from 3D points projected through the local frame; non-planar faces keep the calibrated stored-UV path.
2. **`merge_duplicate_edges`** never flipped closed edges — endpoints cannot distinguish direction when start == end, and the code assumed coincident circles always parameterize the same way. A section-minted circle vs a kept operand rim can wind opposite ways. The flip is now decided by quarter-point comparison of the two curves. (This changes the merge's orientation *mapping* only — the terminal merge-key doctrine is untouched.)
3. **`rebuild_face_with_cb_edges`** degenerated to `forward=true` for a closed rim swapped to its CommonBlock circle (the oriented-start position test reads "same start" for either traversal). Same quarter-point comparison, carrying the original traversal across the direction map.

## Verification

- New probe `interface_fuse_probe` (rect/circle/pocket modes; `BK_WINDING=1` prints per-edge effective directions with owning faces — verified against first-principles halfedge math on single edges).
- Rect and circle through-hole chains (cut, then interface fuse) now **strictly valid end-to-end**; regressions in `interface_fuse_winding.rs`.
- Remaining sub-classes pinned ignored and recorded in the roadmap: the coincident-cap pocket rim (cylinder-band rim emission), the deep-cutout line-edge residue, the captured arc-cornered interface fuse.
- Full workspace 2742/2742, wasm gridfinity 27/27.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix winding direction on closed edges by sampling curve direction instead of relying on endpoint convention, removing same-direction shared edges in coplanar interface fuses (#1538). Through-hole cuts and fuses (circle and rectangle) now validate and export cleanly.

- **Bug Fixes**
  - Face splitter: decide disc/hole winding on planes using 3D points projected to the local frame; non‑planar faces keep stored-UV path. Fixes down-facing plane inversion.
  - `merge_duplicate_edges`: allow flipping closed edges by comparing quarter-point samples; updates orientation mapping only, not merge keys.
  - `rebuild_face_with_cb_edges`: preserve closed-rim orientation when swapping to CommonBlock circles using the same quarter-point comparison.
  - Added `interface_fuse_probe` example and `interface_fuse_winding` tests. Rect and circle chains are strictly valid. The coincident-cap pocket rim is pinned ignored and tracked in #1538.

<sup>Written for commit 588bdbf8168389d3700ef89dc8e062ef27e71dec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

