### PR TITLE
fix(algo): skip open-curve windowing on fragmented curve populations

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -1300,6 +1300,14 @@ fn restrict_curves_to_faces(
     };
 
     const N: usize = 24;
+    // Open-curve windowing is skipped for pathologically fragmented curve
+    // populations: a near-coaxial quadric pair can arrive as dozens of
+    // marched chains (the 1u spacer fuse: 64 per pair), and windowing each
+    // one multiplies the section flood the splitter then grinds on (a 12s
+    // doomed-anyway analytic attempt became 128s before the same mesh
+    // fallback, #1570). Genuine windowing cases carry a handful of curves
+    // (the circleinsert corner: 2 per pair).
+    let window_open_curves = raw_curves.len() <= 12;
     let mut out = Vec::with_capacity(raw_curves.len());
     for raw in raw_curves {
         // Lines are clipped downstream by `clip_line_to_face`; only the
@@ -1421,7 +1429,8 @@ fn restrict_curves_to_faces(
             if f1 - f0 < n_fine
                 && !matches!(raw.curve, EdgeCurve::Circle(_))
                 && (closed
-                    || (!matches!(surf_a, FaceSurface::Plane { .. })
+                    || (window_open_curves
+                        && !matches!(surf_a, FaceSurface::Plane { .. })
                         && !matches!(surf_b, FaceSurface::Plane { .. })))
             {
                 emit_curve_windows(
@@ -1471,6 +1480,7 @@ fn restrict_curves_to_faces(
         // full circumference of a quarter band whose in-both run is 5 of 24
         // segments. Emit the exact in-both windows instead.
         if !closed
+            && window_open_curves
             && b1 - b0 < N
             && !matches!(surf_a, FaceSurface::Plane { .. })
             && !matches!(surf_b, FaceSurface::Plane { .. })


### PR DESCRIPTION
## Summary

Fixes #1570 (spacer export timeout since 3.2.30).

The 1u spacer's lip fuse arrives at phase FF with a pre-existing pathological curve population — a few near-coaxial quadric pairs each carrying 64 marched chains (verified identical on the 3.2.29 tag: 584 restrict entries both). The 3.2.30 open-curve windowing processed each of those chains, multiplying the section flood: a doomed-anyway analytic attempt went from 12.6s (3.2.29) to 128s (3.2.30+) before the same mesh fallback, which pushed the tool-side export past its 30s test budget.

Pairs with more than 12 raw curves now keep the historic whole-curve behavior. Genuine windowing cases carry a handful of curves (the circleinsert corner pairs: 2 each), so the #1538 close is unaffected.

## Measured

- Spacer operand replay: raw GFA 128s → 12.7s (3.2.29 parity, same fast fallback).
- circleinsert chain: still free=0, over=0, strict pin green.
- Honeycomb foils 4/4; full workspace suite green.

Note for the backlog: the spacer fuse was ALREADY failing analytically on 3.2.29 (free=41/over=18 → mesh fallback) — that latent defect predates the windowing and is tracked separately in the roadmap; this PR restores the fast-fallback behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips open-curve windowing for fragmented curve populations to remove a 3.2.30 performance regression that caused spacer export timeouts. Old behavior windowed every open-curve chain; new behavior keeps whole-curve restriction when a pair has >12 raw curves, preventing section flood and restoring 3.2.29 timings.

- Gate: windowing only when raw_curves.len() <= 12 in restrict_curves_to_faces; otherwise use historic whole-curve restriction.
- Genuine windowing cases with few curves (e.g., circleinsert corners with 2) remain unchanged; closed and circular edges are unaffected.
- Results: spacer replay 128s → 12.7s; circleinsert free=0/over=0; honeycomb foils 4/4; full workspace suite green. Analytic outcome is unchanged; this only removes extra work before the same mesh fallback.

<sup>Written for commit 301f6f85ffdbadb3ac3977c29ce6b7b81635d3cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

