### PR TITLE
test(algo): pin the junction-band discriminant on marched sections

### DIFF
--- a/crates/algo/src/builder/face_splitter/edge_splitting.rs
+++ b/crates/algo/src/builder/face_splitter/edge_splitting.rs
@@ -581,6 +581,26 @@ mod tests {
         }
     }
 
+    /// The junction-band discriminant: an on-curve point midway between the
+    /// finder's 64 samples sits ~half a sample step from its nearest sample,
+    /// so the narrow broad phase (boundary-split calibration, honeycomb
+    /// foil) must reject it while the junction bands (T-splits at other
+    /// sections' endpoints — the wedge-corner junction) must accept it.
+    #[test]
+    fn junction_bands_accept_on_curve_points_between_samples() {
+        let edge = parabola_section_edge(false);
+        let eval = |t: f64| evaluate_edge_at_t(&edge.curve_3d, edge.start_3d, edge.end_3d, t);
+        let sp = eval(0.507);
+        let tol = 1e-7;
+        assert!(
+            find_splits_on_nurbs_section(&edge, &[sp], tol, false).is_empty(),
+            "narrow bands must reject a mid-segment candidate"
+        );
+        let splits = find_splits_on_nurbs_section(&edge, &[sp], tol, true);
+        assert_eq!(splits.len(), 1, "junction bands must accept the junction");
+        assert!((splits[0].1 - sp).length() < 1e-6);
+    }
+
     #[test]
     fn nurbs_section_splits_ordered_along_forward_edge() {
         let edge = parabola_section_edge(false);


### PR DESCRIPTION
Follow-up to #1606 addressing the review comment: pins that an on-curve point midway between the finder's 64 samples is rejected with junction_bands=false (the boundary-split calibration the honeycomb foil guards) and accepted with junction_bands=true (the T-junction path).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the junction-band discriminant for marched NURBS sections by adding a test that proves behavior. Previously unguarded, the mid-sample on-curve case is now enforced: narrow bands reject it; junction bands accept it, protecting boundary-split calibration and the T-junction path.

- Adds `junction_bands_accept_on_curve_points_between_samples` in `crates/algo/src/builder/face_splitter/edge_splitting.rs`. It evaluates a parabola section at t=0.507 with tol=1e-7, asserts no split when `junction_bands=false`, and one split near the probe when `junction_bands=true`.
- No behavior change; increases coverage and prevents regressions in the coarse-sample discriminant on marched sections.

<sup>Written for commit 0c9d3a60f011cf8db59eed9f7c1a30f764944d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

