### PR TITLE
fix(algo): window open marched sections between non-plane faces

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1279,12 +1279,18 @@ fn restrict_curves_to_faces(
     tol: Tolerance,
     junctions: &mut JunctionRegistry,
 ) -> Vec<RawCurve> {
+    // `BK_RESTRICT=1`: the in-both window each section is trimmed to. Reports
+    // whether a curve reached this clip at all, which is what separates "the
+    // window was computed wrong" from "a special-case path emitted the section
+    // and skipped the clip entirely".
+    let trace_restrict = std::env::var_os("BK_RESTRICT").is_some();
+
     let (Some(ext_a), Some(ext_b)) = (
         FaceExtent::new(topo, fa, surf_a, v_range_a, tol),
         FaceExtent::new(topo, fb, surf_b, v_range_b, tol),
     ) else {
         // Conservative: if either face's extent can't be built, don't restrict.
-        if std::env::var("BK_RESTRICT").is_ok() {
+        if trace_restrict {
             log::debug!(
                 "RESTRICT-SKIP fa={fa:?} fb={fb:?} no extent ({} curves pass unclipped)",
                 raw_curves.len()
@@ -1294,11 +1300,6 @@ fn restrict_curves_to_faces(
     };
 
     const N: usize = 24;
-    // `BK_RESTRICT=1`: the in-both window each section is trimmed to. Reports
-    // whether a curve reached this clip at all, which is what separates "the
-    // window was computed wrong" from "a special-case path emitted the section
-    // and skipped the clip entirely".
-    let trace_restrict = std::env::var("BK_RESTRICT").is_ok();
     let mut out = Vec::with_capacity(raw_curves.len());
     for raw in raw_curves {
         // Lines are clipped downstream by `clip_line_to_face`; only the
@@ -1445,7 +1446,9 @@ fn restrict_curves_to_faces(
         // ellipse from an inner tapered wall meeting an outer corner (the
         // gridfinity lip knife-edge) would survive as a degenerate loop and
         // over-connect the rim. Circles are left whole (seam adoption handles
-        // them); open curves are left whole (the splitter clips them).
+        // them); open curves between plane faces are left whole (the splitter
+        // and `trim_open_curve_to_plane_face_lines` clip those), while open
+        // curves between two non-plane faces are windowed below.
         if closed && b1 - b0 < N && !matches!(raw.curve, EdgeCurve::Circle(_)) {
             // EVERY maximal in-both run, not just the longest: a closed
             // ellipse crossing a notched face has one window per side of the
@@ -1820,13 +1823,14 @@ fn rescue_corner_crossing(
     })
 }
 
-/// Emit every maximal in-both window of a CLOSED section curve. Non-wrapping
+/// Emit every maximal in-both window of a section curve, closed or open
+/// (`closed` selects whether runs may wrap the sample seam). Non-wrapping
 /// windows get their in/out transitions bisected to the exact mutual-extent
 /// boundary and their endpoints snapped to the boundary triple junction —
 /// sample-index endpoints land ~a sample-spacing off the junction the chain
-/// must weld to. Seam-wrapping windows keep the historical sample-index trim
-/// (bisection across the seam is curve-type dependent; `trim_closed_curve_to_inboth_arc`
-/// owns the wrap split).
+/// must weld to. Seam-wrapping windows (closed curves only) keep the
+/// historical sample-index trim (bisection across the seam is curve-type
+/// dependent; `trim_closed_curve_to_inboth_arc` owns the wrap split).
 #[allow(clippy::too_many_arguments)]
 fn emit_curve_windows(
     topo: &Topology,

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1284,6 +1284,12 @@ fn restrict_curves_to_faces(
         FaceExtent::new(topo, fb, surf_b, v_range_b, tol),
     ) else {
         // Conservative: if either face's extent can't be built, don't restrict.
+        if std::env::var("BK_RESTRICT").is_ok() {
+            log::debug!(
+                "RESTRICT-SKIP fa={fa:?} fb={fb:?} no extent ({} curves pass unclipped)",
+                raw_curves.len()
+            );
+        }
         return raw_curves;
     };
 
@@ -1411,9 +1417,15 @@ fn restrict_curves_to_faces(
                 ));
                 continue;
             }
-            if closed && f1 - f0 < n_fine && !matches!(raw.curve, EdgeCurve::Circle(_)) {
-                emit_closed_curve_windows(
-                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb_fine, n_fine, tol, junctions, &mut out,
+            if f1 - f0 < n_fine
+                && !matches!(raw.curve, EdgeCurve::Circle(_))
+                && (closed
+                    || (!matches!(surf_a, FaceSurface::Plane { .. })
+                        && !matches!(surf_b, FaceSurface::Plane { .. })))
+            {
+                emit_curve_windows(
+                    topo, fa, fb, &raw, &ext_a, &ext_b, &inb_fine, n_fine, closed, tol, junctions,
+                    &mut out,
                 );
                 continue;
             }
@@ -1442,8 +1454,26 @@ fn restrict_curves_to_faces(
             // Non-wrapping windows get bisected in/out transitions and
             // boundary-junction snapping — sample-index endpoints sit ~0.03
             // off the junction and never weld.
-            emit_closed_curve_windows(
-                topo, fa, fb, &raw, &ext_a, &ext_b, &inb, N, tol, junctions, &mut out,
+            emit_curve_windows(
+                topo, fa, fb, &raw, &ext_a, &ext_b, &inb, N, closed, tol, junctions, &mut out,
+            );
+            continue;
+        }
+        // OPEN marched curve between two non-plane faces: no downstream path
+        // clips it (`trim_open_curve_to_plane_face_lines` is plane-gated, and
+        // the splitter trims open sections only against plane-face
+        // boundaries), so an over-long chain reaches the splitter whole and
+        // mints regions outside the face domain — the circleinsert corner: a
+        // near-coaxial cone×cylinder loop arrives as open chains spanning the
+        // full circumference of a quarter band whose in-both run is 5 of 24
+        // segments. Emit the exact in-both windows instead.
+        if !closed
+            && b1 - b0 < N
+            && !matches!(surf_a, FaceSurface::Plane { .. })
+            && !matches!(surf_b, FaceSurface::Plane { .. })
+        {
+            emit_curve_windows(
+                topo, fa, fb, &raw, &ext_a, &ext_b, &inb, N, closed, tol, junctions, &mut out,
             );
             continue;
         }
@@ -1798,7 +1828,7 @@ fn rescue_corner_crossing(
 /// (bisection across the seam is curve-type dependent; `trim_closed_curve_to_inboth_arc`
 /// owns the wrap split).
 #[allow(clippy::too_many_arguments)]
-fn emit_closed_curve_windows(
+fn emit_curve_windows(
     topo: &Topology,
     fa: FaceId,
     fb: FaceId,
@@ -1807,6 +1837,7 @@ fn emit_closed_curve_windows(
     ext_b: &FaceExtent,
     inb: &[bool],
     n: usize,
+    closed: bool,
     tol: Tolerance,
     junctions: &mut JunctionRegistry,
     out: &mut Vec<RawCurve>,
@@ -1830,7 +1861,7 @@ fn emit_closed_curve_windows(
         let p = point_at(t);
         ext_a.contains(p) && ext_b.contains(p)
     };
-    for (r0, r1) in all_inboth_runs(inb, true) {
+    for (r0, r1) in all_inboth_runs(inb, closed) {
         if r1 - r0 < 2 {
             continue;
         }
@@ -5670,7 +5701,7 @@ mod tests {
         let mut junctions = JunctionRegistry::default();
         // Both extents the same square: the second face in a real pair only
         // narrows the window further, which this test doesn't need.
-        emit_closed_curve_windows(
+        emit_curve_windows(
             &topo,
             face,
             face,
@@ -5679,6 +5710,7 @@ mod tests {
             &ext,
             &inb,
             N,
+            true,
             tol,
             &mut junctions,
             &mut out,


### PR DESCRIPTION
## Summary

`restrict_curves_to_faces` kept open marched sections whole ("the downstream splitter trims them") — but that downstream trim only exists for plane faces (`trim_open_curve_to_plane_face_lines` is plane-gated, and the splitter clips open sections only against plane-face boundaries). Between two quadrics, an over-long open chain reaches the splitter whole and mints sub-faces outside the face domain.

The circleinsert socket fuse hits this at every bin corner: the socket's chamfer cone and the bin's corner cylinder are near-coaxial (axes 0.354mm apart), so their intersection is a closed wavy loop around the full cylinder, arriving from the marcher as two open chains. The quarter-band corner face's in-both window is 5 of 24 samples; the unclipped chains made the splitter emit an unsplit band plus out-of-domain fragments, which `remove_doubled_faces` then cancelled (identical post-merge edge sets), cascading into an 84-edge free ring and 4 over-shared corner arcs.

The fix generalizes `emit_closed_curve_windows` to `emit_curve_windows` (explicit closed flag) and emits exact bisection-refined in-both windows for OPEN marched curves when NEITHER face is a plane — plane pairs keep their existing paths. Applied in both the main sample-clip and the fine-resample branch.

## Measured on the circleinsert chain repro

- socket fuse: free 84 → 56, over-shared 4 → 0
- builder: 227 selected with 11 eaten as doubled + 2 sliver shells → 214 selected, ONE clean 214-face shell, zero doubled groups
- the remaining 56 free edges are the z=0/1.2 pocket/channel ring — a separate mechanism, tracked in the roadmap entry (the ignored fuse pin stays ignored)

## Verification

Full workspace suite green (render excluded per the known SIGSEGV), including the goma band fixtures, honeycomb and kumiko chains, the torus-notch whole-loop canary, and wasm gridfinity. Clippy/fmt via hooks.

Advances #1538.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Windows open marched intersection sections between two non‑plane faces instead of passing them through. Previously we left open chains intact expecting plane‑only downstream trimming, which produced out‑of‑domain regions; now we emit exact in‑both windows for those cases while keeping plane‑involved behavior unchanged.

- Generalizes `emit_closed_curve_windows` to `emit_curve_windows` (adds `closed` flag) and uses it in both sample‑clip and fine‑resample paths; applies to open curves only when neither face is a plane.
- Hoists the `BK_RESTRICT` env lookup and adds debug logging when extent construction fails, noting unclipped passes.
- Keeps circles whole; continues windowing of closed non‑circles; open curves with any plane face still rely on splitter/plane trimming.
- Circleinsert repro: free edges 84 → 56, over‑shared edges 4 → 0; one clean 214‑face shell; the z=0/1.2 ring remains tracked separately.
- Test suite green.

<sup>Written for commit 816c8e41fae8fcc22c9ca8df798b29e53ad24274. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

