### PR TITLE
fix(wasm): drop deprecated tsify into_wasm_abi impls

### DIFF
--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -1,14 +1,14 @@
 //! Typed result structs for structured WASM returns.
 //!
-//! Types annotated with `Tsify` automatically generate TypeScript definitions
-//! and can be serialized via `serde-wasm-bindgen` for zero-copy JS interop.
+//! Types annotated with `Tsify` generate the TypeScript definitions that
+//! describe these shapes. They cross the boundary as JSON strings, not over
+//! the wasm ABI, so they deliberately carry no `into_wasm_abi` impl.
 
 use tsify::Tsify;
 
 /// Typed result for `tessellateSolidGrouped`.
 #[derive(serde::Serialize, Tsify)]
 #[serde(rename_all = "camelCase")]
-#[tsify(into_wasm_abi)]
 pub struct GroupedMeshResult {
     pub positions: Vec<f64>,
     pub normals: Vec<f64>,
@@ -18,7 +18,6 @@ pub struct GroupedMeshResult {
 
 /// Typed result for `tessellateSolidUV`.
 #[derive(serde::Serialize, Tsify)]
-#[tsify(into_wasm_abi)]
 pub struct UvMeshResult {
     pub positions: Vec<f64>,
     pub normals: Vec<f64>,
@@ -26,33 +25,3 @@ pub struct UvMeshResult {
     pub uvs: Vec<f64>,
 }
 
-/// Typed result for `boundingBox`.
-#[derive(serde::Serialize, Tsify)]
-#[tsify(into_wasm_abi)]
-pub struct BoundingBoxResult {
-    pub min_x: f64,
-    pub min_y: f64,
-    pub min_z: f64,
-    pub max_x: f64,
-    pub max_y: f64,
-    pub max_z: f64,
-}
-
-/// Typed result for boolean operations with evolution tracking.
-#[derive(serde::Serialize, Tsify)]
-#[serde(rename_all = "camelCase")]
-#[tsify(into_wasm_abi)]
-pub struct EvolutionResult {
-    pub solid: u32,
-    pub generated: Vec<u32>,
-    pub modified: Vec<u32>,
-}
-
-/// Typed result for `sketchSolve`.
-#[derive(serde::Serialize, Tsify)]
-#[tsify(into_wasm_abi)]
-pub struct SketchSolveResult {
-    pub converged: bool,
-    pub points: Vec<f64>,
-    pub residual: f64,
-}

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -24,4 +24,3 @@ pub struct UvMeshResult {
     pub indices: Vec<u32>,
     pub uvs: Vec<f64>,
 }
-


### PR DESCRIPTION
## Why every PR in this repo is red

`tsify` 0.5.7 marked `into_wasm_abi` / `from_wasm_abi` deprecated over the memory leak in [madonoharu/tsify#65](https://github.com/madonoharu/tsify/issues/65). `Cargo.lock` is gitignored here, so CI re-resolves `tsify = "0.5"` on every run and picks up the new release; `RUSTFLAGS: -Dwarnings` then promotes the deprecation to a hard error. That is what fails Clippy, Test, Coverage, MSRV, WASM Build, WASM Size, Publish Dry Run and Publish benchmark on #1623 and #1624, neither of which touches Rust.

## Why removal rather than migrating to `tsify::Ts`

The attribute was never doing any work. `tessellate_solid_grouped` and `tessellate_solid_uv` return `Result<JsValue, JsError>` built with `serde_json::to_string`, so no struct in `types.rs` has ever crossed the wasm ABI. The `Tsify` derive stays, so the TypeScript declarations are unchanged for the two live types.

## The three deleted structs

Dropping the attribute removed the generated `IntoWasmAbi` impl that had been counting as a use, and `dead_code` immediately flagged `BoundingBoxResult`, `EvolutionResult` and `SketchSolveResult`. All three are unreachable (`mod types` is private) and none describes the binding it is named for:

| Struct | What the binding actually returns |
| --- | --- |
| `BoundingBoxResult` | `bounding_box` returns `Vec<f64>` |
| `EvolutionResult` | `*_with_evolution` hand-build `{"solid":…,"evolution":{…}}` |
| `SketchSolveResult` | no sketch-solve binding exists |

Keeping them would have required an `#[allow(dead_code)]` to preserve declarations that are already wrong, so they are deleted.

## Verification

`RUSTFLAGS=-Dwarnings cargo check --workspace --all-features` and `-p brepkit-wasm --all-features --all-targets` both clean locally against a fresh resolution (which now picks `tsify` 0.5.8).

## Follow-up worth considering

CI is not hermetic: any upstream release can redden every open PR without a diff being at fault. Committing `Cargo.lock` would put Rust bumps under Dependabot's control the way `elevator-core` does. Not done here — happy to split it out if you want it.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes deprecated `into_wasm_abi` usage from `tsify`-derived types and deletes three dead structs to stop CI failures from deprecation warnings. Behavior is unchanged: results still cross the wasm boundary as JSON strings and TypeScript declarations for live types stay the same.

- Drops `#[tsify(into_wasm_abi)]` (deprecated in `tsify` ≥0.5.7). Without a committed `Cargo.lock`, CI resolves the new release and `-Dwarnings` makes the deprecation a hard error.
- Deletes `BoundingBoxResult`, `EvolutionResult`, and `SketchSolveResult` flagged as dead and mismatched to actual bindings; keeps `Tsify` derives on live result types so d.ts output remains.
- No API or runtime change: tessellation still returns `Result<JsValue, JsError>` via `serde_json`; `bounding_box` returns `Vec<f64>`. No migration required.
- Minor style: removes a trailing blank line in `types.rs`.

<sup>Written for commit 2d6265a3db4b375c75abc94cb0a2b2e797fce0fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

