### PR TITLE
refactor(algo): adopt the nearest canon UV at interior junctions

### DIFF
--- a/crates/algo/src/builder/face_splitter/mod.rs
+++ b/crates/algo/src/builder/face_splitter/mod.rs
@@ -5773,7 +5773,12 @@ fn split_face_2d_impl(
                 };
                 let adopted = canon
                     .iter()
-                    .find(|(q3, _)| (*q3 - p3).length_squared() <= weld3_sq)
+                    .filter(|(q3, _)| (*q3 - p3).length_squared() <= weld3_sq)
+                    .min_by(|(a3, _), (b3, _)| {
+                        (*a3 - p3)
+                            .length_squared()
+                            .total_cmp(&(*b3 - p3).length_squared())
+                    })
                     .map(|&(_, quv)| quv);
                 let new_uv = adopted.unwrap_or_else(|| {
                     canon.push((p3, uv));


### PR DESCRIPTION
Follow-up to #1609 addressing the review comment: the interior-junction canonicalization now adopts the MINIMUM-distance representative within the weld band (consistent with the boundary co-registration) instead of the first match, so dense junction clusters cannot adopt a farther representative.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts the nearest canonical UV at interior junctions instead of the first match within the weld band. This aligns interior-junction canonicalization with boundary co-registration and prevents dense junction clusters from adopting a farther representative.

- When multiple `canon` candidates are within `weld3_sq`, select the one with minimum squared distance to `p3`; otherwise fall back to pushing the new UV as before.
- Removes order dependence from adoption and slightly increases per-junction work by scanning all candidates within the band. No API or migration changes.

<sup>Written for commit 8d42dbf66ea922192546eb83023f068cfeb3bd03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

