### PR TITLE
docs(roadmap): record the tool-side verification of the strut campaign

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -143,7 +143,7 @@ One line each; the fixture/PR carries the story. Newest first.
   exact watertight fuse (70 faces, free=0 over=0); every root was marched-geometry
   ~1e-6..1e-5 drift meeting an exact-tol gate (endpoints, vertices, tangents) — fixed by
   weld-scale bands with 10x ambiguity guards or shared-anchor adoption at each altitude.
-  Fixtures and instrument census: `crates/io/tests/kumiko_strut_fuse_inmem.rs` + replay_pair.
+  Fixtures and instrument census: `crates/io/tests/kumiko_strut_fuse_inmem.rs` + replay_pair. Tool-side verified same-day on 3.3.7: generator suite 2883/2883 (292 files) vs a 2883/2883 control on 3.3.0, wall 221s vs 229s.
 
 - **bp 6x4 magnets residual + every baseplate row (CLOSED 2026-08-13 on released 3.2.38; row 775 vs 1383ms = 0.56x, was 1.10x; aggregate 0.45x, faster 25/26)** —
   the #1488-era "no dominant stage" reading had rotted: pocketsCut owned the


### PR DESCRIPTION
Same-day tool-side verification of the closed kumiko strut campaign: generator suite 2883/2883 (292 files) on brepkit-wasm 3.3.7 vs a 2883/2883 control on 3.3.0, wall 221s vs 229s. Measurement worktrees per the parity-benchmarking recipe, since removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents same-day tool-side verification of the closed kumiko strut campaign in `.claude/skills/roadmap/SKILL.md`. Adds the comparison on `brepkit-wasm` 3.3.7 vs 3.3.0—generator suite 2883/2883 (292 files) vs 2883/2883 control, wall 221s vs 229s—to make the roadmap entry auditable; no runtime changes.

<sup>Written for commit 2e04d0d72529b52a306b1667656ac493c4b4e849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

