### PR TITLE
chore(algo): trace SD selection decisions and analytic overlap spans

### DIFF
--- a/crates/algo/src/bop.rs
+++ b/crates/algo/src/bop.rs
@@ -162,6 +162,25 @@ fn apply_sd_selection(
     for pair in sd_pairs {
         let sf_a = &sub_faces[pair.idx_a];
 
+        if std::env::var("BK_SD_SEL").is_ok() {
+            log::debug!(
+                "SD select {:?}: a={:?} b={:?} same_ori={} rep={:?} -> {}",
+                op,
+                sub_faces[pair.idx_a].face_id,
+                sub_faces[pair.idx_b].face_id,
+                pair.same_orientation,
+                sub_faces[pair.representative].face_id,
+                if same_ori_needed == pair.same_orientation {
+                    if op == BooleanOp::Cut {
+                        "keep A"
+                    } else {
+                        "keep rep"
+                    }
+                } else {
+                    "drop both"
+                }
+            );
+        }
         if same_ori_needed == pair.same_orientation {
             // Orientations match what the operation needs:
             // - Fuse + same-ori: keep the larger (containing) face for a

--- a/crates/algo/src/builder/same_domain.rs
+++ b/crates/algo/src/builder/same_domain.rs
@@ -1474,6 +1474,30 @@ fn analytic_faces_overlap(
     let area_i = super::classify_2d::signed_area_2d(&poly_i).abs();
     let area_j = super::classify_2d::signed_area_2d(&poly_j).abs();
     let smaller = area_i.min(area_j);
+    if std::env::var("BK_SD_AREA").is_ok() {
+        let span = |poly: &[brepkit_math::vec::Point2]| {
+            let (mut ulo, mut uhi, mut vlo, mut vhi) = (
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+            );
+            for p in poly {
+                ulo = ulo.min(p.x());
+                uhi = uhi.max(p.x());
+                vlo = vlo.min(p.y());
+                vhi = vhi.max(p.y());
+            }
+            (ulo, uhi, vlo, vhi)
+        };
+        log::debug!(
+            "SD area (analytic) {:?}x{:?}: span_i={:?} span_j={:?} shift={best_shift:.3} ip_i_in_j={ip_i_in_j} ip_j_in_i={ip_j_in_i} inter={overlap_area:.4} area_i={area_i:.3} area_j={area_j:.3}",
+            sub_faces[i].face_id,
+            sub_faces[j].face_id,
+            span(&poly_i),
+            span(&poly_j)
+        );
+    }
     smaller > tol.linear_sq() && overlap_area > smaller * 0.5
 }
 


### PR DESCRIPTION
## Summary
- `BK_SD_SEL` logs each same-domain pair's faces, orientation flag, representative, and the keep/drop verdict at selection time.
- `BK_SD_AREA` on the analytic (coaxial cylinder/cone) overlap pass logs the unwrapped `(arc-length, axial)` spans, the chosen periodic shift, containment flags, and clip areas.
- Log-only, both env-gated; no behavior change.

These two traces exonerated SD for the spacer lip fuse residue (#1570 tail): the wall-strip pairs are detected by edge-set hash and resolved keep-A/drop-B correctly, and every analytic candidate pair is a genuinely disjoint stacked band. The residue is downstream (a missing inner-skirt wall in the selected face set).

## Test plan
- `cargo test -p brepkit-algo` green; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Traces same-domain (SD) selection decisions and analytic overlap spans to aid debugging. No behavior change; logs emit only when BK_SD_SEL or BK_SD_AREA is set.

- With BK_SD_SEL: logs op, face IDs for A/B, same-orientation flag, representative face, and the keep/rep/drop verdict for each SD pair.
- With BK_SD_AREA: during analytic (coaxial cylinder/cone) overlap, logs unwrapped spans (arc-length, axial) for each polygon, chosen periodic shift, containment flags, intersection area, and per-face areas.
- Default off; enable by setting BK_SD_SEL and/or BK_SD_AREA in the environment.

<sup>Written for commit 9c5e0257c268401963ec08f82cccb3589cf6e90b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

