### PR TITLE
refactor(algo): polish the wire-vertex weld per review

### DIFF
--- a/crates/algo/src/builder/fill_images_faces.rs
+++ b/crates/algo/src/builder/fill_images_faces.rs
@@ -146,7 +146,7 @@ pub fn fill_images_faces<S: BuildHasher, S2: BuildHasher>(
     };
 
     // PB vertex registry: cross-face pool of FRESH vertices at CB positions.
-    // Wire vertices minted by THIS build, by position. The layered caches
+    // Wire vertices this build has resolved or minted, by position. The layered caches
     // quantize exactly (1e-10 cells), but each face's sub-face wires carry
     // their own marched endpoint drift (~1e-5 at the kumiko strut corner:
     // four distinct vertices minted at one junction), so the mint fallback
@@ -3283,11 +3283,11 @@ fn resolve_edge_vertices(
     )],
                 p: brepkit_math::vec::Point3|
      -> Option<brepkit_topology::vertex::VertexId> {
-        let band = tol.linear * 250.0;
+        let band = (tol.linear * 250.0) * (tol.linear * 250.0);
         let mut best: Option<(f64, brepkit_topology::vertex::VertexId)> = None;
         let mut second = f64::INFINITY;
         for &(q, vid) in wire_pool {
-            let d = (q - p).length();
+            let d = (q - p).length_squared();
             match best {
                 Some((bd, _)) if d < bd => {
                     second = bd;

--- a/crates/io/examples/replay_pair.rs
+++ b/crates/io/examples/replay_pair.rs
@@ -635,8 +635,9 @@ fn main() {
             }
         }
     }
+    let vcorner_enabled = std::env::var("VCORNER").is_ok();
     let vcorner_scan = |topo: &Topology, tag: &str| {
-        if std::env::var("VCORNER").is_ok() {
+        if vcorner_enabled {
             for i in 0..topo.num_vertices() {
                 let Some(vid) = topo.vertex_id_from_index(i) else {
                     continue;


### PR DESCRIPTION
Follow-up to #1612 addressing the review comments: squared-distance comparison in the weld scan, accurate pool comment (resolved-or-minted), and a captured VCORNER flag in replay_pair.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the wire-vertex weld scan to squared-distance comparisons and captures the `VCORNER` flag once in the replay example. This keeps weld semantics while removing sqrt costs and clarifying the FRESH vertex pool comment.

- Weld scan: compare `length_squared()` against a squared band (`(tol.linear * 250.0)^2`). Old behavior used `length()` and a linear band. This avoids sqrt and makes threshold math consistent; borderline picks may shift slightly due to float precision.
- Update comment to “resolved or minted” for the cross-face vertex pool.
- Replay tool: read `VCORNER` once into `vcorner_enabled` and close over it. Old behavior re-read the env var on each scan; changing the env at runtime now has no effect.

<sup>Written for commit a10904525263a39e8f5632119ff6308a3315f272. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

