### PR TITLE
fix(algo): close hole-dangling fence loops and weave them into the hole

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -7665,6 +7665,77 @@ mod tests {
         )
     }
 
+    /// The hole-dangling rescue: a fence chain whose two loose ends dangle
+    /// inside an inner wire must be trimmed at its exact rim crossings and
+    /// closed with the rim arc between the anchors (through the side away
+    /// from the chain), yielding a fully degree-2 loop web. The hole edge is
+    /// a closed circle (seam vertex), the codebase's common hole shape.
+    #[test]
+    fn hole_dangling_chain_is_rescued_with_a_rim_connector() {
+        use brepkit_math::curves::Circle3D;
+        let mut topo = Topology::new();
+        let face_id = make_unit_square_face(&mut topo);
+        let face = topo.face(face_id).unwrap();
+        let surface = face.surface().clone();
+        let wire_pts = collect_wire_points(&topo, face.outer_wire());
+        let normal = extract_plane_normal(&surface);
+        let frame = PlaneFrame::from_plane_face(normal, &wire_pts);
+        let boundary =
+            boundary_edges_to_pcurve(&topo, face.outer_wire(), &surface, &wire_pts, Some(&frame));
+
+        let center = Point3::new(0.5, 0.5, 0.0);
+        let r = 0.2;
+        let circle = Circle3D::new(center, brepkit_math::vec::Vec3::new(0.0, 0.0, 1.0), r).unwrap();
+        let seam = Point3::new(0.7, 0.5, 0.0);
+        let hole = vec![OrientedPCurveEdge {
+            curve_3d: EdgeCurve::Circle(circle),
+            pcurve: brepkit_math::curves2d::Curve2D::Circle(
+                brepkit_math::curves2d::Circle2D::new(frame.project(center), r).unwrap(),
+            ),
+            start_uv: frame.project(seam),
+            end_uv: frame.project(seam),
+            start_3d: seam,
+            end_3d: seam,
+            forward: true,
+            source_edge_idx: None,
+            pave_block_id: None,
+        }];
+
+        // U-shaped chain; both loose ends dangle inside the hole.
+        let sections = [
+            line_section(Point3::new(0.1, 0.4, 0.0), Point3::new(0.45, 0.4, 0.0)),
+            line_section(Point3::new(0.1, 0.4, 0.0), Point3::new(0.1, 0.6, 0.0)),
+            line_section(Point3::new(0.1, 0.6, 0.0), Point3::new(0.45, 0.6, 0.0)),
+        ];
+        let rescued = plane_internal_line_loops(&sections, &frame, &boundary, &[hole], 1e-7)
+            .expect("chain must be rescued");
+        assert_eq!(rescued.len(), 4, "3 trimmed sections + 1 rim connector");
+        let connector = rescued
+            .iter()
+            .find(|s| matches!(s.curve_3d, EdgeCurve::Circle(_)))
+            .expect("rim connector arc");
+        for p in [connector.start, connector.end] {
+            assert!(
+                ((p - center).length() - r).abs() < 1e-6,
+                "connector anchors on the rim"
+            );
+        }
+        // Trimmed line ends sit exactly on the rim; x = 0.5 - sqrt(r^2 - 0.1^2).
+        let x_rim = 0.5 - (r * r - 0.01_f64).sqrt();
+        for s in &rescued {
+            if matches!(s.curve_3d, EdgeCurve::Line) {
+                for p in [s.start, s.end] {
+                    let on_rim = ((p - center).length() - r).abs() < 1e-6;
+                    let inside = (p - center).length() < r - 1e-6;
+                    assert!(!inside, "no endpoint may remain inside the hole");
+                    if on_rim {
+                        assert!((p.x() - x_rim).abs() < 1e-6);
+                    }
+                }
+            }
+        }
+    }
+
     fn line_section(start: Point3, end: Point3) -> SectionEdge {
         SectionEdge {
             curve_3d: EdgeCurve::Line,

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -4910,8 +4910,13 @@ fn split_face_2d_impl(
         if single_closed {
             true
         } else {
-            deduped_line_loops =
-                plane_internal_line_loops(sections, frame, &boundary_edges, tol.linear);
+            deduped_line_loops = plane_internal_line_loops(
+                sections,
+                frame,
+                &boundary_edges,
+                &original_inner_wires,
+                tol.linear,
+            );
             deduped_line_loops.is_some()
         }
     } else {
@@ -7134,6 +7139,7 @@ fn plane_internal_line_loops(
     sections: &[SectionEdge],
     frame: &PlaneFrame,
     boundary_edges: &[OrientedPCurveEdge],
+    inner_wires: &[Vec<OrientedPCurveEdge>],
     tol_linear: f64,
 ) -> Option<Vec<SectionEdge>> {
     use std::collections::{HashMap, HashSet};
@@ -7303,6 +7309,24 @@ fn plane_internal_line_loops(
         }
     }
     if degree.values().any(|&d| d != 2) {
+        // Chains whose loose ends dangle strictly inside an INNER wire are
+        // fence loops overshooting into a hole: their in-hole tails lie
+        // outside the face material and the connecting geometry (a tool
+        // column swallowed by the hole) is not on this face at all, so the
+        // loop legitimately closes along the hole rim (the circleinsert
+        // slab's foot rings across the pocket). Trim each such chain at its
+        // exact rim crossing and close it with the rim arc between its two
+        // anchors. Any other degree defect keeps the historical bail.
+        if let Some(rescued) =
+            rescue_hole_dangling_loops(&deduped, &degree, &quant, inner_wires, frame, tol_linear)
+        {
+            log::debug!(
+                "plane_internal_line_loops: rescued {} hole-dangling sections into {} loop sections",
+                deduped.len(),
+                rescued.len()
+            );
+            return Some(rescued);
+        }
         let bad: Vec<_> = degree.iter().filter(|&(_, &d)| d != 2).collect();
         log::debug!(
             "plane_internal_line_loops: {} endpoints with degree != 2 (deduped {} of {}): {bad:?}",
@@ -7313,6 +7337,315 @@ fn plane_internal_line_loops(
         return None;
     }
     Some(deduped)
+}
+
+/// Rescue for [`plane_internal_line_loops`]: every degree-1 endpoint lies
+/// strictly inside one of the face's inner wires (holes). Trims each loose
+/// chain at its exact hole-rim crossing, drops the fully-in-hole tail
+/// sections, and closes each chain with the rim arc between its two anchors
+/// (the candidate arc containing no other chains' anchors). Returns `None`
+/// unless every step resolves unambiguously — the historical bail then
+/// stands.
+#[allow(clippy::too_many_lines)]
+fn rescue_hole_dangling_loops(
+    deduped: &[SectionEdge],
+    degree: &std::collections::HashMap<(i64, i64, i64), u32>,
+    quant: &dyn Fn(Point3) -> (i64, i64, i64),
+    inner_wires: &[Vec<OrientedPCurveEdge>],
+    frame: &PlaneFrame,
+    tol_linear: f64,
+) -> Option<Vec<SectionEdge>> {
+    if inner_wires.is_empty() || degree.values().any(|&d| d > 2) {
+        return None;
+    }
+    let margin = tol_linear * 100.0;
+
+    // Arc-true hole polygons in the local frame, plus per-hole edge geometry.
+    let mut hole_polys: Vec<Vec<Point2>> = Vec::new();
+    for wire in inner_wires {
+        let mut poly = Vec::new();
+        for e in wire {
+            poly.push(frame.project(e.start_3d));
+            if !matches!(e.curve_3d, EdgeCurve::Line) {
+                let (t0, t1) = e.curve_3d.domain_with_endpoints(e.start_3d, e.end_3d);
+                for k in 1..32 {
+                    let t = (t1 - t0).mul_add(f64::from(k) / 32.0, t0);
+                    poly.push(
+                        frame.project(e.curve_3d.evaluate_with_endpoints(t, e.start_3d, e.end_3d)),
+                    );
+                }
+            }
+        }
+        if poly.len() < 3 {
+            return None;
+        }
+        hole_polys.push(poly);
+    }
+    let hole_of = |p: Point3| -> Option<usize> {
+        let uv = frame.project(p);
+        hole_polys.iter().position(|poly| {
+            super::classify_2d::point_in_polygon_2d(uv, poly)
+                && super::classify_2d::distance_to_polygon_boundary(uv, poly) > margin
+        })
+    };
+
+    // Gate: every loose end strictly inside some hole.
+    let loose: Vec<(i64, i64, i64)> = degree
+        .iter()
+        .filter(|&(_, &d)| d == 1)
+        .map(|(&q, _)| q)
+        .collect();
+    if loose.is_empty() {
+        return None;
+    }
+    let mut loose_hole: std::collections::HashMap<(i64, i64, i64), usize> =
+        std::collections::HashMap::new();
+    for s in deduped {
+        for p in [s.start, s.end] {
+            if loose.contains(&quant(p)) {
+                let hi = hole_of(p)?;
+                loose_hole.insert(quant(p), hi);
+            }
+        }
+    }
+    if loose_hole.len() != loose.len() {
+        return None;
+    }
+
+    // Exact crossing of a Line section with a hole edge, in the local frame.
+    let line_hole_crossing = |sec_start: Point3, sec_end: Point3, hi: usize| -> Option<Point3> {
+        let wire = &inner_wires[hi];
+        let a2 = frame.project(sec_start);
+        let b2 = frame.project(sec_end);
+        let d2 = b2 - a2;
+        let mut best: Option<(f64, Point3)> = None;
+        for e in wire {
+            match &e.curve_3d {
+                EdgeCurve::Circle(c) => {
+                    let c2 = frame.project(c.center());
+                    let r = c.radius();
+                    // |a2 + t*d2 - c2|^2 = r^2
+                    let f = a2 - c2;
+                    let qa = d2.dot(d2);
+                    let qb = 2.0 * f.dot(d2);
+                    let qc = f.dot(f) - r * r;
+                    let disc = qb.mul_add(qb, -4.0 * qa * qc);
+                    if disc < 0.0 || qa.abs() < 1e-30 {
+                        continue;
+                    }
+                    for t in [
+                        (-qb - disc.sqrt()) / (2.0 * qa),
+                        (-qb + disc.sqrt()) / (2.0 * qa),
+                    ] {
+                        if !(0.0..=1.0).contains(&t) {
+                            continue;
+                        }
+                        let p3 = sec_start + (sec_end - sec_start) * t;
+                        // Within the arc's own span?
+                        let (t0, t1) = e.curve_3d.domain_with_endpoints(e.start_3d, e.end_3d);
+                        let ang = c.project(p3);
+                        let span = t1 - t0;
+                        let rel = (ang - t0).rem_euclid(std::f64::consts::TAU);
+                        if rel <= span + 1e-9 {
+                            match best {
+                                Some((bt, _)) if bt <= t => {}
+                                _ => best = Some((t, p3)),
+                            }
+                        }
+                    }
+                }
+                EdgeCurve::Line => {
+                    let s2 = frame.project(e.start_3d);
+                    let e2 = frame.project(e.end_3d);
+                    let sd = e2 - s2;
+                    let det = d2.x().mul_add(sd.y(), -(d2.y() * sd.x()));
+                    if det.abs() < 1e-14 {
+                        continue;
+                    }
+                    let dx = s2 - a2;
+                    let t = dx.x().mul_add(sd.y(), -(dx.y() * sd.x())) / det;
+                    let u = dx.x().mul_add(d2.y(), -(dx.y() * d2.x())) / det;
+                    if (0.0..=1.0).contains(&t) && (-1e-9..=1.0 + 1e-9).contains(&u) {
+                        let p3 = sec_start + (sec_end - sec_start) * t;
+                        match best {
+                            Some((bt, _)) if bt <= t => {}
+                            _ => best = Some((t, p3)),
+                        }
+                    }
+                }
+                _ => return None,
+            }
+        }
+        best.map(|(_, p)| p)
+    };
+
+    // Walk each loose chain, trimming at the rim.
+    let mut sections: Vec<Option<SectionEdge>> = deduped.iter().cloned().map(Some).collect();
+    let mut adjacency: std::collections::HashMap<(i64, i64, i64), Vec<usize>> =
+        std::collections::HashMap::new();
+    for (i, s) in deduped.iter().enumerate() {
+        adjacency.entry(quant(s.start)).or_default().push(i);
+        adjacency.entry(quant(s.end)).or_default().push(i);
+    }
+    // (hole idx, anchor point, chain id) per trimmed end.
+    let mut anchors: Vec<(usize, Point3, usize)> = Vec::new();
+    let mut visited_loose: std::collections::HashSet<(i64, i64, i64)> =
+        std::collections::HashSet::new();
+    let mut chain_id = 0usize;
+    for &start_q in &loose {
+        if visited_loose.contains(&start_q) {
+            continue;
+        }
+        let hi = *loose_hole.get(&start_q)?;
+        // Walk from this loose end through degree-2 nodes to the other end.
+        let mut prev_q = start_q;
+        let mut cur_idx = *adjacency.get(&start_q)?.first()?;
+        let mut chain_members: Vec<usize> = Vec::new();
+        loop {
+            chain_members.push(cur_idx);
+            let s = deduped.get(cur_idx)?;
+            let (aq, bq) = (quant(s.start), quant(s.end));
+            let next_q = if aq == prev_q { bq } else { aq };
+            if loose.contains(&next_q) {
+                visited_loose.insert(start_q);
+                visited_loose.insert(next_q);
+                break;
+            }
+            let nbrs = adjacency.get(&next_q)?;
+            let next_idx = *nbrs.iter().find(|&&i| i != cur_idx)?;
+            prev_q = next_q;
+            cur_idx = next_idx;
+        }
+        // Trim both ends of this chain.
+        for end_of_chain in [false, true] {
+            let iter: Box<dyn Iterator<Item = &usize>> = if end_of_chain {
+                Box::new(chain_members.iter().rev())
+            } else {
+                Box::new(chain_members.iter())
+            };
+            let mut trimmed = false;
+            for &mi in iter {
+                let Some(sec) = sections[mi].clone() else {
+                    continue;
+                };
+                let in_s = hole_of(sec.start).is_some();
+                let in_e = hole_of(sec.end).is_some();
+                if in_s && in_e {
+                    sections[mi] = None;
+                    continue;
+                }
+                if !in_s && !in_e {
+                    return None;
+                }
+                if !matches!(sec.curve_3d, EdgeCurve::Line) {
+                    return None;
+                }
+                let cross = line_hole_crossing(sec.start, sec.end, hi)?;
+                let mut new_sec = sec;
+                if in_s {
+                    new_sec.start = cross;
+                } else {
+                    new_sec.end = cross;
+                }
+                new_sec.start_uv_a = None;
+                new_sec.end_uv_a = None;
+                new_sec.start_uv_b = None;
+                new_sec.end_uv_b = None;
+                sections[mi] = Some(new_sec);
+                anchors.push((hi, cross, chain_id));
+                trimmed = true;
+                break;
+            }
+            if !trimmed {
+                return None;
+            }
+        }
+        chain_id += 1;
+    }
+    if anchors.len() != 2 * chain_id {
+        return None;
+    }
+
+    // Rim connector per chain: the arc between its two anchors that contains
+    // no other chains' anchors.
+    let mut out: Vec<SectionEdge> = sections.into_iter().flatten().collect();
+    for cid in 0..chain_id {
+        let pair: Vec<&(usize, Point3, usize)> =
+            anchors.iter().filter(|(_, _, c)| *c == cid).collect();
+        let [(hi_a, pa, _), (hi_b, pb, _)] = pair[..] else {
+            return None;
+        };
+        if hi_a != hi_b {
+            return None;
+        }
+        // One shared circle for the whole hole rim.
+        let circle = inner_wires[*hi_a].iter().find_map(|e| {
+            if let EdgeCurve::Circle(c) = &e.curve_3d {
+                Some(c.clone())
+            } else {
+                None
+            }
+        })?;
+        let on_rim = |p: Point3| ((p - circle.center()).length() - circle.radius()).abs() <= margin;
+        if !on_rim(*pa) || !on_rim(*pb) {
+            return None;
+        }
+        let ang = |p: Point3| circle.project(p);
+        let (ta, tb) = (ang(*pa), ang(*pb));
+        let span_ab = (tb - ta).rem_euclid(std::f64::consts::TAU);
+        let others: Vec<f64> = anchors
+            .iter()
+            .filter(|(h, _, c)| *c != cid && h == hi_a)
+            .map(|(_, p, _)| ang(*p))
+            .collect();
+        let contains_other = |from: f64, span: f64| {
+            others.iter().any(|&o| {
+                let rel = (o - from).rem_euclid(std::f64::consts::TAU);
+                rel > 1e-9 && rel < span - 1e-9
+            })
+        };
+        let ab_clear = !contains_other(ta, span_ab);
+        let ba_clear = !contains_other(tb, std::f64::consts::TAU - span_ab);
+        let (from_p, to_p) = match (ab_clear, ba_clear) {
+            (true, false) => (*pa, *pb),
+            (false, true) => (*pb, *pa),
+            (true, true) => {
+                if span_ab <= std::f64::consts::PI {
+                    (*pa, *pb)
+                } else {
+                    (*pb, *pa)
+                }
+            }
+            (false, false) => return None,
+        };
+        let uv_c = frame.project(circle.center());
+        let pc2 = brepkit_math::curves2d::Circle2D::new(uv_c, circle.radius()).ok()?;
+        out.push(SectionEdge {
+            curve_3d: EdgeCurve::Circle(circle),
+            pcurve_a: brepkit_math::curves2d::Curve2D::Circle(pc2.clone()),
+            pcurve_b: brepkit_math::curves2d::Curve2D::Circle(pc2),
+            start: from_p,
+            end: to_p,
+            start_uv_a: None,
+            end_uv_a: None,
+            start_uv_b: None,
+            end_uv_b: None,
+            target_face: None,
+            pave_block_id: None,
+        });
+    }
+
+    // The rescued web must be fully degree-2.
+    let mut deg2: std::collections::HashMap<(i64, i64, i64), u32> =
+        std::collections::HashMap::new();
+    for s in &out {
+        *deg2.entry(quant(s.start)).or_insert(0) += 1;
+        *deg2.entry(quant(s.end)).or_insert(0) += 1;
+    }
+    if deg2.values().any(|&d| d != 2) {
+        return None;
+    }
+    Some(out)
 }
 
 #[cfg(test)]

--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -7606,6 +7606,9 @@ fn rescue_hole_dangling_loops(
         };
         let ab_clear = !contains_other(ta, span_ab);
         let ba_clear = !contains_other(tb, std::f64::consts::TAU - span_ab);
+        log::debug!(
+            "rescue connector: ta={ta:.4} tb={tb:.4} span_ab={span_ab:.4} ab_clear={ab_clear} ba_clear={ba_clear}"
+        );
         let (from_p, to_p) = match (ab_clear, ba_clear) {
             (true, false) => (*pa, *pb),
             (false, true) => (*pb, *pa),

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1670,6 +1670,213 @@ pub(super) fn split_face_with_internal_loops(
         }
     }
 
+    // Multi-loop rim-tangent union: several rescued fence loops can each
+    // touch the SAME hole along one rim-coincident connector arc (the
+    // circleinsert slab: four foot rings, one pocket). The pairwise union
+    // above cannot take them (chord-based, and it consumes the hole after
+    // one loop). Weave ONE combined inner boundary instead: the rim spans
+    // not covered by any connector, spliced with each tangent loop's ring
+    // chain; the loops' own hole contributions are absorbed into it.
+    let mut hole_absorbed: Vec<bool> = vec![false; loops.len()];
+    if let Some(frame) = plane_frame.as_ref() {
+        'hole: for (hi, hole) in original_inner_wires.iter().enumerate() {
+            if consumed_holes.contains(&hi) {
+                continue;
+            }
+            let Some(circle) = hole.iter().find_map(|e| {
+                if let EdgeCurve::Circle(c) = &e.curve_3d {
+                    Some(c.clone())
+                } else {
+                    None
+                }
+            }) else {
+                continue;
+            };
+            if hole
+                .iter()
+                .any(|e| !matches!(e.curve_3d, EdgeCurve::Circle(_)))
+            {
+                continue;
+            }
+            let weld = tol_3d * 100.0;
+            let on_rim =
+                |p: Point3| ((p - circle.center()).length() - circle.radius()).abs() <= weld;
+            // Tangent loops: exactly one edge with both endpoints and its own
+            // midpoint on the rim; every other edge midpoint OFF the rim.
+            let mid_of = |e: &OrientedPCurveEdge| -> Point3 {
+                let (t0, t1) = e.curve_3d.domain_with_endpoints(e.start_3d, e.end_3d);
+                e.curve_3d
+                    .evaluate_with_endpoints(f64::midpoint(t0, t1), e.start_3d, e.end_3d)
+            };
+            // (loop idx, connector idx)
+            let mut tangent: Vec<(usize, usize)> = Vec::new();
+            for (li, loop_edges) in loops.iter().enumerate() {
+                if union_hole_by_loop[li].is_some() {
+                    continue;
+                }
+                let rim_edges: Vec<usize> = loop_edges
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, e)| on_rim(e.start_3d) && on_rim(e.end_3d) && on_rim(mid_of(e)))
+                    .map(|(i, _)| i)
+                    .collect();
+                if rim_edges.len() == 1
+                    && loop_edges
+                        .iter()
+                        .enumerate()
+                        .all(|(i, e)| i == rim_edges[0] || !on_rim(mid_of(e)))
+                {
+                    tangent.push((li, rim_edges[0]));
+                }
+            }
+            log::debug!(
+                "rim-tangent union: hole {hi} tangent loops {:?} of {}",
+                tangent,
+                loops.len()
+            );
+            if tangent.is_empty() {
+                continue;
+            }
+            let ang_of = |p: Point3| circle.project(p);
+            // Covered spans: (start angle, span, loop idx). The covered arc is
+            // the connector's own geometry; its midpoint disambiguates which
+            // way round the circle it runs.
+            let mut covered: Vec<(f64, f64, usize)> = Vec::new();
+            for &(li, ci) in &tangent {
+                let e = &loops[li][ci];
+                let (a, b) = (ang_of(e.start_3d), ang_of(e.end_3d));
+                let m = ang_of(mid_of(e));
+                let span_ab = (b - a).rem_euclid(std::f64::consts::TAU);
+                let rel_m = (m - a).rem_euclid(std::f64::consts::TAU);
+                if rel_m <= span_ab {
+                    covered.push((a, span_ab, li));
+                } else {
+                    covered.push((b, std::f64::consts::TAU - span_ab, li));
+                }
+            }
+            covered.sort_by(|x, y| x.0.partial_cmp(&y.0).unwrap_or(std::cmp::Ordering::Equal));
+            // Overlapping covered spans: not this shape; leave everything as is.
+            for w in covered.windows(2) {
+                if w[0].0 + w[0].1 > w[1].0 + 1e-9 {
+                    continue 'hole;
+                }
+            }
+            if let (Some(first), Some(last)) = (covered.first(), covered.last())
+                && last.0 + last.1 > first.0 + std::f64::consts::TAU + 1e-9
+            {
+                continue 'hole;
+            }
+            // Weave the union wire: for each covered span, the loop's ring
+            // chain (connector removed) traversed from the span's start
+            // anchor to its end anchor; between spans, rim pieces cut from
+            // the circle.
+            let pt_at = |a: f64| circle.evaluate(a);
+            let rim_piece = |a0: f64, a1: f64| -> Option<OrientedPCurveEdge> {
+                let span = (a1 - a0).rem_euclid(std::f64::consts::TAU);
+                if span * circle.radius() < tol_3d {
+                    return None;
+                }
+                let (s3, e3) = (pt_at(a0), pt_at(a1));
+                let pc = brepkit_math::curves2d::Circle2D::new(
+                    frame.project(circle.center()),
+                    circle.radius(),
+                )
+                .ok()?;
+                Some(OrientedPCurveEdge {
+                    curve_3d: EdgeCurve::Circle(circle.clone()),
+                    pcurve: brepkit_math::curves2d::Curve2D::Circle(pc),
+                    start_uv: frame.project(s3),
+                    end_uv: frame.project(e3),
+                    start_3d: s3,
+                    end_3d: e3,
+                    forward: true,
+                    source_edge_idx: None,
+                    pave_block_id: None,
+                })
+            };
+            let mut union_wire: Vec<OrientedPCurveEdge> = Vec::new();
+            let mut ok = true;
+            for (k, &(a0, span, li)) in covered.iter().enumerate() {
+                // Ring chain for this loop, from the anchor at angle a0
+                // (span start) to the anchor at its end, connector removed.
+                let ci = tangent.iter().find(|(l, _)| *l == li).map(|(_, c)| *c);
+                let Some(ci) = ci else {
+                    ok = false;
+                    break;
+                };
+                let start_anchor = pt_at(a0);
+                let mut chain: Vec<OrientedPCurveEdge> = loops[li]
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != ci)
+                    .map(|(_, e)| e.clone())
+                    .collect();
+                // Orient the chain to run start_anchor -> end_anchor by
+                // endpoint chaining.
+                let mut ordered: Vec<OrientedPCurveEdge> = Vec::new();
+                let mut cur = start_anchor;
+                while !chain.is_empty() {
+                    let Some(pos) = chain.iter().position(|e| {
+                        (e.start_3d - cur).length() < weld || (e.end_3d - cur).length() < weld
+                    }) else {
+                        ok = false;
+                        break;
+                    };
+                    let mut e = chain.remove(pos);
+                    if (e.end_3d - cur).length() < weld {
+                        std::mem::swap(&mut e.start_3d, &mut e.end_3d);
+                        std::mem::swap(&mut e.start_uv, &mut e.end_uv);
+                        e.forward = !e.forward;
+                    }
+                    cur = e.end_3d;
+                    ordered.push(e);
+                }
+                if !ok {
+                    break;
+                }
+                union_wire.extend(ordered);
+                // Rim piece from this span's end to the next span's start.
+                let end_a = a0 + span;
+                let next_a = covered[(k + 1) % covered.len()].0
+                    + if k + 1 == covered.len() {
+                        std::f64::consts::TAU
+                    } else {
+                        0.0
+                    };
+                if let Some(piece) = rim_piece(
+                    end_a.rem_euclid(std::f64::consts::TAU),
+                    next_a.rem_euclid(std::f64::consts::TAU),
+                ) {
+                    union_wire.push(piece);
+                }
+            }
+            if !ok || union_wire.is_empty() {
+                log::debug!(
+                    "rim-tangent union: weave failed ok={ok} n={}",
+                    union_wire.len()
+                );
+                continue;
+            }
+            // Positional closure check.
+            let closed = union_wire
+                .windows(2)
+                .all(|w| (w[0].end_3d - w[1].start_3d).length() < weld)
+                && union_wire
+                    .last()
+                    .is_some_and(|l| (l.end_3d - union_wire[0].start_3d).length() < weld);
+            if !closed {
+                log::debug!("rim-tangent union: wire not closed");
+                continue;
+            }
+            let first_li = tangent[0].0;
+            union_hole_by_loop[first_li] = Some(union_wire);
+            for &(li, _) in &tangent[1..] {
+                hole_absorbed[li] = true;
+            }
+            consumed_holes.insert(hi);
+        }
+    }
+
     let mut result = Vec::new();
 
     // For each closed loop: create an "inside" sub-face.
