### PR TITLE
docs(roadmap): record the 3.3.7 head-to-head matrix

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -143,7 +143,7 @@ One line each; the fixture/PR carries the story. Newest first.
   exact watertight fuse (70 faces, free=0 over=0); every root was marched-geometry
   ~1e-6..1e-5 drift meeting an exact-tol gate (endpoints, vertices, tangents) — fixed by
   weld-scale bands with 10x ambiguity guards or shared-anchor adoption at each altitude.
-  Fixtures and instrument census: `crates/io/tests/kumiko_strut_fuse_inmem.rs` + replay_pair. Tool-side verified same-day on 3.3.7: generator suite 2883/2883 (292 files) vs a 2883/2883 control on 3.3.0, wall 221s vs 229s.
+  Fixtures and instrument census: `crates/io/tests/kumiko_strut_fuse_inmem.rs` + replay_pair. Tool-side verified same-day on 3.3.7: generator suite 2883/2883 (292 files) vs a 2883/2883 control on 3.3.0, wall 221s vs 229s; head-to-head matrix 0.49x aggregate (10476ms vs 5155ms), nm 0 vs 5, only the three known scoop-family reference double-cover volume flags.
 
 - **bp 6x4 magnets residual + every baseplate row (CLOSED 2026-08-13 on released 3.2.38; row 775 vs 1383ms = 0.56x, was 1.10x; aggregate 0.45x, faster 25/26)** —
   the #1488-era "no dominant stage" reading had rotted: pocketsCut owned the


### PR DESCRIPTION
Same-day head-to-head on 3.3.7: 0.49x aggregate (10476ms reference vs 5155ms brepkit), non-manifold 0 vs 5, and only the three documented scoop-family volume flags (the reference's double-cover over-count). Completes the post-campaign verification checklist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the 3.3.7 head-to-head matrix in the roadmap entry to capture performance and validation results from the same-day run. Previously the entry only listed suite pass counts and wall times; now it adds 0.49x aggregate (10476ms vs 5155ms), non-manifold 0 vs 5, and the three known scoop-family volume flags (reference double-cover), completing the post-campaign verification checklist.

**Review notes**
- Single-line docs edit in `.claude/skills/roadmap/SKILL.md`; no runtime impact or migration.

<sup>Written for commit 522b2055faaa3a50aba8e346cff406d3a5e9d553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

