### PR TITLE
fix(ci): drop stale criterion dir before the tracking bench

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,6 +47,15 @@ jobs:
         # (the default `bash -e` shell does NOT set it).
         run: |
           set -o pipefail
+          # rust-cache restores target/, and its pruning leaves
+          # target/criterion/<group>/<bench>/base/ present but without
+          # sample.json. Criterion then prints "Criterion.rs ERROR: ... base/
+          # sample.json: No such file or directory" *between* "test <name> ... "
+          # and "bench: <n> ns/iter", so the bencher line is split across two
+          # lines and the cargo parser in `publish` reports "No benchmark result
+          # was found". The trend baseline lives on gh-pages, not here, so this
+          # directory is pure scratch and safe to drop.
+          rm -rf target/criterion
           cargo bench -p brepkit-operations --bench boolean_tracking -- --output-format bencher | tee bench-output.txt
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
`Publish benchmark` has been failing on `main` and every PR with:

> No benchmark result was found in bench-output.txt

## The benchmark was never actually broken

The `bench:` numbers are produced correctly. `Boolean perf` exits 0 and the values are all there — but Criterion writes its baseline-load error **mid-line**, so what reaches the parser is:

```
test boolean/cut_box_box ... Criterion.rs ERROR: error: Failed to access file ".../base/sample.json": No such file or directory (os error 2)
bench:   1,024,312 ns/iter (+/- 919)
```

instead of the single line `test boolean/cut_box_box ... bench: 1,024,312 ns/iter (+/- 919)` that github-action-benchmark's `cargo` parser matches. Every one of the five benches is split this way, so it sees zero results.

## Why the file is missing

`rust-cache` restores `target/` (the failing run logs `full match: true`) and its pruning leaves `target/criterion/<group>/<bench>/base/` as an empty directory. Criterion sees the directory, tries to load the baseline, and fails. A clean checkout never hits this, which is why it only shows up in CI.

## Verified locally

Reproduced byte-for-byte by deleting just the `base/sample.json` files and leaving the directories:

```
test boolean/cut_box_box ... Criterion.rs ERROR: error: Failed to access file ".../base/sample.json" ...
bench:   1,012,794 ns/iter (+/- 18,127)
```

With `rm -rf target/criterion` first, all 5 lines match the parser's shape again (`grep -cE '^test .+ \.\.\. bench: +[0-9,]+ ns/iter'` → 5).

Dropping the directory costs nothing: the trend baseline this pipeline actually compares against lives on `gh-pages` via github-action-benchmark, as the workflow header describes. `target/criterion` is scratch.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores CI benchmark publishing by removing stale `target/criterion` before running the tracking bench. Before: `rust-cache` left `.../base/` without `sample.json`, `Criterion` logged a baseline-load error mid-line, and `github-action-benchmark` found zero results; after: benches emit single-line bencher output and the job passes. Side effects: none—the trend baseline stays on `gh-pages`.

**Review notes**
- Adds `rm -rf target/criterion` before `cargo bench` in `.github/workflows/benchmark.yml`.
- CI-only change; no benchmark code or thresholds modified.

<sup>Written for commit ee01a9b8065855a4d5bba6f44180a237e0d221bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/brepkit/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

