### PR TITLE
fix(algo): test circular holes analytically in the ray-cast classifier

### DIFF
--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -23,6 +23,12 @@ enum FaceGeom {
     Planar {
         verts: Vec<Point3>,
         holes: Vec<Vec<Point3>>,
+        /// Holes whose wire is circular, kept ANALYTIC (center, radius): a
+        /// chord-sampled hole polygon under-covers the true circle by its
+        /// sagitta, and a ray passing through that band counts a phantom
+        /// crossing while reading clean (the circleinsert pocket-mouth
+        /// sample: a hit 0.03 inside the r=10 pocket rim, sagitta ~0.09).
+        circle_holes: Vec<(Point3, f64)>,
         normal: Vec3,
         d: f64,
     },
@@ -240,8 +246,22 @@ fn votes_from_geoms(face_data: &[FaceGeom], point: Point3) -> Result<u8, AlgoErr
         for (i, ray_dir) in dirs.iter().enumerate() {
             let mut crossings = 0i32;
             let mut suspicious = false;
-            for geom in face_data {
+            for (gi, geom) in face_data.iter().enumerate() {
                 let (c, s) = ray_geom_crossings(point, *ray_dir, geom, tol);
+                if traced && (c != 0 || s) {
+                    let tag = match geom {
+                        FaceGeom::Planar { verts, .. } => format!("planar[{}v]", verts.len()),
+                        FaceGeom::Cylinder { .. } => "cylinder".to_string(),
+                        FaceGeom::Cone { .. } => "cone".to_string(),
+                        FaceGeom::Torus { .. } => "torus".to_string(),
+                    };
+                    log::debug!(
+                        "RAYHIT {label} dir=({:.3},{:.3},{:.3}) geom#{gi} {tag} c={c} susp={s}",
+                        ray_dir.x(),
+                        ray_dir.y(),
+                        ray_dir.z()
+                    );
+                }
                 crossings += c;
                 suspicious |= s;
             }
@@ -650,7 +670,34 @@ fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, 
         }
 
         let mut holes = Vec::with_capacity(face.inner_wires().len());
+        let mut circle_holes: Vec<(Point3, f64)> = Vec::new();
         for &iw in face.inner_wires() {
+            // A hole whose edges all lie on ONE circle stays analytic.
+            let circular: Option<(Point3, f64)> = (|| {
+                let wire = topo.wire(iw).ok()?;
+                let mut c: Option<(Point3, f64)> = None;
+                for oe in wire.edges() {
+                    let edge = topo.edge(oe.edge()).ok()?;
+                    let brepkit_topology::edge::EdgeCurve::Circle(circ) = edge.curve() else {
+                        return None;
+                    };
+                    match &c {
+                        None => c = Some((circ.center(), circ.radius())),
+                        Some((cc, cr)) => {
+                            if (circ.center() - *cc).length() > 1e-6
+                                || (circ.radius() - cr).abs() > 1e-6
+                            {
+                                return None;
+                            }
+                        }
+                    }
+                }
+                c
+            })();
+            if let Some(ch) = circular {
+                circle_holes.push(ch);
+                continue;
+            }
             let hole = wire_polygon(topo, iw)?;
             if hole.len() >= 3 {
                 holes.push(hole);
@@ -673,6 +720,7 @@ fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, 
         result.push(FaceGeom::Planar {
             verts,
             holes,
+            circle_holes,
             normal,
             d,
         });
@@ -738,9 +786,19 @@ fn ray_geom_crossings(
         FaceGeom::Planar {
             verts,
             holes,
+            circle_holes,
             normal,
             d,
-        } => ray_face_crossing(origin, ray_dir, verts, holes, *normal, *d, tol),
+        } => ray_face_crossing(
+            origin,
+            ray_dir,
+            verts,
+            holes,
+            circle_holes,
+            *normal,
+            *d,
+            tol,
+        ),
         FaceGeom::Cylinder {
             surface,
             v_min,
@@ -773,11 +831,13 @@ fn ray_geom_crossings(
 /// Returns +1 for a crossing, 0 for no intersection. Hits inside a hole
 /// polygon do not count.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn ray_face_crossing(
     origin: Point3,
     ray_dir: Vec3,
     verts: &[Point3],
     holes: &[Vec<Point3>],
+    circle_holes: &[(Point3, f64)],
     normal: Vec3,
     d: f64,
     tol: Tolerance,
@@ -804,11 +864,17 @@ fn ray_face_crossing(
     let boundary_graze = dist_to_polygon_boundary(hit, verts) <= near
         || holes
             .iter()
-            .any(|h| dist_to_polygon_boundary(hit, h) <= near);
+            .any(|h| dist_to_polygon_boundary(hit, h) <= near)
+        || circle_holes
+            .iter()
+            .any(|(c, r)| ((hit - *c).length() - r).abs() <= near);
     if !point_in_face_3d(hit, verts, &normal) {
         return (0, boundary_graze);
     }
     if holes.iter().any(|h| point_in_face_3d(hit, h, &normal)) {
+        return (0, boundary_graze);
+    }
+    if circle_holes.iter().any(|(c, r)| (hit - *c).length() < *r) {
         return (0, boundary_graze);
     }
     (1, boundary_graze)

--- a/crates/algo/src/classifier/ray_cast.rs
+++ b/crates/algo/src/classifier/ray_cast.rs
@@ -671,9 +671,21 @@ fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, 
 
         let mut holes = Vec::with_capacity(face.inner_wires().len());
         let mut circle_holes: Vec<(Point3, f64)> = Vec::new();
+        // Analytic holes only on a genuine plane face: the fallback path
+        // reaches here for non-planar surfaces via a Newell normal, where a
+        // hole's circle need not be coplanar with the polygon and the exact
+        // distance test below would be wrong.
+        let plane_normal =
+            if let brepkit_topology::face::FaceSurface::Plane { normal, .. } = face.surface() {
+                Some(*normal)
+            } else {
+                None
+            };
         for &iw in face.inner_wires() {
-            // A hole whose edges all lie on ONE circle stays analytic.
+            // A hole whose edges all lie on ONE circle IN THE FACE PLANE
+            // stays analytic.
             let circular: Option<(Point3, f64)> = (|| {
+                let pn = plane_normal?;
                 let wire = topo.wire(iw).ok()?;
                 let mut c: Option<(Point3, f64)> = None;
                 for oe in wire.edges() {
@@ -681,6 +693,9 @@ fn collect_face_geoms(topo: &Topology, solid: SolidId) -> Result<Vec<FaceGeom>, 
                     let brepkit_topology::edge::EdgeCurve::Circle(circ) = edge.curve() else {
                         return None;
                     };
+                    if circ.normal().cross(pn).length() > 1e-6 {
+                        return None;
+                    }
                     match &c {
                         None => c = Some((circ.center(), circ.radius())),
                         Some((cc, cr)) => {

--- a/crates/io/tests/circleinsert_interface_fuse_inmem.rs
+++ b/crates/io/tests/circleinsert_interface_fuse_inmem.rs
@@ -99,7 +99,6 @@ fn circleinsert_pocket_cut_is_strictly_valid() {
 }
 
 #[test]
-#[ignore = "open residue: with BOTH operands validation-clean the socket fuse still emits 84 free edges around the pocket mouth (z=0/1.2 rim arcs and inter-feet gap channels) plus 4 over-shared bin corner arcs at z=5; native repro `cargo run --release -p brepkit-io --example circleinsert_chain` (FREE_EDGES=1 dumps owners); see #1538"]
 fn circleinsert_socket_fuse_is_strictly_valid() {
     let mut topo = Topology::new();
     let base = load("circleinsert_base.bin", &mut topo);


### PR DESCRIPTION
## Summary

The last residue of the #1538 circleinsert socket fuse was a phantom ray crossing: the ray-cast classifier's holed-plane test uses chord-sampled hole polygons, and a generic ray's crossing landed 0.03 inside the true r=10 pocket circle but outside the sampled polygon (sagitta ≈0.09, graze band 1e-6) — a miscount that self-reported clean and flipped one quadrant's pad piece to Inside, dropping it and leaving a 4-edge open sliver.

`FaceGeom::Planar` now carries holes whose wire lies on a single circle as analytic (center, radius) pairs, tested exactly for both containment and graze. Non-circular holes keep the polygon path, and NO verdict logic changes — the calibrated conflict/re-cast machinery is untouched (the honeycomb landscape that vetoed four vote-layer rule variants passes 4/4).

## Result

- circleinsert chain: free **4 → 0**, over 0 — the socket fuse validates strictly end to end, and the long-ignored pin `circleinsert_socket_fuse_is_strictly_valid` is ACTIVATED.
- With #1559 (3.2.30) and #1563 (3.2.31), the full #1538 arc this session: free 84 / over 4 → **0 / 0**.
- Full workspace suite green (render excluded per the known SIGSEGV); wasm gridfinity included.

Also includes the per-geom RAYHIT trace (BK_RAY_POINT-gated) that found the phantom, and the roadmap close.

Closes the circleinsert chain of #1538.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes phantom ray crossings in the ray-cast classifier by testing circular holes analytically on true planar faces. Previously, polygon-sampled circles under-covered the hole and rays in the sagitta band counted as face hits; now coplanar circular holes stay as (center, radius) and we test containment and graze exactly. Verdict logic is unchanged.

- Adds `circle_holes` to `FaceGeom::Planar`; `collect_face_geoms` extracts analytic circular holes only when the face surface is a Plane and all inner-wire edges are the same circle whose normal is parallel to the plane (center/radius match within 1e-6). Otherwise holes remain polygons.
- Extends `ray_face_crossing` to reject hits inside analytic circles and mark grazes on circle rims using the existing tolerance band.
- Adds optional per-geom `RAYHIT` debug tracing (gated by `BK_RAY_POINT`); no runtime behavior change when disabled.
- Unignores `circleinsert_socket_fuse_is_strictly_valid`; the circleinsert chain validates strictly.

<sup>Written for commit cb19fbcbec337130e4aec046982da0e0a8f39396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

