### PR TITLE
feat(algo): march quadric x NURBS face pairs into real sections

### DIFF
--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -3526,13 +3526,10 @@ fn compute_raw_curves(
         }
 
         (analytic_surf, FaceSurface::Nurbs(nurbs)) if analytic_surf.as_analytic().is_some() => {
-            // Deferred to later phases -- analytic-NURBS is complex
-            let _ = nurbs;
-            Ok(Vec::new())
+            analytic_nurbs_intersection(analytic_surf, v_range_a, nurbs)
         }
         (FaceSurface::Nurbs(nurbs), analytic_surf) if analytic_surf.as_analytic().is_some() => {
-            let _ = nurbs;
-            Ok(Vec::new())
+            analytic_nurbs_intersection(analytic_surf, v_range_b, nurbs)
         }
 
         (FaceSurface::Nurbs(na), FaceSurface::Nurbs(nb)) => nurbs_nurbs_intersection(na, nb),
@@ -3964,6 +3961,54 @@ fn nurbs_nurbs_intersection(
     }
 
     Ok(results)
+}
+
+/// Quadric × NURBS intersection: convert the analytic surface to its NURBS
+/// representation over the face's v-range (exact rational for cylinder and
+/// cone) and march it against the partner. This arm used to return no curves
+/// ("deferred to later phases" — no such phase existed), so any boolean
+/// pairing a quadric with a NURBS face silently never split either side:
+/// the NURBS solid's kept pieces and the quadric's kept pieces shared no
+/// seam and the result shelled apart (the kumiko wedge × ruled-strut fuse).
+fn analytic_nurbs_intersection(
+    surf: &FaceSurface,
+    v_range: Option<(f64, f64)>,
+    nurbs: &brepkit_math::nurbs::surface::NurbsSurface,
+) -> Result<Vec<RawCurve>, AlgoError> {
+    // Cylinder and cone are unbounded along their axis; without a stored
+    // v-range, bound the band by the NURBS partner's control-point extent
+    // projected on the axis (convex hull property), padded so a curve
+    // grazing the ends is not clipped.
+    let axial_range = |origin: Point3, axis: Vec3| -> (f64, f64) {
+        let mut lo = f64::MAX;
+        let mut hi = f64::MIN;
+        for row in nurbs.control_points() {
+            for p in row {
+                let v = (*p - origin).dot(axis);
+                lo = lo.min(v);
+                hi = hi.max(v);
+            }
+        }
+        let pad = (hi - lo).abs().mul_add(0.1, 1.0);
+        (lo - pad, hi + pad)
+    };
+    let converted = match surf {
+        FaceSurface::Cylinder(c) => {
+            let (v0, v1) = v_range.unwrap_or_else(|| axial_range(c.origin(), c.axis()));
+            c.to_nurbs(v0, v1)
+        }
+        FaceSurface::Cone(c) => {
+            let (v0, v1) = v_range.unwrap_or_else(|| axial_range(c.apex(), c.axis()));
+            c.to_nurbs(v0, v1)
+        }
+        FaceSurface::Sphere(s) => s.to_nurbs(),
+        FaceSurface::Torus(t) => t.to_nurbs(),
+        _ => return Ok(Vec::new()),
+    };
+    match converted {
+        Ok(as_nurbs) => nurbs_nurbs_intersection(&as_nurbs, nurbs),
+        Err(_) => Ok(Vec::new()),
+    }
 }
 
 /// Compute AABB for a circle.

--- a/crates/algo/src/pave_filler/phase_ff.rs
+++ b/crates/algo/src/pave_filler/phase_ff.rs
@@ -3964,12 +3964,13 @@ fn nurbs_nurbs_intersection(
 }
 
 /// Quadric × NURBS intersection: convert the analytic surface to its NURBS
-/// representation over the face's v-range (exact rational for cylinder and
-/// cone) and march it against the partner. This arm used to return no curves
-/// ("deferred to later phases" — no such phase existed), so any boolean
-/// pairing a quadric with a NURBS face silently never split either side:
-/// the NURBS solid's kept pieces and the quadric's kept pieces shared no
-/// seam and the result shelled apart (the kumiko wedge × ruled-strut fuse).
+/// representation over the face's v-range (exact rational for the cylinder;
+/// cone, sphere and torus use their sampled conversions) and march it
+/// against the partner. This arm used to return no curves ("deferred to
+/// later phases" — no such phase existed), so any boolean pairing a quadric
+/// with a NURBS face silently never split either side: the NURBS solid's
+/// kept pieces and the quadric's kept pieces shared no seam and the result
+/// shelled apart (the kumiko wedge × ruled-strut fuse).
 fn analytic_nurbs_intersection(
     surf: &FaceSurface,
     v_range: Option<(f64, f64)>,
@@ -4005,10 +4006,7 @@ fn analytic_nurbs_intersection(
         FaceSurface::Torus(t) => t.to_nurbs(),
         _ => return Ok(Vec::new()),
     };
-    match converted {
-        Ok(as_nurbs) => nurbs_nurbs_intersection(&as_nurbs, nurbs),
-        Err(_) => Ok(Vec::new()),
-    }
+    nurbs_nurbs_intersection(&converted?, nurbs)
 }
 
 /// Compute AABB for a circle.


### PR DESCRIPTION
## Result

Booleans pairing a quadric face (cylinder, cone, sphere, torus) with a NURBS face now produce intersection sections. The FF dispatch arm for that pairing returned no curves with a "deferred to later phases" comment (no such phase existed), so both faces silently survived unsplit and the result shelled apart: on the kumiko wedge x ruled-strut fuse the entire wedge detached as an open growth shell because its cylinders never received a single section.

## Fix

Convert the quadric to its NURBS representation (exact rational for cylinder and cone, over the face's stored v-range, or the partner's control-point extent projected on the axis when no range is stored) and march it with the existing NURBS x NURBS intersector. Sphere and torus use their existing conversions.

## Scope and verification

- With the arm live, the wedge's cylinders split (3 and 7 sections) where they previously stayed whole. The kumiko strut ready-repro stays ignored: its remaining roots are section chaining and seam welding, not section existence — the failure signature improves from a 5-face to a 7-face detached shell as splitting progresses.
- Full battery green: operations (33 binaries, incl. every sweep/boolean foil), algo, io (all captured-operand fixtures incl. compartscoop/labelbracket/bp64), wasm gridfinity canary 27/27.
- approx_census: all boolean rows exact analytic, unchanged.
- clippy -D warnings green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
March quadric × NURBS face pairs into real intersection sections so booleans split correctly. Previously this dispatch returned no curves, leaving both faces unsplit and causing detached shells (e.g., kumiko wedge × ruled-strut).

- Convert the quadric to NURBS and reuse the existing NURBS × NURBS intersector; cylinders use an exact rational form over the face’s v-range or, if absent, a range from the NURBS partner’s projected control-point extent with padding. Cones, spheres, and tori use existing sampled conversions.
- Both analytic→NURBS and NURBS→analytic arms now call this path; conversion errors are propagated to prevent silent no-section fallbacks.
- Behavior: wedge cylinders now split (3 and 7 sections) instead of staying whole; remaining issues are in section chaining/seam welding, not section existence.
- Verification: full suite green; `approx_census` unchanged; `clippy -D` clean.
- No migrations or API changes.

<sup>Written for commit 4c570691e640611ad62ebb0164ceec6dbfe7c039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