@@ -1826,6 +2033,9 @@ pub(super) fn split_face_with_internal_loops(
         // Build the outside sub-face's hole: the merged union outline when
         // this loop consumed an overlapping pre-existing hole, otherwise the
         // reversed loop.
+        if hole_absorbed[li] {
+            continue;
+        }
         let hole: Vec<OrientedPCurveEdge> = if let Some(u) = union_hole_by_loop[li].take() {
             // Normalize to hole winding: effective-CW about the effective
             // normal, i.e. stored CW (positive trapezoid area) for an

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1703,10 +1703,21 @@ pub(super) fn split_face_with_internal_loops(
                 |p: Point3| ((p - circle.center()).length() - circle.radius()).abs() <= weld;
             // Tangent loops: exactly one edge with both endpoints and its own
             // midpoint on the rim; every other edge midpoint OFF the rim.
+            // A reversed edge (forward == false) stores swapped endpoints;
+            // its geometry is the stored CCW span sampled REVERSED, never the
+            // complement — evaluate through the effective endpoint order.
+            let eff = |e: &OrientedPCurveEdge| -> (Point3, Point3) {
+                if e.forward {
+                    (e.start_3d, e.end_3d)
+                } else {
+                    (e.end_3d, e.start_3d)
+                }
+            };
             let mid_of = |e: &OrientedPCurveEdge| -> Point3 {
-                let (t0, t1) = e.curve_3d.domain_with_endpoints(e.start_3d, e.end_3d);
+                let (f, t) = eff(e);
+                let (t0, t1) = e.curve_3d.domain_with_endpoints(f, t);
                 e.curve_3d
-                    .evaluate_with_endpoints(f64::midpoint(t0, t1), e.start_3d, e.end_3d)
+                    .evaluate_with_endpoints(f64::midpoint(t0, t1), f, t)
             };
             // (loop idx, connector idx)
             let mut tangent: Vec<(usize, usize)> = Vec::new();
@@ -1744,7 +1755,8 @@ pub(super) fn split_face_with_internal_loops(
             let mut covered: Vec<(f64, f64, usize)> = Vec::new();
             for &(li, ci) in &tangent {
                 let e = &loops[li][ci];
-                let (a, b) = (ang_of(e.start_3d), ang_of(e.end_3d));
+                let (ef, et) = eff(e);
+                let (a, b) = (ang_of(ef), ang_of(et));
                 let m = ang_of(mid_of(e));
                 let span_ab = (b - a).rem_euclid(std::f64::consts::TAU);
                 let rel_m = (m - a).rem_euclid(std::f64::consts::TAU);

--- a/crates/algo/src/builder/face_splitter/special_cases.rs
+++ b/crates/algo/src/builder/face_splitter/special_cases.rs
@@ -1755,15 +1755,18 @@ pub(super) fn split_face_with_internal_loops(
                 }
             }
             covered.sort_by(|x, y| x.0.partial_cmp(&y.0).unwrap_or(std::cmp::Ordering::Equal));
+            log::debug!("rim-tangent union: covered {covered:?}");
             // Overlapping covered spans: not this shape; leave everything as is.
             for w in covered.windows(2) {
                 if w[0].0 + w[0].1 > w[1].0 + 1e-9 {
+                    log::debug!("rim-tangent union: covered spans overlap");
                     continue 'hole;
                 }
             }
             if let (Some(first), Some(last)) = (covered.first(), covered.last())
                 && last.0 + last.1 > first.0 + std::f64::consts::TAU + 1e-9
             {
+                log::debug!("rim-tangent union: covered spans wrap");
                 continue 'hole;
             }
             // Weave the union wire: for each covered span, the loop's ring

--- a/crates/io/examples/circleinsert_chain.rs
+++ b/crates/io/examples/circleinsert_chain.rs
@@ -154,4 +154,38 @@ fn main() {
         brepkit_algo::gfa::boolean(&mut topo, brepkit_algo::bop::BooleanOp::Fuse, body, sockets)
             .unwrap();
     report(&topo, fused, "socket fuse");
+
+    // `CHANNEL_EDGE=1`: every result edge lying on the -x channel line
+    // (y ~= 2.4, z ~= 1.2), with owners and full-precision endpoints — the
+    // instrument for "who owns the other side of the freed slab edge".
+    if std::env::var("CHANNEL_EDGE").is_ok() {
+        for fid in solid_faces(&topo, fused).unwrap() {
+            let face = topo.face(fid).unwrap();
+            for wid in std::iter::once(face.outer_wire()).chain(face.inner_wires().iter().copied())
+            {
+                for oe in topo.wire(wid).unwrap().edges() {
+                    let e = topo.edge(oe.edge()).unwrap();
+                    let a = topo.vertex(e.start()).unwrap().point();
+                    let b = topo.vertex(e.end()).unwrap().point();
+                    let on = |p: brepkit_math::vec::Point3| {
+                        (p.y() - 2.4).abs() < 1e-3 && (p.z() - 1.2).abs() < 1e-3 && p.x() < -4.0
+                    };
+                    if on(a) && on(b) {
+                        println!(
+                            "CHANNEL {fid:?}:{} {:?} fwd={} ({:.9},{:.9},{:.9})->({:.9},{:.9},{:.9})",
+                            face.surface().type_tag(),
+                            oe.edge(),
+                            oe.is_forward(),
+                            a.x(),
+                            a.y(),
+                            a.z(),
+                            b.x(),
+                            b.y(),
+                            b.z()
+                        );
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Two coordinated extensions of the face splitter's internal-loops path, closing most of the circleinsert socket-fuse residue (#1538):

1. **Hole-dangling rescue** (`rescue_hole_dangling_loops`): when `plane_internal_line_loops` fails its degree gate and EVERY loose endpoint lies strictly inside an inner wire, the dangling chains are fence loops overshooting into a hole — their in-hole tails lie outside the face material and the connecting geometry is not on the face. The rescue trims each chain at its exact rim crossing, drops fully-in-hole sections, and closes each chain with the rim arc containing no other chains' anchors.

2. **Rim-tangent union**: several rescued loops can touch the SAME hole along rim-coincident connectors (four foot rings, one pocket). The existing pairwise union is chord-based and consumes the hole after one loop; the new weave builds ONE combined inner boundary — uncovered rim spans spliced with each loop's ring chain — and absorbs the loops' individual hole contributions.

Plus the load-bearing correction inside the union: a reversed `OrientedPCurveEdge` stores swapped endpoints with `forward=false`, and its geometry is the stored CCW span sampled reversed — never the complement. The span detection now reads through the flag (it originally read raw endpoints, saw every connector as the long complement, and silently never fired).

## Measured on the circleinsert chain repro

- socket fuse: free **84 → 4**, over-shared **4 → 0** (combined with the already-shipped #1559)
- the remaining 4 free edges bound one z=0 sliver in a single quadrant (tracked in the roadmap entry; the ignored fuse pin stays ignored until free=0)

## Verification

Full workspace suite green (render excluded per the known SIGSEGV), including the groove-chain, dovetail hole-cut, coincident-lip-fuse, deepened-wall-opening, deepcutout, and shelled-bin fixtures, plus wasm gridfinity. The rescue is gated on the exact failure signature and the three sentinel foils were verified not to reach it.

Advances #1538.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes hole‑dangling fence loops in the face splitter and weaves rim‑tangent loops into their hole to prevent missed unions on circle‑insert faces. Previously the internal‑loops path bailed on degree defects and pairwise union consumed the hole after the first loop; now chains trim at rim crossings, close on the rim, multiple tangent loops merge into one inner boundary, and span detection handles reversed edges.

- Rescue in `plane_internal_line_loops`: when every degree‑1 endpoint lies strictly inside an inner wire, trim each chain at the exact rim crossing, drop in‑hole tails, and close it with the rim arc that contains no other chains’ anchors; any other defect keeps the prior bail.
- Rim‑tangent union: when several rescued loops touch the same circular hole via rim‑coincident connectors, weave one combined inner boundary (uncovered rim spans spliced with each loop’s ring chain), absorb those loops’ hole contributions, and consume the hole.
- Corrects reversed edge handling: connector span detection now respects `OrientedPCurveEdge.forward` so reversed edges use the stored span. On the circle‑insert repro: free edges 84 → 4; over‑shared 4 → 0.

**Review and rollout**
- Gated: rescue triggers only for strict in‑hole dangling endpoints; the weave triggers only for circular holes with clean, non‑overlapping connector spans; ambiguous cases fall back to the prior behavior.
- Tolerances: rim checks use 100× linear tol or weld; closure is validated before emitting unions; debug logs cover rescue and rim‑span decisions.
- Tests and instrumentation: adds a unit test that pins the rescue; example `crates/io/examples/circleinsert_chain.rs` prints channel edges when `CHANNEL_EDGE` is set. No migrations required.

<sup>Written for commit 851589a67388ac9843bc4e1f6ebdb34c649e25a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

