### PR TITLE
refactor(algo): polish the stale-pcurve check per review

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -139,23 +139,11 @@ that does not exist yet; without it, stop.
 
 One line each; the fixture/PR carries the story. Newest first.
 
-- **Kumiko corner-window strut fuse (CLOSED 2026-08-15; ten roots over #1594-#1616-era PRs; acceptance pin `kumiko_diagonal_strut_fuse_is_exact` ACTIVE)** —
-  the ruled diagonal strut x wedge fuse is exact and watertight (70 faces, free=0
-  over=0, all quadrics + NURBS kept). The arc: marcher domain-clamp margin
-  (#1599), no-seam gate for non-periodic quads (#1599), marching-squares
-  plane-NURBS connectivity (#1601), UV co-registration by 3D junction identity
-  at boundaries (#1603) and interior T-junctions (#1609), junction-gated
-  T-split bands (#1606, honeycomb-guarded), cross-face wire-vertex weld
-  (#1612), and the closer: STALE-PCURVE tangents — junction co-registration
-  moves edge UVs without refitting pcurves, so walkers' departure angles
-  disagreed with welded endpoints and grand-toured degree-6 junctions;
-  `pcurve_tangent_at_endpoint` now falls back to the chord when the stored
-  pcurve's endpoint is off the welded UV. Durable lesson: marched geometry is
-  ~1e-6-to-1e-5 off at EVERY altitude (endpoints, vertices, tangents), and
-  each exact-tol gate it meets needs either a weld-scale band with a 10x
-  ambiguity guard or a shared-anchor adoption. Fixtures
-  `crates/io/tests/kumiko_strut_fuse_inmem.rs` (4 active pins); instruments
-  TWIN=2/VCORNER/RAW_ONLY in replay_pair, strut probes in io/examples.
+- **Kumiko corner-window strut fuse (CLOSED 2026-08-15, ten roots, #1599-#1616; pin `kumiko_diagonal_strut_fuse_is_exact` ACTIVE)** —
+  exact watertight fuse (70 faces, free=0 over=0); every root was marched-geometry
+  ~1e-6..1e-5 drift meeting an exact-tol gate (endpoints, vertices, tangents) — fixed by
+  weld-scale bands with 10x ambiguity guards or shared-anchor adoption at each altitude.
+  Fixtures and instrument census: `crates/io/tests/kumiko_strut_fuse_inmem.rs` + replay_pair.
 
 - **bp 6x4 magnets residual + every baseplate row (CLOSED 2026-08-13 on released 3.2.38; row 775 vs 1383ms = 0.56x, was 1.10x; aggregate 0.45x, faster 25/26)** —
   the #1488-era "no dominant stage" reading had rotted: pocketsCut owned the

--- a/crates/algo/src/builder/wire_builder.rs
+++ b/crates/algo/src/builder/wire_builder.rs
@@ -643,8 +643,9 @@ fn pcurve_tangent_at_endpoint(edge: &OrientedPCurveEdge, at_start: bool) -> (f64
             let anchor = if at_start { edge.start_uv } else { edge.end_uv };
             let t_anchor = if at_start { t_start } else { t_end };
             let pe = nurbs.evaluate(t_anchor);
+            let stale_eps_sq: f64 = 1e-9 * 1e-9;
             let stale =
-                ((pe.x() - anchor.x()).powi(2) + (pe.y() - anchor.y()).powi(2)).sqrt() > 1e-9;
+                (pe.x() - anchor.x()).powi(2) + (pe.y() - anchor.y()).powi(2) > stale_eps_sq;
             if !stale {
                 if at_start {
                     let p0 = nurbs.evaluate(t_start);

--- a/crates/io/tests/kumiko_strut_fuse_inmem.rs
+++ b/crates/io/tests/kumiko_strut_fuse_inmem.rs
@@ -142,11 +142,9 @@ fn kumiko_wedge_outer_cylinder_partitions_at_strut_chains() {
     );
 }
 
-/// READY-REPRO: fusing a wedge strut with the honest (ruled-patch) diagonal
-/// strut must stay exact. Today the wedge's kept pieces fail to weld to the
-/// strut's marched-NURBS section seams and detach as a 5-face open growth
-/// shell, so the op pays the mesh fallback (the kumiko corner-window
-/// frontier).
+/// The campaign's acceptance pin: fusing a wedge strut with the honest
+/// (ruled-patch) diagonal strut stays exact — no mesh fallback, zero free
+/// edges (the kumiko corner-window frontier, closed over ten roots).
 #[test]
 fn kumiko_diagonal_strut_fuse_is_exact() {
     let mut topo = Topology::new();


### PR DESCRIPTION
Follow-up to #1616 addressing the review comments: squared-distance stale check without the sqrt, the acceptance pin's doc comment updated to what it now validates, and the roadmap Closed entry collapsed toward the one-line rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses squared UV distance to flag stale p-curve endpoints in `pcurve_tangent_at_endpoint`, replacing sqrt(distance) > 1e-9 with distance_sq > 1e-18. Behavior is unchanged; we simply avoid sqrt while keeping the same tolerance, and the tangent fallback remains the same. Also updates the acceptance pin comment and collapses the roadmap entry.

**Review notes**
- Check `wire_builder.rs`: verify the `stale_eps_sq` threshold matches the previous 1e-9 norm and that fallback-on-stale still gates as before.
- No test logic changes; only the acceptance pin docstring was clarified.
- No config, migration, or rollout steps required.

<sup>Written for commit be65d1dc5cc8ce26428419bc53608d40c63a1c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

