### PR TITLE
chore(algo): enrich SD miss traces with plane data and clip areas

### DIFF
--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -373,11 +373,18 @@ fn build_sd_grouping(
                 // boundary-identical edge sets.
                 geometric_overlap_groups.insert(uf.find(i));
             } else if sd_miss_trace {
-                log::debug!(
-                    "SD miss (planar): {:?} vs {:?}",
-                    sub_faces[i].face_id,
-                    sub_faces[j].face_id
-                );
+                let probe = |idx: usize| {
+                    let sf = &sub_faces[idx];
+                    let d = topo.face(sf.face_id).ok().and_then(|f| {
+                        if let FaceSurface::Plane { normal, d } = *f.surface() {
+                            Some((normal.z(), d))
+                        } else {
+                            None
+                        }
+                    });
+                    (sf.face_id, d, sf.interior_point)
+                };
+                log::debug!("SD miss (planar): {:?} vs {:?}", probe(i), probe(j));
             }
         }
     }
@@ -1119,6 +1126,15 @@ fn planar_faces_overlap(
                 brepkit_math::polygon_boolean::BooleanOp::Intersection,
                 tol.linear,
             );
+            if std::env::var("BK_SD_AREA").is_ok() {
+                log::debug!(
+                    "SD area {:?}x{:?}: area_i={area_i:.3} area_j={area_j:.3} inter={:.3} thresh={:.3}",
+                    sub_faces[i].face_id,
+                    sub_faces[j].face_id,
+                    inter.area().abs(),
+                    smaller * 0.5
+                );
+            }
             if inter.area().abs() > smaller * 0.5 {
                 return true;
             }


### PR DESCRIPTION
## Summary
- `BK_SD_MISS` planar miss lines now print each face's plane (normal z, d) and stored interior point, which is what separates a correctly-rejected hole-contained sliver from a genuinely missed coincident pair.
- The planar partial-overlap clip logs its area arithmetic (`area_i`, `area_j`, intersection, threshold) under a new `BK_SD_AREA` gate.
- Log-only, both behind env gates; no behavior change.

## Test plan
- `cargo test -p brepkit-algo --lib same_domain` green; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriches same-domain (SD) miss debug logs with per-face plane data and interior points, and adds gated area arithmetic logs for planar partial-overlap clips. This improves diagnosis of hole-contained slivers vs real coincident gaps; no behavior change.

- Planar SD miss logs now show each face as (face_id, (plane normal.z, d) if planar, interior_point).
- When `BK_SD_AREA` is set, planar overlap logs area_i, area_j, intersection area, and the acceptance threshold.
- Logs are behind `BK_SD_MISS` and `BK_SD_AREA`; unset by default. Set `BK_SD_MISS=1` or `BK_SD_AREA=1` to enable.

<sup>Written for commit 8f01d5aab1e9754aef2ae57088038795b2e583fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

